### PR TITLE
fix prop:cpointer so that it works with a procedure value (as per the docs)

### DIFF
--- a/src/foreign/foreign.c
+++ b/src/foreign/foreign.c
@@ -1532,7 +1532,7 @@ static Scheme_Object *unwrap_cpointer_property(Scheme_Object *orig_v)
       if (val) {
         if (SCHEME_INTP(val))
           v = scheme_struct_ref(v, SCHEME_INT_VAL(val));
-        else if (SCHEME_PROCP(v)) {
+        else if (SCHEME_PROCP(val)) {
           Scheme_Object *a[1];
           a[0] = v;
           v = _scheme_apply(val, 1, a);

--- a/src/foreign/foreign.rktc
+++ b/src/foreign/foreign.rktc
@@ -1320,7 +1320,7 @@ static Scheme_Object *unwrap_cpointer_property(Scheme_Object *orig_v)
       if (val) {
         if (SCHEME_INTP(val))
           v = scheme_struct_ref(v, SCHEME_INT_VAL(val));
-        else if (SCHEME_PROCP(v)) {
+        else if (SCHEME_PROCP(val)) {
           Scheme_Object *a[1];
           a[0] = v;
           v = _scheme_apply(val, 1, a);


### PR DESCRIPTION
This is a tiny change to allow prop:cpointer to work the way the documentation says it does:

> The property value must be either an exact non-negative integer indicating an 
> immutable field in the structure (which must, in turn, be initialized to a C pointer 
> value), a procedure that takes the structure instance and returns a C pointer 
> value, or a C pointer value.

Procedure values don't currently work. Test case:

``` racket
#lang racket/base

(require ffi/unsafe)
(struct foo (ptr)
  #:property prop:cpointer 0)

(define a-foo (foo (malloc 16 'raw)))
(free a-foo)

(struct bar (ptr)
  #:property prop:cpointer (λ (s) (bar-ptr s)))

(define a-bar (bar (malloc 16 'raw)))
(free a-bar)
```
