### PR TITLE
Fix sleeping on infinite timeouts.

### DIFF
--- a/src/racket/src/thread.c
+++ b/src/racket/src/thread.c
@@ -3963,8 +3963,8 @@ static int check_sleep(int need_activity, int sleep_now)
       float mst = (float)max_sleep_time;
 
       /* Make sure that mst didn't go to infinity: */
-      if ((double)mst > (2 * max_sleep_time)) {
-	mst = 100000000.0;
+      if (mst && !((double)mst < (2 * max_sleep_time))) {
+        mst = 1000000.0;
       }
 
       {


### PR DESCRIPTION
This is a possible solution to PR 12661. It fixes detection of infinite value of mst / max_sleep_time, and reduces the replacement finite value with one that will not overflow 31 bits when converted to milliseconds (in default_sleep()), while still remaining big enough to be practically almost infinite.
