### PR TITLE
Optimize the argument of not

### DIFF
--- a/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
+++ b/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
@@ -1318,6 +1318,9 @@
 (test-comp '(lambda (x) (not (if x #f 2)))
            '(lambda (x) (not (if x #f #t))))
 
+(test-comp '(not (list 2))
+           '#f)
+
 (test-comp '(lambda (x) (if x x #f))
            '(lambda (x) x))
 (test-comp '(lambda (x) (if (cons 1 x) 78 78))

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -2511,7 +2511,8 @@ static Scheme_Object *try_reduce_predicate(Scheme_Object *rator, Scheme_Object *
 /* Change (pair? (list X complex-Y Z)) => (begin complex-Y #t), etc.
    So much more could be done with type inference, but we're checking some
    known predicates against the results of some known constructors, because
-   it's especially nice to avoid the constructions. */
+   it's especially nice to avoid the constructions.
+   Also change (not (list X complex-Y Z)) => (begin complex-Y #f) */
 {
   int i, count, matches;
   Scheme_Object *arg, *pred;
@@ -2520,7 +2521,8 @@ static Scheme_Object *try_reduce_predicate(Scheme_Object *rator, Scheme_Object *
   if (!SCHEME_PRIMP(arg_rator))
     return NULL;
 
-  if (!relevant_predicate(rator))
+  if (!relevant_predicate(rator)
+      && !SAME_PTR(scheme_not_prim, rator))
     return NULL;
 
   if (arg_app2)


### PR DESCRIPTION
Optimize the argument of a “not” in a Boolean context. Also, recognize some constructors to eliminate them from the “not” argument. 

(not (if x y 1)) => (not (if x y #t))
(not (list x (random) z)) => (begin (random) #f))
## 

But this still doesn’t work: (not (if x y (list 1 2))) => (not (if x y #t))
