### PR TITLE
Make optimizer not lazy required.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/tc-setup.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/tc-setup.rkt
@@ -4,10 +4,10 @@
          (except-in syntax/parse id) syntax/stx
          racket/pretty racket/promise racket/lazy-require
          (env type-name-env type-alias-env mvar-env)
+         (optimizer optimizer)
          (utils tc-utils disarm mutated-vars)
          (for-syntax racket/base)
          (for-template racket/base))
-(lazy-require [typed-racket/optimizer/optimizer (optimize-top)])
 
 (provide tc-setup invis-kw maybe-optimize init-current-type-names)
 


### PR DESCRIPTION
Make typed racket code actually depend on the optimizer instead of just users of it. This means that dependency information is more correct (compilation of the unit tests in particular), but '#lang typed/racket #:no-optimize' users have to spend a bit more time and compilation time to load up the optimizer.
