### PR TITLE
racket/draw: Check for libjpeg.so.8 on unix

### DIFF
--- a/collects/racket/draw/unsafe/jpeg.rkt
+++ b/collects/racket/draw/unsafe/jpeg.rkt
@@ -7,7 +7,7 @@
          "../private/libs.rkt")
 
 (define-runtime-lib jpeg-lib
-  [(unix) (ffi-lib "libjpeg" '("62" ""))]
+  [(unix) (ffi-lib "libjpeg" '("62" "8" ""))]
   [(macosx) 
    ;; for PPC, it's actually version 8!
    (ffi-lib "libjpeg.62.dylib")]


### PR DESCRIPTION
Although racket/draw/unsafe/jpeg.rkt supports the libjpeg v8 API, it isn't looking for the library itself.  As the next major releases of both Debian and Ubuntu will be using libjpeg v8-compatible libraries, this will be necessary to run drracket or leverage racket/draw.

collects/scribblings/draw/libs.scrbl should be updated to reflect this as well, but I wasn't sure on the correct style to use in the documentation.
