### PR TITLE
Extend heaps to allow removing arbitrary elements via an additional equality operator.

### DIFF
--- a/pkgs/data-pkgs/data-doc/data/scribblings/heap.scrbl
+++ b/pkgs/data-pkgs/data-doc/data/scribblings/heap.scrbl
@@ -109,6 +109,15 @@ empty, an exception is raised.
   (heap-min a-heap)]
 }
 
+@defproc[(heap-remove! [h heap?] [v any/c] [#:same? same? (-> any/c any/c any/c) equal?]) void?]{
+Removes @racket[v] from the heap @racket[h] if it exists. 
+@examples[#:eval the-eval
+  (define a-heap (make-heap string<=? string=?))
+  (heap-add! a-heap "a" "b" "c")
+  (heap-remove! a-heap "b")
+  (for/list ([a (in-heap a-heap)]) a)]
+}
+
 @defproc[(vector->heap [<=? (-> any/c any/c any/c)] [items vector?]) heap?]{
 
 Builds a heap with the elements from @racket[items]. The vector is not

--- a/pkgs/data-pkgs/data-test/tests/data/heap.rkt
+++ b/pkgs/data-pkgs/data-test/tests/data/heap.rkt
@@ -32,6 +32,12 @@
     (heap->vector h))
   '#(4 6 8 10))
 
+(test-equal? "heap-remove!"
+  (let ([h (mkheap)])
+    (heap-remove! h 4)
+    (heap->vector h))
+  '#(2 6 8 10))
+
 (define (rand-test range count1 count2 count3)
   (let ([h (make-heap <=)]
         [xs null]) ;; mutated


### PR DESCRIPTION
Obviously a comparison function yielding an ordering/c would be better,
but this change is backwards compatible. I needed this change for implementing
the self-adjusting computation algorithm that uses a priority queue that additionally
removes elements that are discovered to be "obsolete."
