### PR TITLE
TR: Provides better error message for PR 11889.

### DIFF
--- a/collects/typed-scheme/typecheck/tc-app.rkt
+++ b/collects/typed-scheme/typecheck/tc-app.rkt
@@ -563,6 +563,7 @@
         (match (map single-value (syntax->list #'pos-args))
           [(list (tc-result1: argtys-t) ...)
            (let* ([subst (infer vars null argtys-t dom rng (and expected (tc-results->values expected)))])
+             (unless subst (fail))
              (tc-keywords form (list (subst-all subst ar))
                           (type->list (tc-expr/t #'kws)) #'kw-arg-list #'pos-args expected))])]
        [(tc-result1: (Function: arities))


### PR DESCRIPTION
This patch provides a user level error message for PR 11889. The error message before was an internal typed/racket error, now it is that there is no support for inference on keyword functions. This is not the best error message but is better than an internal error.
