### PR TITLE
automatic-parenthesis mode improvements

### DIFF
--- a/collects/framework/private/racket.rkt
+++ b/collects/framework/private/racket.rkt
@@ -501,11 +501,14 @@
     
     (define/public (get-limit pos) 0)
     
-    (define/public (balance-parens key-event)
+    (define/public (balance-parens key-event [smart-skip #f])
       (insert-close-paren (get-start-position) 
                           (send key-event get-key-code)
                           (preferences:get 'framework:paren-match)
-                          (preferences:get 'framework:fixup-parens)))
+                          (preferences:get 'framework:fixup-parens)
+                          (or smart-skip
+                              (and (preferences:get 'framework:automatic-parens)
+                                   'adjacent))))
     
     (define/public (tabify-on-return?) #t)
     (define/public (tabify [pos (get-start-position)])
@@ -1312,6 +1315,47 @@
          [(and lam-reg (regexp-match lam-reg text)) 'lambda]
          [else #f])))))
 
+
+(define (position-type-when-inserted text char)
+  (define selection-start (send text get-start-position))
+  (define selection-end (send text get-end-position))
+  (send text begin-edit-sequence #t #f)
+  (send text insert char selection-start)
+  (define actual-type (send text classify-position selection-start))
+  (send text delete selection-start (+ 1 selection-start))
+  (send text end-edit-sequence)
+  (send text undo)  ; to avoid messing up the editor's modified state
+  ;(printf "check: |~a| actual: ~a~n" char actual-type)
+  actual-type)
+
+
+  ;; determines if the cursor is currently sitting in a string
+  ;; literal or a comment. To do this more accurately, first
+  ;; insert a space at the current cursor start position, then
+  ;; check what classification of that space character itself
+  (define (in-string/comment? text)
+    (define selection-start (send text get-start-position))
+    (define selection-end (send text get-end-position))
+    (send text begin-edit-sequence #t #f)
+    (send text insert " " selection-start)
+    (define type (send text classify-position selection-start))
+    (send text delete selection-start (add1 selection-start))
+    (send text end-edit-sequence)
+    (send text undo)  ; to avoid messing up the editor's modified state
+                      ; in case of a simple skip
+    (and (member type '(comment string)) #t))
+
+  ;; produces the 1 character string immediately following
+  ;; the cursor, if there is one and if there is not a current
+  ;; selection, in which case produces #f
+  (define (immediately-following-cursor text)
+    (define selection-start (send text get-start-position))
+    (and (= selection-start (send text get-end-position))   ; nothing selected
+         (< selection-start (send text last-position))
+         (send text get-text selection-start (+ selection-start 1))))
+
+
+
 (define set-mode-mixin
   (mixin (-text<%> mode:host-text<%>) ()
     (super-new)
@@ -1425,6 +1469,9 @@
   (send keymap add-function "balance-parens"
         (λ (edit event)
           (send edit balance-parens event)))
+  (send keymap add-function "balance-parens-forward"
+        (λ (edit event)
+          (send edit balance-parens event 'forward)))
   
   (send keymap map-function "TAB" "tabify-at-caret")
   
@@ -1444,17 +1491,62 @@
   
   (send keymap map-function "leftbuttondouble" "paren-double-select")
   
+
+
   (define (insert-brace-pair text open-brace close-brace)
     (define selection-start (send text get-start-position))
+    (define hash-before?  ; tweak to detect and correctly close block comments #| ... |#
+      (and (< 0 selection-start)
+           (string=? "#" (send text get-text (- selection-start 1) selection-start))))
+    (send text begin-edit-sequence)
     (send text set-position (send text get-end-position))
     (send text insert close-brace)
+    (when (and (char=? #\| open-brace) hash-before?) (send text insert #\#))
     (send text set-position selection-start)
-    (send text insert open-brace))
+    (send text insert open-brace)
+    (send text end-edit-sequence))
   
+  ;; only insert a pair if:
+  ;;   - automatic-parens is on, and
+  ;;   - cursor is not in a string or line/block comment, and
+  ;;   - cursor is not preceded by #\ or \ escape characters
   (define (maybe-insert-brace-pair text open-brace close-brace)
+    (define open-parens 
+      (for/list ([x (racket-paren:get-paren-pairs)]) (string-ref (car x) 0)))
     (cond
       [(preferences:get 'framework:automatic-parens)
-       (insert-brace-pair text open-brace close-brace)]
+       (define c (immediately-following-cursor text))
+       (define when-inserted (position-type-when-inserted text (string open-brace)))
+       (cond
+         ; insert paren pair if it results valid parenthesis token...
+         [(member open-brace open-parens)
+          (if (eq? (position-type-when-inserted text (string open-brace)) 'parenthesis)
+              (insert-brace-pair text open-brace close-brace)
+              (send text insert open-brace))]
+         
+         ; ASSUME: from here on, open-brace is either "  or  |
+         ; is there a token error at current position which would 
+         ; be fixed by inserting the character...
+         [(and (eq? 'error (send text classify-position (send text get-start-position)))
+               (not (eq? 'error when-inserted)))
+          (send text insert open-brace)]
+         
+         ; smart-skip over a  "  |  or  |# ...
+         [(and c (char=? #\" open-brace) (string=? c "\""))
+          (send text set-position (+ 1 (send text get-end-position)))]
+         [(and c (char=? #\| open-brace) (string=? c "|"))
+          (send text set-position (+ 1 (send text get-end-position)))
+          (define d (immediately-following-cursor text))
+          (when (and d (string=? d "#"))   ; a block comment?
+            (send text set-position (+ 1 (send text get-end-position))))]
+
+         ; are we in a string or comment...
+         [(in-string/comment? text) (send text insert open-brace)]
+         
+         ; otherwise if open-brace would result in some literal
+         [(eq? 'constant when-inserted) (send text insert open-brace)]
+         
+         [else (insert-brace-pair text open-brace close-brace)])]
       [else
        (send text insert open-brace)]))
   
@@ -1549,6 +1641,10 @@
   
   ;(map-meta "c:m" "mark-matching-parenthesis")
   ; this keybinding doesn't interact with the paren colorer
+
+  (map-meta ")" "balance-parens-forward")
+  (map-meta "]" "balance-parens-forward")
+  (map-meta "}" "balance-parens-forward")
   
   (map-meta "(" "insert-()-pair")
   (map-meta "[" "insert-[]-pair")
@@ -1673,7 +1769,9 @@
     (send text delete pos (+ pos 1) #f)
     (send text end-edit-sequence)
     (cond
-      [(preferences:get 'framework:automatic-parens)
+      [(and (preferences:get 'framework:automatic-parens)
+            (not (in-string/comment? text))
+            (eq? (position-type-when-inserted text real-char) 'parenthesis))
        (send text insert (case real-char
                            [(#\() #\)]
                            [(#\[) #\]]

--- a/collects/scribblings/framework/color.scrbl
+++ b/collects/scribblings/framework/color.scrbl
@@ -217,16 +217,40 @@
 
     Must only be called while the tokenizer is started.
   }
-  @defmethod*[(((insert-close-paren (position natural-number/c) (char char?) (flash? boolean?) (fixup? boolean?)) void?))]{
-
-    The @racket[position] is the place to put the parenthesis, and
+  @defmethod*[(((insert-close-paren (position natural-number/c) (char char?)
+                                    (flash? boolean?) (fixup? boolean?)
+                                    (smart-skip? (or/c #f 'adjacent 'forward) #f)) void?))]{
+    Inserts a close parentheses, or, under scenarios described further below, skips
+    past a subsequent one. The @racket[position] is the place to put the parenthesis, or
+    from which to start searching for a subsequent one, and
     @racket[char] is the parenthesis to be added (e.g., that the user typed).
     If @racket[fixup?] is true, the right kind of closing parenthesis will be
     chosen from the set previously passed to @method[color:text<%> start-colorer]---but only
     if an inserted @racket[char] would be colored as a parenthesis (i.e., with
     the @racket['parenthesis] classification).  Otherwise, @racket[char] will
-    be inserted, even if it is not the right kind.  If @racket[flash?] is true,
-    the matching open parenthesis will be flashed.
+    be inserted (or skipped past), even if it is not the right kind.  
+    If @racket[flash?] is true, the matching open parenthesis will be flashed when
+    the insertion or skip is done.
+    
+    The "smart skipping" behavior of this function is determined by
+    @racket[smart-skip?]. If @racket[smart-skip?] is false, no skip will 
+    take place. A parenthesis will simply be inserted as described in the 
+    paragraph above. When @racket[smart-skip?] is @racket['adjacent], if
+    the next token after @racket[position], ignoring whitespace and 
+    comments (see @racket[skip-whitespace]), is a properly matched closing
+    parenthesis (which may not necessarily match @racket[char] if
+    @racket[fixup?] is true) then simply move the cursor to the position
+    immediately after that already present closing parenthesis. When
+    @racket[smart-skip?] is @racket['forward], this function attempts to
+    determine the closest pair of properly balanced parentheses around
+    @racket[position]. If that exists, then the cursor position skips
+    to the position immediately after the closing parenthesis of that 
+    outer pair. If a properly balanced outer pair is not present, then
+    the cursor attempts to skip immediately after the next closing
+    parenthesis that occurs after @racket[position], ignoring whitespace,
+    comments, and all other tokens. In both non-false cases of 
+    @racket[smart-skip?], if there is no subsequent parenthesis, then
+    a parenthesis is simply inserted, as previously described.
   }
   @defmethod*[(((classify-position (position exact-nonnegative-integer?)) (or/c symbol? #f)))]{
 

--- a/doc/release-notes/drracket/HISTORY.txt
+++ b/doc/release-notes/drracket/HISTORY.txt
@@ -8,6 +8,36 @@
     more to use the #lang language (unless they are using the teaching
     languages)
 
+  . Automatic-parenthesis mode improvements:
+    - Added some "smart-skip" behavior to insert-close-paren,
+      described in the documentation.
+      - When auto-parens mode is enabled,
+        the existing "balance-parens" keybinding invokes
+        insert-close-paren with a smart-skip argument of
+        'adjacent
+      - A new "balance-parens-forward" keybinding invokes
+        insert-close-paren with a smart-skip argument of
+        'forward (whether or not auto-parens mode is
+                        enabled)
+
+    - Some basic smart-skip behavior is also enabled for
+      strings ("...") and |...| pairs, specifically, typing
+      a double-quote or bar character when the cursor
+      immediately precedes one causes the cursor to simply
+      skip over the existing one
+
+    - Tweaked insertion of block comment pairs in
+      auto-parens mode
+
+    - In strings and line/block comments, auto-parens mode
+      no longer has any effect (you can still use the M+..
+      keybindings to force insertion of a particular brace
+      pair)
+
+    - Detect when a character constant is being typed, and
+      don't insert brace pairs if so
+
+
 ------------------------------
        Version 5.3.1
 ------------------------------


### PR DESCRIPTION
Handle close parentheses in a smarter way while in
auto-parens mode and be a little more smart about
inserting brace pairs in general.

In summary:
- Add some "smart-skip" behavior to insert-close-paren,
  described in the documentation.
  - When auto-parens mode is enabled,
    the existing "balance-parens" keybinding invokes
    insert-close-paren with a smart-skip argument of
    'adjacent
  - A new "balance-parens-forward" keybinding invokes
    insert-close-paren with a smart-skip argument of
    'forward (whether or not auto-parens mode is
    enabled)
- Enable basic smart-skip behavior for
  strings ("...") and |...| pairs, specifically, typing
  a double-quote or bar character when the cursor
  immediately precedes one causes the cursor to simply
  skip over the existing one
- Tweak auto-insertion of block comment pairs; i.e.
  typing hash and a bar results in a properly balanced
  # ||# pair. Also, when you type a bar character when
  
  the cursor immediately precedes a closing bar and
  hash of a comment, then the cursor skips over both
  characters (this seems better than having it just
  skip over the bar, and then having to introduce a
  new keybinding to detect when a hash is typed while
  the cursor is between a bar and a hash)
- In strings and line/block comments, auto-parens mode
  no longer has any effect (you can still use the M+..
  keybindings to force insertion of a particular brace
  pair)
- Detect when a character constant is being typed, and
  don't insert brace pairs if so; i.e. if the cursor
  is immediately after #\ , then typing any open parens,
  double quote, or bar, does _not_ result in the
  insertion of an open/close pair even in auto-parens
  mode
- Add a bunch of tests related to auto-parens, matching
  pairs of braces, strings, comments, etc. to
  collects/tests/framework/racket.rkt
