### PR TITLE
TR: generalize rest argument types [draft]

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
@@ -4,6 +4,7 @@
          syntax/parse/experimental/template
          "../private/parse-classes.rkt"
          "../private/syntax-properties.rkt"
+         (for-template "base-types.rkt")
          (for-label "colon.rkt"))
 (provide (all-defined-out))
 
@@ -82,7 +83,7 @@
   #:literal-sets (colon)
   (pattern (~seq name:id : ty s:star)
            #:with formal-ty #'(ty s)
-           #:with ann-name (type-label-property #'name #'ty)))
+           #:with ann-name (type-label-property #'name #'(Listof ty))))
 
 (define-splicing-syntax-class annotated-dots-rest
   #:attributes (name ann-name bound ty formal-ty)
@@ -227,7 +228,7 @@
   #:opaque
   (pattern rest:id #:attr form #'rest)
   (pattern (rest:id : type:expr :star)
-           #:attr form (type-label-property #'rest #'type))
+           #:attr form (type-label-property #'rest #'(Listof type)))
   (pattern (rest:id : type:expr bnd:ddd/bound)
            #:attr bound (attribute bnd.bound)
            #:attr form (type-dotted-property

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -24,6 +24,7 @@
  (only-in (types numeric-tower) [-Number N])
  (only-in (rep type-rep)
           make-ClassTop
+          make-Function
           make-Name
           make-ValuesDots
           make-MPairTop
@@ -764,8 +765,7 @@
 [hash-eqv? (-> -HashTop B)]
 [hash-equal? (-> -HashTop B)]
 [hash-weak? (-> -HashTop B)]
-;; not a very useful type, but better than nothing
-[hash (-poly (a b) (-> (-HT a b)))]
+[hash (-poly (a b) (make-Function (list (make-arr* '() (-HT a b) #:full-rest (-mu x (Un (-val '()) (-pair a (-pair b x))))))))]
 [hasheqv (-poly (a b) (-> (-HT a b)))]
 [hasheq (-poly (a b) (-> (-HT a b)))]
 [make-hash (-poly (a b) (->opt [(-lst (-pair a b))] (-HT a b)))]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/parse-classes.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/parse-classes.rkt
@@ -3,7 +3,7 @@
 (require syntax/parse
          "../utils/literal-syntax-class.rkt"
          (for-label "../base-env/base-types-extra.rkt"))
-(provide star ddd ddd/bound omit-parens)
+(provide star star-at ddd ddd/bound omit-parens)
 
 (define-literal-syntax-class #:for-label ->)
 
@@ -13,6 +13,11 @@
            #:fail-unless (eq? '* (syntax-e #'star)) "missing *")
   (pattern star:id
            #:fail-unless (eq? '...* (syntax-e #'star)) "missing ...*"))
+
+(define-syntax-class star-at
+  #:description "*@"
+  (pattern star-at:id
+           #:fail-unless (eq? '*@ (syntax-e #'star-at)) "missing *@"))
 
 (define-syntax-class ddd
   #:description "..."

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -420,13 +420,21 @@
             (parse-type #'rng)
             : (-FS (attribute latent.positive) (attribute latent.negative))
             : (attribute latent.object))]
-      [(~or (:->^ dom:non-keyword-ty ... kws:keyword-tys ... rest:non-keyword-ty ddd:star rng)
-            (dom:non-keyword-ty ... kws:keyword-tys ... rest:non-keyword-ty ddd:star :->^ rng))
+      [(~or (:->^ dom:non-keyword-ty ... kws:keyword-tys ... rest:non-keyword-ty
+                  (~or (~and ddd:star (~bind [full-rest? #f]))
+                       (~and ddd:star-at (~bind [full-rest? #t])))
+                  rng)
+            (dom:non-keyword-ty ... kws:keyword-tys ... rest:non-keyword-ty
+             (~or (~and ddd:star (~bind [full-rest? #f]))
+                  (~and ddd:star-at (~bind [full-rest? #t])))
+             :->^ rng))
        (make-Function
         (list (make-arr
                (parse-types #'(dom ...))
                (parse-values-type #'rng)
-               #:rest (parse-type #'rest)
+               #:full-rest (if (attribute full-rest?)
+                               (parse-type #'rest)
+                               (-lst (parse-type #'rest)))
                #:kws (attribute kws.Keyword))))]
       [(~or (:->^ dom:non-keyword-ty ... rest:non-keyword-ty :ddd/bound rng)
             (dom:non-keyword-ty ... rest:non-keyword-ty :ddd/bound :->^ rng))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -501,7 +501,7 @@
               (values (map conv mand-kws)
                       (map conv opt-kws))))
           (define range (map t->sc rngs))
-          (define rest (and rst (listof/sc (t->sc/neg rst))))
+          (define rest (and rst (t->sc/neg rst)))
           (function/sc (process-dom mand-args) opt-args mand-kws opt-kws rest range)])]
       [else
        (define ((f case->) a)
@@ -523,7 +523,7 @@
                     (map conv mand-kws)
                     (map conv opt-kws)
                     (or
-                      (and rst (listof/sc (t->sc/neg rst)))
+                      (and rst (t->sc/neg rst))
                       (and drst (listof/sc (t->sc/neg (car drst)
                                                       #:recursive-values
                                                         (hash-set recursive-values (cdr drst) (same any/sc))))))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-keywords.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-keywords.rkt
@@ -95,7 +95,7 @@
     [(list (and a (arr: dom rng rest #f ktys)))
      (tc-keywords/internal a kws kw-args #t)
      (tc/funapp (car (syntax-e form)) kw-args
-                (ret (make-Function (list (make-arr* dom rng #:rest rest))))
+                (ret (make-Function (list (make-arr* dom rng #:full-rest rest))))
                 (stx-map tc-expr pos-args) expected)]
     [(list (and a (arr: doms rngs rests (and drests #f) ktyss)) ...)
      (let ([new-arities
@@ -103,7 +103,7 @@
                        ;; find all the arities where the keywords match
                        #:when (tc-keywords/internal a kws kw-args #f))
               (match a
-                [(arr: dom rng rest #f ktys) (make-arr* dom rng #:rest rest)]))])
+                [(arr: dom rng rest #f ktys) (make-arr* dom rng #:full-rest rest)]))])
        (if (null? new-arities)
            (domain-mismatches
             (car (syntax-e form)) (cdr (syntax-e form))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-apply.rkt
@@ -79,7 +79,7 @@
            (-Tuple* domain
                     (cond
                       ;; the actual work, when we have a * function
-                      [rest (make-Listof rest)]
+                      [rest]
                       ;; ... function
                       [drest (make-ListDots (car drest) (cdr drest))]
                       ;; the function has no rest argument,
@@ -99,7 +99,7 @@
            [(and rest
                  (infer fixed-vars (list dotted-var)
                         (list (-Tuple* arg-tys full-tail-ty))
-                        (list (-Tuple* domain (make-Listof rest)))
+                        (list (-Tuple* domain rest))
                         range))
             => finish]
            ;; ... function, ... arg
@@ -130,7 +130,7 @@
                       fixed-vars (list dotted-var)
                       (cons tail-arg-ty (append arg-tys tail-arg-tys))
                       (cons (car drest) domain)
-                      (car drest)
+                      (-lst (car drest))
                       range)]
                    [(List: tail-arg-tys)
                     (infer/dots fixed-vars dotted-var (append arg-tys tail-arg-tys) domain

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -159,18 +159,21 @@
 ;; Function types
 (define/cond-contract (make-arr* dom rng
                                  #:rest [rest #f] #:drest [drest #f] #:kws [kws null]
+                                 #:full-rest [full-rest #f]
                                  #:filters [filters -top-filter] #:object [obj -empty-obj])
   (c:->* ((c:listof Type/c) (c:or/c SomeValues/c Type/c))
          (#:rest (c:or/c #f Type/c)
           #:drest (c:or/c #f (c:cons/c Type/c symbol?))
           #:kws (c:listof Keyword?)
+          #:full-rest (c:or/c #f Type/c)
           #:filters FilterSet?
           #:object Object?)
          arr?)
   (make-arr dom (if (Type/c? rng)
                     (make-Values (list (-result rng filters obj)))
                     rng)
-            rest drest (sort #:key Keyword-kw kws keyword<?)))
+            (if full-rest full-rest (and rest (make-Listof rest)))
+            drest (sort #:key Keyword-kw kws keyword<?)))
 
 (define-syntax (->* stx)
   (define-syntax-class c

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/match-expanders.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/match-expanders.rkt
@@ -16,7 +16,7 @@
 (define-match-expander Listof:
   (lambda (stx)
     (syntax-parse stx
-      [(_ elem-pat (~optional var-pat #:defaults ([var-pat #'var])))
+      [(_ elem-pat (~optional var-pat #:defaults ([var-pat #'_])))
        ;; Note: in practice it's unlikely that the second pattern will ever come up
        ;;       because the sequence number for '() will be low and the union will
        ;;       be sorted by sequence number. As a paranoid precaution, however,

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/substitute.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/substitute.rkt
@@ -4,7 +4,7 @@
          racket/match racket/set
          racket/lazy-require
          (contract-req)
-         (only-in (types base-abbrev) -lst* -result)
+         (only-in (types base-abbrev) -lst -lst* -result)
          (rep type-rep rep-utils)
          (utils tc-utils)
          (rep free-variance)
@@ -122,7 +122,7 @@
                                        (let ([expanded (sb (car drest))])
                                          (map (lambda (img) (substitute img name expanded)) images)))
                                       (sb rng)
-                                      rimage
+                                      (and rimage (-lst rimage))
                                       #f
                                       (map sb kws))
                             (make-arr (map sb dom)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -156,8 +156,7 @@
       [(and (null? dom) (null? argtys)) A]
       [(null? argtys) #f]
       [(and (null? dom) rst)
-       (cond [(subtype* A (car argtys) rst) => (lambda (A) (loop-varargs dom (cdr argtys) A))]
-             [else #f])]
+       (subtype* A (apply -lst* argtys) rst)]
       [(null? dom) #f]
       [(subtype* A (car argtys) (car dom)) => (lambda (A) (loop-varargs (cdr dom) (cdr argtys) A))]
       [else #f])))

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/dead-substruct.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/dead-substruct.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred 2)
+(exn-pred 1)
 #lang typed/scheme
 
 (define-struct: parent ((x : Integer)))


### PR DESCRIPTION
This draft pull request is for an unfinished feature that's been under discussion but won't necessarily be merged (so don't code review it in detail). It generalizes the current `Foo *` rest arguments (i.e., uniform rest argument types) so that any list type can be specified for the rest argument type.

The reason this is a draft is because I'm not sure the feature is worth it. It's somewhat complex to implement (inference is broken right now) and the benefits are relatively small. It's also awkward for the type syntax.

The main benefit is that you can give a type for `hash`:

```
Welcome to Racket v6.0.0.1.
-> hash
- : (All (a b)
      ((Rec x (U Null (Pairof a (Pairof b x)))) *@ -> (HashTable a b)))
#<procedure:hash>
-> ((inst hash Symbol String) 'k1 "val")
- : (HashTable Symbol String)
'#hash((k1 . "val"))
-> ((inst hash Symbol String) 'k1 "val" 'k2)
; readline-input:4:0: Type Checker: type mismatch
;   expected: (Rec g532 (U Null (Pairof Symbol (Pairof String g532))))
;   given: (List 'k1 String 'k2)
;   in: ((inst hash Symbol String) (quote k1) "val" (quote k2))
; [,bt for context]
-> ((inst hash Symbol String) 'k1)
; readline-input:5:0: Type Checker: type mismatch
;   expected: (Rec g542 (U Null (Pairof Symbol (Pairof String g542))))
;   given: (List 'k1)
;   in: ((inst hash Symbol String) (quote k1))
; [,bt for context]
```
