### PR TITLE
Offset error in planet/private/command.rkt

### DIFF
--- a/collects/planet/private/command.rkt
+++ b/collects/planet/private/command.rkt
@@ -112,7 +112,7 @@
 ;; are eaten in the process.
 (define (wrap-to-count str n)
   (cond
-    [(< (string-length str) n) (list str)]
+    [(<= (string-length str) n) (list str)]
     [(regexp-match-positions #rx"\n" str 0 n)
      =>
      (λ (posn)


### PR DESCRIPTION
correcting an offset error: if the string str is exactly n characters long, the use of string-ref in the last case will die.
