### PR TITLE
Bugfix: Make the text-outline method of dc-path% handle curves correctly

### DIFF
--- a/collects/racket/draw/private/dc-path.rkt
+++ b/collects/racket/draw/private/dc-path.rkt
@@ -290,8 +290,8 @@
             [(move) (move-to (cadr a) (caddr a))]
             [(line) (line-to (cadr a) (caddr a))]
             [(curve) (curve-to (cadr a) (caddr a)
-                               (list-ref a 2) (list-ref a 3)
-                               (list-ref a 4) (list-ref a 5))]
+                               (list-ref a 3) (list-ref a 4)
+                               (list-ref a 5) (list-ref a 6))]
             [(close) (close)])))
       (close))
 


### PR DESCRIPTION
The text-outline method of dc-path% incorrectly handles curves.

Before this change, this snippet is rendered incorrectly:

![Incorrect render](http://img580.imageshack.us/img580/9038/garbled.jpg)

``` scheme
(dc                                        
 (λ (dc x y)                               
   (define r (new region%))                
   (let ([p (new dc-path%)])               
     (send p text-outline                  
           (make-object font% 35 'default) 
           "Hello world"                   
           x y)                            
     (send r set-path p))                  
   (send dc set-clipping-region r)         
   (send dc set-brush "black" 'solid)      
   (send dc draw-rectangle 0 0 500 200))   
 500 200)                                  
```
