### PR TITLE
collects/db/private/mysql/message.rkt: parse-decimal: negative number fi...

### DIFF
--- a/pkgs/db-pkgs/db-lib/db/private/mysql/message.rkt
+++ b/pkgs/db-pkgs/db-lib/db/private/mysql/message.rkt
@@ -749,7 +749,7 @@ computed string on the server can be. See also:
          ;; big integer
          => (lambda (m)
               (string->number s))]
-        [(regexp-match #rx"^-?([0-9]*)\\.([0-9]*)$" s)
+        [(regexp-match #rx"^(-?[0-9]*)\\.([0-9]*)$" s)
          => (lambda (m)
               (+ (string->number (cadr m))
                  (parse-exact-fraction (caddr m))))]


### PR DESCRIPTION
Fixes bug in Mysql->Racket datatype conversion for DECIMAL.

before:
(parse-decimal "-123.12") => 3078/25

after:
(parse-decimal "-123.12") => -3078/25
