### PR TITLE
Added a missing word in the lambda section of syntax.scrbl

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -1769,7 +1769,7 @@ as follows:
        @racket[keyword].}
 
        @specsubform[(code:line keyword [id default-expr])]{The
-       procedure accepts a keyword-based using @racket[keyword]. The
+       procedure accepts a keyword-based argument using @racket[keyword]. The
        @racket[id] is associated with a keyword-based actual argument
        using @racket[keyword], if supplied in an application;
        otherwise, the @racket[default-expr] is evaluated to obtain a


### PR DESCRIPTION
I was reading the Racket Reference manual and it seemed that someone had missed a word; hopefully this is helpful.

Thanks!
Edward
