### PR TITLE
Add -l flag to `raco test`.

### DIFF
--- a/pkgs/compiler-pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-pkgs/compiler-lib/compiler/commands/test.rkt
@@ -608,6 +608,7 @@
 
 (define collections? #f)
 (define packages? #f)
+(define libraries? #f)
 (define check-top-suffix? #f)
 
 (define (test-top e 
@@ -621,7 +622,18 @@
        [l
         (with-summary
          `(collection ,e)
-         (map/parallel test-files l #:sema continue-sema))])]
+         (map/parallel test-files (collection-file-path l) #:sema continue-sema))])]
+    [libraries?     
+     (define (find x)
+       (define rmp ((current-module-name-resolver) x #f #f #f))
+       (define p (resolved-module-path-name rmp))
+       (and (file-exists? p) p))
+     (match (find (string->symbol e))
+       [#f (error 'test "Library ~e does not exist" e)]
+       [l
+        (with-summary
+         `(library ,l)
+         (test-files l #:sema continue-sema))])]
     [packages?
      (define pd (pkg-directory e))
      (if pd
@@ -803,6 +815,9 @@
  [("--collection" "-c")
   "Interpret arguments as collections"
   (set! collections? #t)]
+ [("--lib" "-l")
+  "Interpret arguments as libraries"
+  (set! libraries? #t)]
  [("--package" "-p")
   "Interpret arguments as packages"
   (set! packages? #t)]

--- a/pkgs/racket-pkgs/racket-doc/scribblings/raco/test.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/raco/test.scrbl
@@ -33,12 +33,15 @@ The @exec{raco test} command accepts several flags:
 @itemize[
 
  @item{@Flag{c} or @DFlag{collection}
-       --- Intreprets the arguments as collections where whose files should be tested.}
+       --- Interprets the arguments as collections where whose files should be tested.}
 
  @item{@Flag{p} or @DFlag{package}
-       --- Intreprets the arguments as packages whose files should
+       --- Interprets the arguments as packages whose files should
        be tested. (All package scopes are searched for the first, most
        specific package.)}
+ 
+ @item{@Flag{l} or @DFlag{lib}
+       --- Interprets the arguments as packages whose libraries to be tested.}
 
  @item{@Flag{m} or @DFlag{modules}
        --- Not only interprets the arguments as paths (which is the


### PR DESCRIPTION
Behaves similarly to `-l` for plain `racket`.
