### PR TITLE
Allow re-definition at TR top-level

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/global-env.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/global-env.rkt
@@ -73,8 +73,8 @@
 (define (unregister-type id)
   (free-id-table-remove! the-mapping id))
 
-(define (finish-register-type id)
-  (unless (maybe-finish-register-type id)
+(define (finish-register-type id [top-level? #f])
+  (unless (or top-level? (maybe-finish-register-type id))
     (tc-error/expr #:stx id "Duplicate definition for ~a" (syntax-e id)))
   (void))
 

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -167,7 +167,9 @@
               (map make-def-binding vars ts))]
            ;; if this already had an annotation, we just construct the binding reps
            [(andmap (lambda (s) (lookup-type s (lambda () #f))) vars)
-            (for-each finish-register-type vars)
+            (define top-level? (eq? (syntax-local-context) 'top-level))
+            (define (finish id) (finish-register-type id top-level?))
+            (for-each finish vars)
             (map (lambda (s) (make-def-binding s (lookup-type s))) vars)]
            ;; special case to infer types for top level defines
            [else


### PR DESCRIPTION
For code review.

This allows `define` to redefine variables at the top-level. Mainly I'm submitting this as a PR since I'm worried about soundness, but I couldn't think of any ways that this is more problematic than `set!` (and it should be less problematic anyway since  you can't redefine from an inner scope).
