### PR TITLE
check-match for rackunit

### DIFF
--- a/collects/rackunit/private/test.rkt
+++ b/collects/rackunit/private/test.rkt
@@ -104,6 +104,7 @@
          check-not-eqv?
          check-not-equal?
          check-regexp-match
+         check-match
          fail)
 
 (define (void-thunk) (void))

--- a/collects/rackunit/scribblings/check.scrbl
+++ b/collects/rackunit/scribblings/check.scrbl
@@ -15,7 +15,8 @@ information detailing the failure.
 
 Although checks are implemented as macros, which is
 necessary to grab source location, they are conceptually
-functions.  This means, for instance, checks always evaluate
+functions (with the exception of @racket[check-match] below).
+This means, for instance, checks always evaluate
 their arguments.  You can use checks as first class
 functions, though you will lose precision in the reported
 source locations if you do so.
@@ -178,6 +179,47 @@ The following check fails:
 @interaction[#:eval rackunit-eval
   (check-regexp-match "a+bba" "aaaabbba")
 ]
+}
+
+@defform*[((check-match v pattern)
+           (check-match v pattern pred))]{
+
+A check that pattern matches on the test value.  Matches the test value
+@racket[v] against @racket[pattern] as a @racket[match] clause.  If no
+@racket[pred] is provided, then if the match succeeds, the entire check
+succeeds.  For example, this use succeeds:
+
+@interaction[#:eval rackunit-eval
+  (check-match (list 1 2 3) (list _ _ 3))
+]
+
+This check fails to match:
+
+@interaction[#:eval rackunit-eval
+  (check-match (list 1 2 3) (list _ _ 4))
+]
+
+If @racket[pred] is provided, it is evaluated with the bindings from the
+match pattern.  If it produces @racket[#t], the entire check succeeds,
+otherwise it fails.  For example, this use succeeds, binding @racket[x]
+in the predicate:
+
+@interaction[#:eval rackunit-eval
+  (check-match (list 1 (list 3)) (list x (list _)) (odd? x))
+]
+
+This check fails because the @racket[pred] fails:
+
+@interaction[#:eval rackunit-eval
+  (check-match 6 x (odd? x))
+]
+
+This check fails because of a failure to match:
+
+@interaction[#:eval rackunit-eval
+  (check-match (list 1 2) (list x) (odd? x))
+]
+
 }
 
 


### PR DESCRIPTION
Thread

http://www.mail-archive.com/dev@racket-lang.org/msg07427.html

Files

check.rkt:
  Added the actual check-match macro.

test.rkt:
  Just a provide statement

check-test.rkt:
  7 additional tests for check-match, and a macro to help create tests for it

check.scrbl:
  Documentation and examples for check-match

Notes
1.  I tested with

> raco test collects/tests/rackunit

It prints out a lot of stuff because there are existing tests hardcoded to fail in there.  But, I wrote seven tests and it claims that 127 tests (rather than 120 before) succeed now, so that seems promising.
1.  I don't know how to get the use of @racket[match] in the docs to link over to the actual match page.  I'm a Scribble noob.
2.  I'm also a syntaxy-macros noob, it might be possible to get the useful error information through check-match itself in a more appropriate/less crappy way.
