### PR TITLE
Fix problem handling `examples` and `interaction`.

### DIFF
--- a/collects/scribble/markdown-render.rkt
+++ b/collects/scribble/markdown-render.rkt
@@ -88,6 +88,8 @@
         (define tick? (member (style-name (table-style i))
                               (list 'boxed "defmodule" "RktBlk")))
         (when tick?
+          (when (zero? (table-ticks-depth))
+            (displayln "```racket"))
           (table-ticks-depth (add1 (table-ticks-depth))))
         (define strs (map (lambda (flows)
                             (map (lambda (d)
@@ -111,8 +113,6 @@
                                     (apply max d (map string-length i)))))
                             (apply map list strs)))
         (define x-length (lambda (col) (if (eq? col 'cont) 0 (length col))))
-        (when tick?
-          (displayln (string-append "```racket")))
         (for/fold ([indent? #f]) ([row (in-list strs)])
           (let ([h (apply max 0 (map x-length row))])
             (let ([row* (for/list ([i (in-range h)])
@@ -133,8 +133,9 @@
                 #t)))
           #t)
         (when tick?
-          (displayln "```")
-          (table-ticks-depth (sub1 (table-ticks-depth)))))
+          (table-ticks-depth (sub1 (table-ticks-depth)))
+          (when (zero? (table-ticks-depth))
+            (displayln "```"))))
       null)
 
     (define/override (render-itemization i part ht)

--- a/collects/tests/scribble/markdown-docs/example.md
+++ b/collects/tests/scribble/markdown-docs/example.md
@@ -26,6 +26,8 @@ _Italic_. \_Just underlines\_.
 
 “Dobule quoted”. ‘Single quoted’.
 
+This should NOT be ‘code‘ in Markdown.
+
 Example of vebatim:
 
 `Hi, world.`  
@@ -63,6 +65,28 @@ Example of a defproc:
 
 Returns a new mutable string of length `k` where each position in the
 string is initialized with the character `char`
+
+Blah blah `(``or/c`` ``string?`` ``bytes?``)`.
+
+Example of Scribble `examples`:
+
+```racket
+Examples:      
+> (define x 0) 
+               
+> (displayln x)
+0              
+               
+```
+
+Example of Scribble `interaction`:
+
+```racket
+> (define x 0)
+              
+> x           
+0             
+```
 
 > Note: This is a note. Let’s make it long enough that the markdown output
 > will have to line-wrap, to make sure the > mark starts each line

--- a/collects/tests/scribble/markdown-docs/example.scrbl
+++ b/collects/tests/scribble/markdown-docs/example.scrbl
@@ -1,7 +1,9 @@
-#lang scribble/doc
+#lang scribble/manual
 
-@(require scribble/manual
+@(require scribble/eval
           (for-label racket/base racket/contract racket/string))
+@(define my-eval (make-base-eval))
+@(my-eval '(require racket/base))
 
 @section{Section}
 
@@ -34,6 +36,8 @@ _Just underlines_.
 
 ``Dobule quoted''.
 `Single quoted'.
+
+This should NOT be `code` in Markdown.
 
 Example of vebatim:
 
@@ -71,7 +75,23 @@ Example of a defproc:
 Returns a new mutable string of length @racket[k] where each position in the
 string is initialized with the character @racket[char]
 
+Blah blah @racket[(or/c string? bytes?)].
+
 }
+
+Example of Scribble @racket[examples]:
+
+@examples[#:eval my-eval
+(define x 0)
+(displayln x)
+]
+
+Example of Scribble @racket[interaction]:
+
+@interaction[#:eval my-eval
+(define x 0)
+x
+]
 
 @margin-note{Note: This is a note. Let's make it long enough that the
 markdown output will have to line-wrap, to make sure the > mark starts


### PR DESCRIPTION
> @soegaard reported this to me yesterday on IRC. He noticed it [here](https://github.com/soegaard/bind/blob/master/README.md).

Unlike plain `racketblock`, `examples` and `interaction` are
"nested". As a result we emitted bad Markdown like:

``````
```racket
Examples:
```racket
some-code
```
```
``````

Markdown code blocks can't nest, so this needs to be:

``````
```racket
Examples:
some-code
```
``````

Also: Updated the unit test with examples of `examples` and
`interaction`.
