### PR TITLE
path-element? should disallow '.' and '..'

### DIFF
--- a/racket/collects/racket/path.rkt
+++ b/racket/collects/racket/path.rkt
@@ -184,7 +184,8 @@
 (define (path-element? path)
   (and (path-for-some-system? path)
        (let-values ([(base name d?) (split-path path)])
-         (eq? base 'relative))))
+         (and (eq? base 'relative)
+              (path-for-some-system? name)))))
 
 
 


### PR DESCRIPTION
The implementation of `path-element?` does not match the documentation.

This patch fixes `path-element?` to check whether the name returned by split-path
is a path or a special entry. This behavior matches both the documentation
of `path-element?` and the implementation of `string->path-element`.
It might be better to use a less expensive check, but I wasn't sure.

If allowing special entries is the intended behavior, the documentation should be
changed instead and conversion functions like string->path-element should be
changed to match. The current behavior differs between them:

```
> (path-element? (string->path "."))
#t
> (string->path-element ".")
string->path-element: cannot be converted to a path element
  path: "."
  explanation: path can be split, is not relative, or names a special element
```
