### PR TITLE
Fix issues with linker on OpenBSD

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -4030,7 +4030,8 @@ case "$host_os" in
     try_kqueue_syscall=yes
     ;;
   openbsd*)
-    LIBS="$LIBS -rdynamic -Wl,--export-dynamic"
+    LIBS="$LIBS -Wl,--export-dynamic"
+    EXTRALIBS="-lcrypto -lGLU -lGL -lcurses"
     enable_pthread=yes
     try_kqueue_syscall=yes
     ;;


### PR DESCRIPTION
"-rdynamic" doesn't work with GCC 4.7 on OpenBSD: "cc: error:
unrecognized command line option '-rdynamic'". The switch isn't
necessary because it is only a wrapper to "-Wl,--export-dynamic".
Look GCC bug 37454.

The patch also adds some extra libs:
- "crypto" is needed by openssl.
- "GL" and "GLU" is needed by OpenGL libs.
- "curses" is needed by readline.
