### PR TITLE
Fix misspelling of scheme_detach_multple_array

### DIFF
--- a/racket/src/racket/cmdline.inc
+++ b/racket/src/racket/cmdline.inc
@@ -495,7 +495,7 @@ static int finish_cmd_line_run(FinishArgs *fa, Repl_Proc repl)
             int cnt;
             mv = p->ku.multiple.array;
             cnt = p->ku.multiple.count;
-            scheme_detach_multple_array(mv);
+            scheme_detach_multiple_array(mv);
             e = scheme_make_null();
             while (cnt--) {
               e = scheme_make_pair(mv[cnt], e);

--- a/racket/src/racket/include/mzscheme.exp
+++ b/racket/src/racket/include/mzscheme.exp
@@ -179,7 +179,7 @@ scheme_load_compiled_stx_string
 scheme_compiled_stx_symbol
 scheme_eval_compiled_sized_string
 scheme_eval_compiled_sized_string_with_magic
-scheme_detach_multple_array
+scheme_detach_multiple_array
 GC_malloc
 GC_malloc_atomic
 GC_malloc_stubborn

--- a/racket/src/racket/include/mzscheme3m.exp
+++ b/racket/src/racket/include/mzscheme3m.exp
@@ -179,7 +179,7 @@ scheme_load_compiled_stx_string
 scheme_compiled_stx_symbol
 scheme_eval_compiled_sized_string
 scheme_eval_compiled_sized_string_with_magic
-scheme_detach_multple_array
+scheme_detach_multiple_array
 GC_malloc
 GC_malloc_atomic
 GC_malloc_one_tagged

--- a/racket/src/racket/include/mzwin.def
+++ b/racket/src/racket/include/mzwin.def
@@ -196,7 +196,7 @@ EXPORTS
  scheme_compiled_stx_symbol
  scheme_eval_compiled_sized_string
  scheme_eval_compiled_sized_string_with_magic
- scheme_detach_multple_array
+ scheme_detach_multiple_array
  scheme_malloc_code
  scheme_malloc_permanent_code
  scheme_free_code

--- a/racket/src/racket/include/mzwin3m.def
+++ b/racket/src/racket/include/mzwin3m.def
@@ -196,7 +196,7 @@ EXPORTS
  scheme_compiled_stx_symbol
  scheme_eval_compiled_sized_string
  scheme_eval_compiled_sized_string_with_magic
- scheme_detach_multple_array
+ scheme_detach_multiple_array
  GC_malloc
  GC_malloc_atomic
  GC_malloc_one_tagged

--- a/racket/src/racket/include/racket.exp
+++ b/racket/src/racket/include/racket.exp
@@ -204,7 +204,7 @@ scheme_load_compiled_stx_string
 scheme_compiled_stx_symbol
 scheme_eval_compiled_sized_string
 scheme_eval_compiled_sized_string_with_magic
-scheme_detach_multple_array
+scheme_detach_multiple_array
 GC_malloc
 GC_malloc_atomic
 GC_malloc_stubborn

--- a/racket/src/racket/include/racket3m.exp
+++ b/racket/src/racket/include/racket3m.exp
@@ -204,7 +204,7 @@ scheme_load_compiled_stx_string
 scheme_compiled_stx_symbol
 scheme_eval_compiled_sized_string
 scheme_eval_compiled_sized_string_with_magic
-scheme_detach_multple_array
+scheme_detach_multiple_array
 GC_malloc
 GC_malloc_atomic
 GC_malloc_one_tagged

--- a/racket/src/racket/src/fun.c
+++ b/racket/src/racket/src/fun.c
@@ -3883,7 +3883,7 @@ Scheme_Object *scheme_values(int argc, Scheme_Object *argv[])
   return SCHEME_MULTIPLE_VALUES;
 }
 
