### PR TITLE
Fixup tc/plambda.

### DIFF
--- a/collects/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/collects/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -1640,6 +1640,11 @@
                        (apply (inst values A B ... B) a b)) 
                      (All (A B ...) (A B ... -> (values A B ... B))))
               (-polydots (a b) ((list a) (b b) . ->... . (make-ValuesDots (list (-result a)) b 'b)))]
+
+        [tc-err (lambda (x) x)
+                #:expected (ret (-poly (a) (cl->* (t:-> a a) (t:-> a a a))))]
+        [tc-err (plambda: (A) ((x : A)) x)
+                #:expected (ret (list -Symbol -Symbol))]
         )
   (test-suite
    "check-type tests"


### PR DESCRIPTION
Makes it so that returned type is actually what was calculated by
type checking instead of the expected type. Closes PR 13751.

Makes catch all case be an actual catch all case. Closes PR 13754.
