### PR TITLE
Combine adjacent code spans into one.

### DIFF
--- a/collects/scribble/markdown-render.rkt
+++ b/collects/scribble/markdown-render.rkt
@@ -159,7 +159,17 @@
       (define o (open-output-string))
       (parameterize ([current-output-port o])
         (super render-paragraph p part ri))
-      (define to-wrap (regexp-replace* #rx"\n" (get-output-string o) " "))
+      ;; 1. Remove newlines so we can re-wrap the text.
+      ;;
+      ;; 2. Combine adjacent code spans into one. These result from
+      ;; something like @racket[(x y)] being treated as multiple
+      ;; RktXXX items rather than one. (Although it would be
+      ;; more-correct to handle them at that level, I don't easily see
+      ;; how. As a result I'm handling it after-the-fact, at the
+      ;; text/Markdown stage.)
+      (define to-wrap (regexp-replaces (get-output-string o)
+                                       '([#rx"\n" " "]   ;1
+                                         [#rx"``" ""]))) ;2
       (define lines (wrap-line (string-trim to-wrap) (- 72 (current-indent))))
       (write-note)
       (write-string (car lines))

--- a/collects/tests/scribble/markdown-docs/example.md
+++ b/collects/tests/scribble/markdown-docs/example.md
@@ -64,6 +64,8 @@ Example of a defproc:
 Returns a new mutable string of length `k` where each position in the
 string is initialized with the character `char`
 
+Blah blah `(or/c string? bytes?)`.
+
 > Note: This is a note. Let’s make it long enough that the markdown output
 > will have to line-wrap, to make sure the > mark starts each line
 > properly.

--- a/collects/tests/scribble/markdown-docs/example.scrbl
+++ b/collects/tests/scribble/markdown-docs/example.scrbl
@@ -71,6 +71,8 @@ Example of a defproc:
 Returns a new mutable string of length @racket[k] where each position in the
 string is initialized with the character @racket[char]
 
+Blah blah @racket[(or/c string? bytes?)].
+
 }
 
 @margin-note{Note: This is a note. Let's make it long enough that the


### PR DESCRIPTION
> As with https://github.com/plt/racket/pull/296, @soegaard reported this issue after noticing it [here](https://github.com/soegaard/bind/blob/master/README.md)

These result from something like

```
@racket[(x y)]
```

being treated by Scribble as multiple RktXXX items rather than one. As
a result the Markdown emitted was:

```
`(``x`` ``y``)`
```

But obviously instead we want:

```
`(x y)`
```

Kludgosity alert: Although it would probably be more-correct to
consolidate the RktXXX items at the Scribble structure level, I don't
easily see how. `@racket` is baking in the concept of Racket
lexing (classifying text as various kinds of Racket elements). This is
handy when the render will be HTML or Latek, and is benignly N/A when
it will be plain text. But it's a bit square-peg/round-hole when the
render will be Markdown. Rather than attempt to "un-lex" the Scribble
structures (I'm having trouble seeing how), I'm handling it
"after-the-fact" -- adjusting the generated Markdown text.

If anyone thinks the preceding is an elaborate rationalization for an
ugly kludge, I wouldn't argue, but I would need some help
understanding the preferable way to go about it.
