### PR TITLE
Fix type of split-at and make some vector operations use index type.

### DIFF
--- a/collects/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/collects/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -1596,6 +1596,12 @@
           (let ((s (ann (set 2) Any)))
             (if (set? s) (ann s (Setof String)) ((inst set String))))]
 
+        [tc-e (split-at (list 0 2 3 4 5 6) 3)
+              (list (-lst -Byte) (-lst -Byte))]
+        [tc-e (vector-split-at (vector 2 3 4 5 6) 3)
+              (list (-vec -Integer) (-vec -Integer))]
+
+
         )
   (test-suite
    "check-type tests"

--- a/collects/typed-racket/base-env/base-env-indexing-abs.rkt
+++ b/collects/typed-racket/base-env/base-env-indexing-abs.rkt
@@ -243,9 +243,9 @@
    [take-right   (-poly (a) ((-lst a) index-type . -> . (-lst a)))]
    [drop-right   (-poly (a) ((-lst a) index-type . -> . (-lst a)))]
    [split-at
-    (-poly (a) ((list (-lst a)) index-type . ->* . (-values (list (-lst a) (-lst a)))))]
+    (-poly (a) ((-lst a) index-type . -> . (-values (list (-lst a) (-lst a)))))]
    [split-at-right
-    (-poly (a) ((list (-lst a)) index-type . ->* . (-values (list (-lst a) (-lst a)))))]
+    (-poly (a) ((-lst a) index-type . -> . (-values (list (-lst a) (-lst a)))))]
 
    [vector-ref (-poly (a) (cl->* ((-vec a) index-type . -> . a)
                                  (-VectorTop index-type . -> . Univ)))]

--- a/collects/typed-racket/base-env/base-env.rkt
+++ b/collects/typed-racket/base-env/base-env.rkt
@@ -1587,9 +1587,9 @@
 [vector-take-right   (-poly (a) ((-vec a) -Integer . -> . (-vec a)))]
 [vector-drop-right   (-poly (a) ((-vec a) -Integer . -> . (-vec a)))]
 [vector-split-at
- (-poly (a) ((list (-vec a)) -Integer . ->* . (-values (list (-vec a) (-vec a)))))]
+ (-poly (a) ((-vec a) -Integer . -> . (-values (list (-vec a) (-vec a)))))]
 [vector-split-at-right
- (-poly (a) ((list (-vec a)) -Integer . ->* . (-values (list (-vec a) (-vec a)))))]
+ (-poly (a) ((-vec a) -Integer . -> . (-values (list (-vec a) (-vec a)))))]
 
 ;vector->values
 


### PR DESCRIPTION
Closes PR12700.
