### PR TITLE
Hacked algol60 #lang line into place

### DIFF
--- a/collects/algol60/examples/euler.a60
+++ b/collects/algol60/examples/euler.a60
@@ -1,3 +1,4 @@
+#lang algol60
 begin
 
 procedure euler (fct,sum,eps,tim); value eps,tim; integer tim;

--- a/collects/algol60/examples/jensen.a60
+++ b/collects/algol60/examples/jensen.a60
@@ -1,3 +1,4 @@
+#lang algol60
 begin
   integer procedure SIGMA(x, i, n);
     value n;

--- a/collects/algol60/examples/nqueen.a60
+++ b/collects/algol60/examples/nqueen.a60
@@ -1,3 +1,4 @@
+#lang algol60
 begin
         comment
           -- From the NASE A60 distribution --

--- a/collects/algol60/examples/primes.a60
+++ b/collects/algol60/examples/primes.a60
@@ -1,3 +1,4 @@
+#lang algol60
 begin
         comment
           -- From the NASE A60 distribution --

--- a/collects/algol60/lang/algol60.rkt
+++ b/collects/algol60/lang/algol60.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(require "../runtime.rkt"
+         "../prims.rkt")
+
+(provide (all-from-out racket/base)
+         (all-from-out "../prims.rkt")
+         (all-from-out "../runtime.rkt"))

--- a/collects/algol60/lang/reader.rkt
+++ b/collects/algol60/lang/reader.rkt
@@ -1,0 +1,53 @@
+#lang s-exp syntax/module-reader
+algol60/lang/algol60
+#:read my-read
+#:read-syntax my-read-syntax
+#:info my-get-info
+#:whole-body-readers? #t
+
+
+(require "../parse.rkt"
+         ;; Parses to generate an AST. Identifiers in the AST
+         ;; are represented as syntax objects with source location.
+         
+         "../simplify.rkt"
+         ;; Desugars the AST, transforming `for' to `if'+`goto',
+         ;; and flattening `if' statements so they are always
+         ;; of the for `if <exp> then goto <label> else goto <label>'
+         
+         "../compile.rkt"
+         ;; Compiles a simplified AST to Scheme.
+         
+         mzlib/file
+         syntax/strip-context)
+
+
+(define (my-read in)
+  (map syntax->datum (my-read-syntax #f in)))
+
+
+(define (my-read-syntax src in)
+  (define parsed (parse-a60-port in src))
+  (define simplified (simplify parsed #'here))
+  (define compiled (compile-simplified simplified #'here))
+  (define stripped (strip-context compiled))
+
+  (list stripped))
+
+
+
+;; Extension: we'd like to cooperate with DrRacket and tell
+;; it to use the default, textual lexer and color scheme when
+;; editing bf programs.
+;;
+;; See: http://docs.racket-lang.org/guide/language-get-info.html
+;; for more details, as well as the documentation in
+;; syntax/module-reader.
+(define (my-get-info key default default-filter)
+  (case key
+    [(color-lexer)
+     (dynamic-require 'syntax-color/default-lexer
+                      'default-lexer)]
+    [else
+     (default-filter key default)]))
+


### PR DESCRIPTION
# lang algol60 works now.  Added algol60/lang/reader.rkt.  All the examples in algol60/examples are converted to use the lang line.
