### PR TITLE
Use libpng 1.6.x if 1.5.x can't be found

### DIFF
--- a/collects/racket/draw/unsafe/png.rkt
+++ b/collects/racket/draw/unsafe/png.rkt
@@ -11,10 +11,12 @@
    ;; Most Linux distros supply "libpng12", while other Unix
    ;; variants often have just "libpng", etc.
    (ffi-lib "libpng15" '("15" "")
-	    #:fail (lambda ()
-		     (ffi-lib "libpng12" '("0" "")
-			      #:fail (lambda ()
-				       (ffi-lib "libpng")))))]
+      #:fail (lambda ()
+         (ffi-lib "libpng16" '("16" "")
+            #:fail (lambda ()
+               (ffi-lib "libpng12" '("0" "")
+                  #:fail (lambda ()
+                     (ffi-lib "libpng")))))))]
   [(macosx) (ffi-lib "libpng15.15.dylib")]
   [(windows)
    (ffi-lib "zlib1.dll")


### PR DESCRIPTION
libpng 1.6.x has superseded 1.5.x on (at least) Archlinux. This change
adds libpng16.so to the set of names tried when looking for the system
libpng.
