### PR TITLE
Redex wildcard

### DIFF
--- a/collects/redex/private/enum.rkt
+++ b/collects/redex/private/enum.rkt
@@ -86,6 +86,7 @@
              (match-a-pattern
               pat
               [`any s]
+              [`_ s]
               [`number s]
               [`string s]
               [`natural s]
@@ -147,6 +148,7 @@
     (match-a-pattern
      pat
      [`any #f]
+     [`_ #f]
      [`number #f]
      [`string #f]
      [`natural #f]
@@ -277,9 +279,10 @@
 (define (sep-names pat)
   (let loop ([pat pat]
              [named-pats empty-named-pats])
-    (match-a-pattern
+    (match-a-pattern #:allow-wc-name
      pat
      [`any named-pats]
+     [`_ named-pats]
      [`number named-pats]
      [`string named-pats]
      [`natural named-pats]
@@ -293,6 +296,7 @@
      [`hole named-pats]
      ;; names inside nts are separate
      [`(nt ,id) named-pats]
+     [`(name ,n _) named-pats] ;; Don't name wildcards!
      [`(name ,n ,pat)
       (loop pat
             (add-named n pat named-pats))]
@@ -479,6 +483,7 @@
       (sum/enum
        any/enum
        (listof/enum any/enum))]
+     [`_ (loop `any)]
      [`number num/enum]
      [`string string/enum]
      [`natural natural/enum]

--- a/collects/redex/private/jdg-gen.rkt
+++ b/collects/redex/private/jdg-gen.rkt
@@ -7,6 +7,7 @@
          (only-in "reduction-semantics.rkt"
                   do-test-match)
          "pat-unify.rkt"
+         "match-a-pattern.rkt"
          (for-syntax racket/base))
 
 (provide pat->term
@@ -68,7 +69,7 @@
                             (and/fail (for/and ([nt (remove nt-pat all-nts)])
                                         ((get-matcher nt) term))
                                       term))]
-           [`any
+           [(or `any (== wildcard eq?))
             (for/not-failed ([nt-pat nts])
                             (define term (recur `(nt ,nt-pat)))
                             (and/fail (for/and ([nt (remove nt-pat nts)])

--- a/collects/redex/private/matcher.rkt
+++ b/collects/redex/private/matcher.rkt
@@ -255,6 +255,7 @@ See match-a-pattern.rkt for more details
   (let loop ([pat pat])
     (match-a-pattern pat
       [`any (void)]
+      [`_ (void)]
       [`number (void)]
       [`string (void)]
       [`natural (void)]
@@ -295,6 +296,7 @@ See match-a-pattern.rkt for more details
   (let loop ([pat pat])
     (match-a-pattern pat
       [`any pat]
+      [`_ pat]
       [`number pat]
       [`string pat]
       [`natural pat]
@@ -332,6 +334,7 @@ See match-a-pattern.rkt for more details
      (let loop ([pattern pattern])
        (match-a-pattern pattern
          [`any #f]
+         [`_ #f]
          [`number #f]
          [`string #f]
          [`natural #f]
@@ -475,6 +478,7 @@ See match-a-pattern.rkt for more details
          (values pattern #f))
        (match-a-pattern pattern
          [`any untouched-pattern]
+         [`_ untouched-pattern]
          [`number untouched-pattern]
          [`string untouched-pattern]
          [`natural untouched-pattern]
@@ -581,6 +585,7 @@ See match-a-pattern.rkt for more details
   (let loop ([pattern pattern])
     (match-a-pattern pattern
       [`any #t]
+      [`_ #t]
       [`number #f]
       [`string #f]
       [`natural #f]
@@ -616,6 +621,7 @@ See match-a-pattern.rkt for more details
   (let loop ([pattern pattern])
     (match-a-pattern pattern
       [`any #t]
+      [`_ #t]
       [`number #t]
       [`string #t]
       [`natural #t]
@@ -778,6 +784,7 @@ See match-a-pattern.rkt for more details
   (define (true-compile-pattern pattern)
     (match-a-pattern pattern
       [`any (simple-match (λ (x) #t))]
+      [`_ (simple-match (λ (x) #t))]
       [`number (simple-match number?)]
       [`string (simple-match string?)]
       [`natural (simple-match exact-nonnegative-integer?)]
@@ -824,6 +831,7 @@ See match-a-pattern.rkt for more details
         has-hole?
         #f
         '())]
+      ;; IAN: LOOK
       [`(name ,name ,pat)
        (define-values (match-pat has-hole? has-hide-hole? names) 
          (parameterize ([in-name-parameter #t])
@@ -1829,8 +1837,9 @@ See match-a-pattern.rkt for more details
 (define (extract-empty-bindings pattern)
   (let loop ([pattern pattern]
              [ribs null])
-    (match-a-pattern pattern
+    (match-a-pattern #:allow-wc-name pattern
       [`any ribs]
+      [`_ ribs]
       [`number ribs]
       [`string ribs]
       [`natural ribs]
@@ -1844,6 +1853,7 @@ See match-a-pattern.rkt for more details
       
       [`hole ribs]
       [`(nt ,nt) ribs]
+      [`(name ,name _) ribs] ;; Don't bind wildcards!
       [`(name ,name ,pat)
        (cons (make-bind name '()) (loop pat ribs))]
       [`(mismatch-name ,name ,pat) 

--- a/collects/redex/private/rewrite-side-conditions.rkt
+++ b/collects/redex/private/rewrite-side-conditions.rkt
@@ -213,8 +213,10 @@
                 (define suffix-sym (string->symbol suffix))
                 (define prefix-sym (string->symbol prefix))
                 (define prefix-stx (datum->syntax term prefix-sym))
-                (define mismatch? (regexp-match? #rx"^!_" suffix))
+                (define mismatch? (regexp-match? #rx"^!_" suffix)) ;; As in e_!_
                 (cond
+                 [(eq? (syntax-e term) '_)
+                   (values `_ (list))]
                   [(eq? prefix-sym '...)
                    (raise-syntax-error 
                     what

--- a/collects/redex/private/rg.rkt
+++ b/collects/redex/private/rg.rkt
@@ -283,8 +283,9 @@
         (define (build-mismatch var) 
           (set! mismatch-id (+ mismatch-id 1))
           (make-mismatch mismatch-id var))
-        (match-a-pattern pat
+        (match-a-pattern #:allow-wc-name pat
           [`any (values pat '())]
+          [`_ (values pat '())]
           [`number (values pat '())]
           [`string (values pat '())]
           [`natural (values pat '())]
@@ -297,6 +298,7 @@
           [`variable-not-otherwise-mentioned (values pat '())]
           [`hole (values pat '())]
           [`(nt ,x) (values pat '())]
+          [`(name ,name _) (values '_ '())]
           [`(name ,name ,p) 
            (define-values (p-rewritten p-names) (loop p))
            (add/ret `(name ,name ,p-rewritten) (cons name p-names))]
@@ -367,6 +369,7 @@
                    (let*-values ([(lang nt) ((next-any-decision) langc sexpc)]
                                  [(term) (gen-nt lang nt #f r s a the-not-hole)])
                      (values term e)))]
+                [`_ (recur `any)]
                 [`number (generator/attempts (λ (a) ((next-number-decision) a)))]
                 [`string (generator/attempts (λ (a) ((next-string-decision) lits a)))]
                 [`natural (generator/attempts (λ (a) ((next-natural-decision) a)))]
@@ -524,6 +527,7 @@
       (let loop ([pat pat])
         (match-a-pattern pat
           [`any (void)]
+          [`_ (void)]
           [`number (void)]
           [`string (void)]
           [`natural (void)]
@@ -687,6 +691,7 @@
     (let recur ([pat pattern] [under null])
       (match-a-pattern pat
                        [`any assignments]
+                       [`_ assignments]
                        [`number assignments]
                        [`string assignments]
                        [`natural assignments]

--- a/collects/redex/private/term-fn.rkt
+++ b/collects/redex/private/term-fn.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require (for-template racket/base "defined-checks.rkt"))
+(require (for-template racket/base "defined-checks.rkt")
+         "match-a-pattern.rkt")
 (provide make-term-fn
          term-fn?
          term-fn-get-id
@@ -73,8 +74,8 @@
     (language-id-get (set!-transformer-procedure val) n)))
 (define (language-id-nt-identifiers stx id) (language-id-getter stx id 2))
 
-(define pattern-symbols '(any number natural integer real string variable 
-                              variable-not-otherwise-mentioned hole symbol))
+(define pattern-symbols `(any number natural integer real string variable 
+                              variable-not-otherwise-mentioned hole symbol ,wildcard))
 
 (define-values (struct:metafunc-proc make-metafunc-proc metafunc-proc? metafunc-proc-ref metafunc-proc-set!)
   (make-struct-type 'metafunc-proc #f 10 0 #f null (current-inspector) 0))

--- a/collects/redex/scribblings/ref.scrbl
+++ b/collects/redex/scribblings/ref.scrbl
@@ -100,7 +100,8 @@ references are wrapped with angle brackets; otherwise identifiers
 in the grammar are terminals.
 
 @(racketgrammar* #;#:literals #;(any number string variable variable-except variable-prefix variable-not-otherwise-mentioned hole hide-hole name in-hole side-condition cross) 
-   [pattern any 
+   [pattern any
+            _
             number 
             natural
             integer
@@ -132,6 +133,11 @@ This @pattern may also be suffixed with an underscore and another
 identifier, in which case they bind the full name (as if it
 were an implicit @pattech[name] @pattern) and match the portion
 before the underscore.
+}
+
+@item{The @defpattech[any] @pattern matches any sexpression but does
+not bind, even when wrapped in @pattech[name].  This @pattern may not
+be suffixed.
 }
 
 @item{The @defpattech[number] @pattern matches any number.
@@ -230,7 +236,7 @@ example, this @|pattern|:
 matches lists of three @tt{e}s, but where all three of them are
 distinct.
 
-Unlike a @tt{_} @|pattern|, the @tt{_!_} @|pattern|s do not bind names.
+Unlike a symbol @tt{_} symbol @|pattern|, the @tt{_!_} @|pattern|s do not bind names.
 
 If @tt{_} names and @tt{_!_} are mixed, they are treated as
 separate. That is, this @pattern @tt{(e_1 e_!_1)} matches just the
@@ -265,7 +271,7 @@ matches what the embedded @ttpattern matches, and then the guard
 expression is evaluated. If it returns @racket[#f], the @pattern fails
 to match, and if it returns anything else, the @pattern matches. Any
 occurrences of @racket[name] in the @pattern (including those implicitly
-there via @tt{_} pattersn) are bound using @racket[term-let] in the
+there via @tt{_} patterns) are bound using @racket[term-let] in the
 guard. 
 }
 

--- a/collects/redex/tests/unify-tests.rkt
+++ b/collects/redex/tests/unify-tests.rkt
@@ -1079,6 +1079,7 @@
                 ((list (name z ,(bound)) (name y ,(bound)))
                  . (list 5 4)))
               #t)
+(test-unify `_ 5 '() '() #t)
 
 ;; mismatch-name
 (test-unify `(list (name a any) foo)


### PR DESCRIPTION
any and any_!_ do not match absolutely anything regardless of anything else in the pattern. This patch introduces _ as its own pattern as a non-binding, unnameable pattern that matches anything.
