### PR TITLE
Fix typo.

### DIFF
--- a/collects/db/scribblings/connect.scrbl
+++ b/collects/db/scribblings/connect.scrbl
@@ -665,7 +665,7 @@ ODBC's DSNs.
 
 @;{============================================================}
 
-@section[#:tag "managing-connections"]{Mangaging Connections}
+@section[#:tag "managing-connections"]{Managing Connections}
 
 @declare-exporting[db db/base #:use-sources (db/base)]
 


### PR DESCRIPTION
Fix typo in a section title of the DB collect.
