### PR TITLE
Fixed a bug with undo, delete, and clickbacks in DrRacket

### DIFF
--- a/collects/mred/private/wxme/undo.rkt
+++ b/collects/mred/private/wxme/undo.rkt
@@ -156,7 +156,7 @@
       (for-each disown deletions)
       (send editor do-insert-snips deletions start)
       (for-each (lambda (cb)
-                  (send editor set-clickback cb))
+                  (send editor add-back-clickback cb))
                 clickbacks)
 
       (send editor set-position startsel endsel)

--- a/collects/typed-scheme/optimizer/tool/tool.rkt
+++ b/collects/typed-scheme/optimizer/tool/tool.rkt
@@ -64,9 +64,9 @@
            (send this remove-clickback start end)]))
       (set! highlights '()))
 
-    (define/augment (after-insert start len)
+    (define/augment (on-insert start len)
       (clear-highlights))
-    (define/augment (after-delete start len)
+    (define/augment (on-delete start len)
       (clear-highlights))
 
     (super-new)))


### PR DESCRIPTION
Undoing the deletion of a block of text with a clickback registered to it would throw an exception. This can be repro'd by undoing after deleting a sexpr highlighted by the Performance Report tool. 

This seems to have been caused by the delete-record% class calling the wrong method to add back clickbacks when undoing a deletion. After this fix, trying the repro case would not throw an exception, but would restore the clickbacks with no way to remove them. This secondary issue was fixed by changing to on-delete instead of after-delete for clearing highlights/clickbacks in Performance Report.
