### PR TITLE
Mark class support as experimental in the TR docs

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/typed-classes.scrbl
+++ b/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/typed-classes.scrbl
@@ -13,6 +13,11 @@
 
 @title{Typed Classes}
 
+@bold{Warning}: the features described in this section are experimental
+and may not work correctly. Some of the features will change by
+the next release. In particular, typed-untyped interaction for classes
+will not be backwards compatible so do not rely on the current semantics.
+
 Typed Racket provides support for object-oriented programming with
 the classes and objects provided by the @racketmodname[racket/class]
 library.


### PR DESCRIPTION
This PR is a doc change for Racket v6.0.1 to note that TR class support is experimental and likely to change in the next release.

@rmculpepper can you merge this into the release branch?
