### PR TITLE
Correctly handle moving dotted vars to the dmap.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -2943,6 +2943,14 @@
          #:ret (ret -Nat -true-filter)
          #:expected (ret -Nat -no-filter)]
 
+       [tc-e
+         (lambda (a . b) (apply values a b))
+
+         #:ret (ret (-polydots (A B ...) (->... (list A) (B B) (-values-dots (list A) B 'B))))
+         #:expected (ret (-polydots (A B ...) (->... (list A) (B B) (-values-dots (list A) B 'B))))
+         ]
+
+
         )
   (test-suite
    "tc-literal tests"


### PR DESCRIPTION
I believe that the old algorithm for moving the dotted rest to the dmap was wrong because it kept the old dbound as the bound even though it was supposed to be replaced with what it was inferred to.
