### PR TITLE
Fix automated tests for systems without IPv6

### DIFF
--- a/pkgs/racket-pkgs/racket-test/tests/racket/file.rktl
+++ b/pkgs/racket-pkgs/racket-test/tests/racket/file.rktl
@@ -1491,8 +1491,12 @@
 	   (tcp-close l)))])
   (do-once #f "localhost")
   (do-once #t "localhost")
-  (do-once #f "::1")
-  (do-once #t "::1"))
+  (with-handlers ([exn:fail:network:errno? (lambda (e)
+                                             ;; catch EAFNOSUPPORT Address family not supported by protocol
+                                             (unless (regexp-match? #rx"Address family not supported by protocol" (exn-message e))
+                                               (raise e)))])
+    (do-once #f "::1")
+    (do-once #t "::1")))
 
 (test #f tcp-port? (current-input-port))
 (test #f tcp-port? (current-output-port))


### PR DESCRIPTION
This should work for most *nix based systems.
A more consistent way to check if IPv6 is available would be preferable but does not exist.
