### PR TITLE
Use Racket lexer for code blocks.

### DIFF
--- a/collects/scribble/markdown-render.rkt
+++ b/collects/scribble/markdown-render.rkt
@@ -102,7 +102,7 @@
                             (apply map list strs)))
         (define x-length (lambda (col) (if (eq? col 'cont) 0 (length col))))
         (when tick?
-          (displayln (string-append "```scheme")))
+          (displayln (string-append "```racket")))
         (for/fold ([indent? #f]) ([row (in-list strs)])
           (let ([h (apply max 0 (map x-length row))])
             (let ([row* (for/list ([i (in-range h)])

--- a/collects/tests/scribble/markdown-docs/example.md
+++ b/collects/tests/scribble/markdown-docs/example.md
@@ -49,13 +49,13 @@ Another example of verbatim, with ticks/quotes:
 
 Example of a defmodule:
 
-```scheme
+```racket
  (require racket/string)
 ```
 
 Example of a defproc:
 
-```scheme
+```racket
 (make-string k [char]) -> string?
   k : exact-nonnegative-integer? 
   char : char? = #\nul           


### PR DESCRIPTION
Had been specifying Scheme lexer for code blocks, while waiting for
new Racket lexer to wend its way from Pygments to Pygments.rb to
Linguist to GitHub.

That day is almost here: Linguist will soon update and deploy to
GitHub.  And Racket 5.3.2 is about to release.  As a result, I think
this is the correct time to switch to the Racket lexer: It should be
live on GitHub by the time people are using Racket 5.3.2.

/cc @rmculpepper -- I think this commit should go into the 5.3.2
release.
