### PR TITLE
optimizer: test use of virtual clock in branches

### DIFF
--- a/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
+++ b/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
@@ -1575,6 +1575,13 @@
            '(lambda (x y)
               (list (if x x y) (+ x y))))
 
+(test-comp '(lambda (x y)
+              (let ([z (car y)])
+                (if x x z)))
+           '(lambda (x y)
+              (if x x (car y)))
+           #f)
+
 (test-comp '(let-values ([(x y) (values 1 2)])
               (+ x y))
            3)


### PR DESCRIPTION
I tried to remove the vclock increment in the branches of an if expression. It was wrong, but no test in optimize.rktl detected it. (The change I tried breaks some tests for unrelated modules.) 
