### PR TITLE
Fix polymorphic class checking.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -214,11 +214,10 @@
     [(? Class? class-type)
      (ret (parse-and-check form class-type))]
     [(Poly-names: ns body-type)
-     ;; FIXME: make sure this case is correct, does it
-     ;; introduce the right names in scope?
-     (check-class form (ret body-type))]
-    [#f (ret (parse-and-check form #f))]
-    [_ (check-below (ret (parse-and-check form #f)) expected)]))
+     (match (check-class form (ret body-type))
+       [(tc-result1: t f o)
+        (ret (make-Poly ns t) f o)])]
+    [_ (ret (parse-and-check form #f))]))
 
 ;; Syntax Option<Type> -> Type
 ;; Parse the syntax and extract useful information to pass to the

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -236,8 +236,7 @@
       #:literal-sets (kernel-literals tc-expr-literals)
       ;; a TR-annotated class
       [stx:tr:class^
-       (check-class form expected)
-       expected]
+       (check-class form expected)]
       [stx:exn-handlers^
        (register-ignored! form)
        (check-subforms/with-handlers/check form expected)]


### PR DESCRIPTION
@takikawa, I belive this is the correct fix to the FIXME. It also cleans up the else case because tc-expr already does the check below so it was unnecessary.
