### PR TITLE
Add newline and redisplay to readline api

### DIFF
--- a/collects/readline/mzrl.rkt
+++ b/collects/readline/mzrl.rkt
@@ -4,7 +4,8 @@
 (provide readline readline-bytes
          add-history add-history-bytes
          history-length history-get history-delete
-         set-completion-function!)
+         set-completion-function!
+         readline-newline readline-redisplay)
 
 ;; libtermcap needed on some platforms
 (define libtermcap  (with-handlers ([exn:fail? void]) (ffi-lib "libtermcap")))
@@ -117,3 +118,12 @@
 ;; make it possible to run Scheme threads while waiting for input
 (set-ffi-obj! "rl_event_hook" libreadline (_fun -> _int)
               (lambda () (sync/enable-break real-input-port) 0))
+
+
+;; force cursor on a new line
+(define readline-newline
+  (get-ffi-obj "rl_crlf" libreadline (_fun -> _void)))
+
+;; force redisplay of prompt and current user input
+(define readline-redisplay
+  (get-ffi-obj "rl_forced_update_display" libreadline (_fun -> _void)))

--- a/collects/readline/readline.scrbl
+++ b/collects/readline/readline.scrbl
@@ -240,6 +240,29 @@ Sets @|readline|'s @tt{rl_completion_entry_function} to
 from @racketmodname[ffi/unsafe], determines the type of value supplied
 to the @racket[proc].}
 
+@defproc[(readline-newline) void?]{
+
+Sets the cursors to the start of a new line.}
+
+
+@defproc[(readline-redisplay) void?]{
+
+Forces a redisplay of the readline prompt and current user input. It can be used
+together with @racket[readline-newline] to prevent a background thread from 
+cluttering up the user input by interleaving its output.
+
+A wrapper function for the threads output might look like the following:
+@racketblock[
+(define (with-thread-safe-output output-thunk)
+  (dynamic-wind
+    (lambda ()
+      (start-atomic)
+      (readline-newline))
+    output-thunk
+    (lambda ()
+      (readline-redisplay)
+      (end-atomic))))]}
+
 
 @section[#:tag "readline-license"]{License Issues}
 


### PR DESCRIPTION
mzrl.rkt:
  Add and provide readline-newline and readline-readisplay.

readline.scrbl:
  Documentation and example code.
