### PR TITLE
Make tc-let do unions correctly.

### DIFF
--- a/collects/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/collects/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -611,6 +611,16 @@
 
         [tc-e (letrec: ([x : Number (values 1)]) (add1 x)) N]
 
+        [tc-e (let ()
+                 (: complicated Boolean)
+                 (define complicated #f)
+                 (: undefined Undefined)
+                 (define undefined (letrec: ((x : Undefined x)) x))
+                 (letrec: ((x : Undefined (if complicated undefined undefined))
+                           (y : Undefined (if complicated x undefined)))
+                   y))
+          -Undefined]
+
         [tc-err (let ([x (add1 5)])
                   (set! x "foo")
                   x)]

--- a/collects/typed-racket/typecheck/tc-let-unit.rkt
+++ b/collects/typed-racket/typecheck/tc-let-unit.rkt
@@ -3,7 +3,7 @@
 (require (rename-in "../utils/utils.rkt" [infer r:infer])
          "signatures.rkt" "tc-metafunctions.rkt" "tc-subst.rkt"
          "check-below.rkt"
-         (types utils abbrev)
+         (types utils abbrev union)
          (private type-annotation parse-type)
          (env lexical-env type-alias-env global-env type-env-structs)
          (rep type-rep filter-rep object-rep)
@@ -165,10 +165,7 @@
                                                       (s:member x safe-bindings bound-identifier=?))
                                                    l)
                                            types-from-user
-                                           (map (λ (x) (make-Union (if (type<? x -Undefined)
-                                                                       (list x -Undefined)
-                                                                       (list -Undefined x))))
-                                                types-from-user)))))
+                                           (map (λ (x) (Un x -Undefined)) types-from-user)))))
                          names))
                    ;; types the user gave. check against that to error if we could get undefined
                    (map (λ (l) (ret (map get-type l))) names)


### PR DESCRIPTION
The types from the user may be Unions themselves or Undefined, and so the real logic of Un should be used.
