### PR TITLE
Make tc-literal deal with complicated expected types better.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-tests/tests/typed-racket/optimizer/tests/binary-nonzero-fixnum.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-tests/tests/typed-racket/optimizer/tests/binary-nonzero-fixnum.rkt
@@ -1,6 +1,6 @@
 #;
 (
-TR opt: binary-nonzero-fixnum.rkt 11:8 (vector-length (quote #(1 2 3))) -- vector-length
+TR opt: binary-nonzero-fixnum.rkt 11:8 (vector-length (quote #(1 2 3))) -- known-length vector-length
 TR opt: binary-nonzero-fixnum.rkt 11:0 (modulo (vector-length (quote #(1 2 3))) 2) -- binary nonzero fixnum
 1
 )

--- a/pkgs/typed-racket-pkgs/typed-racket-tests/tests/typed-racket/optimizer/tests/fixnum-comparison.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-tests/tests/typed-racket/optimizer/tests/fixnum-comparison.rkt
@@ -1,6 +1,6 @@
 #;
 (
-TR opt: fixnum-comparison.rkt 12:3 (vector-length (quote #(1 2 3))) -- vector-length
+TR opt: fixnum-comparison.rkt 12:3 (vector-length (quote #(1 2 3))) -- known-length vector-length
 TR opt: fixnum-comparison.rkt 12:29 (string-length "asdf") -- string-length
 TR opt: fixnum-comparison.rkt 12:0 (< (vector-length (quote #(1 2 3))) (string-length "asdf")) -- binary fixnum comp
 #t


### PR DESCRIPTION
Also fixes bug in literal heterogeneous vector typing.

Closes PR 13842.
