### PR TITLE
Add #:lang and input-program inputs to make-base-eval and friends.

### DIFF
--- a/collects/scribble/eval.rkt
+++ b/collects/scribble/eval.rkt
@@ -332,13 +332,13 @@
       (namespace-attach-module ns 'racket/pretty)
       (current-print (dynamic-require 'racket/pretty 'pretty-print-handler)))))
 
-(define (make-base-eval #:pretty-print? [pretty-print? #t])
+(define (make-base-eval #:lang [lang '(begin)] #:pretty-print? [pretty-print? #t] . ips)
   (call-with-trusted-sandbox-configuration
    (lambda ()
      (parameterize ([sandbox-output 'string]
                     [sandbox-error-output 'string]
                     [sandbox-propagate-breaks #f])
-       (let ([e (make-evaluator '(begin))])
+       (let ([e (apply make-evaluator lang ips)])
          (let ([ns (namespace-anchor->namespace anchor)])
            (call-in-sandbox-context
             e
@@ -347,7 +347,8 @@
          e)))))
 
 (define (make-base-eval-factory mod-paths
-                                #:pretty-print? [pretty-print? #t])
+                                #:lang [lang '(begin)]
+                                #:pretty-print? [pretty-print? #t] . ips)
   (let ([ns (delay (let ([ns 
                           ;; This namespace-creation choice needs to be consistent
                           ;; with the sandbox (i.e., with `make-base-eval')
@@ -360,7 +361,7 @@
                        (when pretty-print? (dynamic-require 'racket/pretty #f)))
                      ns))])
     (lambda ()
-      (let ([ev (make-base-eval #:pretty-print? #f)]
+      (let ([ev (apply make-base-eval #:lang lang #:pretty-print? #f ips)]
             [ns (force ns)])
         (when pretty-print? (install-pretty-printer! ev ns))
         (call-in-sandbox-context
@@ -371,8 +372,9 @@
         ev))))
 
 (define (make-eval-factory mod-paths
-                           #:pretty-print? [pretty-print? #t])
-  (let ([base-factory (make-base-eval-factory mod-paths #:pretty-print? pretty-print?)])
+                           #:lang [lang '(begin)]
+                           #:pretty-print? [pretty-print? #t] . ips)
+  (let ([base-factory (apply make-base-eval-factory mod-paths #:lang lang #:pretty-print? pretty-print? ips)])
     (lambda ()
       (let ([ev (base-factory)])
         (call-in-sandbox-context

--- a/collects/scribblings/scribble/eval.scrbl
+++ b/collects/scribblings/scribble/eval.scrbl
@@ -151,10 +151,16 @@ Like @racket[examples], but each definition using @racket[define] or
 prompt, and with line of space after it.}
 
 
-@defproc[(make-base-eval [#:pretty-print? pretty-print? any/c #t])
+@defproc[(make-base-eval [#:pretty-print? pretty-print? any/c #t]
+                         [#:lang lang
+                          (or/c module-path?
+                                (list/c 'special symbol?)
+                                (cons/c 'begin list?))
+                          '(begin)]
+                         [input-program any/c] ...)
          (any/c . -> . any)]{
 
-Creates an evaluator using @racket[(make-evaluator 'racket/base)],
+Creates an evaluator using @racket[(make-evaluator 'racket/base #:lang lang input-program ...)],
 setting sandbox parameters to disable limits, setting the outputs to
 @racket['string], and not adding extra security guards.
 
@@ -164,6 +170,12 @@ If @racket[pretty-print?] is true, the sandbox's printer is set to
 
 @defproc[(make-base-eval-factory [mod-paths (listof module-path?)]
                                  [#:pretty-print? pretty-print? any/c #t])
+                                 [#:lang lang
+                                  (or/c module-path?
+                                        (list/c 'special symbol?)
+                                        (cons/c 'begin list?))
+                                  '(begin)]
+
          (-> (any/c . -> . any))]{
 
 Produces a function that is like @racket[make-base-eval], except that
@@ -175,6 +187,12 @@ time) and then attached to each evaluator that is created.}
 
 @defproc[(make-eval-factory [mod-paths (listof module-path?)]
                             [#:pretty-print? pretty-print? any/c #t])
+                            [#:lang lang
+                             (or/c module-path?
+                                   (list/c 'special symbol?)
+                                   (cons/c 'begin list?))
+                             '(begin)]
+
          (-> (any/c . -> . any))]{
 
 Like @racket[make-base-eval-factory], but each module in @racket[mod-paths] is


### PR DESCRIPTION
This commit extends make-base-eval, make-base-eval-factory, and
make-eval-factory with an #:eval and input-program inputs so that
these functions are more like racket/sandbox make-evaluator.
