### PR TITLE
Make parallel compile not call exit.

### DIFF
--- a/pkgs/compiler-pkgs/compiler-lib/compiler/commands/make.rkt
+++ b/pkgs/compiler-pkgs/compiler-lib/compiler/commands/make.rkt
@@ -98,19 +98,20 @@
                         dest)))))))]
   ;; Parallel make:
   [else 
-   (parallel-compile-files 
-    source-files
-    #:worker-count (worker-count)
-    #:handler (lambda (type work msg out err)
-                (match type
-                  ['done (when (verbose) (printf " Made ~a\n" work))]
-                  ['output (printf " Output from: ~a\n~a~a" work out err)]
-                  [else (printf " Error compiling ~a\n~a\n~a~a" work msg out err)]))
-    #:options (let ([cons-if-true (lambda (bool carv cdrv)
-                                    (if bool
-                                        (cons carv cdrv)
-                                        cdrv))])
-                (cons-if-true 
-                 (very-verbose) 
-                 'very-verbose
-                 (cons-if-true (disable-inlining) 'disable-inlining null))))])
+   (or (parallel-compile-files
+        source-files
+        #:worker-count (worker-count)
+        #:handler (lambda (type work msg out err)
+                    (match type
+                      ['done (when (verbose) (printf " Made ~a\n" work))]
+                      ['output (printf " Output from: ~a\n~a~a" work out err)]
+                      [else (printf " Error compiling ~a\n~a\n~a~a" work msg out err)]))
+        #:options (let ([cons-if-true (lambda (bool carv cdrv)
+                                        (if bool
+                                            (cons carv cdrv)
+                                            cdrv))])
+                    (cons-if-true
+                     (very-verbose)
+                     'very-verbose
+                     (cons-if-true (disable-inlining) 'disable-inlining null))))
+       (exit 1))])

--- a/pkgs/racket-pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -465,7 +465,7 @@ functionality of @exec{raco setup} and @exec{raco make}.}
                                                           [err string?])
                                                          void?)
                                             void])
-         void?]{
+         (or/c void? #f)]{
 
 The @racket[parallel-compile] utility function is used by @exec{raco make} to
 compile a list of paths in parallel.  The optional
@@ -476,6 +476,7 @@ parallel compilation.  The callback, @racket[handler], is called with the symbol
 successful compilation produces stdout/stderr output, @racket['error] when a
 compilation error has occured, or @racket['fatal-error] when a unrecoverable
 error occurs. The other arguments give more information for each status update.
+The return value is @racket[(void)] if it was successful, or @racket[#f] if there was an error.
  
   @racketblock[
     (parallel-compile-files 

--- a/racket/collects/setup/parallel-build.rkt
+++ b/racket/collects/setup/parallel-build.rkt
@@ -298,8 +298,7 @@
                                 #:worker-count [worker-count (processor-count)]
                                 #:handler [handler void]
                                 #:options [options '()])
-  (or (parallel-build (make-object file-list-queue% list-of-files handler options) worker-count)
-      (exit 1)))
+  (parallel-build (make-object file-list-queue% list-of-files handler options) worker-count))
 
 (define (parallel-compile worker-count setup-fprintf append-error collects-tree)
   (setup-fprintf (current-output-port) #f "--- parallel build using ~a jobs ---" worker-count)


### PR DESCRIPTION
This removes the call to exit from parallel-compile-files where it is very out of place, (and undocumented), and puts it where it belongs. This now allows 'parallel-compile-files' to return #f instead of void, I updated the documentation but it seems messy.
