### PR TITLE
failed to open drracket on kuhio day

### DIFF
--- a/collects/drracket/private/drracket-normal.rkt
+++ b/collects/drracket/private/drracket-normal.rkt
@@ -104,7 +104,7 @@
           (set! key-codes null)
           (set-splash-bitmap
            (if (eq? special-state match)
-               (begin (set! special-state #f) the-splash-bitmap)
+               (begin (set! special-state #f) (read-bitmap the-splash-spec))
                (begin (set! special-state match)
                       (magic-image-bitmap match))))
           (refresh-splash))))))
@@ -132,19 +132,19 @@
     [(currently-the-weekend?)
      weekend-bitmap-spec]
     [else normal-bitmap-spec]))
-(define the-splash-bitmap (read-bitmap the-bitmap-spec))
+(define the-splash-spec the-bitmap-spec)
 (set-splash-char-observer drracket-splash-char-observer)
 
 (when (eq? (system-type) 'macosx)
   (define initial-state (current-icon-state))
   (define weekend-bitmap (if (equal? the-bitmap-spec weekend-bitmap-spec)
-                             the-splash-bitmap
+                             (read-bitmap the-splash-spec)
                              #f))
   (define weekday-bitmap (if (equal? the-bitmap-spec normal-bitmap-spec)
-                             the-splash-bitmap
+                             (read-bitmap the-splash-spec)
                              #f))
   (define valentines-bitmap (if (equal? the-bitmap-spec valentines-days-spec)
-                                the-splash-bitmap
+                                (read-bitmap the-splash-spec)
                                 #f))
   (define set-doc-tile-bitmap (dynamic-require doc-icon.rkt 'set-dock-tile-bitmap))
   (define (set-icon state)
@@ -169,7 +169,7 @@
           (set-icon next-state))
         (loop next-state))))))
 
-(start-splash the-splash-bitmap
+(start-splash the-splash-spec
               "DrRacket"
               700
               #:allow-funny? #t


### PR DESCRIPTION
The splash spec on kuhio day is not bitmap but with code creating a vector containing palaka's draw-honu proc. 
Then the vector is fed into a read-bitmap form in drracket/private/drracket-normal.rkt.

Unfortunately, read-bitmap does not expect vector arg.

This bug is introduced since commit f210692.
