### PR TITLE
Remove ability to check unreachable code.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/type-env-structs.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/type-env-structs.rkt
@@ -64,7 +64,9 @@
 
 (r:define/cond-contract (env-map f e)
   ((any/c any/c . -> . any/c) env? . -> . env?)
-  (mk-env e (dict-map f (env-l e))))
+  (mk-env e
+    (for/fold ([d (env-l e)]) ([(k v) (in-dict (env-l e))])
+      (dict-set d k (f k v)))))
 
 ;; extend that works on single arguments
 (define (extend e k v)

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/check-unreachable.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/check-unreachable.rkt
@@ -1,0 +1,29 @@
+#lang racket/load
+
+
+(require (for-syntax typed-racket/utils/tc-utils))
+
+(begin-for-syntax
+  (check-unreachable-code? #t))
+
+(require typed/racket)
+
+
+
+(require racket/flonum
+         math/private/flonum/flvector
+         math/private/flonum/flonum-functions
+         math/private/flonum/flonum-more-functions)
+
+(define-predicate float-complex? Float-Complex)
+(: atanh (case-> (Zero -> Zero)
+                 (Float -> Float)
+                 (Real -> Real)
+                 (Float-Complex -> Float-Complex)
+                 (Number -> Number)))
+(define (atanh x)
+  (cond [(flonum? x) (flatanh x)]
+        [(eqv? x 0)  0]
+        [(real? x)  (flatanh (fl x))]
+        [(float-complex? x)  (* 0.5 (- (log (+ 1.0 x)) (log (- 1.0 x))))]
+        [else  (* 1/2 (- (log (+ 1 x)) (log (- 1 x))))]))


### PR DESCRIPTION
Currently if we enable this feature, the math library doesn't type check. Given that we don't actively test with it, I'm proposing we get rid of it.

This commit also moves more of the logic to the module that stores the table from tc-if, which now just records if branches are taken.
