### PR TITLE
Fix missing initialization in filesystem-change-evt

### DIFF
--- a/racket/src/racket/src/inotify.inc
+++ b/racket/src/racket/src/inotify.inc
@@ -170,7 +170,10 @@ static int mz_inotify_add(char *filename)
     s->wds = new_wds;
     s->size = new_size;
     for (i = s->count; i < s->size; i++)
+    {
       s->wds[i].wd = -1;
+      s->wds[i].refcount = 0;
+    }
   }
 
   wd = inotify_add_watch(s->fd, filename, 


### PR DESCRIPTION
Reproducibly crashes the racket/file.rktl test by hitting the abort() in inotify.inc:62
