### PR TITLE
Latex utf-8 inputenc missing when using scribble/sigplan

### DIFF
--- a/collects/scribble/sigplan/lang.rkt
+++ b/collects/scribble/sigplan/lang.rkt
@@ -68,8 +68,8 @@ Read here for more:
                    (string->bytes/utf-8
                     (format "\\documentclass~a{sigplanconf}\n~a~a~a~a"
                             options
-                            "\\usepackage[utf8]{inputenc}"
-                            "\\usepackage[T1]{fontenc}"
+                            "\\usepackage[utf8]{inputenc}\n"
+                            "\\usepackage[T1]{fontenc}\n"
                             (if times? 
                                 "\\usepackage{times}\n"
                                 "")


### PR DESCRIPTION
Since scribble-prefix.tex is not imported, there was no inclusion of inputenc and therefore non-ascii characters where mishandled.

See Scribble PDF for

```
#lang scribble/base

My name is Felipe Bañados, not Baados.
```

versus

```
#lang scribble/sigplan

My name is Felipe Bañados, not Baados.
```
