### PR TITLE
Addressing PR13212

### DIFF
--- a/collects/file/sha1.rkt
+++ b/collects/file/sha1.rkt
@@ -290,7 +290,7 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
     (sha1-hash-bytes (get-output-bytes p))))
 
 (define (sha1 in)
-  (format "~x" (sha1-input in)))
+  (bytes->hex-string (hash-value->bytes (sha1-input in))))
 
 (define (sha1-bytes in)
   (hash-value->bytes (sha1-input in)))

--- a/collects/file/tests/sha1.rkt
+++ b/collects/file/tests/sha1.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(require file/sha1 rackunit)
+
+
+;; The docs say that sha1 must return a 40-character string,
+;; and should include leading zeros.
+(check-equal? (string-length (sha1 (open-input-string " r a c k et")))
+              40)


### PR DESCRIPTION
file/sha1 should not use raw format because leading zeros are being incorrectly suppressed.  This patch simply uses Jon Rafkind's suggested workaround the problem in the bug report at 

http://bugs.racket-lang.org/query/?cmd=view%20audit-trail&database=default&pr=13212&return_url=http%3A%2F%2Fbugs.racket-lang.org%2Fquery%2F%3Fdatabase%3Ddefault%3Bdebug%3D%3BState%3Dany%3Bignoreclosed%3DIgnore%2520Closed%3BSynopsis%3D%3Bmultitext%3D%3Bcolumns%3DState%3Bcolumns%3DSynopsis%3Bcolumns%3DCategory%3Bcolumns%3DLast-Modified%3Bcolumns%3DRelease%3Bcmd%3Dsubmit%2520query%3Bsortby%3DNumber
