### PR TITLE
It installs the docs to standard location in unix-like systems.

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -2301,7 +2301,7 @@ else
   libpltdir="${libdir}/racket"
   collectsdir="${libdir}/racket/collects"
   includepltdir="${includedir}/racket"
-  docdir="${datadir}/racket/doc"
+  docdir="${datadir}/doc/racket"
   MAKE_COPYTREE=copytree
   COLLECTS_PATH='${collectsdir}'
   INSTALL_ORIG_TREE=no


### PR DESCRIPTION
In unix-like systems the default dir for documentation is PREFIX/share/doc/packagename.

Reported by @jasperla.
