### PR TITLE
supporting http proxy (without authorization) during make install

### DIFF
--- a/src/download-libs.rkt
+++ b/src/download-libs.rkt
@@ -9,7 +9,7 @@
 (define http-proxy-port null)
 
 (when http-proxy
-    (let ((matched (regexp-match #rx"([Hh][Tt][Tt][Pp]://)?([1-2]?[0-9]?[0-9]\\.[1-2]?[0-9]?[0-9]\\.[1-2]?[0-9]?[0-9]\\.[1-2]?[0-9]?[0-9])(:([0-9]+))?" "http://192.168.0.1:3128")))
+    (let ((matched (regexp-match #rx"([Hh][Tt][Tt][Pp]://)?([^:]*)(:([0-9]+))?" http-proxy)))
       (set! http-proxy-host (third matched))
       (set! http-proxy-port (or (string->number (fifth matched)) 80))
       (printf "Proxy detected: host ~a port ~a~%" http-proxy-host http-proxy-port)))


### PR DESCRIPTION
I try to "make install" and get error on downloading win32 binary libraries. So solution is proxy server supporting for download-libs.rkt.

Usage
 env http_proxy="http://192.168.0.1:3128"  make install
