### PR TITLE
Fix scribble/markdown title rendering

### DIFF
--- a/pkgs/scribble-pkgs/scribble-lib/scribble/markdown-render.rkt
+++ b/pkgs/scribble-pkgs/scribble-lib/scribble/markdown-render.rkt
@@ -44,9 +44,7 @@
     (define/override (render-part d ht)
       (let ([number (collected-info-number (part-collected-info d ht))])
         (unless (part-style? d 'hidden)
-          (unless (zero? (number-depth number))
-            (printf (make-string (number-depth number) #\#))
-            (printf " "))
+          (printf (string-append (make-string (add1 (number-depth number)) #\#) " "))
           (let ([s (format-number number '())])
             (unless (null? s)
               (printf "~a.~a" 

--- a/pkgs/scribble-pkgs/scribble-test/tests/scribble/markdown-docs/example.md
+++ b/pkgs/scribble-pkgs/scribble-test/tests/scribble/markdown-docs/example.md
@@ -1,12 +1,14 @@
-# 1. Section
+# Title
+
+## 1. Section
 
 This is a top-level section.
 
-## 1.1. Subsection
+### 1.1. Subsection
 
 This is a subsection.
 
-### 1.1.1. Subsubsection
+#### 1.1.1. Subsubsection
 
 This is a subsubsection.
 

--- a/pkgs/scribble-pkgs/scribble-test/tests/scribble/markdown-docs/example.scrbl
+++ b/pkgs/scribble-pkgs/scribble-test/tests/scribble/markdown-docs/example.scrbl
@@ -5,6 +5,8 @@
 @(define my-eval (make-base-eval))
 @(my-eval '(require racket/base))
 
+@title{Title}
+
 @section{Section}
 
 This is a top-level section.
@@ -66,7 +68,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 Example of a defmodule:
 
-@defmodule[racket/string]
+@defmodule[racket/string #:packages ()]
 
 Example of a defproc:
 


### PR DESCRIPTION
Titles were not rendered at all for scribble/markdown.
Now they are rendered as "# Title", and (sub*)sections have been shifted by one level (which also looks better on Github), so a section is now "## 1. Section" (previously they were "# 1. Section"). 
