### PR TITLE
Fixes build-struct-expand-info to create correct struct info.

### DIFF
--- a/collects/racket/private/struct-info.rkt
+++ b/collects/racket/private/struct-info.rkt
@@ -103,6 +103,7 @@
              (identifier/#f? (caddr x))
              (id/#f-list? identifier? (list-ref x 3))
              (id/#f-list? identifier/#f? (list-ref x 4))
+             (= (length (list-ref x 3)) (length (list-ref x 4)))
              (or (eq? #t (list-ref x 5)) (identifier/#f? (list-ref x 5)))))))
 
   (define-values (prop:struct-auto-info

--- a/collects/syntax/struct.rkt
+++ b/collects/syntax/struct.rkt
@@ -201,25 +201,27 @@
 			   base))]
 	     [qs (lambda (x) (if (eq? x #t)
 				 x
-				 (and x `(quote-syntax ,x))))])
+				 (and x `(quote-syntax ,x))))]
+         [self-sels (reverse (if omit-sel?
+                                 null
+                                 (map qs (if omit-set? flds (every-other flds)))))]
+         [self-sets (reverse (if omit-sel?
+                                 null
+                                 (if omit-set?
+                                     (map (lambda (sel) #f) self-sels)
+                                     (map qs (every-other (if (null? flds)
+                                                              null
+                                                              (cdr flds)))))))])
         `(let ()
            (list
             ,(qs (car names))
             ,(qs (cadr names))
             ,(qs (caddr names))
             (list 
-             ,@(reverse (if omit-sel?
-                            null
-                            (map qs (if omit-set? flds (every-other flds)))))
+             ,@self-sels
              ,@(map qs (add-#f omit-sel? base-getters)))
             (list
-             ,@(reverse (if omit-set?
-                            null
-                            (map qs (if omit-sel?
-                                        flds
-                                        (every-other (if (null? flds)
-                                                         null
-                                                         (cdr flds)))))))
+             ,@self-sets
              ,@(map qs (add-#f omit-set? base-setters)))
             ,(qs base-name))))))
 


### PR DESCRIPTION
Adds a check to struct-info? to make sure selectors
and mutators are the same length. Closes PR12017.
