### PR TITLE
Fix a crash of racket on OpenBSD systems

### DIFF
--- a/racket/src/foreign/libffi/src/x86/freebsd.S
+++ b/racket/src/foreign/libffi/src/x86/freebsd.S
@@ -49,6 +49,9 @@ ffi_call_SYSV:
 	movl  16(%ebp),%ecx
 	subl  %ecx,%esp
 
+	/* Align the stack pointer to 16-bytes */
+	andl  $0xfffffff0, %esp
+
 	movl  %esp,%eax
 
 	/* Place all of the ffi_prep_args in position  */


### PR DESCRIPTION
Fix a crash of racket on OpenBSD systems, when pixman is compiled with SSE support and racket tries to load cairo using libffi.

Bug found initially by Juan Francisco Cantero Hurtado. Reported by many.

Mark Kettenis (from the OpenBSD Project) found the real reason of the crash and created this patch for libffi. Patch taken from OpenBSD Ports.
