### PR TITLE
ffi: extend _list and _vector to support zero-length output

### DIFF
--- a/collects/ffi/unsafe.rkt
+++ b/collects/ffi/unsafe.rkt
@@ -926,7 +926,8 @@
 ;; (_list <mode> <type> [<len>])
 ;; Similar to _ptr, except that it is used for converting lists to/from C
 ;; vectors.  The length is needed for output values where it is used in the
-;; post code, and in the pre code of an output mode to allocate the block.  In
+;; post code, and in the pre code of an output mode to allocate the block.  (If
+;; the length is 0, then NULL is passed in and an empty list is returned.)  In
 ;; any case it can refer to a previous binding for the length of the list which
 ;; the C function will most likely require.
 (provide _list)
@@ -935,7 +936,7 @@
     [(_ i  t  ) (type: _pointer
                  pre:  (x => (list->cblock x t)))]
     [(_ o  t n) (type: _pointer
-                 pre:  (malloc n t)
+                 pre:  (if (zero? n) #f (malloc n t))
                  post: (x => (cblock->list x t n)))]
     [(_ io t n) (type: _pointer
                  pre:  (x => (list->cblock x t))
@@ -949,7 +950,7 @@
     [(_ i  t  ) (type: _pointer
                  pre:  (x => (vector->cblock x t)))]
     [(_ o  t n) (type: _pointer
-                 pre:  (malloc n t)
+                 pre:  (if (zero? n) #f (malloc n t))
                  post: (x => (cblock->vector x t n)))]
     [(_ io t n) (type: _pointer
                  pre:  (x => (vector->cblock x t))

--- a/collects/scribblings/foreign/types.scrbl
+++ b/collects/scribblings/foreign/types.scrbl
@@ -784,7 +784,8 @@ A @tech{custom function type} that is similar to @racket[_ptr], except
 that it is used for converting lists to/from C vectors.  The optional
 @racket[maybe-len] argument is needed for output values where it is used in
 the post code, and in the pre code of an output mode to allocate the
-block.  In either case, it can refer to a previous binding for the
+block.  (If the length is 0, then NULL is passed in and an empty list is
+returned.)  In either case, it can refer to a previous binding for the
 length of the list which the C function will most likely require.}
 
 @defform[(_vector mode type maybe-len)]{


### PR DESCRIPTION
The use case I have for this is a C function that takes in a num_fields argument and a caller-allocated output array of fields, where num_fields can optionally be 0.
