### PR TITLE
Changed `define-union-language' to merge nonterminals

### DIFF
--- a/collects/redex/examples/union-lang.rkt
+++ b/collects/redex/examples/union-lang.rkt
@@ -1,0 +1,40 @@
+#lang racket
+
+(provide LBase L1 L2 LMergeUntagged LMergeTagged)
+(require redex/reduction-semantics)
+
+;; ------------------------------------------------------------------------
+
+(define-language LBase
+  (e (+ e e) number))
+
+(define-extended-language L1 LBase
+  (e ....  (- e e)))
+
+(define-extended-language L2 LBase
+  (e ....  (* e e)))
+
+;; Untagged union of two languages that define the same nonterminal
+(define-union-language LMergeUntagged L1 L2)
+
+;; Tagged merge of two extended languages that define the same
+;; nonterminal
+(define-union-language LMergeTagged (f. L1) (d. L2))
+
+;; ------------------------------------------------------------------------
+
+(module+ test 
+
+  (for ([t (list (term 1) (term (* 1 1)) (term (+ 1 1)) (term (- 1 1)))])
+       (test-equal (redex-match? LMergeUntagged e t) #t))
+
+  (test-equal (redex-match? LMergeTagged f.e 1) #t)
+  (test-equal (redex-match? LMergeTagged d.e 1) #t)
+
+  (test-equal (redex-match? LMergeTagged f.e (term (+ 1 1))) #t)
+  (test-equal (redex-match? LMergeTagged f.e (term (- 1 1))) #t)
+  (test-equal (redex-match? LMergeTagged f.e (term (* 1 1))) #f)
+
+  (test-equal (redex-match? LMergeTagged d.e (term (+ 1 1))) #t)
+  (test-equal (redex-match? LMergeTagged d.e (term (* 1 1))) #t)
+  (test-equal (redex-match? LMergeTagged d.e (term (- 1 1))) #f))

--- a/collects/redex/tests/tl-test.rkt
+++ b/collects/redex/tests/tl-test.rkt
@@ -448,8 +448,14 @@
       (one. L1)
     |#
 
+
     (test (and (redex-match LMerge one.e (term (- 0 0))) #t) #t)
-    (test (and (redex-match LMerge two.e (term (* 0 0))) #t) #t))
+    (test (and (redex-match LMerge two.e (term (* 0 0))) #t) #t)
+
+    (define-union-language LMergeUntagged L1 L2)
+
+    (for ([t (list (term 1) (term (* 1 1)) (term (+ 1 1)) (term (- 1 1)))])
+       (test (redex-match? LMergeUntagged e t) #t)))
 
   (let ()
     (define-language UT


### PR DESCRIPTION
Changed `define-union-language' to merge nonterminals and their right-hand-sides instead of causing an error when more than one language in the union defines the same nonterminal.
