### PR TITLE
Add reorder tabs facility in DrRacket

### DIFF
--- a/pkgs/drracket-pkgs/drracket-test/tests/drracket/reorder-tabs.rkt
+++ b/pkgs/drracket-pkgs/drracket-test/tests/drracket/reorder-tabs.rkt
@@ -1,0 +1,21 @@
+#lang racket/base
+(require "private/drracket-test-util.rkt"
+         racket/list
+         racket/class
+         rackunit)
+
+(fire-up-drracket-and-run-tests 
+ (λ ()
+   (define drs (wait-for-drracket-frame))
+   (send drs create-new-tab)
+   (send drs create-new-tab)
+   (define tabs (send drs get-tabs))
+
+   (send drs reorder-tabs (reverse (range (length tabs))))
+   (define new-tabs (send drs get-tabs))
+   (check-equal? new-tabs (reverse tabs))
+
+   (send drs reorder-tabs (reverse (range (length tabs))))
+   (define new-tabs2 (send drs get-tabs))
+   (check-equal? new-tabs2 tabs)
+   ))

--- a/pkgs/drracket-pkgs/drracket/drracket/private/main.rkt
+++ b/pkgs/drracket-pkgs/drracket/drracket/private/main.rkt
@@ -747,6 +747,24 @@
                         (when frame
                           (send frame next-tab))))])
      
+     (new menu-item% 
+          [parent windows-menu]
+          [label (string-constant move-current-tab-right)]
+          [demand-callback dc]
+          [callback (λ (item _) 
+                      (let ([frame (find-frame item)])
+                        (when frame
+                          (send frame move-current-tab-right))))])
+     
+     (new menu-item% 
+          [parent windows-menu]
+          [label (string-constant move-current-tab-left)]
+          [demand-callback dc]
+          [callback (λ (item _) 
+                      (let ([frame (find-frame item)])
+                        (when frame
+                          (send frame move-current-tab-left))))])
+     
      (let ([frame (find-frame windows-menu)])
        (unless (or (not frame) (= 1 (send frame get-tab-count)))
          (unless (eq? (system-type) 'macosx)

--- a/pkgs/drracket-pkgs/drracket/scribblings/tools/unit.scrbl
+++ b/pkgs/drracket-pkgs/drracket/scribblings/tools/unit.scrbl
@@ -635,6 +635,26 @@ Returns the currently active tab.
   Switches to the previous tab.
 }
 
+@defmethod[(move-current-tab-right) void?]{
+  Swaps the current tab with its right-hand neighbor.
+}
+
+@defmethod[(move-current-tab-left) void?]{
+  Swaps the current tab with its left-hand neighbor.
+}
+
+@defmethod[(reorder-tabs [tab-order (listof exact-nonnegative-integer?)]) void?]{
+  Reorders the tabs according to @racket[tab-order].
+                                 
+  Each element in @racket[tab-order] identifies a tab by its position in the list
+  @method[drracket:unit:frame<%> get-tabs], and the position of this element identifies
+  the new position of the tab.
+  
+  For example, considering that there are only 3 tabs open, 
+  @racket[(send a-drracket-frame reorder-tabs '(2 1 0))]
+  swaps the first and last tabs, leaving the middle one unchanged.
+}
+
 @defmethod[#:mode public-final (close-current-tab) void?]{
   Closes the current tab, making some other tab visible.
   If there is only one tab open, this method does nothing.

--- a/pkgs/string-constants/string-constants-lib/string-constants/private/english-string-constants.rkt
+++ b/pkgs/string-constants/string-constants-lib/string-constants/private/english-string-constants.rkt
@@ -854,6 +854,8 @@ please adhere to these guidelines:
  (most-recent-window "Most Recent Window")
   (next-tab "Next Tab")
   (prev-tab "Previous Tab")
+  (move-current-tab-right "Move Tab &Right")
+  (move-current-tab-left "Move Tab &Left")
   ;; menu item in the windows menu under mac os x. first ~a is filled with a number between 1 and 9; second one is the filename of the tab
   (tab-i "Tab ~a: ~a")
 

--- a/pkgs/string-constants/string-constants-lib/string-constants/private/french-string-constants.rkt
+++ b/pkgs/string-constants/string-constants-lib/string-constants/private/french-string-constants.rkt
@@ -836,6 +836,8 @@
   (most-recent-window "Fenêtre la plus récente")
   (next-tab "Onglet suivant")
   (prev-tab "Onglet précédent")
+  (move-current-tab-right "Déplacer à &droite")
+  (move-current-tab-left "Déplacer à &gauche")
   ;; menu item in the windows menu under mac os x. first ~a is filled with a number between 1 and 9; second one is the filename of the tab
   (tab-i "Onglet ~a: ~a")
 


### PR DESCRIPTION
Adds two menu items in DrRacket/Windows: Move Tab Left and Move Tab Right, that swap the currently active tab in DrRacket with its left-hand or right-hand neighbor.
Adds also a more generic method in drracket/private/unit.rkt to allow for arbitrary reordering of the tabs.
