### PR TITLE
Make tc-results: and Results: not use ... over patterns.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-expr-unit.rkt
@@ -529,9 +529,9 @@
   (define props
     (match results
       [(tc-any-results:) empty]
-      [(tc-results: _ (FilterSet: f+ f-) _)
+      [(tc-results: _ (list (FilterSet: f+ f-) ...) _)
        (map -or f+ f-)]
-      [(tc-results: _ (FilterSet: f+ f-) _ _ _)
+      [(tc-results: _ (list (FilterSet: f+ f-) ...) _ _ _)
        (map -or f+ f-)]))
   (with-lexical-env (env+ (lexical-env) props (box #t))
     (add-unconditional-prop (k) (apply -and props))))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-let-unit.rkt
@@ -50,7 +50,7 @@
                [e-r   (in-list expected-results)]
                [names (in-list namess)])
               (match* (r e-r)
-                [((tc-results: ts (FilterSet: fs+ fs-) os) (tc-results: e-ts _ _)) ; rest should be the same
+                [((tc-results: ts (list (FilterSet: fs+ fs-) ...) os) (tc-results: e-ts _ _)) ; rest should be the same
                  ;(printf "f+: ~a\n" fs+)
                  ;(printf "f-: ~a\n" fs-)
                  (values ts
@@ -63,7 +63,7 @@
                                       (list)
                                       (list (-imp (-not-filter (-val #f) n) f+)
                                             (-imp (-filter (-val #f) n) f-))))))]
-                [((tc-results: ts (NoFilter:) _) (tc-results: e-ts (NoFilter:) _))
+                [((tc-results: ts (list (NoFilter:) ...) _) (tc-results: e-ts (list (NoFilter:) ...) _))
                  (values ts e-ts null)]))))
      (with-cond-contract append-region ([p1 (listof Filter?)]
                                         [p2 (listof Filter?)])

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/filter-ops.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/filter-ops.rkt
@@ -214,12 +214,12 @@
   (match results
     ;; TODO add support for filters on tc-any-results
     [(tc-any-results:) results]
-    [(tc-results: ts (FilterSet: fs+ fs-) os)
+    [(tc-results: ts (list (FilterSet: fs+ fs-) ...) os)
      (ret ts
           (for/list ([f+ fs+] [f- fs-])
             (-FS (-and prop f+) (-and prop f-)))
           os)]
-    [(tc-results: ts (FilterSet: fs+ fs-) os dty dbound)
+    [(tc-results: ts (list (FilterSet: fs+ fs-) ...) os dty dbound)
      (ret ts
           (for/list ([f+ fs+] [f- fs-])
             (-FS (-and prop f+) (-and prop f-)))


### PR DESCRIPTION
This avoids a case where match is silently wrong.
