### PR TITLE
Fix subtyping of (ListDots t 'a) <: (Listof t).

### DIFF
--- a/collects/tests/typed-racket/unit-tests/subtype-tests.rkt
+++ b/collects/tests/typed-racket/unit-tests/subtype-tests.rkt
@@ -212,6 +212,10 @@
 
    [(-polydots (a) (->... (list) (a a) (make-ListDots a 'a)))
     (-polydots (b a) (->... (list b) (a a) (-pair b (make-ListDots a 'a))))]
+
+   [FAIL (make-ListDots (-box (make-F 'a)) 'a) (-lst (-box Univ))]
+   [(make-ListDots (-> -Symbol (make-F 'a)) 'a) (-lst (-> -Symbol Univ))]
+
    ))
 
 (define-go

--- a/collects/typed-racket/types/abbrev.rkt
+++ b/collects/typed-racket/types/abbrev.rkt
@@ -269,23 +269,6 @@
 (define -force (make-ForcePE))
 
 
-;; convenient syntax
-
-
-(define-syntax -poly
-  (syntax-rules ()
-    [(_ (vars ...) ty)
-     (let ([vars (-v vars)] ...)
-       (make-Poly (list 'vars ...) ty))]))
-
-(define-syntax -polydots
-  (syntax-rules ()
-    [(_ (vars ... dotted) ty)
-     (let ([dotted (-v dotted)]
-           [vars (-v vars)] ...)
-       (make-PolyDots (list 'vars ... 'dotted) ty))]))
-
-
 ;; function type constructors
 
 (define top-func (make-Function (list (make-top-arr))))

--- a/collects/typed-racket/types/base-abbrev.rkt
+++ b/collects/typed-racket/types/base-abbrev.rkt
@@ -220,3 +220,18 @@
 
 (define (make-arr-dots dom rng dty dbound)
   (make-arr* dom rng #:drest (cons dty dbound)))
+
+
+;; convenient syntax
+(define-syntax -poly
+  (syntax-rules ()
+    [(_ (vars ...) ty)
+     (let ([vars (-v vars)] ...)
+       (make-Poly (list 'vars ...) ty))]))
+
+(define-syntax -polydots
+  (syntax-rules ()
+    [(_ (vars ... dotted) ty)
+     (let ([dotted (-v dotted)]
+           [vars (-v vars)] ...)
+       (make-PolyDots (list 'vars ... 'dotted) ty))]))

--- a/collects/typed-racket/types/subtype.rkt
+++ b/collects/typed-racket/types/subtype.rkt
@@ -354,7 +354,7 @@
               [((ListDots: s-dty dbound) (ListDots: t-dty dbound))
                (subtype* A0 s-dty t-dty)]
               [((ListDots: s-dty dbound) (Listof: t-elem))
-               (subtype* A0 (substitute Univ dbound s-dty) t-elem)]
+               (subtype* A0 (-poly (dbound) s-dty) t-elem)]
               ;; quantification over two types preserves subtyping
               [((Poly: ns b1) (Poly: ms b2))
                (=> unmatch)


### PR DESCRIPTION
Closes PR 13636.
