### PR TITLE
Readline-to-Racket: Use racket everywhere.

### DIFF
--- a/collects/readline/main.rkt
+++ b/collects/readline/main.rkt
@@ -1,4 +1,4 @@
-#lang scheme
+#lang racket
 
 (require "rep.rkt")
 (provide (all-from-out "rep.rkt"))

--- a/collects/readline/pread.rkt
+++ b/collects/readline/pread.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require "mzrl.rkt" racket/list racket/file)
+(require "rktrl.rkt" racket/list racket/file)
 
 ;; --------------------------------------------------------------------------
 ;; Configuration

--- a/collects/readline/readline.rkt
+++ b/collects/readline/readline.rkt
@@ -1,3 +1,3 @@
-(module readline mzscheme
-  (require "mzrl.rkt")
-  (provide (all-from "mzrl.rkt")))
+#lang racket
+(require "rktrl.rkt")
+(provide (all-from-out "rktrl.rkt"))

--- a/collects/readline/rep-start.rkt
+++ b/collects/readline/rep-start.rkt
@@ -1,7 +1,7 @@
 ;; This module initializes readline unconditionally, "rep.rkt" uses it if we're
 ;; using a `terminal-port?' for input.
 
-#lang scheme/base
+#lang racket/base
 
 (require "pread.rkt")
 

--- a/collects/readline/rep.rkt
+++ b/collects/readline/rep.rkt
@@ -1,7 +1,7 @@
 ;; This is a wrapper around "rep-start.rkt" -- use it if we're using a terminal
-#lang scheme/base
+#lang racket/base
 
-(require scheme/runtime-path scheme/file)
+(require racket/runtime-path racket/file)
 
 (define-runtime-path rep-start "rep-start.rkt")
 

--- a/collects/readline/rktrl.rkt
+++ b/collects/readline/rktrl.rkt
@@ -1,6 +1,6 @@
-#lang scheme/base
+#lang racket/base
 
-(require mzlib/foreign (only-in '#%foreign ffi-obj)) (unsafe!)
+(require ffi/unsafe (only-in '#%foreign ffi-obj))
 (provide readline readline-bytes
          add-history add-history-bytes
          history-length history-get history-delete
@@ -108,14 +108,14 @@
                (malloc (add1 (bytes-length cur)) cur 'raw)))))
     complete))
 
-(set-ffi-obj! "rl_readline_name" libreadline _bytes #"mzscheme")
+(set-ffi-obj! "rl_readline_name" libreadline _bytes #"racket")
 
 ;; need to capture the real input port below
 (define real-input-port (current-input-port))
 (unless (eq? 'stdin (object-name real-input-port))
-  (log-warning "mzrl warning: could not capture the real input port\n"))
+  (log-warning "rkt-rl warning: could not capture the real input port\n"))
 (unless (terminal-port? real-input-port)
-  (log-warning "mzrl warning: input port is not a terminal\n"))
+  (log-warning "rkt-rl warning: input port is not a terminal\n"))
 
 
 ;; We need to tell readline to pull content through our own function,


### PR DESCRIPTION
Readline-to-Racket: Rename file to mzrl.rkt to rktrl.rkt