-void scheme_detach_multple_array(Scheme_Object **values)
+void scheme_detach_multiple_array(Scheme_Object **values)
 {
   Scheme_Thread *t = scheme_current_thread;
 

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -390,7 +390,7 @@ MZ_EXTERN Scheme_Object *scheme_eval_compiled_sized_string_with_magic(const char
 								      Scheme_Object *magic_symbol, Scheme_Object *magic_val,
 								      int multi_ok);
 
-MZ_EXTERN void scheme_detach_multple_array(Scheme_Object **a);
+MZ_EXTERN void scheme_detach_multiple_array(Scheme_Object **a);
 
 /*========================================================================*/
 /*                           memory management                            */

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -301,7 +301,7 @@ Scheme_Object *(*scheme_eval_compiled_sized_string)(const char *str, int len, Sc
 Scheme_Object *(*scheme_eval_compiled_sized_string_with_magic)(const char *str, int len, Scheme_Env *env, 
 								      Scheme_Object *magic_symbol, Scheme_Object *magic_val,
 								      int multi_ok);
-void (*scheme_detach_multple_array)(Scheme_Object **a);
+void (*scheme_detach_multiple_array)(Scheme_Object **a);
 /*========================================================================*/
 /*                           memory management                            */
 /*========================================================================*/

--- a/racket/src/racket/src/schemex.inc
+++ b/racket/src/racket/src/schemex.inc
@@ -212,7 +212,7 @@
   scheme_extension_table->scheme_compiled_stx_symbol = scheme_compiled_stx_symbol;
   scheme_extension_table->scheme_eval_compiled_sized_string = scheme_eval_compiled_sized_string;
   scheme_extension_table->scheme_eval_compiled_sized_string_with_magic = scheme_eval_compiled_sized_string_with_magic;
-  scheme_extension_table->scheme_detach_multple_array = scheme_detach_multple_array;
+  scheme_extension_table->scheme_detach_multiple_array = scheme_detach_multiple_array;
 #ifndef SCHEME_NO_GC
 # ifndef SCHEME_NO_GC_PROTO
   scheme_extension_table->GC_malloc = GC_malloc;

--- a/racket/src/racket/src/schemexm.h
+++ b/racket/src/racket/src/schemexm.h
@@ -212,7 +212,7 @@
 #define scheme_compiled_stx_symbol (scheme_extension_table->scheme_compiled_stx_symbol)
 #define scheme_eval_compiled_sized_string (scheme_extension_table->scheme_eval_compiled_sized_string)
 #define scheme_eval_compiled_sized_string_with_magic (scheme_extension_table->scheme_eval_compiled_sized_string_with_magic)
-#define scheme_detach_multple_array (scheme_extension_table->scheme_detach_multple_array)
+#define scheme_detach_multiple_array (scheme_extension_table->scheme_detach_multiple_array)
 #ifndef SCHEME_NO_GC
 # ifndef SCHEME_NO_GC_PROTO
 #define GC_malloc (scheme_extension_table->GC_malloc)

--- a/racket/src/racket/src/thread.c
+++ b/racket/src/racket/src/thread.c
@@ -6765,7 +6765,7 @@ static Scheme_Object *do_sync(const char *name, int argc, Scheme_Object *argv[],
             if (SAME_OBJ(o, SCHEME_MULTIPLE_VALUES)) {
               rc = scheme_multiple_count;
               mv = scheme_multiple_array;
-              scheme_detach_multple_array(mv);
+              scheme_detach_multiple_array(mv);
             } else {
               rc = 1;
               mv = NULL;
@@ -6812,7 +6812,7 @@ static Scheme_Object *do_sync(const char *name, int argc, Scheme_Object *argv[],
             if (SAME_OBJ(o, SCHEME_MULTIPLE_VALUES)) {
               rc = scheme_multiple_count;
               mv = scheme_multiple_array;
-              scheme_detach_multple_array(mv);
+              scheme_detach_multiple_array(mv);
               if (!to_call_is_handle)
                 scheme_pop_break_enable(&cframe, 1);
               return scheme_values(rc, mv);


### PR DESCRIPTION
Fixes a misspelling in the C API. The reason I'm submitting a PR is in case anyone thinks we should leave the old name in for backwards compatibility (this function has existed for about six years). I'm leaning against since it's been documented with the correct name for all that time.

Relevant people: @mflatt
