### PR TITLE
TR: Fix subtyping for keyword function types

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -86,13 +86,13 @@
 	       (and ;; if t is optional, s must be as well
 		(or rt (not rs))
 		(loop (subtype* A tt ts) rest-t rest-s))]
-	      ;; extra keywords in s are ok
+	      ;; optional extra keywords in s are ok
 	      ;; we just ignore them
-	      [(keyword<? ks kt) (loop A t rest-s)]
+	      [(and (not rs) (keyword<? ks kt)) (loop A t rest-s)]
 	      ;; extra keywords in t are a problem
 	      [else #f])]
-       ;; no more keywords to satisfy
-       [('() _) A]
+       ;; no more keywords to satisfy, the rest in t must be optional
+       [('() _) (and (andmap (match-lambda [(Keyword: _ _ rs) (not rs)]) s) A)]
        ;; we failed to satisfy all the keyword
        [(_ _) #f]))))
 

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/subtype-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/subtype-tests.rkt
@@ -254,10 +254,12 @@
    [(make-ListDots (-> -Symbol (make-F 'a)) 'a) (-lst (-> -Symbol Univ))]
 
    ;; keyword function types
-   [(->key #:x -Symbol #t Univ) (->key Univ)]
+   [(->key #:x -Symbol #f Univ) (->key Univ)]
+   [FAIL (->key #:x -Symbol #t Univ) (->key Univ)]
    [FAIL (->key Univ) (->key #:x -Symbol #t Univ)]
-   [(->key #:x -Symbol #t #:y -Symbol #t Univ) (->key Univ)]
    [(->key #:x -Symbol #f #:y -Symbol #f Univ) (->key Univ)]
+   [FAIL (->key #:x -Symbol #f #:y -Symbol #t Univ) (->key Univ)]
+   [(->key #:x -Symbol #f #:y -Symbol #f Univ) (->key #:x -Symbol #f Univ)]
    [(->key #:x -Symbol #f #:y -Symbol #f Univ) (->key #:x -Symbol #t Univ)]
    [FAIL (->key #:x -Symbol #f Univ) (->key #:x -Symbol #f #:y -Symbol #f Univ)]
    [(->key #:x -Symbol #f #:y -Symbol #f Univ)
@@ -265,22 +267,24 @@
    [FAIL
     (->key #:x -Symbol #t #:y -Symbol #f Univ)
     (->key #:x -Symbol #f #:y -Symbol #t Univ)]
-   [(->key #:x -Number #f #:y -Symbol #f Univ) (->key #:x -Integer #t Univ)]
+   [(->key #:x (-opt -String) #f #:y -Symbol #f Univ)
+    (->key #:x -String #t Univ)]
    [FAIL
-    (->key #:x -Integer #f #:y -Symbol #f Univ) (->key #:x -Number #t Univ)]
-   [(->key -Integer #:x -Symbol #f #:y -Symbol #f Univ)
-    (->key -Integer #:x -Symbol #t Univ)]
+    (->key #:x -String #f #:y -Symbol #f Univ)
+    (->key #:x (-opt -String) #t Univ)]
+   [(->key -String #:x -Symbol #f #:y -Symbol #f Univ)
+    (->key -String #:x -Symbol #t Univ)]
    [FAIL
     (->key -String #:x -Symbol #f #:y -Symbol #f Univ)
-    (->key -Integer #:x -Symbol #t Univ)]
-   [(->optkey -Integer [-Integer] #:x -Symbol #f #:y -Symbol #f Univ)
-    (->key -Integer #:x -Symbol #t Univ)]
-   [(->optkey -Integer [-Integer] #:x -Symbol #f #:y -Symbol #f Univ)
-    (->optkey -Integer [-Integer] #:x -Symbol #t Univ)]
+    (->key -Void #:x -Symbol #t Univ)]
+   [(->optkey -String [-String] #:x -Symbol #f #:y -Symbol #f Univ)
+    (->key -String #:x -Symbol #t Univ)]
+   [(->optkey -String [-String] #:x -Symbol #f #:y -Symbol #f Univ)
+    (->optkey -String [-String] #:x -Symbol #t Univ)]
    [FAIL
-    (->optkey -Integer [-String] #:x -Symbol #f #:y -Symbol #f Univ)
-    (->optkey -Integer [-Integer] #:x -Symbol #t Univ)]
+    (->optkey -String [-String] #:x -Symbol #f #:y -Symbol #f Univ)
+    (->optkey -String [-Void] #:x -Symbol #t Univ)]
    [FAIL
-    (->key -Integer #:x -Symbol #f #:y -Symbol #f Univ)
-    (->optkey -Integer [-Integer] #:x -Symbol #t Univ)]
+    (->key -String #:x -Symbol #f #:y -Symbol #f Univ)
+    (->optkey -String [-Void] #:x -Symbol #t Univ)]
    ))


### PR DESCRIPTION
I'd like to get this relatively small commit reviewed because despite the small number of lines, getting the subtyping reasoning correct is tricky and it's quite possible that I made a mistake in fixing the bug.
