### PR TITLE
Render Scribble margin-note as Markdown block-quote.

### DIFF
--- a/collects/scribble/markdown-render.rkt
+++ b/collects/scribble/markdown-render.rkt
@@ -18,6 +18,7 @@
 
 (define table-ticks-depth (make-parameter 0))
 (define phrase-ticks-depth (make-parameter 0))
+(define note-depth (make-parameter 0))
 
 (define (render-mixin %)
   (class %
@@ -140,14 +141,19 @@
                  (render-flow d part ht #f)))))))
 
     (define/override (render-paragraph p part ri)
+      (define (write-note)
+        (write-string (make-string (note-depth) #\>))
+        (unless (zero? (note-depth))
+          (write-string " ")))
       (define o (open-output-string))
       (parameterize ([current-output-port o])
         (super render-paragraph p part ri))
       (define to-wrap (regexp-replace* #rx"\n" (get-output-string o) " "))
       (define lines (wrap-line (string-trim to-wrap) (- 72 (current-indent))))
+      (write-note)
       (write-string (car lines))
       (for ([line (in-list (cdr lines))])
-        (newline) (indent) (write-string line))
+        (newline) (indent) (write-note) (write-string line))
       (newline)
       null)
 
@@ -207,7 +213,12 @@
     (define/override (render-nested-flow i part ri starting-item?)
       (define s (nested-flow-style i))
       (unless (memq 'decorative (style-properties s))
-        (super render-nested-flow i part ri starting-item?)))
+        (define note? (equal? (style-name s) "refcontent"))
+        (when note?
+          (note-depth (add1 (note-depth))))
+        (begin0 (super render-nested-flow i part ri starting-item?)
+          (when note?
+            (note-depth (sub1 (note-depth)))))))
 
     (define/override (render-other i part ht)
       (cond

--- a/collects/tests/scribble/markdown-docs/example.md
+++ b/collects/tests/scribble/markdown-docs/example.md
@@ -21,8 +21,6 @@ _Italic_. \_Just underlines\_.
 `Second line.`
 `Last line.`  
 
-The end.
-
 `THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS`   
 `“AS IS” AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT`     
 `LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR` 
@@ -43,3 +41,7 @@ The end.
 
 Returns a new mutable string of length `k` where each position in the
 string is initialized with the character `char`
+
+> Note: This is a note. Let’s make it long enough that the markdown output
+> will have to line-wrap, to make sure the > mark starts each line
+> properly.

--- a/collects/tests/scribble/markdown-docs/example.scrbl
+++ b/collects/tests/scribble/markdown-docs/example.scrbl
@@ -30,8 +30,6 @@ Second line.
 Last line.
 }
 
-The end.
-
 @verbatim{
 THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
 ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
@@ -52,3 +50,7 @@ Returns a new mutable string of length @racket[k] where each position in the
 string is initialized with the character @racket[char]
 
 }
+
+@margin-note{Note: This is a note. Let's make it long enough that the
+markdown output will have to line-wrap, to make sure the > mark starts
+each line properly.}


### PR DESCRIPTION
Render Scribble margin-note as Markdown block-quote.

More precisely, do this for nested flows with the "refcontent" style.

For instance this Scribble:

```
@margin-note{Note: This is a note. Let's make it long enough that the
markdown output will have to line-wrap, to make sure the > mark starts
each line properly.}
```

Will render as this Markdown:

```
> Note: This is a note. Let's make it long enough that the markdown output
> will have to line-wrap, to make sure the > mark starts each line
> properly.
```

A site like GitHub.com will render this in a block-quote style
suitable for notes:

> Note: This is a note. Let's make it long enough that the markdown output
> will have to line-wrap, to make sure the > mark starts each line
> properly.
