### PR TITLE
Make unary float complex operations optimize.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/optimizer/float-complex.rkt
@@ -122,6 +122,10 @@
                (list
                 #`((real-binding) #,(fl-sum #'(cs.real-binding ...)))
                 #`((imag-binding) #,(fl-sum #'(cs.imag-binding ...)))))))
+  (pattern (#%plain-app op:+^ :unboxed-float-complex-opt-expr)
+    #:when (subtypeof? this-syntax -FloatComplex)
+    #:do [(log-unboxing-opt "unboxed unary float complex")])
+
 
   (pattern (#%plain-app op:-^ (~between cs:unboxed-float-complex-opt-expr 2 +inf.0) ...)
     #:when (subtypeof? this-syntax -FloatComplex)
@@ -188,6 +192,9 @@
                                                #`(unsafe-fl- (unsafe-fl* #,o1 #,(car e1))
                                                              (unsafe-fl* #,o2 #,(car e2))))))
                                  res))))))))
+  (pattern (#%plain-app op:*^ :unboxed-float-complex-opt-expr)
+    #:when (subtypeof? this-syntax -FloatComplex)
+    #:do [(log-unboxing-opt "unboxed unary float complex")])
 
   (pattern (#%plain-app op:/^
                         c1:unboxed-float-complex-opt-expr

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/optimizer/tests/float-complex-float-small.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/optimizer/tests/float-complex-float-small.rkt
@@ -1,23 +1,24 @@
 #;#;
 #<<END
-TR opt: float-complex-float-small.rkt 34:0 (+ 1.0+2.0i 3.0) -- unboxed binary float complex
-TR opt: float-complex-float-small.rkt 34:12 3.0 -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 34:3 1.0+2.0i -- unboxed literal
-TR opt: float-complex-float-small.rkt 35:0 (+ 1.0 2.0+4.0i) -- unboxed binary float complex
-TR opt: float-complex-float-small.rkt 35:3 1.0 -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 35:7 2.0+4.0i -- unboxed literal
-TR opt: float-complex-float-small.rkt 36:0 (- 1.0+2.0i 3.0) -- unboxed binary float complex
-TR opt: float-complex-float-small.rkt 36:12 3.0 -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 36:3 1.0+2.0i -- unboxed literal
-TR opt: float-complex-float-small.rkt 37:0 (- 1.0 2.0+4.0i) -- unboxed binary float complex
-TR opt: float-complex-float-small.rkt 37:3 1.0 -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 37:7 2.0+4.0i -- unboxed literal
-TR opt: float-complex-float-small.rkt 38:0 (+ 1.0+2.0i (+ 1.0 2.0)) -- unboxed binary float complex
-TR opt: float-complex-float-small.rkt 38:12 (+ 1.0 2.0) -- binary float
-TR opt: float-complex-float-small.rkt 38:12 (+ 1.0 2.0) -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 38:15 1.0 -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 38:19 2.0 -- float-arg-expr in complex ops
-TR opt: float-complex-float-small.rkt 38:3 1.0+2.0i -- unboxed literal
+TR opt: float-complex-float-small.rkt 35:0 (+ 1.0+2.0i 3.0) -- unboxed binary float complex
+TR opt: float-complex-float-small.rkt 35:12 3.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 35:3 1.0+2.0i -- unboxed literal
+TR opt: float-complex-float-small.rkt 36:0 (+ 1.0 2.0+4.0i) -- unboxed binary float complex
+TR opt: float-complex-float-small.rkt 36:3 1.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 36:7 2.0+4.0i -- unboxed literal
+TR opt: float-complex-float-small.rkt 37:0 (- 1.0+2.0i 3.0) -- unboxed binary float complex
+TR opt: float-complex-float-small.rkt 37:12 3.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 37:3 1.0+2.0i -- unboxed literal
+TR opt: float-complex-float-small.rkt 38:0 (- 1.0 2.0+4.0i) -- unboxed binary float complex
+TR opt: float-complex-float-small.rkt 38:3 1.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 38:7 2.0+4.0i -- unboxed literal
+TR opt: float-complex-float-small.rkt 39:0 (+ 1.0+2.0i (+ 1.0 2.0)) -- unboxed binary float complex
+TR opt: float-complex-float-small.rkt 39:12 (+ 1.0 2.0) -- binary float
+TR opt: float-complex-float-small.rkt 39:12 (+ 1.0 2.0) -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 39:15 1.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 39:15 1.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 39:19 2.0 -- float-arg-expr in complex ops
+TR opt: float-complex-float-small.rkt 39:3 1.0+2.0i -- unboxed literal
 END
 #<<END
 4.0+2.0i

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/optimizer/tests/float-complex-unary.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/optimizer/tests/float-complex-unary.rkt
@@ -1,0 +1,33 @@
+#;#;
+#<<END
+TR opt: float-complex-unary.rkt 31:0 (real-part (+ 1.0+2.0i (+ (* 3.0+4.0i 5.0+6.0i)))) -- complex accessor elimination
+TR opt: float-complex-unary.rkt 31:11 (+ 1.0+2.0i (+ (* 3.0+4.0i 5.0+6.0i))) -- unboxed binary float complex
+TR opt: float-complex-unary.rkt 31:14 1.0+2.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 31:23 (+ (* 3.0+4.0i 5.0+6.0i)) -- unboxed unary float complex
+TR opt: float-complex-unary.rkt 31:26 (* 3.0+4.0i 5.0+6.0i) -- unboxed binary float complex
+TR opt: float-complex-unary.rkt 31:26 (* 3.0+4.0i 5.0+6.0i) -- unboxed binary float complex
+TR opt: float-complex-unary.rkt 31:29 3.0+4.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 31:29 3.0+4.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 31:38 5.0+6.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 31:38 5.0+6.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 32:0 (real-part (+ 7.0+8.0i (* (+ 9.0+10.0i 11.0+12.0i)))) -- complex accessor elimination
+TR opt: float-complex-unary.rkt 32:11 (+ 7.0+8.0i (* (+ 9.0+10.0i 11.0+12.0i))) -- unboxed binary float complex
+TR opt: float-complex-unary.rkt 32:14 7.0+8.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 32:23 (* (+ 9.0+10.0i 11.0+12.0i)) -- unboxed unary float complex
+TR opt: float-complex-unary.rkt 32:26 (+ 9.0+10.0i 11.0+12.0i) -- unboxed binary float complex
+TR opt: float-complex-unary.rkt 32:26 (+ 9.0+10.0i 11.0+12.0i) -- unboxed binary float complex
+TR opt: float-complex-unary.rkt 32:29 9.0+10.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 32:29 9.0+10.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 32:39 11.0+12.0i -- unboxed literal
+TR opt: float-complex-unary.rkt 32:39 11.0+12.0i -- unboxed literal
+END
+#<<END
+-8.0
+27.0
+
+END
+#lang typed/racket
+
+(real-part (+ 1.0+2.0i (+ (* 3.0+4.0i 5.0+6.0i))))
+(real-part (+ 7.0+8.0i (* (+ 9.0+10.0i 11.0+12.0i))))
+


### PR DESCRIPTION
This removes an unnecessary allocation.
