### PR TITLE
Correcting type error in latex-render

### DIFF
--- a/collects/scribble/latex-render.rkt
+++ b/collects/scribble/latex-render.rkt
@@ -388,7 +388,12 @@
                   (let ([v (car l)])
                     (cond
                      [(target-url? v)
-                      (printf "\\href{~a}{" (regexp-replace* #rx"%" (target-url-addr v) "\\\\%"))
+                      (printf "\\href{~a}{" (regexp-replace* #rx"%"
+                                                             (let ([p (target-url-addr v)])
+                                                               (if (path? p)
+                                                                   (path->string p)
+                                                                   p))
+                                                             "\\\\%"))
                       (loop (cdr l) #t)
                       (printf "}")]
                      [(color-property? v)


### PR DESCRIPTION
target-url-addr can be a path, which can't be consumed by regexp-replace
