### PR TITLE
further dehackify .toptoclink style in Scribble CSS

### DIFF
--- a/pkgs/scribble-pkgs/scribble-lib/scribble/manual-style.css
+++ b/pkgs/scribble-pkgs/scribble-lib/scribble/manual-style.css
@@ -518,6 +518,9 @@ table.tocsublist {
 .toptoclink {
     font-weight: bold;
     font-size: 110%
+    margin-bottom: 0.5rem;
+    margin-top: 1.5rem;
+    display: inline-block;
 }
 
 .toclink {


### PR DESCRIPTION
Adjustment to replace vertical space in TOC headings that disappeared [with this commit](https://github.com/plt/racket/commit/cc26a86cb1975bdbb1ed3f816b6a50decfdec510).
