### PR TITLE
Delay Redex Enumeration Unsupported/Unimplemented Errors

### DIFF
--- a/pkgs/redex/private/enumerator.rkt
+++ b/pkgs/redex/private/enumerator.rkt
@@ -32,9 +32,7 @@
          nats
          range/enum
          nats+/enum
-         
-         error/enum
-         unsupported/enum)
+         )
 
 ;; an enum a is a struct of < Nat or +Inf, Nat -> a, a -> Nat >
 (struct enum
@@ -591,14 +589,6 @@
     (enum 1
           t
           t)))
-
-(define (error/enum . args)
-  (define (fail n) (apply error args))
-  (enum +inf.0 fail fail))
-
-(define (unsupported/enum pat)
-  (error/enum 'generate-term "#:i-th does not support ~s patterns" pat))
-
 
 (module+
  test


### PR DESCRIPTION
Redex enumerators using unsupported or unimplemented patterns won't raise exceptions when defined, only when run.
