### PR TITLE
Added script to get collection roots from packages for zsh auto-complete

### DIFF
--- a/pkgs/shell-completion/racket-completion.bash
+++ b/pkgs/shell-completion/racket-completion.bash
@@ -9,6 +9,9 @@
 # will need to make sure that you have bash completions enabled, usually
 # with "source /etc/bash_completion".
 
+# Identify bash as the completion client
+export RACKET_COMPLETION_CLIENT=bash
+
 # This completes only *.{rkt,ss,scm,scrbl} files unless there are none,
 # in which case it completes other things.
 _racket_filedir() {
@@ -116,7 +119,7 @@ _complete_collects() {
   local cur="$1"
   if [[ "${#_racket_collects[@]}" -eq 0 ]]; then
     _racket_collects=(
-      $( $_racket_cmd -e '(require shell-completion/list-collects)' )
+      $( $_racket_cmd -e '(require (submod shell-completion/list-collects main))' )
     )
   fi
   local wordlist=""

--- a/pkgs/shell-completion/racket-completion.zsh
+++ b/pkgs/shell-completion/racket-completion.zsh
@@ -36,6 +36,9 @@
 # the function since it's loaded on first use.)
 #
 
+# Identify zsh as the completion client
+export RACKET_COMPLETION_CLIENT=zsh
+
 ###############################################################################
 
 _racket_file_expander() {
@@ -60,8 +63,7 @@ _racket_call() {
 _racket_read_libfile_or_collect() {
   local -a dirs
   dirs=(
-    "${(f)$(_racket_call directories '
-             (for-each displayln (current-library-collection-paths))')}"
+    "${(f)$(_racket_call directories '(require (submod shell-completion/list-collects main))')}"
   )
   local -a ignored
   ignored=('*.dep' '*.zo' 'compiled' '*/compiled')


### PR DESCRIPTION
This fixes the zsh auto-complete feature to work with both the standard collection paths as well as the collection roots from the various links files. It doesn't work with individually installed collections, though, which would require more changes to the .zsh script.
