### PR TITLE
Fixed Unicode character for \Delta TeX insertion

### DIFF
--- a/collects/mrlib/tex-table.rkt
+++ b/collects/mrlib/tex-table.rkt
@@ -92,7 +92,7 @@
     ("Lambda" "Λ")
     ("Sigma" "Σ")
     ("Psi" "Ψ")
-    ("Delta" "∆")
+    ("Delta" "Δ")
     ("Xi" "Ξ")
     ("Upsilon" "Υ")
     ("Omega" "Ω")


### PR DESCRIPTION
DrRacket has been using the Unicode character for "increment" (U+2206) when doing the TeX-compress for "\Delta". It looks like a Delta character, but the proper unicode character is U+0394. It also causes interoperability problems with editors that use U+0394, like Emacs. I've fixed the character used in this patch.
