### PR TITLE
Fixing the comment-at-end-of-file bug (PR#11982)

### DIFF
--- a/collects/scribble/reader.rkt
+++ b/collects/scribble/reader.rkt
@@ -50,7 +50,7 @@
 ;; regexps based on the above (more in make-dispatcher)
 (define re:whitespaces   (^px "\\s+"))
 (define re:comment-start (^px ch:comment))
-(define re:comment-line  (^px "[^\n]*\n[ \t]*")) ; like tex's `%'
+(define re:comment-line  (^px "[^\n]*(\n|$)[ \t]*")) ; like tex's `%'
 (define re:expr-escape   (^px ch:expr-escape))
 (define re:datums-begin  (^px ch:datums-begin))
 (define re:datums-end    (^px ch:datums-end))

--- a/collects/tests/scribble/reader.rkt
+++ b/collects/tests/scribble/reader.rkt
@@ -404,6 +404,10 @@ fo@o  -@->  fo@o
 -@->
 (1 2 3 4)
 ---
+hello @; another comment at eof
+-@->
+hello
+---
 @foo{bar @; comment
      baz@;
      blah}


### PR DESCRIPTION
Added test case and adjusted the reader so it handles EOF when the last line is @; commented.
