### PR TITLE
Fix typito in INSTALL.txt

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,7 +1,7 @@
 Quick Instructions
 ==================
 
-On Unix of Mac OS X, `make' (or `make in-place') creates a build in
+On Unix or Mac OS X, `make' (or `make in-place') creates a build in
 the "racket" directory.
 
 The build includes (via links) all packages that are in the "pkgs"


### PR DESCRIPTION
**typito** _n._ - a tiny typo, often trivial.

> If users of open-source libraries correct **typitos** and other
> little errors themselves, the creators and maintainers are free
> to spend their creative energies elsewhere.
