### PR TITLE
Add contract enforcing expected values don't get returned.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-below.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-below.rkt
@@ -8,12 +8,12 @@
          (only-in (types printer) pretty-format-type))
 
 (provide/cond-contract
- [check-below (-->i ([s (-or/c Type/c tc-results/c)]
+ [check-below (-->i ([s (-or/c Type/c tc-results/no-expected/c)]
                      [t (s) (if (Type/c? s) Type/c tc-results/c)])
-                    [_ (s) (if (Type/c? s) Type/c tc-results/c)])]
- [cond-check-below (-->i ([s (-or/c Type/c tc-results/c)]
+                    [_ (s) (if (Type/c? s) Type/c tc-results/no-expected/c)])]
+ [cond-check-below (-->i ([s (-or/c Type/c tc-results/no-expected/c)]
                           [t (s) (-or/c #f (if (Type/c? s) Type/c tc-results/c))])
-                         [_ (s) (-or/c #f (if (Type/c? s) Type/c tc-results/c))])]
+                         [_ (s) (-or/c #f (if (Type/c? s) Type/c tc-results/no-expected/c))])]
  [type-mismatch (-->* ((-or/c Type/c string?) (-or/c Type/c string?))
                       ((-or/c string? #f))
                       -any)])

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/signatures.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/signatures.rkt
@@ -6,13 +6,13 @@
 (provide (all-defined-out))
 
 (define-signature tc-expr^
-  ([cond-contracted tc-expr (syntax? . -> . tc-results/c)]
-   [cond-contracted tc-expr/check (syntax? tc-results/c . -> . tc-results/c)]
+  ([cond-contracted tc-expr (syntax? . -> . tc-results/no-expected/c)]
+   [cond-contracted tc-expr/check (syntax? tc-results/c . -> . tc-results/no-expected/c)]
    [cond-contracted tc-expr/check/t (syntax? tc-results/c . -> . Type/c)]
-   [cond-contracted tc-body (syntax? . -> . tc-results/c)]
-   [cond-contracted tc-body/check (syntax? tc-results/c . -> . tc-results/c)]
+   [cond-contracted tc-body (syntax? . -> . tc-results/no-expected/c)]
+   [cond-contracted tc-body/check (syntax? tc-results/c . -> . tc-results/no-expected/c)]
    [cond-contracted tc-expr/t (syntax? . -> . Type/c)]
-   [cond-contracted single-value ((syntax?) ((or/c tc-results/c #f)) . ->* . tc-results/c)]))
+   [cond-contracted single-value ((syntax?) ((or/c tc-results/c #f)) . ->* . tc-results/no-expected/c)]))
 
 (define-signature check-subforms^
   ([cond-contracted check-subforms/ignore (syntax? . -> . any)]
@@ -20,34 +20,34 @@
    [cond-contracted check-subforms/with-handlers/check (syntax? tc-results/c . -> . any)]))
 
 (define-signature check-class^
-  ([cond-contracted check-class (syntax? (or/c tc-results/c #f) . -> . tc-results/c)]))
+  ([cond-contracted check-class (syntax? (or/c tc-results/c #f) . -> . tc-results/no-expected/c)]))
 
 (define-signature tc-if^
-  ([cond-contracted tc/if-twoarm ((syntax? syntax? syntax?) (tc-results/c) . ->* . tc-results/c)]))
+  ([cond-contracted tc/if-twoarm ((syntax? syntax? syntax?) (tc-results/c) . ->* . tc-results/no-expected/c)]))
 
 (define-signature tc-literal^
   ([cond-contracted tc-literal (->* (syntax?) ((or/c Type/c #f)) Type/c)]))
 
 (define-signature tc-send^
-  ([cond-contracted tc/send ((syntax? syntax? syntax? syntax?) ((or/c tc-results/c #f)) . ->* . tc-results/c)]))
+  ([cond-contracted tc/send ((syntax? syntax? syntax? syntax?) ((or/c tc-results/c #f)) . ->* . tc-results/no-expected/c)]))
 
 (define-signature tc-lambda^
-  ([cond-contracted tc/lambda (syntax? syntax? syntax? . -> . tc-results/c)]
-   [cond-contracted tc/lambda/check (syntax? syntax? syntax? tc-results/c . -> . tc-results/c)]
+  ([cond-contracted tc/lambda (syntax? syntax? syntax? . -> . tc-results/no-expected/c)]
+   [cond-contracted tc/lambda/check (syntax? syntax? syntax? tc-results/c . -> . tc-results/no-expected/c)]
    [cond-contracted tc/rec-lambda/check (syntax? syntax? syntax? (listof Type/c) tc-results/c . -> .
-                                                 (values tc-results/c tc-results/c))]))
+                                                 (values tc-results/no-expected/c tc-results/no-expected/c))]))
 
 (define-signature tc-app^
-  ([cond-contracted tc/app (syntax? . -> . tc-results/c)]
-   [cond-contracted tc/app/check (syntax? tc-results/c . -> . tc-results/c)]
-   [cond-contracted tc/app-regular (syntax? (or/c tc-results/c #f) . -> . tc-results/c)]))
+  ([cond-contracted tc/app (syntax? . -> . tc-results/no-expected/c)]
+   [cond-contracted tc/app/check (syntax? tc-results/c . -> . tc-results/no-expected/c)]
+   [cond-contracted tc/app-regular (syntax? (or/c tc-results/c #f) . -> . tc-results/no-expected/c)]))
 
 (define-signature tc-apply^
-  ([cond-contracted tc/apply (syntax? syntax? . -> . tc-results/c)]))
+  ([cond-contracted tc/apply (syntax? syntax? . -> . tc-results/no-expected/c)]))
 
 (define-signature tc-let^
-  ([cond-contracted tc/let-values ((syntax? syntax? syntax?) ((or/c #f tc-results/c)) . ->* . tc-results/c)]
-   [cond-contracted tc/letrec-values ((syntax? syntax? syntax?) ((or/c #f tc-results/c)) . ->* . tc-results/c)]))
+  ([cond-contracted tc/let-values ((syntax? syntax? syntax?) ((or/c #f tc-results/c)) . ->* . tc-results/no-expected/c)]
+   [cond-contracted tc/letrec-values ((syntax? syntax? syntax?) ((or/c #f tc-results/c)) . ->* . tc-results/no-expected/c)]))
 
 (define-signature tc-dots^
   ([cond-contracted tc/dots (syntax? . -> . (values Type/c symbol?))]))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -15,7 +15,7 @@
   [tc/funapp1
     ((syntax? stx-list? arr? (listof tc-results/c) (or/c #f tc-results/c))
      (#:check boolean?)
-     . ->* . tc-results/c)])
+     . ->* . tc-results/no-expected/c)])
 (define (tc/funapp1 f-stx args-stx ftype0 argtys expected #:check [check? #t])
   (match* (ftype0 argtys)
     ;; we check that all kw args are optional

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-lambda.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-lambda.rkt
@@ -53,7 +53,7 @@
 
 (define/cond-contract
   (let-loop-check lam lp actuals args body expected)
-  (syntax? syntax? syntax? syntax? syntax? tc-results/c . --> . tc-results/c)
+  (syntax? syntax? syntax? syntax? syntax? tc-results/c . --> . tc-results/no-expected/c)
   (syntax-parse #`(#,args #,body #,actuals)
     #:literal-sets (kernel-literals lambda-literals)
     [((val acc ...)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -140,7 +140,7 @@
 ;; the identifier has variable effect
 ;; tc-id : identifier -> tc-results
 (define/cond-contract (tc-id id)
-  (--> identifier? tc-results/c)
+  (--> identifier? tc-results/no-expected/c)
   (let* ([ty (lookup-type/lexical id)])
     (ret ty
          (make-FilterSet (-not-filter (-val #f) id)
@@ -226,7 +226,7 @@
 
 ;; tc-expr/check : syntax tc-results -> tc-results
 (define/cond-contract (tc-expr/check/internal form expected)
-  (--> syntax? tc-results/c tc-results/c)
+  (--> syntax? tc-results/c tc-results/no-expected/c)
   (parameterize ([current-orig-stx form])
     ;(printf "form: ~a\n" (syntax-object->datum form))
     ;; the argument must be syntax

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-funapp.rkt
@@ -6,7 +6,7 @@
          (for-syntax syntax/parse racket/base)
          (types utils union subtype resolve abbrev
                 substitute classes)
-         (typecheck tc-metafunctions tc-app-helper)
+         (typecheck tc-metafunctions tc-app-helper check-below)
          (rep type-rep)
          (r:infer infer))
 
@@ -14,7 +14,7 @@
   [tc/funapp
    (syntax? stx-list? tc-results/c (c:listof tc-results/c)
     (c:or/c #f tc-results/c)
-    . c:-> . tc-results/c)])
+    . c:-> . tc-results/no-expected/c)])
 
 (define-syntax (handle-clauses stx)
   (syntax-parse stx

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/tc-result.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/tc-result.rkt
@@ -21,6 +21,20 @@
   (or (tc-results? v)
       (tc-any-results? v)))
 
+(define (tc-results/no-expected/c r)
+  (match r
+    [(tc-any-results:) #t]
+    [(tc-results: _ fs os)
+     (and
+       (not (member -no-filter fs))
+       (not (member -no-obj os)))]
+    [(tc-results: _ fs os _ _)
+     (and
+       (not (member -no-filter fs))
+       (not (member -no-obj os)))]
+    [else #f]))
+
+
 (define-match-expander tc-result:
   (syntax-rules ()
    [(_ tp fp op) (struct tc-result (tp fp op))]
@@ -139,4 +153,5 @@
  [rename tc-results-ts* tc-results-ts (tc-results? . c:-> . (c:listof Type/c))]
  [tc-result-equal? (tc-result? tc-result? . c:-> . boolean?)]
  [tc-results? (c:any/c . c:-> . boolean?)]
- [tc-results/c c:flat-contract?])
+ [tc-results/c c:flat-contract?]
+ [tc-results/no-expected/c c:flat-contract?])


### PR DESCRIPTION
Any better suggestions for a name than tc-results/no-expected/c?
