### PR TITLE
New indentation rules implemented

### DIFF
--- a/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
+++ b/pkgs/gui-pkgs/gui-lib/scribble/private/indentation.rkt
@@ -186,7 +186,6 @@
         (for/first ([start-skip-space (in-range (sub1 para-end) para-start -1)];;ignore the newline
                     #:when (not (member (send txt get-character start-skip-space)  (list #\space #\tab))))
           start-skip-space))))
-;;TODO: start-skip-spaces return false, test cases
 
 ;;(delete-end-spaces a-racket:text para) → void?
 ;;para : exact-integer? = paragraph(line) number
@@ -689,4 +688,3 @@
 
 (provide determine-spaces adjust-para-width paragraph-indentation
          surrogate%)
-;;sdsdsdsdsdsd


### PR DESCRIPTION
1) Indentation rules applied to count-paren function:
Count number of parenthesis before given position till the outmost '@'
annotation, if the there is '[', we check if it has '@' right after it within the
same line, if so, we add the number of characters between this '[' and the
beginning of the line it appears to the total parenthesis counting
2) line push back rules:
We do not push back lines begin with '@ that
a) Has keyword 'codeblock' or 'verbatim' after
b) Contains '[' and multiple lines between it and the closing ']'
