### PR TITLE
switch to unitless line-heights

### DIFF
--- a/pkgs/scribble-pkgs/scribble-lib/scribble/manual-racket.css
+++ b/pkgs/scribble-pkgs/scribble-lib/scribble/manual-racket.css
@@ -43,7 +43,7 @@ span.RktValDef, span.RktStxDef, span.RktSymDef
 .inherited td {
   font-size: 82%;
   padding-left: 0.5rem;
-  line-height: 1.3em;
+  line-height: 1.3;
   text-indent: 0;
   padding-right: 0;
 }

--- a/pkgs/scribble-pkgs/scribble-lib/scribble/manual-style.css
+++ b/pkgs/scribble-pkgs/scribble-lib/scribble/manual-style.css
@@ -85,7 +85,7 @@ h3 .stt, h4 .stt, h5 .stt {
 p, .SIntrapara {
     display: block;
     margin: 0 0 1em 0;
-    line-height: 140%;
+    line-height: 1.4;
 }
 
 
@@ -101,7 +101,7 @@ h1, h2, h3, h4, h5, h6, h7, h8 {
     color: #333;
     margin-top: inherit;
     margin-bottom: 1rem;
-    line-height: 125%;
+    line-height: 1.25;
     -moz-font-feature-settings: 'tnum=1';
     -moz-font-feature-settings: 'tnum' 1;
     -webkit-font-feature-settings: 'tnum' 1;
@@ -122,7 +122,7 @@ h2 { /* per-page main title */
     font-weight: bold;
     margin-top: 4rem;
     font-size: 3rem;
-    line-height: 110%;
+    line-height: 1.1;
     width: 90%;
 }
 
@@ -280,7 +280,7 @@ a:hover {
 /* ---------------------------------------- */
 /* Margin notes */
 
-/* cancel scribvle.css styles: */
+/* cancel scribble.css styles: */
 .refpara, .refelem {
   position: static;
   float: none;
@@ -305,7 +305,7 @@ a:hover {
 }
 
 .refcontent p {
-    line-height: 1.5rem;
+    line-height: 1.5;
     margin: 0;
 }
 
@@ -347,7 +347,7 @@ a:hover {
 .refcontent {
     font-family: 'Fira';
     font-size: 1rem;
-    line-height: 160%;
+    line-height: 1.6;
     margin: 0 0 0 0;
 }
 
@@ -391,7 +391,7 @@ a:hover {
     vertical-align: text-top;
     padding-bottom: 0.4rem;
     padding-left: 0.2rem;
-    line-height: 110%;
+    line-height: 1.1;
     font-family: 'Fira';
     -moz-font-feature-settings: 'tnum=1';
     -moz-font-feature-settings: 'tnum' 1;
@@ -415,7 +415,7 @@ a:hover {
 
 
 .tocview td, .tocsub td {
-    line-height: 1.3em;
+    line-height: 1.3;
 }
 
 
@@ -560,7 +560,7 @@ blockquote {
     margin-left: 0em;
     margin-right: 2em;
     white-space: nowrap;
-    line-height: 1.4em;
+    line-height: 1.4;
 }
 
 .SCodeFlow img {


### PR DESCRIPTION
This change fixes a [bizarre line-spacing problem](http://stackoverflow.com/questions/20695333/in-css-why-does-decimal-line-height-behave-differently-from-percentage-or-em) that crops up when CSS line-height is specified with a percentage or an em value, and the paragraph contains mutiple font sizes. ([Illustrated here](http://jsfiddle.net/Y7Jta/2/).) The fix is to use unitless line-height values.
