### PR TITLE
call/input-url - support headers and polymorphism

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-more/typed/net/url.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-more/typed/net/url.rkt
@@ -66,7 +66,9 @@
   [make-http-connection (-> HTTP-Connection)]
   [http-connection-close (HTTP-Connection -> Void)]
 
-  [call/input-url (case-lambda [url url (Input-Port -> Any) -> Any])] ;;FIXME - need polymorphism
+  [call/input-url (All (T) (case-lambda
+                             [url (url -> Input-Port) (Input-Port -> T) -> T]
+                             [url (url (Listof String) -> Input-Port) (Input-Port -> T) (Listof String) -> T]))]
 
   [current-proxy-servers (Parameter (Listof (List String String Integer)))]
 


### PR DESCRIPTION
The types are tweaked to match the contracts and to support passing a list of headers to the connect procedure.

The FIXME for polymorphism has also been removed as it is now parameterized to support "...The result of the handle procedure is the result of call/input-url..."
