### PR TITLE
Extend heaps to allow removing arbitrary elements via an additional equality operator.

### DIFF
--- a/pkgs/data-pkgs/data-doc/data/scribblings/heap.scrbl
+++ b/pkgs/data-pkgs/data-doc/data/scribblings/heap.scrbl
@@ -17,10 +17,11 @@ Binary heaps are a simple implementation of priority queues.
 
 Operations on binary heaps are not thread-safe.
 
-@defproc[(make-heap [<=? (-> any/c any/c any/c)])
+@defproc[(make-heap [<=? (-> any/c any/c any/c)]
+                    [=? (-> any/c any/c any/c) eq?])
          heap?]{
 
-Makes a new empty heap using @racket[<=?] to order elements.
+Makes a new empty heap using @racket[<=?] to order elements, and optionally @racket[=?] to compare elements in order to delete them via @racket[heap-remove!].
 
 @examples[#:eval the-eval
   (define a-heap-of-strings (make-heap string<=?))
@@ -109,7 +110,18 @@ empty, an exception is raised.
   (heap-min a-heap)]
 }
 
-@defproc[(vector->heap [<=? (-> any/c any/c any/c)] [items vector?]) heap?]{
+@defproc[(heap-remove-min! [h heap?] [v any/c]) void?]{
+
+Removes @racket[v] from the heap @racket[h] if it exists. 
+
+@examples[#:eval the-eval
+  (define a-heap (make-heap string<=? string=?))
+  (heap-add! a-heap "a" "b" "c")
+  (heap-remove! a-heap "b")
+  (for/list ([a (in-heap a-heap)]) a)]
+}
+
+@defproc[(vector->heap [<=? (-> any/c any/c any/c)] [items vector?] [#:=? (-> any/c any/c any/c) eq?]) heap?]{
 
 Builds a heap with the elements from @racket[items]. The vector is not
 modified.

--- a/pkgs/data-pkgs/data-test/tests/data/heap.rkt
+++ b/pkgs/data-pkgs/data-test/tests/data/heap.rkt
@@ -32,6 +32,12 @@
     (heap->vector h))
   '#(4 6 8 10))
 
+(test-equal? "heap-remove!"
+  (let ([h (mkheap)])
+    (heap-remove! h 4)
+    (heap->vector h))
+  '#(2 6 8 10))
+
 (define (rand-test range count1 count2 count3)
   (let ([h (make-heap <=)]
         [xs null]) ;; mutated

--- a/racket/collects/syntax/define.rkt
+++ b/racket/collects/syntax/define.rkt
@@ -1,3 +1,3 @@
 (module define racket/base
   (require racket/private/norm-define)
-  (provide normalize-definition))
+  (provide normalize-definition normalize-definition/mk-rhs))

--- a/racket/collects/syntax/doc.txt
+++ b/racket/collects/syntax/doc.txt
@@ -132,6 +132,18 @@ _define.ss_: handling all the same function forms as `define'
   `keyword id', and `keyword [id expr]' are allowed, and they are
   preserved in the expansion.
 
+> (normalize-definition/mk-rhs defn-stx lambda-id-stx [check-context? opt+kws? err-no-body?]) -
+
+  the helper for `normalize-definition' that produces three values:
+  the defined identifier, a function that takes the syntax of the body
+  and produces syntax that has the expected binding structure, and
+  finally the right-hand side expression that `normalize-definition'
+  gives to the previous function.
+
+  If `err-no-body?' is true, then there must be a right-hand side
+  expression or else it is a syntax error. This is true for uses of
+  `normalize-definition'.
+
 ======================================================================
 _struct.ss_: generating the same names as `define-struct'
 ======================================================================


### PR DESCRIPTION
Obviously a comparison function yielding an ordering/c would be better,
but this change is backwards compatible. I needed this change for implementing
the self-adjusting computation algorithm that uses a priority queue that additionally
removes elements that are discovered to be "obsolete."
