### PR TITLE
It fixes a crash on OpenBSD

### DIFF
--- a/src/racket/sconfig.h
+++ b/src/racket/sconfig.h
@@ -297,6 +297,9 @@
 #  define SCHEME_PLATFORM_LIBRARY_SUBPATH "i386-openbsd"
 # endif
 
+# define ASSUME_FIXED_STACK_SIZE
+# define FIXED_STACK_SIZE 1048576
+
 # include "uconfig.h"
 # undef HAS_STANDARD_IOB
 


### PR DESCRIPTION
It fixes a crash in the installation on OpenBSD. Racket reaches the limits of the shell when it is compiled with a non-root user account.

Tested on OpenBSD-current amd64.
