### PR TITLE
Added another example for for/fold/derived: for/max.

### DIFF
--- a/collects/scribblings/reference/for.scrbl
+++ b/collects/scribblings/reference/for.scrbl
@@ -364,6 +364,8 @@ source for all syntax errors.
                (values (+ n (* d k)) (* k 10)))])
            n))]))
 
+@code:comment{If we misuse for/digits, we can get good error reporting}
+@code:comment{because the use of orig-datum allows for source correlation:}
 (for/digits
     [a (in-list '(1 2 3))]
     [b (in-list '(4 5 6))]
@@ -373,6 +375,24 @@ source for all syntax errors.
     ([a (in-list '(1 2 3))]
      [b (in-list '(2 4 6))])
   (+ a b))
+
+
+@code:comment{Another example: compute the max during iteration:}
+(define-syntax (for/max stx)
+  (syntax-case stx ()
+     [(_ clauses . defs+exprs)
+      (with-syntax ([original stx])
+        #'(for/fold/derived original
+                            ([current-max -inf.0])
+                            clauses
+            (define maybe-new-max
+              (let () . defs+exprs))
+            (if (> maybe-new-max current-max)
+                maybe-new-max
+                current-max)))]))
+(for/max ([n '(3.14159 2.71828 1.61803)]
+          [s '(-1      1       1)])
+  (* n s))
 ]
 }
 

--- a/collects/scribblings/reference/sequences.scrbl
+++ b/collects/scribblings/reference/sequences.scrbl
@@ -25,7 +25,7 @@ vice-versa.
 
 @(define sequence-evaluator
    (let ([evaluator (make-base-eval)])
-     (evaluator '(require racket/generic racket/list racket/stream))
+     (evaluator '(require racket/generic racket/list racket/stream racket/sequence))
      evaluator))
 
 @guideintro["sequences"]{sequences}
@@ -699,6 +699,17 @@ each element in the sequence.
 
   If @racket[s] is a @tech{stream}, then the result is also a
   @tech{stream}.
+
+  @examples[#:eval sequence-evaluator
+    (let* ([all-reds (in-cycle '("red"))]
+           [red-and-blues (sequence-add-between all-reds "blue")])
+      (for/list ([n (in-range 10)]
+                 [elt red-and-blues])
+        elt))
+
+    (for ([text (sequence-add-between '("veni" "vidi" "duci") ", ")])
+      (display text))
+    ]
 }
 
 @; ======================================================================


### PR DESCRIPTION
Updated example for for/digits to avoid confusion: it's not clear
otherwise that the intentional syntax error wasn't just a casual
mistake.

Added an example for sequence-add-between.
