### PR TITLE
Add `set-some-element' which returns some element of the given set.

### DIFF
--- a/collects/racket/set.rkt
+++ b/collects/racket/set.rkt
@@ -8,7 +8,7 @@
 (provide set seteq seteqv
          set? set-eq? set-eqv? set-equal?
          set-empty? set-count
-         set-member? set-add set-remove
+         set-member? set-add set-remove set-some-element
          set-union set-intersect set-subtract set-symmetric-difference
          subset? proper-subset?
          set-map set-for-each 
@@ -146,6 +146,10 @@
 (define (set-remove set v)
   (unless (set? set) (raise-type-error 'set-remove "set" 0 set v))
   (make-set (hash-remove (set-ht set) v)))
+
+(define (set-some-element set)
+  (unless (set? set) (raise-type-error 'set-some-element "set" 0 set))
+  (car (hash-keys (set-ht set))))
 
 (define set-union
   (case-lambda

--- a/collects/scribblings/reference/sets.scrbl
+++ b/collects/scribblings/reference/sets.scrbl
@@ -65,6 +65,11 @@ Produces a set that includes @racket[v] plus all elements of
 Produces a set that includes all elements of @racket[st] except
 @racket[v]. This operation runs in constant time.}
 
+@defproc[(set-some-element [st set?]) any/c]{
+
+Produces a random element from @racket[st]. This procedure is not guaranteed to
+produce the same element if it is called again with the same set. This operation
+runs in constant time.}
 
 @defproc[(set-union [st set?] ...+) set?]{
 

--- a/collects/tests/racket/set.rktl
+++ b/collects/tests/racket/set.rktl
@@ -50,6 +50,8 @@
   (test #t set-member? (set-remove s 5) 3)
   (test #f set-member? (set-remove s 3) 3)
 
+  (test #t set-member? s (set-some-element s))
+
   (test #t subset? (set 1 3) s)
   (test #t subset? (set 1 2 3) s)
   (test #f subset? (set 1 4) s)


### PR DESCRIPTION
The procedure `set-some-element` returns a random element from the set. It is
not guaranteed to return the same element if it is called twice on the same set.

This has been discussed before: http://lists.racket-lang.org/users/archive/2011-September/047919.html

Shriram suggested a procedure of the type:
`get-one/rest : (forall (A) (Set A) -> (values A (Set A)))`
However, since this procedure is not called "set-first", I don't think there is any expectation that there exists a "set-rest".

I could certainly add a `set-get-one/rest` with little effort if that is also desired.
