### PR TITLE
Adds make-applicable-struct-info to racket/struct-info

### DIFF
--- a/collects/racket/contract/private/provide.rkt
+++ b/collects/racket/contract/private/provide.rkt
@@ -21,24 +21,6 @@
     [(_ name x) (a:known-good-contract? #'x) #'x]
     [(_ name x) #'(coerce-contract name x)]))
 
-(define-for-syntax (self-ctor-transformer orig stx)
-  (with-syntax ([orig orig])
-    (syntax-case stx ()
-      [(_ arg ...) (datum->syntax stx
-                                  (syntax-e (syntax (orig arg ...)))
-                                  stx
-                                  stx)]
-      [_ (syntax orig)])))
-
-(define-for-syntax make-applicable-struct-info
-  (letrec-values ([(struct: make- ? ref set!)
-                   (make-struct-type 'self-ctor-struct-info struct:struct-info
-                                     1 0 #f
-                                     (list (cons prop:procedure
-                                                 (lambda (v stx)
-                                                   (self-ctor-transformer ((ref v 0)) stx))))
-                                     (current-inspector) #f '(0))])
-    make-))
 
 (define-for-syntax (make-provide/contract-transformer contract-id id external-id pos-module-source)
   (make-set!-transformer

--- a/collects/racket/private/define-struct.rkt
+++ b/collects/racket/private/define-struct.rkt
@@ -14,6 +14,7 @@
              struct-field-index
              struct-copy
              (for-syntax 
+               make-applicable-struct-info
 	      (rename checked-struct-info-rec? checked-struct-info?)))
   
   (define-values-for-syntax
@@ -83,6 +84,25 @@
                                                      (self-ctor-transformer ((ref v 0)) stx))))
                                        (current-inspector) #f '(0))])
       make-))
+
+
+ (define-for-syntax make-applicable-struct-info
+  (letrec-values ([(struct: make- ? ref set!)
+                   (make-struct-type 'self-ctor-struct-info struct:struct-info
+                                     1 0 #f
+                                     (list (cons prop:procedure
+                                                 (lambda (v stx)
+                                                   (self-ctor-transformer ((ref v 0)) stx))))
+                                     (current-inspector) #f '(0)
+                                     (lambda (info-proc stx-proc subtype)
+                                       (if (and (procedure? stx-proc)
+                                                (procedure-arity-includes? stx-proc 0))
+                                           (values info-proc stx-proc)
+                                           (raise-type-error 'make-applicable-struct-info
+                                                             "procedure (arity 0)"
+                                                             stx-proc))))])
+    make-))
+
 
   (define-syntax-parameter struct-field-index
     (lambda (stx)

--- a/collects/racket/struct-info.rkt
+++ b/collects/racket/struct-info.rkt
@@ -3,4 +3,5 @@
   (#%require "private/struct-info.rkt"
              (for-template "private/define-struct.rkt"))
   (#%provide (all-from "private/struct-info.rkt")
-             checked-struct-info?))
+             checked-struct-info?
+             make-applicable-struct-info))

--- a/collects/scribblings/reference/struct.scrbl
+++ b/collects/scribblings/reference/struct.scrbl
@@ -698,6 +698,15 @@ specified through a transformer binding to such a value.}
 Encapsulates a thunk that returns structure-type information in list
 form.}
 
+@defproc[(make-applicable-struct-info [info-thunk (-> (and/c struct-info? list?))]
+                                      [id-thunk (-> identifier?)])
+         (and/c struct-info? (-> syntax? syntax?))]{
+
+Works like make-struct-info, but the returned value is also a syntax transformer.
+The syntax transformer works like the constructor bound by @racket[struct] and
+replaces uses of itself with the identifier returned by  @racket[id-thunk].}
+
+
 @defproc[(extract-struct-info [v struct-info?])
          (and/c struct-info? list?)]{
 


### PR DESCRIPTION
Currently the base library has no mechanism for creating bindings for struct-info objects in the transformer environment that act as normal value bindings as well. This is a common feature when implementing struct like forms. Currently provide/contract uses a mechanism like this, and TR needs it. This patch adds this capability in a common location so that users will not have to re-implement it each time.
