### PR TITLE
Fix font% family modern on macosx bug

### DIFF
--- a/collects/racket/draw/private/font-dir.rkt
+++ b/collects/racket/draw/private/font-dir.rkt
@@ -50,7 +50,7 @@
     (define/private (default-font s)
       (case s
         [(modern) (case (system-type)
-                    [(windows macosx) "Courier New"]
+                    [(windows) "Courier New"]
                     [else "Monospace"])]
         [(roman) (case (system-type)
                    [(windows) "Times New Roman"]


### PR DESCRIPTION
when use (make-object font% size family) on macosx, set family to 'modern(fixed width),
the font will be cut a piece on the right side. here is example:
# lang racket

(require racket/draw racket/gui)

(define test-bitmap (make-object bitmap% 200 200))
(define image-dc (send test-bitmap make-dc))

(send image-dc set-background "white")
(send image-dc clear)
(send image-dc set-smoothing 'smoothed)
(send image-dc set-text-foreground "black")
(send image-dc set-brush "white" 'transparent)
(send image-dc set-pen "black" 1 'solid)
(define my-font (make-object font% 100 'modern 'normal 'bold))
(send image-dc set-font my-font)
(let-values ([(width height _1 _2)
              (send image-dc get-text-extent "3" my-font)])
  (send image-dc draw-text "3"
        (- (quotient 200 2) (quotient width 2))
        (- (quotient 200 2) (quotient height 2))))

(make-object image-snip% test-bitmap)

check the code, find that 'modern on macosx use the font "Courier New", change it to "Monospace"(default) , bug fixed.
