### PR TITLE
Remove extraneous compile of non existent file.

### DIFF
--- a/racket/collects/setup/setup-core.rkt
+++ b/racket/collects/setup/setup-core.rkt
@@ -952,7 +952,6 @@
                        (member (cc-info-root cc)
                                (current-library-collection-paths)))
               (compile-cc cc 0))))
-        (managed-compile-zo (collection-file-path "parallel-build-worker.rkt" "setup"))
         (with-specified-mode
           (lambda ()
             (define cct


### PR DESCRIPTION
This file has been deleted a long time ago, https://github.com/plt/racket/commit/3f1a6ee94a6dac05a30a1fea664564701872ecbc

There might be something new to compile instead though.
