### PR TITLE
Render `@hyperlink` in Markdown.

### DIFF
--- a/collects/tests/scribble/markdown-docs/example.md
+++ b/collects/tests/scribble/markdown-docs/example.md
@@ -8,6 +8,8 @@
 
 ## 1. Section
 
+[I am a hyperlink to Racket.](http://www.racket-lang.org/)
+
 Italic. \_Just underlines\_.
 
 Bold. \*Just asterisks.\*

--- a/collects/tests/scribble/markdown-docs/example.scrbl
+++ b/collects/tests/scribble/markdown-docs/example.scrbl
@@ -12,6 +12,8 @@
 
 @section{Section}
 
+@hyperlink["http://www.racket-lang.org/" "I am a hyperlink to Racket."]
+
 @italic{Italic}.
 _Just underlines_.
 


### PR DESCRIPTION
Render Scribble like

```
@hyperlink["url" "content"]
```

as Markdown like

```
[content](url)
```

Note that this only works for `@hyperlink`. The motivation is to
preserve content the author has explicitly written. (Previously,
`markdown-render.rkt` was discarding this; `text-render.rkt` still
does so.)

This does _not_ attempt to handle everything that `html-render.rkt`
would automatically generate and render as `<a>`. It simply can't --
things like hotlinked Racket keywords in code blocks simply won't work
in Markdown.
