### PR TITLE
A tiny bug in document of ftp

### DIFF
--- a/collects/net/scribblings/ftp.scrbl
+++ b/collects/net/scribblings/ftp.scrbl
@@ -106,6 +106,7 @@ is intended to limit polling.
 @racketblock[
 (ftp-download-file
  ftp-conn "." "testfile"
+ #:progress
  (lambda (get-count)
    (thread
     (lambda ()


### PR DESCRIPTION
ftp-download-file example forget to add keyword #:progress.

I don't know tiny thing like this is worth a commit?

But I see it , I think it should be fixed.
