### PR TITLE
Add sequence support for id-tables

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/syntax/scribblings/id-table.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/syntax/scribblings/id-table.scrbl
@@ -137,12 +137,19 @@ Like @racket[hash-count].
 @defproc[(free-id-table-iterate-key [table free-id-table?]
                                     [position id-table-iter?])
          identifier?]
-@defproc[(free-id-table-iterate-value [table bound-it-table?]
+@defproc[(free-id-table-iterate-value [table free-id-table?]
                                       [position id-table-iter?])
-         identifier?]]]{
+         any/c]
+@defproc[(in-free-id-table [table free-id-table?])
+         sequence?]
+@defproc[(in-free-id-table-keys [table free-id-table?])
+         sequence?]
+@defproc[(in-free-id-table-values [table free-id-table?])
+         sequence?]]]{
 
 Like @racket[hash-iterate-first], @racket[hash-iterate-next],
-@racket[hash-iterate-key], and @racket[hash-iterate-value],
+@racket[hash-iterate-key], @racket[hash-iterate-value], @racket[in-hash],
+@racket[in-hash-keys], and @racket[in-hash-values]
 respectively.
 }
 
@@ -222,7 +229,13 @@ etc) can be used on bound-identifier tables.
          identifier?]
 @defproc[(bound-id-table-iterate-value [table bound-id-table?]
                                        [position id-table-position?])
-         identifier?]
+         any/c]
+@defproc[(in-bound-id-table [table bound-id-table?])
+         sequence?]
+@defproc[(in-bound-id-table-keys [table bound-id-table?])
+         sequence?]
+@defproc[(in-bound-id-table-values [table bound-id-table?])
+         sequence?]
 @defproc[(bound-id-table/c [key-ctc flat-contract?]
                            [val-ctc chaperone-contract?]
                            [#:immutable immutable (or/c #t #f 'dont-care) 'dont-care])

--- a/pkgs/racket-pkgs/racket-test/tests/syntax/tests/iterators.rkt
+++ b/pkgs/racket-pkgs/racket-test/tests/syntax/tests/iterators.rkt
@@ -1,0 +1,18 @@
+#lang racket
+(require syntax/id-table)
+(let*-values ([(a b c) (values #'a #'b #'c)]
+              [(res) (hash a 0 b 1 c 2)]
+              [(t) (make-free-id-table res)])
+ (unless
+     (equal? res
+             (for/hash ([(k v) (in-free-id-table t)])
+               (values k v)))
+   (error 'free-id-table-test "Unexpected failure for in-free-id-table"))
+ (unless
+     (equal? (set a b c)
+             (for/set ([k (in-free-id-table-keys t)]) k))
+   (error 'free-id-table-test "Unexpected failure for in-free-id-table-keys"))
+ (unless
+     (equal? (set 0 1 2)
+             (for/set ([v (in-free-id-table-values t)]) v))
+   (error 'free-id-table-test "Unexpected failure for in-free-id-table-values")))

--- a/racket/collects/syntax/id-table.rkt
+++ b/racket/collects/syntax/id-table.rkt
@@ -200,6 +200,7 @@
           idtbl-count
           idtbl-iterate-first idtbl-iterate-next
           idtbl-iterate-key idtbl-iterate-value
+          in-idtbl in-idtbl-keys in-idtbl-values
           idtbl-map idtbl-for-each
           idtbl-mutable-methods idtbl-immutable-methods
           idtbl/c))
@@ -256,7 +257,8 @@
              (make-id-table/c 'idtbl/c
                               idtbl? mutable-idtbl? immutable-idtbl?
                               immutable-idtbl))
-
+           ;; Contracts destroy the benefits of define-sequence-syntax
+           (provide in-idtbl in-idtbl-keys in-idtbl-values)
            (provide/contract
             [make-idtbl
              (->* () (dict? #:phase (or/c #f exact-integer?)) mutable-idtbl?)]


### PR DESCRIPTION
An obvious deficiency now patched for id-tables.
