### PR TITLE
racket/draw: Check for libpng15, libpng12, and libpng on unix

### DIFF
--- a/collects/racket/draw/unsafe/png.rkt
+++ b/collects/racket/draw/unsafe/png.rkt
@@ -10,9 +10,13 @@
   [(unix)
    ;; Most Linux distros supply "libpng12", while other Unix
    ;; variants often have just "libpng":
-   (with-handlers ([exn:fail:filesystem?
-                    (lambda (exn) (ffi-lib "libpng"))])
-     (ffi-lib "libpng12" '("0" "")))]
+   (let loop ([libs '(("libpng15" ("15" ""))
+                      ("libpng12" ("0" ""))
+                      ("libpng"))])
+     (apply ffi-lib (car libs)
+            #:fail (let ([rest (cdr libs)])
+                     (and (pair? rest)
+                          (lambda () (loop rest))))))
   [(macosx) (ffi-lib "libpng15.15.dylib")]
   [(windows)
    (ffi-lib "zlib1.dll")


### PR DESCRIPTION
libpng 1.5 has started making its way into Linux distributions.  This adds support for loading libpng15.so, but it's not as clean as the libjpeg changes were since the library has different names per-major version.
