### PR TITLE
Add missing fender to define-cstruct

### DIFF
--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -1588,6 +1588,7 @@
            stx xs))
   (syntax-case stx ()
     [(_ type ([slot slot-type] ...) . more)
+     (stx-pair? #'(slot ...))
      (let-values ([(_TYPE _SUPER)
                    (syntax-case #'type ()
                      [(t s) (values #'t #'s)]


### PR DESCRIPTION
prevents internal error from libffi for
(define-cstruct _S ())
