### PR TITLE
Include empty symbol in variable enumeration

### DIFF
--- a/pkgs/redex-pkgs/redex-lib/redex/private/enumerator.rkt
+++ b/pkgs/redex-pkgs/redex-lib/redex/private/enumerator.rkt
@@ -926,7 +926,7 @@
   (map/e
    (compose string->symbol list->string)
    (compose string->list symbol->string)
-   (many1/e char/e)))
+   (many/e char/e)))
 
 (define base/e
   (disj-sum/e #:alternate? #t


### PR DESCRIPTION
Please merge into 6.0.
