### PR TITLE
Speed up set-argb-pixels by using unsafe operations and local variable references

### DIFF
--- a/collects/racket/draw/private/bitmap.rkt
+++ b/collects/racket/draw/private/bitmap.rkt
@@ -728,33 +728,39 @@
                   (let ([row (* j row-width)]
                         [p (* 4 (* dj w))])
                     (for ([i (in-range x w2)])
-                      (let* ([4i (* 4 i)]
-                             [pi (+ p (* 4 (- i x)))]
-                             [ri (+ row 4i)])
+                      (let* ([4i (unsafe-fx* 4 i)]
+                             [pi (unsafe-fx+ p (unsafe-fx* 4 (unsafe-fx- i x)))]
+                             [ri (unsafe-fx+ row 4i)])
                         (if b&w-local?
-                            (let ([v (if (and (= (bytes-ref bstr (+ pi 1)) 255)
-                                              (= (bytes-ref bstr (+ pi 2)) 255)
-                                              (= (bytes-ref bstr (+ pi 3)) 255))
+                            (let ([v (if (and (= (unsafe-bytes-ref bstr (+ pi 1)) 255)
+                                              (= (unsafe-bytes-ref bstr (+ pi 2)) 255)
+                                              (= (unsafe-bytes-ref bstr (+ pi 3)) 255))
                                          255
                                          0)])
-                              (bytes-set! data (+ ri A) (- 255 v))
-                              (bytes-set! data (+ ri 1) v)
-                              (bytes-set! data (+ ri 2) v)
-                              (bytes-set! data (+ ri B) v))
+                              (unsafe-bytes-set! data (unsafe-fx+ ri A) (- 255 v))
+                              (unsafe-bytes-set! data (unsafe-fx+ ri 1) v)
+                              (unsafe-bytes-set! data (unsafe-fx+ ri 2) v)
+                              (unsafe-bytes-set! data (unsafe-fx+ ri B) v))
                             (if alpha-channel-local?
                                 (let ([a (bytes-ref bstr pi)]
                                       [pm (lambda (a v)
                                             (if m
                                                 (unsafe-bytes-ref m (fx+ (fx* a 256) v))
                                                 (min a v)))])
-                                  (bytes-set! data (+ ri A) a)
-                                  (bytes-set! data (+ ri R) (pm a (bytes-ref bstr (+ pi 1))))
-                                  (bytes-set! data (+ ri G) (pm a (bytes-ref bstr (+ pi 2))))
-                                  (bytes-set! data (+ ri B) (pm a (bytes-ref bstr (+ pi 3)))))
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri A) a)
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri R)
+                                              (pm a (unsafe-bytes-ref bstr (unsafe-fx+ pi 1))))
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri G)
+                                              (pm a (unsafe-bytes-ref bstr (unsafe-fx+ pi 2))))
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri B)
+                                              (pm a (unsafe-bytes-ref bstr (unsafe-fx+ pi 3)))))
                                 (begin
-                                  (bytes-set! data (+ ri R) (bytes-ref bstr (+ pi 1)))
-                                  (bytes-set! data (+ ri G) (bytes-ref bstr (+ pi 2)))
-                                  (bytes-set! data (+ ri B) (bytes-ref bstr (+ pi 3))))))))))))
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri R)
+                                              (unsafe-bytes-ref bstr (unsafe-fx+ pi 1)))
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri G)
+                                              (unsafe-bytes-ref bstr (unsafe-fx+ pi 2)))
+                                  (unsafe-bytes-set! data (unsafe-fx+ ri B)
+                                              (unsafe-bytes-ref bstr (unsafe-fx+ pi 3))))))))))))
             (cairo_surface_mark_dirty s)))
         (cond
          [(and set-alpha?


### PR DESCRIPTION
Hey there!

I'm writing some FFmpeg bindings for Racket. It's fast enough to decode video in real time, but on my machine, set-argb-pixels takes 189.35±1.3 msec to run for a 500x500 image, which means I'm limited to displaying frames at ~5fps.

Here's a toy benchmark to test set-argb-pixels:
https://gist.github.com/4a5661dfad984cfdab19

There are some very simple bottlenecks that I've started to address:
1. It turns out that the references to b&w? and alpha-channel-local? for each pixel are slow slow slow. Making them local variables drops the time down to 124.8±1.0msec. This three-line change gives a speedup factor of about ~1.5
2. Using unsafe functions everywhere (unsafe-bytes-ref and friends, unsafe-fx+ and friends) drops it further to 67.05±0.6msec, which is a speedup factor of ~2.82 over the original on my machine

**Possible further improvements:**
If we can assume that the input bytes already contain pre-clipped, premultiplied data, we don't have to loop through each pixel. Instead, we can copy each row using copy-bytes!, which would drop the function to 9.55±6.1 msec (!) which is a speedup factor of ~20x over the original.

The problem with that is on my little-endian machine, Cairo expects the input data in BGRA format, not RGBA, so the colors look wrong. Alas, this is why Racket's doing all the byte swizzling manually.

Is there a fast native way of switching the endianness of a byte vector assumed to contain 32-bit ints? Or some way to do what we want?

If there's a way to do this, this could make playing simple low-resolution videos from Racket pretty feasible.
