### PR TITLE
Change the default stack size to safe values on OpenBSD.

### DIFF
--- a/src/racket/sconfig.h
+++ b/src/racket/sconfig.h
@@ -313,14 +313,16 @@
 #  define SCHEME_PLATFORM_LIBRARY_SUBPATH "i386-openbsd"
 # endif
 
-/* Same reason as for FreeBSD? */
-# define ASSUME_FIXED_STACK_SIZE
-# define FIXED_STACK_SIZE 1048576
-
 # include "uconfig.h"
 # undef HAS_STANDARD_IOB
-
 # define HAS_BSD_IOB
+
+/* Default UNIX_STACK_MAXIMUM is too big for a non-root user.
+   STACK_SAFETY_MARGIN increased for extra safety. */
+# undef UNIX_STACK_MAXIMUM
+# define UNIX_STACK_MAXIMUM 4194304
+# undef STACK_SAFETY_MARGIN
+# define STACK_SAFETY_MARGIN 100000
 
 #ifndef __ELF__
 # define UNDERSCORE_DYNLOAD_SYMBOL_PREFIX


### PR DESCRIPTION
With this patch racket will never grow beyond of the defaults limits of
the OS and also it doesn't limit the stack size to a fixed value.

Tested in version 5.3.3 on amd64 and i386. Please add also the patch to 5.3.4.
