### PR TITLE
Do not update subtype and resolve caches when subtyping.

### DIFF
--- a/collects/tests/typed-racket/succeed/pr13412.rkt
+++ b/collects/tests/typed-racket/succeed/pr13412.rkt
@@ -1,0 +1,12 @@
+#lang typed/racket
+
+(define-type (Tree A) (U (Listof A) (node A)))
+(struct: (A) node ([val : A]
+                   [left : (Tree A)]
+                   [right : (Tree A)]))
+
+(: tree-set (All (A) (A (Tree A) -> (Tree A))))
+(define (tree-set y t)
+  (cond [(node? t)  (node y (node-left t) (node-right t))]
+        [else  (list y)]))
+

--- a/collects/typed-racket/types/current-seen.rkt
+++ b/collects/typed-racket/types/current-seen.rkt
@@ -1,0 +1,13 @@
+#lang racket/base
+(require "../utils/utils.rkt")
+(require (rep type-rep))
+
+(provide (all-defined-out))
+
+(define current-seen (make-parameter null))
+(define (currently-subtyping?) (not (null? (current-seen))))
+
+(define (seen-before s t) (cons (Type-seq s) (Type-seq t)))
+(define (remember s t A) (cons (seen-before s t) A))
+(define (seen? s t) (member (seen-before s t) (current-seen)))
+

--- a/collects/typed-racket/types/resolve.rkt
+++ b/collects/typed-racket/types/resolve.rkt
@@ -4,7 +4,7 @@
 (require (rep type-rep rep-utils free-variance)
          (env type-name-env)
          (utils tc-utils)
-         (types utils)
+         (types utils current-seen)
          racket/match
          racket/contract
          racket/format)
@@ -82,7 +82,7 @@
                   [(App: r r* s)
                    (resolve-app r r* s)]
                   [(Name: _) (resolve-name t)])])
-        (when r*
+        (when (and r* (not (currently-subtyping?)))
           (hash-set! resolver-cache seq r*))
         r*)))
 


### PR DESCRIPTION
There is definitely room for style improvements in the naming. But I believe this is the correct fix for the issue.

Are there any other such caches that also need to be fixed?
