### PR TITLE
Check for structure binding and raise good error if it is not there.

### DIFF
--- a/collects/tests/typed-racket/fail/pr13588.rkt
+++ b/collects/tests/typed-racket/fail/pr13588.rkt
@@ -1,0 +1,5 @@
+#;
+(exn-pred #rx"identifier bound to a structure type")
+#lang typed/racket/base
+(require/typed racket/async-channel
+  [#:struct (async-channel +) ()])

--- a/collects/tests/typed-racket/succeed/foo.scm
+++ b/collects/tests/typed-racket/succeed/foo.scm
@@ -18,9 +18,9 @@
 
 (module require-tests typed-scheme
   (provide z)
-  (require/typed x Number 'm)
+  (require/typed 'm (x Number))
   (+ x 3)
-  (require/typed y (Number -> Number) 'm)
+  (require/typed 'm (y (Number -> Number)))
   (define: z : Number (y (+ x 4))))
 
 

--- a/collects/tests/typed-racket/succeed/leftist-heap.rkt
+++ b/collects/tests/typed-racket/succeed/leftist-heap.rkt
@@ -44,9 +44,10 @@
 
   ;; fixme - type aliases should work in require
 
-  (require/typed current-compare (-> (top top -> number)) srfi/67)
-  (require/typed =? ((top top -> number) top top -> boolean) srfi/67)
-  (require/typed <? ((top top -> number) top top -> boolean) srfi/67)
+  (require/typed srfi/67
+    [current-compare (-> (top top -> number))]
+    [=? ((top top -> number) top top -> boolean)]
+    [<? ((top top -> number) top top -> boolean)])
 
   ;;; DATA DEFINITION
 

--- a/collects/tests/typed-racket/succeed/metrics.rkt
+++ b/collects/tests/typed-racket/succeed/metrics.rkt
@@ -3,18 +3,20 @@
 
 #;(require "../list.scm"
          "../etc.rkt")
-(require/typed apply-to-scheme-files
-               ((Path -> (Listof (Listof (U #f (Listof (U Real #f))))))
-                Path
-                -> (Listof (U #f (Listof  (Listof ( U #f (Listof (U Real #f)))))))) "foldo.rkt")
+(require/typed "foldo.rkt"
+  (apply-to-scheme-files
+                ((Path -> (Listof (Listof (U #f (Listof (U Real #f))))))
+                 Path
+                 -> (Listof (U #f (Listof  (Listof ( U #f (Listof (U Real #f))))))))))
 
 (define-type-alias top Any)
 (define-type-alias str String)
 
-(require/typed filename-extension (Path -> (U #f Bytes)) (lib "file.rkt"))
-(require/typed normalize-path (Path Path -> Path) (lib "file.rkt"))
-(require/typed explode-path (Path -> (Listof Path)) (lib "file.rkt"))
-(require/typed srfi48::format (Port String String top * -> top)  "patch.rkt")
+(require/typed mzlib/file
+  [filename-extension (Path -> (U #f Bytes))]
+  [normalize-path (Path Path -> Path)]
+  [explode-path (Path -> (Listof Path))])
+(require/typed "patch.rkt" [srfi48::format (Port String String top * -> top)])
 ;; FIXME - prefix
 #;(require/typed srfi48:format ( Port String String top * -> top) (prefix-in srfi48: (lib "48.rkt" "srfi")))
 (require (lib "match.rkt")

--- a/collects/tests/typed-racket/succeed/priority-queue.scm
+++ b/collects/tests/typed-racket/succeed/priority-queue.scm
@@ -12,10 +12,12 @@
 (require (prefix-in heap: "leftist-heap.ss")
 	 (except-in (lib "67.ss" "srfi") number-compare current-compare =? <?)
 	 (only-in "leftist-heap.ss" comparator))
-(require/typed number-compare (number number -> number) (lib "67.ss" "srfi"))
-(require/typed current-compare (-> (top top -> number)) (lib "67.ss" "srfi"))
-(require/typed =? ((top top -> number) top top -> boolean) (lib "67.ss" "srfi"))
-(require/typed <? ((top top -> number) top top -> boolean) (lib "67.ss" "srfi"))
+(require/typed
+  srfi/67
+  [number-compare (number number -> number)]
+  [current-compare (-> (top top -> number))]
+  [=? ((top top -> number) top top -> boolean)]
+  [<? ((top top -> number) top top -> boolean)])
 
 ; a priority-queue is a heap of  (cons <priority> <element>)
 


### PR DESCRIPTION
Closes PR 13588.
Also cleans up old require/typed format.

The change to require/typed is no longer needed, as I moved the check to after expansion so that it worked when other struct forms in the require/typed introduce bindings that it needs to detect. I left it is as I think removing it is good as it is undocumented and could confuse someone who accidentally found it.
