### PR TITLE
Fix between/c, </c, >/c random value generators

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -2724,7 +2724,7 @@ Attempts to randomly generate a value which will match the contract. The fuel
 argument limits how hard the generator tries to generate a value matching the
 contract and is a rough limit of the size of the resulting value.
 
-The generator may fail to generate a contract, either because some contracts
+The generator may fail to generate a value, either because some contracts
 do not have corresponding generators (for example, not all predicates have
 generators) or because there is not enough fuel. In either case, the
 thunk @racket[fail] is invoked.

--- a/pkgs/racket-pkgs/racket-test/tests/racket/contract-rand-test.rkt
+++ b/pkgs/racket-pkgs/racket-test/tests/racket/contract-rand-test.rkt
@@ -20,11 +20,16 @@
 (check-not-exn (λ () (test-contract-generation (listof number?))))
 
 (check-not-exn (λ () (test-contract-generation (between/c 1 100))))
+(check-not-exn (λ () (test-contract-generation (between/c 1.0 100.0))))
 (check-not-exn (λ () (test-contract-generation (listof integer?))))
 (check-not-exn (λ () (test-contract-generation (>=/c 0))))
+(check-not-exn (λ () (test-contract-generation (>=/c 0.0))))
 (check-not-exn (λ () (test-contract-generation (<=/c 0))))
+(check-not-exn (λ () (test-contract-generation (<=/c 0.0))))
 (check-not-exn (λ () (test-contract-generation (>/c 0))))
+(check-not-exn (λ () (test-contract-generation (>/c 0.0))))
 (check-not-exn (λ () (test-contract-generation (</c 0))))
+(check-not-exn (λ () (test-contract-generation (</c 0.0))))
 (check-not-exn (λ () (test-contract-generation (or/c boolean? boolean?))))
 
 (check-not-exn (λ () (test-contract-generation (listof boolean?))))

--- a/racket/collects/racket/contract/private/misc.rkt
+++ b/racket/collects/racket/contract/private/misc.rkt
@@ -619,7 +619,7 @@
                 [lower (if (< (between/c-low ctc) min-n)
                          min-n
                          (between/c-low ctc))])
-           (+ (random (- upper lower))
+           (+ (* (random) (- upper lower))
               lower))))))
 
 (define (check-unary-between/c sym x)
@@ -651,7 +651,7 @@
              [upper (if (> x max-n)
                       max-n
                       x)])
-        (+ (random (- upper min-n))
+        (+ (* (random) (- upper min-n))
            min-n)))))
 
 (define (>/c x)
@@ -664,7 +664,7 @@
               [lower (if (< x min-n)
                        min-n
                        x)])
-         (+ (random (- max-n lower))
+         (+ (* (random) (- max-n lower))
             lower)))))
 
 (define (check-two-args name arg1 arg2 pred1? pred2?)


### PR DESCRIPTION
The random value generators for the between/c, </c and >/c contracts all feed random a value computed from a user-provided input without ensuring that the value is an exact integer. So if you feed them an inexact (or rational), they do some math, get something random won't like, and then it explodes.

I feel I should describe the fix, but I can't come up with anything more succinct than the diff.

The change causes the random value generators to always produce inexact numbers, rather than the integers you would've gotten by necessity before. Obviously shouldn't violate any contracts, but I feel I should point it out.

Also fixed a typo in the docs, and added some tests.
