### PR TITLE
Don't export required bindings with all-defined-out and require/typed.

### DIFF
--- a/collects/tests/typed-scheme/fail/rts-prov.rkt
+++ b/collects/tests/typed-scheme/fail/rts-prov.rkt
@@ -1,3 +1,6 @@
+#;
+(exn-pred exn:fail:syntax? #rx".*unbound identifier.*make-q.*")
+
 #lang scheme/load
 
 (module l scheme

--- a/collects/tests/typed-scheme/succeed/pr11425.rkt
+++ b/collects/tests/typed-scheme/succeed/pr11425.rkt
@@ -1,0 +1,12 @@
+#lang racket/load
+
+(module sgn-exporter typed/racket/base
+  (require/typed
+   racket/math
+   [sgn  (Integer -> Fixnum)])
+  (provide (all-defined-out)))
+
+(module sgn-importer typed/racket/base
+  (require racket/math 'sgn-exporter))
+
+(require 'sgn-exporter)

--- a/collects/typed-scheme/utils/require-contract.rkt
+++ b/collects/typed-scheme/utils/require-contract.rkt
@@ -4,6 +4,7 @@
          syntax/location
          (for-syntax scheme/base
                      syntax/parse
+                     racket/syntax
                      (prefix-in tr: "../private/typed-renaming.rkt")))
 
 (provide require/contract define-ignored)
@@ -31,26 +32,32 @@
     [(_ id)
      (tr:get-alternate #'id)]))
 
+
+
+;Requires an identifier from an untyped module into a typed module
+;nm is the import
+;hidden is an id that will end up being the actual definition
+;nm will be bound to a rename transformer so that it is not provided
+;with all-defined-out
 (define-syntax (require/contract stx)
   (define-syntax-class renameable
     (pattern nm:id
-             #:with r ((make-syntax-introducer) #'nm)))
+             #:with orig-nm #'nm
+             #:with orig-nm-r ((make-syntax-introducer) #'nm))
+    (pattern (orig-nm:id nm:id)
+             #:with orig-nm-r ((make-syntax-introducer) #'nm)))
+
   (syntax-parse stx
-    [(require/contract nm:renameable cnt lib)
-     #`(begin (require (only-in lib [nm nm.r]))
-              (define-ignored nm
+    [(require/contract nm:renameable hidden:id cnt lib)
+     #`(begin (require (only-in lib [nm.orig-nm nm.orig-nm-r]))
+              (define-syntax nm.nm (make-rename-transformer
+                (syntax-property (syntax-property (quote-syntax hidden)
+                    'not-free-identifier=? #t)
+                  'not-provide-all-defined #t)))
+              (define-ignored hidden
                 (contract cnt
-                          (get-alternate nm.r)
-                          '(interface for #,(syntax->datum #'nm))
+                          (get-alternate nm.orig-nm-r)
+                          '(interface for #,(syntax->datum #'nm.nm))
                           (current-contract-region)
-                          (quote nm)
-                          (quote-srcloc nm))))]
-    [(require/contract (orig-nm:renameable nm:id) cnt lib)
-     #`(begin (require (only-in lib [orig-nm orig-nm.r]))
-              (define-ignored nm
-                (contract cnt
-                          (get-alternate orig-nm.r)
-                          '#,(syntax->datum #'nm)
-                          (current-contract-region)
-                          (quote nm)
-                          (quote-srcloc nm))))]))
+                          (quote nm.nm)
+                          (quote-srcloc nm.nm))))]))


### PR DESCRIPTION
Closes PR11425.
