### PR TITLE
Changes in net/uri-codec documentation

### DIFF
--- a/collects/net/scribblings/uri-codec.scrbl
+++ b/collects/net/scribblings/uri-codec.scrbl
@@ -131,7 +131,8 @@ associations in @racket[form-urlencoded->alist],
 
 The default value is @racket['amp-or-semi], which means that both
 @litchar{&} and @litchar{;} are treated as separators when parsing,
-and @litchar{&} is used as a separator when encoding. The other modes
+and @litchar{&} is used as a separator when encoding. The @racket['semi-or-amp]
+mode is similar, but @litchar{;} is used when encoding. The other modes
 use/recognize only one of the separators.
 
 @examples[


### PR DESCRIPTION
- There was a missing word in a sentence;
- I tried to make the whole paragraph about `current-alist-separator-mode` a bit more clear.
