### PR TITLE
Add subtitle to scribble/sigplan

### DIFF
--- a/collects/scribble/sigplan.rkt
+++ b/collects/scribble/sigplan.rkt
@@ -28,6 +28,9 @@
   (->* (pre-content? pre-content? pre-content?)
        ((or/c false/c pre-content?))
        content?)]
+ [subtitle
+  (->* () () #:rest (listof pre-content?)
+       block?)]
  [terms
   (->* () () #:rest (listof pre-content?)
        content?)]
@@ -135,3 +138,8 @@
 
 (define (keywords . str)
   (make-element (make-style "SKeywords" sigplan-extras) (decode-content str)))
+
+(define (subtitle . str)
+  (make-paragraph
+    (make-style 'pretitle null)
+    (make-element (make-style "subtitle" null) (decode-content str))))

--- a/collects/scribblings/scribble/sigplan.scrbl
+++ b/collects/scribblings/scribble/sigplan.scrbl
@@ -76,6 +76,9 @@ The @racket[10pt], @racket[preprint], @racket[nocopyright],
 options can be used together and may appear in any order.  
 }
 
+@defproc[(subtitle [pre-content pre-content?] ...) block?]{
+
+Generates a subtitle for a paper.}
 
 @defproc[(abstract [pre-content pre-content?] ...) block?]{
 


### PR DESCRIPTION
The SIGPLAN latex class provides a \subtitle macro for
adding a subtitle to a paper.  This adds a corresponding
subtitle form to scribble/sigplan.

It doesn't quite do the right thing when rendering to HTML, but works
well for PDF.
