### PR TITLE
typo: #:ports -> #:port.  Thanks to Jon Rafkind for finding this.

### DIFF
--- a/collects/web-server/web-server.rkt
+++ b/collects/web-server/web-server.rkt
@@ -107,12 +107,12 @@
          #:initial-connection-timeout [initial-connection-timeout 60])
   (define shutdowns
     (map (match-lambda
-           [(list-rest listen-ip ports)
+           [(list-rest listen-ip port)
             (serve #:dispatch dispatch
                    #:confirmation-channel confirmation-channel
                    #:connection-close? connection-close?
                    #:tcp@ tcp@
-                   #:ports ports
+                   #:port port
                    #:listen-ip listen-ip
                    #:max-waiting max-waiting
                    #:initial-connection-timeout initial-connection-timeout)])


### PR DESCRIPTION
Typo found by Jon Rafkind while testing something.

Is there a test case that exercises serve/ips+ports?  I couldn't find one.
