### PR TITLE
Add equality operations for Reps.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -30,7 +30,12 @@
 ;; free-vars: cached free type variables
 ;; free-idxs: cached free dot sequence variables
 ;; stx: originating syntax for error-reporting
-(define-struct Rep (seq free-vars free-idxs stx) #:transparent)
+(define-struct Rep (seq free-vars free-idxs stx) #:transparent
+               #:methods gen:equal+hash
+               [(define (equal-proc x y recur)
+                  (eq? (unsafe-Rep-seq x) (unsafe-Rep-seq y)))
+                (define (hash-proc x recur) (unsafe-Rep-seq x))
+                (define (hash2-proc x recur) (unsafe-Rep-seq x))])
 
 ;; evil tricks for hygienic yet unhygienic-looking reference
 ;; in say def-type for type-ref-id


### PR DESCRIPTION
This speeds up microbenchmarks by 50%, and new-metrics.rkt by 30%.

My microbenchmarks show that `type-equal?` is still an order of magnitude faster on non `eq?` values. Two options to persue are to use `type-equal?` everywhere or get it so that `eq?` is enough. I think we should be able to do the second with some work.
