### PR TITLE
Correctly recreate Scopes. Closes PR 10552. Closes PR 11532.

### DIFF
--- a/collects/tests/typed-scheme/succeed/pr10552.rkt
+++ b/collects/tests/typed-scheme/succeed/pr10552.rkt
@@ -1,0 +1,5 @@
+#lang typed-scheme
+
+(: z (All (A) (A -> ((Listof A) A -> (Listof A)))))
+(define (z _) (lambda (x y) (cons y x)))
+(define zz (z cons))

--- a/collects/tests/typed-scheme/succeed/pr11532.rkt
+++ b/collects/tests/typed-scheme/succeed/pr11532.rkt
@@ -1,0 +1,4 @@
+#lang typed/racket
+(define-type T (All [X Y ...] String))
+(: f (All [A] (T -> Any)))
+(define f void)

--- a/collects/typed-scheme/rep/type-rep.rkt
+++ b/collects/typed-scheme/rep/type-rep.rkt
@@ -517,10 +517,10 @@
        [#:Mu (Scope: body) (*Mu (*Scope (loop (add1 outer) body)))]
        [#:PolyDots n body*
                    (let ([body (remove-scopes n body*)])
-                     (*PolyDots n (*Scope (loop (+ n outer) body))))]
+                     (*PolyDots n (add-scopes n (loop (+ n outer) body))))]
        [#:Poly n body*
                (let ([body (remove-scopes n body*)])
-                 (*Poly n (*Scope (loop (+ n outer) body))))])))
+                 (*Poly n (add-scopes n (loop (+ n outer) body))))])))
   (let ([n (length names)])
     (let loop ([ty ty] [names names] [count (sub1 n)])
       (if (zero? count)
@@ -568,10 +568,10 @@
        [#:Mu (Scope: body) (*Mu (*Scope (loop (add1 outer) body)))]
        [#:PolyDots n body*
                    (let ([body (remove-scopes n body*)])
-                     (*PolyDots n (*Scope (loop (+ n outer) body))))]
+                     (*PolyDots n (add-scopes n (loop (+ n outer) body))))]
        [#:Poly n body*
                (let ([body (remove-scopes n body*)])
-                 (*Poly n (*Scope (loop (+ n outer) body))))])))
+                 (*Poly n (add-scopes n (loop (+ n outer) body))))])))
   (let ([n (length images)])
     (let loop ([ty (remove-scopes n sc)] [images images] [count (sub1 n)])
       (if (zero? count)


### PR DESCRIPTION
When scopes were removed, only one was replaced. This patch puts the right number back.
