### PR TITLE
Add optional message flags argument to imap-append.

### DIFF
--- a/collects/net/scribblings/imap.scrbl
+++ b/collects/net/scribblings/imap.scrbl
@@ -416,7 +416,8 @@ Pending expunges must be handled before calling this function; see
 
 @defproc[(imap-append [imap imap-connection?]
                       [mailbox string?]
-                      [message (or/c string? bytes?)])
+                      [message (or/c string? bytes?)]
+                      [flags (listof (or/c 'seen 'answered 'flagged 'deleted 'draft 'recent)) '(seen)])
          void?]{
 
 Adds a new message (containing @racket[message]) to the given


### PR DESCRIPTION
Previously this was hard-coded to use the `\Seen` flag. Now that's the
default value when the argument is not supplied.
