### PR TITLE
Changed GDK_BUTTON_MOTION_MASK into GDK_POINTER_MOTION_MASK.

### DIFF
--- a/collects/mred/private/wx/gtk/canvas.rkt
+++ b/collects/mred/private/wx/gtk/canvas.rkt
@@ -392,7 +392,7 @@
                                                     GDK_BUTTON_PRESS_MASK
                                                     GDK_BUTTON_RELEASE_MASK
                                                     GDK_POINTER_MOTION_HINT_MASK
-                                                    GDK_BUTTON_MOTION_MASK
+                                                    GDK_POINTER_MOTION_MASK
                                                     GDK_FOCUS_CHANGE_MASK
                                                     GDK_ENTER_NOTIFY_MASK
                                                     GDK_LEAVE_NOTIFY_MASK))


### PR DESCRIPTION
This means that mouse motion events are now also sent when
none of the mouse buttons are pressed, which seems in line
with the documentation.
