### PR TITLE
Add better support for functions that return Nothing. 

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/annotate-classes.rkt
@@ -4,7 +4,11 @@
          syntax/parse/experimental/template
          "../private/parse-classes.rkt"
          "../private/syntax-properties.rkt"
-         (for-label "colon.rkt"))
+         "../utils/literal-syntax-class.rkt"
+         (for-meta -1 (only-in "base-types-extra.rkt" U ->))
+         (for-label "colon.rkt"
+                    (only-in "base-types-extra.rkt" Values)
+                    (only-in racket/base values)))
 (provide (all-defined-out))
 
 ;; Data definitions
@@ -48,12 +52,26 @@
            #:attr ty #f
            #:with ann-name #'n))
 
-(define-splicing-syntax-class (param-annotated-name trans)
+(define-literal-syntax-class #:for-label Values)
+(define-literal-syntax-class #:for-label values)
+
+(define-splicing-syntax-class cont-annotated-name
   #:attributes (name ty ann-name)
-  #:description "type-annotated identifier"
+  #:description "type-annotated continuation identifier"
   #:literal-sets (colon)
   (pattern [~seq name:id : ty]
-           #:with ann-name (type-label-property #'name (trans #'ty))))
+           #:with ann-name (type-label-property
+                            #'name
+                            (syntax-parse #'ty
+                              [((~or :Values^ :values^)
+                                tys ... dty
+                                :ddd/bound)
+                               #'(tys ... dty -> (U))]
+                              [((~or :Values^ :values^) tys ... dty _:ddd)
+                               #'(tys ... dty -> (U))]
+                              [((~or :Values^ :values^) tys ...)
+                               #'(tys ... -> (U))]
+                              [t #'(t -> (U))]))))
 
 (define-syntax-class annotated-binding
   #:attributes (name ty ann-name binding rhs)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -548,9 +548,11 @@
                   ((-lst b) b) . ->... .(-lst c))))]
 [for-each (-polydots (a b) ((list ((list a) (b b) . ->... . Univ) (-lst a))
                             ((-lst b) b) . ->... . -Void))]
-#;[fold-left (-polydots (c a b) ((list ((list c a) (b b) . ->... . c) c (-lst a))
+#;
+[fold-left (-polydots (c a b) ((list ((list c a) (b b) . ->... . c) c (-lst a))
                                ((-lst b) b) . ->... . c))]
-#;[fold-right (-polydots (c a b) ((list ((list c a) (b b) . ->... . c) c (-lst a))
+#;
+[fold-right (-polydots (c a b) ((list ((list c a) (b b) . ->... . c) c (-lst a))
                                 ((-lst b) b) . ->... . c))]
 [foldl
  (-poly (a b c d)
@@ -1033,7 +1035,7 @@
 [values (-polydots (a b) (cl->*
                            (-> (-values null))
                            (->acc (list a) a null)
-                           ((list a) (b b) . ->... . (make-ValuesDots (list (-result a)) b 'b))))]
+                           ((list a) (b b) . ->... . (simple-ValuesDots (list (-result a)) b 'b))))]
 [call-with-values
   (-polydots (b a)
     (cl->*
@@ -1107,8 +1109,17 @@
        ;; return type here
        (make-ValuesDots '() a 'a)))]
 [call-with-escape-continuation
- (-poly (a b) (((a . -> . (Un)) . -> . b) . -> . (Un a b)))]
-[call/ec (-poly (a b) (((a . -> . (Un)) . -> . b) . -> . (Un a b)))]
+ (-polydots (a b c)
+   (cl->* (-> (-> (-> (Un)) (-values null)) (-values null))
+          (-> (-> (->... (list a) (c c) (Un))
+                  (simple-ValuesDots (list (-result b)) c 'c))
+              (simple-ValuesDots (list (-result (Un a b))) c 'c))))]
+[call/ec
+ (-polydots (a b c)
+   (cl->* (-> (-> (-> (Un)) (-values null)) (-values null))
+          (-> (-> (->... (list a) (c c) (Un))
+                  (simple-ValuesDots (list (-result b)) c 'c))
+              (simple-ValuesDots (list (-result (Un a b))) c 'c))))]
 [call-with-continuation-barrier (-poly (a) (-> (-> a) a))]
 [continuation-prompt-available? (-> (make-Prompt-TagTop) B)]
 [continuation?

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/prims.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/prims.rkt
@@ -1177,7 +1177,7 @@ This file defines two sorts of primitives. All of them are provided into any mod
   (let ()
     (define ((mk l/c) stx)
       (syntax-parse stx
-       [(_ (~or (~var k (param-annotated-name (lambda (s) #`(#,s -> (U)))))
+       [(_ (~or k:cont-annotated-name
                 (~and k:id (~bind [k.ann-name #'k]))) . body)
         (quasisyntax/loc stx (#,l/c k.ann-name . body))]))
     (values (mk #'let/cc) (mk #'let/ec))))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/core.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/core.rkt
@@ -94,7 +94,7 @@
                                [(tc-results: t)
                                 (define tcs (map cleanup-type t))
                                 (define tgs (map generalize tcs))
-                                (define tgs-val (make-Values (map -result tgs)))
+                                (define tgs-val (simple-Values (map -result tgs)))
                                 (define formatted (pretty-format-type tgs-val #:indent 4))
                                 (define indented? (regexp-match? #rx"\n" formatted))
                                 (format "- : ~a~a~a\n"
@@ -102,7 +102,7 @@
                                         (cond [(andmap equal? tgs tcs) ""]
                                               [indented?
                                                (format "\n[more precisely: ~a]"
-                                                       (pretty-format-type (make-Values tcs) #:indent 17))]
+                                                       (pretty-format-type (simple-Values tcs) #:indent 17))]
                                               [else (format " [more precisely: ~a]" (cons 'Values tcs))])
                                         ;; did any get pruned?
                                         (cond [(andmap equal? t tcs) ""]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -46,7 +46,7 @@
 ;; Type Type Seen -> Seen
 ;; Add the type pair to the set of seen type pairs
 (define/cond-contract (remember s t A)
-  ((or/c AnyValues? Values/c ValuesDots?) (or/c AnyValues? Values/c ValuesDots?)
+  (SomeValues/c SomeValues/c
    (listof (cons/c exact-nonnegative-integer?
                    exact-nonnegative-integer?))
    . -> .
@@ -57,7 +57,7 @@
 ;; Type Type -> Boolean
 ;; Check if a given type pair have been seen before
 (define/cond-contract (seen? s t cs)
-  ((or/c AnyValues? Values/c ValuesDots?) (or/c AnyValues? Values/c ValuesDots?)
+  (SomeValues/c SomeValues/c
    (listof (cons/c exact-nonnegative-integer?
                    exact-nonnegative-integer?))
    . -> . any/c)
@@ -353,7 +353,7 @@
 ;; the index variables from the TOPLAS paper
 (define/cond-contract (cgen V X Y S T)
   ((listof symbol?) (listof symbol?) (listof symbol?)
-   (or/c Values/c ValuesDots? AnyValues?) (or/c Values/c ValuesDots? AnyValues?)
+   SomeValues/c SomeValues/c
    . -> . (or/c #F cset?))
   ;; useful quick loop
   (define/cond-contract (cg S T)
@@ -650,7 +650,7 @@
 ;; Y : (listof symbol?) - index variables that must have entries
 ;; R : Type/c - result type into which we will be substituting
 (define/cond-contract (subst-gen C X Y R)
-  (cset? (listof symbol?) (listof symbol?) (or/c Values/c AnyValues? ValuesDots?)
+  (cset? (listof symbol?) (listof symbol?) SomeValues/c
    . -> . (or/c #f substitution/c))
   (define var-hash (free-vars-hash (free-vars* R)))
   (define idx-hash (free-vars-hash (free-idxs* R)))
@@ -751,7 +751,7 @@
   (define/cond-contract (infer X Y S T R [expected #f])
     (((listof symbol?) (listof symbol?) (listof Type/c) (listof Type/c)
       (or/c #f Values/c ValuesDots?))
-     ((or/c #f Values/c AnyValues? ValuesDots?))
+     ((or/c #f SomeValues/c))
      . ->* . (or/c boolean? substitution/c))
     (let* ([expected-cset (if expected
                               (cgen null X Y R expected)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/signatures.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/signatures.rkt
@@ -33,7 +33,7 @@
                             ;; range
                             (or/c #f Values/c ValuesDots?))
                            ;; optional expected type
-                           ((or/c #f Values/c AnyValues? ValuesDots?))
+                           ((or/c #f SomeValues/c))
                            . ->* . any)]
    [cond-contracted infer/vararg ((;; variables from the forall
                                    (listof symbol?)
@@ -48,7 +48,7 @@
                                    ;; range
                                    (or/c #f Values/c ValuesDots?))
                                   ;; [optional] expected type
-                                  ((or/c #f Values/c AnyValues? ValuesDots?)) . ->* . any)]
+                                  ((or/c #f SomeValues/c)) . ->* . any)]
    [cond-contracted infer/dots (((listof symbol?)
                                  symbol?
                                  (listof Values/c)
@@ -56,4 +56,4 @@
                                  Values/c
                                  (or/c Values/c ValuesDots?)
                                  (listof symbol?))
-                                (#:expected (or/c #f Values/c AnyValues? ValuesDots?)) . ->* . any)]))
+                                (#:expected (or/c #f SomeValues/c)) . ->* . any)]))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-metafunctions.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-metafunctions.rkt
@@ -26,9 +26,9 @@
     [(tc-any-results: f)
      (-AnyValues f)]
     [(tc-results: ts fs os)
-     (make-Values (map -result ts fs os))]
+     (simple-Values (map -result ts fs os))]
     [(tc-results: ts fs os dty dbound)
-     (make-ValuesDots (map -result ts fs os) dty dbound)]))
+     (simple-ValuesDots (map -result ts fs os) dty dbound)]))
 
 (define/cond-contract (resolve atoms prop)
   ((listof Filter/c)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/abbrev.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/abbrev.rkt
@@ -74,14 +74,14 @@
   (c:-> (c:listof Type/c) (c:or/c Type/c Values?))
   (match args
     ;[(list t) t]
-    [_ (make-Values (for/list ([i (in-list args)]) (-result i)))]))
+    [_ (simple-Values (for/list ([i (in-list args)]) (-result i)))]))
 
 ;; Convenient constructor for ValuesDots
 ;; (wraps arg types with Result)
 (define/cond-contract (-values-dots args dty dbound)
   (c:-> (c:listof Type/c) Type/c (c:or/c symbol? c:natural-number/c)
         ValuesDots?)
-  (make-ValuesDots (for/list ([i (in-list args)]) (-result i))
+  (simple-ValuesDots (for/list ([i (in-list args)]) (-result i))
                    dty dbound))
 
 ;; Basic types

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -90,6 +90,23 @@
       [args
        (make-union* (remove-dups (sort (append-map flat args) type<?)))])))
 
+(define (Bottom-Result? r)
+  (match r
+    [(Result: t f _)
+     (or (equal? t -Bottom)
+         (filter-equal? f -bot-filter))]
+    [_ #f]))
+
+(define (simple-Values rs)
+  (if (ormap Bottom-Result? rs)
+      -BotValues
+      (make-Values rs)))
+
+(define (simple-ValuesDots rs dty dbound)
+  (if (ormap Bottom-Result? rs)
+      -BotValues
+      (make-ValuesDots rs dty dbound)))
+
 ;; Recursive types
 (define-syntax -v
   (syntax-rules ()
@@ -171,8 +188,12 @@
 ;; return type of functions
 (define (-AnyValues f) (make-AnyValues f))
 (define/decl ManyUniv (make-AnyValues -top))
+(define/decl -BotValues (make-Values (list (make-Result -Bottom -bot-filter -empty-obj))))
+(define-match-expander BotValues:
+  (λ (stx) (syntax-case stx ()
+             [(_) #'(Values: (list (? Bottom-Result?)))])))
 
-;; Function types
+;; function types
 (define/cond-contract (make-arr* dom rng
                                  #:rest [rest #f] #:drest [drest #f] #:kws [kws null]
                                  #:filters [filters -top-filter] #:object [obj -empty-obj])
@@ -184,7 +205,7 @@
           #:object Object?)
          arr?)
   (make-arr dom (if (Type/c? rng)
-                    (make-Values (list (-result rng filters obj)))
+                    (simple-Values (list (-result rng filters obj)))
                     rng)
             rest drest (sort #:key Keyword-kw kws keyword<?)))
 

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/filter-ops.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/filter-ops.rkt
@@ -247,7 +247,7 @@
           (make-Function
            (list (make-arr
                   dom
-                  (make-Values
+                  (simple-Values
                    (list (-result tp
                                   (-FS (-and -true-filter new-filters)
                                        (-and -false-filter new-filters))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/substitute.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/substitute.rkt
@@ -4,7 +4,8 @@
          racket/match racket/set
          racket/lazy-require
          (contract-req)
-         (only-in (types base-abbrev) -Tuple* -lst -Null -result ManyUniv)
+         (only-in (types base-abbrev)
+                  -Tuple* -lst -Null -result ManyUniv simple-Values simple-ValuesDots)
          (rep type-rep rep-utils)
          (utils tc-utils)
          (rep free-variance)
@@ -70,7 +71,7 @@
                                  [(ormap (lambda (x) (and (equal? dbound x) (not (bound-tvar? x)))) names) =>
                                   (lambda (name)
                                     (int-err "substitute used on ... variable ~a in type ~a" name target))]
-                                 [else (make-ValuesDots (map sb types) (sb dty) dbound)])]
+                                 [else (simple-ValuesDots (map sb types) (sb dty) dbound)])]
                  [#:ListDots dty dbound
                              (cond
                                [(ormap (lambda (x) (and (equal? dbound x) (not (bound-tvar? x)))) names) =>
@@ -105,14 +106,14 @@
                                (if (eq? name dbound)
                                    (if rimage
                                        ManyUniv
-                                       (make-Values
+                                       (simple-Values
                                         (append
                                          (map sb types)
                                          ;; We need to recur first, just to expand out any dotted usages of this.
                                          (let ([expanded (sb dty)])
                                            (for/list ([img (in-list images)])
                                              (-result (substitute img name expanded)))))))
-                                   (make-ValuesDots (map sb types) (sb dty) dbound))]
+                                   (simple-ValuesDots (map sb types) (sb dty) dbound))]
                  [#:arr dom rng rest drest kws
                         (if (and (pair? drest)
                                  (eq? name (cdr drest)))
@@ -144,7 +145,7 @@
                  target
                  [#:ValuesDots types dty dbound
                                (let ([extra-types (if (eq? name dbound) pre-image null)])
-                                 (make-ValuesDots (append (map sb types) (map -result extra-types))
+                                 (simple-ValuesDots (append (map sb types) (map -result extra-types))
                                                   (sb dty)
                                                   (if (eq? name dbound) image-bound dbound)))]
                  [#:ListDots dty dbound

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -549,7 +549,8 @@
          ;; subtyping on structs follows the declared hierarchy
          [((Struct: nm (? Type/c? parent) _ _ _ _) other)
           (subtype* A0 parent other)]
-         ;; subtyping on values is pointwise
+         ;; subtyping on values is pointwise, except in the BotValues case.
+         [((BotValues:) (or (BotValues:) (Values: _) (ValuesDots: _ _ _) (AnyValues: _))) A0]
          [((Values: vals1) (Values: vals2)) (subtypes* A0 vals1 vals2)]
          [((ValuesDots: s-rs s-dty dbound) (ValuesDots: t-rs t-dty dbound))
           (subtype-seq A0
@@ -563,7 +564,9 @@
           (for/or ([f (in-list fs)])
             (match f
               [(FilterSet: f+ f-)
-               (and (filter-subtype* A0 f+ t-f) (filter-subtype* A0 f+ t-f) A0)]))]
+               (subtype-seq A0
+                            (filter-subtype* f+ t-f)
+                            (filter-subtype* f- t-f))]))]
          [((Result: t (FilterSet: ft ff) o) (Result: t* (FilterSet: ft* ff*) o))
           (subtype-seq A0
                        (subtype* t t*)


### PR DESCRIPTION
This includes a better type for call/ec. We should consider copying call/ec's type to call/cc too.
Inference could be better to support this without inst:
((inst call/ec Integer Integer Integer)
 (lambda ([f : (Integer Integer -> Nothing)]) (f 0 0)))
