### PR TITLE
added css rules for printing

### DIFF
--- a/collects/scribble/scribble.css
+++ b/collects/scribble/scribble.css
@@ -469,3 +469,16 @@ i {
   display: inline;
   white-space: nowrap;
 }
+
+/* print styles : hide the navigation elements */
+@media print
+  {
+  .tocset,
+  .navsettop,
+  .navsetbottom { display: none; }
+  .maincolumn {
+	width: auto;
+	margin-right: 13em;
+	margin-left: 0;
+  }
+}


### PR DESCRIPTION
I've added some CSS rules to hide navigation elements on printed documents. This way the central column can nearly occupy the whole width of the page (except for the notes in the right column).
