### PR TITLE
More core shrinking

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,4 @@ compiler:
   - gcc
   - clang
 # Change this to your needs
-script: cd racket/src; mkdir build; cd build ; ../configure; make
+script: cd racket/src; mkdir build; cd build ; ../configure; make; make install


### PR DESCRIPTION
To do for the whole shrinking:
- [x] Remove most of `net`.
- [x] Make the core not use `mzscheme`.
- [x] Test the above.
- [ ] Move `mzscheme` out of the core.
- [ ] Move much of the `compiler` collection out of the core.
