### PR TITLE
Fix for default generic implementations

### DIFF
--- a/collects/scribblings/reference/generic.scrbl
+++ b/collects/scribblings/reference/generic.scrbl
@@ -69,7 +69,7 @@ availability.
 
 When @racket[maybe-defaults] is provided, each generic function
 uses @racket[pred?]s to dispatch to the given default implementations,
-@racket[method-impl]s, before dispatching to the generic method table.
+@racket[method-impl]s, if dispatching to the generic method table fails.
 The syntax of the @racket[method-impl]s is the same as the methods
 provided for the @racket[#:methods] keyword for @racket[struct].}
 

--- a/collects/tests/generic/defaults.rkt
+++ b/collects/tests/generic/defaults.rkt
@@ -41,3 +41,25 @@
   (check-false (stream-empty? l4))
   (check-equal? (stream-first l4) 1)
   (check-equal? (stream-first (stream-rest l4)) 2))
+
+(struct a ())
+
+(define-generics bool-able
+  (to-bool bool-able)
+  #:defaults
+  ([a? (define (to-bool a) #t)]))
+
+(struct b a ()
+  #:methods gen:bool-able
+  [(define (to-bool b) #f)])
+
+(module+ test
+  (define my-a (a))
+  (define my-b (b))
+
+  (check-true (bool-able? my-a))
+  (check-true (bool-able? my-b))
+
+  (check-true (to-bool my-a))
+  (check-false (to-bool my-b)))
+


### PR DESCRIPTION
Default implementations provided to `define-generics` should be tried only after dispatching to the generic method table fails.
