### PR TITLE
Added https over http proxy support

### DIFF
--- a/collects/net/scribblings/url.scrbl
+++ b/collects/net/scribblings/url.scrbl
@@ -390,7 +390,7 @@ connections. Each mapping is a list of three elements:
 
 ]
 
-Currently, the only proxiable scheme is @racket["http"]. The default
+Currently, the proxiable schemes are @racket["http"] and @racket["https"]. The default
 mapping is the empty list (i.e., no proxies).}
 
 @defproc[(url-exception? [x any/c])


### PR DESCRIPTION
Currently, the planet2 will access server by https, but net/url cannot support https proxy.
Adding this patch will help to use planet2 by http proxy.
