### PR TITLE
Make generated struct contracts lazy.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -452,7 +452,7 @@
                 (t->sc fty #:recursive-values (hash-set
                                                 recursive-values
                                                 nm (recursive-sc-use nm*)))))
-            (recursive-sc (list nm*) (list (struct/sc nm (ormap values mut?) fields))
+            (recursive-sc (list nm*) (list (struct/sc nm acc-ids (ormap values mut?) fields))
                                 (recursive-sc-use nm*))]
            [else (flat/sc #`(flat-named-contract '#,(syntax-e pred?) #,pred?))])]
         [(Syntax: (Base: 'Symbol _ _ _)) identifier?/sc]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/struct.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/struct.rkt
@@ -11,39 +11,40 @@
 
 (provide
   (contract-out
-    [struct/sc (identifier? boolean? (listof static-contract?) . -> . static-contract?)])
+    [struct/sc (identifier? (listof identifier?) boolean? (listof static-contract?) . -> . static-contract?)])
   struct/sc:)
 
 
-(struct struct-combinator combinator (name mut?)
+(struct struct-combinator combinator (name acc-ids mut?)
   #:transparent
   #:property prop:combinator-name "struct/sc"
   #:methods gen:sc
     [(define (sc-map v f)
        (match v
-        [(struct-combinator args name mut?)
+        [(struct-combinator args name acc-ids mut?)
          (struct-combinator (map (λ (a) (f a (if mut? 'invariant 'covariant))) args)
-                            name mut?)]))
+                            name acc-ids mut?)]))
      (define (sc-traverse v f)
        (match v
-        [(struct-combinator args name mut?)
+        [(struct-combinator args name acc-ids mut?)
          (for-each (λ (a) (f a (if mut? 'invariant 'covariant))) args)
          (void)]))
      (define (sc->contract v f)
        (match v
-        [(struct-combinator args name _)
-         #`(struct/c #,name #,@(map f args))]))
+        [(struct-combinator args name acc-ids _)
+         #`(struct/dc #,name #,@(for/list ([arg args] [acc-id acc-ids])
+                                  #`((#:selector #,acc-id) () #:lazy #,(f arg))))]))
      (define (sc->constraints v f)
        (match v
-        [(struct-combinator args _ mut?)
+        [(struct-combinator args _ acc-ids mut?)
          (merge-restricts*
-           (if mut? 'chaperone 'flat)
+           'chaperone
            (map (lambda (a) (if (not mut?) (add-constraint (f a) 'chaperone) (f a))) args))]))])
 
-(define (struct/sc name mut? fields)
-  (struct-combinator fields name mut?))
+(define (struct/sc name acc-ids mut? fields)
+  (struct-combinator fields name acc-ids mut?))
 
 (define-match-expander struct/sc:
   (syntax-parser
     [(_ name fields)
-     #'(struct-combinator fields name _)]))
+     #'(struct-combinator fields name _ _)]))


### PR DESCRIPTION
This makes it so generated struct contracts are lazy instead of strict. This makes contract checking O(1) instead of having to check the entire data structure on every pass through the contract boundary. The slow down is a factor of 60 for simple checks since chaperone structs are slower than flat structs on the constant factor.
