### PR TITLE
Many changes to avoid generic equals.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/core.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/core.rkt
@@ -85,9 +85,9 @@
                                 (define tg (generalize tc))
                                 (format "- : ~a~a~a\n"
                                         (pretty-format-type tg #:indent 4)
-                                        (cond [(equal? tc tg) ""]
+                                        (cond [(type-equal? tc tg) ""]
                                               [else (format " [more precisely: ~a]" tc)])
-                                        (cond [(equal? tc t) ""]
+                                        (cond [(type-equal? tc t) ""]
                                               [did-I-suggest-:print-type-already? " ..."]
                                               [else (set! did-I-suggest-:print-type-already? #t)
                                                     :print-type-message]))]
@@ -99,13 +99,13 @@
                                 (define indented? (regexp-match? #rx"\n" formatted))
                                 (format "- : ~a~a~a\n"
                                         formatted
-                                        (cond [(andmap equal? tgs tcs) ""]
+                                        (cond [(andmap type-equal? tgs tcs) ""]
                                               [indented?
                                                (format "\n[more precisely: ~a]"
                                                        (pretty-format-type (make-Values tcs) #:indent 17))]
                                               [else (format " [more precisely: ~a]" (cons 'Values tcs))])
                                         ;; did any get pruned?
-                                        (cond [(andmap equal? t tcs) ""]
+                                        (cond [(andmap type-equal? t tcs) ""]
                                               [did-I-suggest-:print-type-already? " ..."]
                                               [else (set! did-I-suggest-:print-type-already? #t)
                                                     :print-type-message]))]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/init-envs.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/env/init-envs.rkt
@@ -64,17 +64,19 @@
      `(-lst ,(sub elem-ty))]
     [(Function: (list (arr: dom (Values: (list (Result: t (FilterSet: (Top:) (Top:)) (Empty:)))) #f #f '())))
      `(simple-> (list ,@(map sub dom)) ,(sub t))]
-    [(Function: (list (arr: dom (Values: (list (Result: t (FilterSet: (TypeFilter: ft pth)
-                                                                      (NotTypeFilter: ft pth))
+    [(Function: (list (arr: dom (Values: (list (Result: t (FilterSet: (TypeFilter: ft obj)
+                                                                      (NotTypeFilter: ft obj*))
                                                         (Empty:))))
                             #f #f '())))
-     `(make-pred-ty (list ,@(map sub dom)) ,(sub t) ,(sub ft) ,(sub pth))]
-    [(Function: (list (arr: dom (Values: (list (Result: t (FilterSet: (NotTypeFilter: (== -False)
+     #:when (object-equal? obj obj*)
+     `(make-pred-ty (list ,@(map sub dom)) ,(sub t) ,(sub ft) ,(sub obj))]
+    [(Function: (list (arr: dom (Values: (list (Result: t (FilterSet: (NotTypeFilter: (== -False type-equal?)
                                                                                       (Path: pth (list 0 0)))
-                                                                      (TypeFilter: (== -False)
-                                                                                   (Path: pth (list 0 0))))
-                                                        (Path: pth (list 0 0)))))
+                                                                      (TypeFilter: (== -False type-equal?)
+                                                                                   (Path: pth* (list 0 0))))
+                                                        (Path: pth** (list 0 0)))))
                             #f #f '())))
+     #:when (and (andmap object-equal? pth pth*) (andmap object-equal? pth pth**))
      `(->acc (list ,@(map sub dom)) ,(sub t) ,(sub pth))]
     [(Result: t (FilterSet: (Top:) (Top:)) (Empty:)) `(-result ,(sub t))]
     [(Union: elems) (split-union elems)]
@@ -101,7 +103,7 @@
                                             (quote ,c) ,(sub b))]
     [(Class: row inits fields methods augments init-rest)
      (cond [(and (current-class-cache)
-                 (dict-ref (unbox (current-class-cache)) v #f)) => car]
+                 (dict-ref (unbox (current-class-cache)) (Rep-seq v) #f)) => car]
            [else
             ;; FIXME: there's probably a better way to do this
             (define (convert members [inits? #f])
@@ -120,7 +122,7 @@
             (define cache-box (current-class-cache))
             (when cache-box
               (set-box! cache-box
-                        (dict-set (unbox cache-box) v (list name class-type))))
+                        (dict-set (unbox cache-box) (Rep-seq v) (list name class-type))))
             (if cache-box name class-type)])]
     [(arr: dom rng rest drest kws)
      `(make-arr ,(sub dom) ,(sub rng) ,(sub rest) ,(sub drest) ,(sub kws))]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/constraint-structs.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/constraint-structs.rkt
@@ -4,7 +4,13 @@
 
 ;; S, T types
 ;; represents S <: X <: T (see "Local Type Inference" pg. 12)
-(define-struct/cond-contract c ([S Type/c] [T Type/c]) #:transparent)
+(define-struct/cond-contract c ([S Type/c] [T Type/c]) #:transparent
+  #:methods gen:equal+hash
+  [(define (equal-proc x y recur)
+     (and (type-equal? (c-S x) (c-S y))
+          (type-equal? (c-T x) (c-T y))))
+   (define (hash-proc x recur) (+ (recur (c-S x)) (recur (c-T x))))
+   (define (hash2-proc x recur) (+ (recur (c-S x)) (recur (c-T x))))])
 
 ;; fixed : Listof[c]
 ;; rest : option[c]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/constraints.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/constraints.rkt
@@ -67,15 +67,14 @@
     [(x y)
      (match* (x y)
       [((struct cset (maps1)) (struct cset (maps2)))
-       (define maps (for*/list ([(map1 dmap1) (in-pairs (remove-duplicates maps1))]
-                                [(map2 dmap2) (in-pairs (remove-duplicates maps2))]
+       (define maps (for*/list ([(map1 dmap1) (in-pairs (in-list (remove-duplicates maps1)))]
+                                [(map2 dmap2) (in-pairs (in-list (remove-duplicates maps2)))]
                                 [v (in-value (% cons
                                                 (hash-union/fail map1 map2 #:combine c-meet)
                                                 (dmap-meet dmap1 dmap2)))]
                                 #:when v)
                       v))
-       (cond [(null? maps)
-              #f]
+       (cond [(null? maps) #f]
              [else (make-cset maps)])])]
     [(x . ys)
      (for/fold ([x x]) ([y (in-list ys)])

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/infer-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/infer-unit.rkt
@@ -187,18 +187,24 @@
 (define/cond-contract (cgen/filter V X Y s t)
   ((listof symbol?) (listof symbol?) (listof symbol?) Filter? Filter? . -> . (or/c #f cset?))
   (match* (s t)
-    [(e e) (empty-cset X Y)]
+    [(e1 e2) #:when (filter-equal? e1 e2)
+     (empty-cset X Y)]
     [(e (Top:)) (empty-cset X Y)]
     ;; FIXME - is there something to be said about the logical ones?
-    [((TypeFilter: s p) (TypeFilter: t p)) (cgen/inv V X Y s t)]
-    [((NotTypeFilter: s p) (NotTypeFilter: t p)) (cgen/inv V X Y s t)]
+    [((TypeFilter: s p1) (TypeFilter: t p2))
+     #:when (object-equal? p1 p2)
+     (cgen/inv V X Y s t)]
+    [((NotTypeFilter: s p1) (NotTypeFilter: t p2))
+     #:when (object-equal? p1 p2)
+     (cgen/inv V X Y s t)]
     [(_ _) #f]))
 
 ;; s and t must be *latent* filter sets
 (define/cond-contract (cgen/filter-set V X Y s t)
   ((listof symbol?) (listof symbol?) (listof symbol?) FilterSet? FilterSet? . -> . (or/c #f cset?))
   (match* (s t)
-    [(e e) (empty-cset X Y)]
+    [(e1 e2) #:when (filter-equal? e1 e2)
+     (empty-cset X Y)]
     [((FilterSet: s+ s-) (FilterSet: t+ t-))
      (% cset-meet (cgen/filter V X Y s+ t+) (cgen/filter V X Y s- t-))]
     [(_ _) #f]))
@@ -206,7 +212,8 @@
 (define/cond-contract (cgen/object V X Y s t)
   ((listof symbol?) (listof symbol?) (listof symbol?) Object? Object? . -> . (or/c #f cset?))
   (match* (s t)
-    [(e e) (empty-cset X Y)]
+    [(e1 e2) #:when (object-equal? e1 e2)
+     (empty-cset X Y)]
     [(e (Empty:)) (empty-cset X Y)]
     ;; FIXME - do something here
     [(_ _) #f]))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/optimizer/unboxed-let.rkt
@@ -142,7 +142,7 @@
                          [dom doms]
                          [i (in-naturals)])
                 (cond
-                  [(and (equal? dom -FloatComplex)
+                  [(and (type-equal? dom -FloatComplex)
                         (could-be-unboxed-in?
                           param
                           #'(begin body ...)))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/parse-type.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/parse-type.rkt
@@ -371,7 +371,7 @@
                (let loop ((ty t*))
                  (match ty
                   [(Union: elems) (andmap loop elems)]
-                  [(F: _) (not (equal? ty tvar))]
+                  [(F: _) (not (type-equal? ty tvar))]
                   [(App: rator rands stx)
                    (loop (resolve-app rator rands stx))]
                   [(Mu: _ body) (loop body)]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-annotation.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-annotation.rkt
@@ -88,7 +88,7 @@
                 (tc-error/expr
                   "Expression should produce ~a values, but produces an unknown number of values"
                   (length stxs))]
-               [(tc-results: (list (== -Bottom)) _ _)
+               [(tc-results: (list (== -Bottom type-equal?)) _ _)
                 (for/list ([_ (in-range (length stxs))])
                   (tc-result -Bottom))]
                [(tc-results: tys fs os)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/private/type-contract.rkt
@@ -534,7 +534,7 @@
            [(arr: dom (Values: (list (Result: rngs (FilterSet: (Top:) (Top:)) (Empty:)) ...)) rst drst kws)
             (convert-arr a)]
            ;; Functions that don't return
-           [(arr: dom (Values: (list (Result: (== -Bottom) _ _) ...)) rst drst kws)
+           [(arr: dom (Values: (list (Result: (== -Bottom type-equal?) _ _) ...)) rst drst kws)
             (convert-arr a)]
            ;; functions with filters or objects
            [(arr: dom (Values: (list (Result: rngs _ _) ...)) rst drst kws)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/filter-rep.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/filter-rep.rkt
@@ -64,4 +64,3 @@
 ;; should only be used for parsing type annotations and expected types
 (def-filter NoFilter () [#:fold-rhs #:base])
 
-(define (filter-equal? a b) (= (Rep-seq a) (Rep-seq b)))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/rep-utils.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/rep-utils.rkt
@@ -24,8 +24,9 @@
   ["../types/printer.rkt" (print-type print-filter print-object print-pathelem)])
 
 
-(provide == defintern hash-id (for-syntax fold-target))
+(provide == defintern hash-id (for-syntax fold-target) raise-error)
 
+(define raise-error (make-parameter #t))
 ;; seq: interning-generated count that is used to compare types (type<).
 ;; free-vars: cached free type variables
 ;; free-idxs: cached free dot sequence variables
@@ -33,6 +34,8 @@
 (define-struct Rep (seq free-vars free-idxs stx) #:transparent
                #:methods gen:equal+hash
                [(define (equal-proc x y recur)
+                  (when (raise-error)
+                    (error 'equal))
                   (eq? (unsafe-Rep-seq x) (unsafe-Rep-seq y)))
                 (define (hash-proc x recur) (unsafe-Rep-seq x))
                 (define (hash2-proc x recur) (unsafe-Rep-seq x))])
@@ -389,6 +392,7 @@
 
 (provide/cond-contract
   [rename rep-equal? type-equal? (Type? Type? . -> . boolean?)]
+  [rename rep-equal? filter-equal? (Filter? Filter? . -> . boolean?)]
   [rename rep<? type<? (Type? Type? . -> . boolean?)]
   [rename rep<? filter<? (Filter? Filter? . -> . boolean?)]
   [struct Rep ([seq exact-nonnegative-integer?]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/type-rep.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/rep/type-rep.rkt
@@ -488,6 +488,12 @@
                [augments (listof (list/c symbol? Function?))]
                [init-rest (or/c Type/c #f)])
   #:no-provide
+  [#:intern 
+    (list (map (λ (l) (list (first l) (Rep-seq (second l)) (third l))) inits)
+          (map (λ (l) (list (first l) (Rep-seq (second l)))) fields)
+          (map (λ (l) (list (first l) (Rep-seq (second l)))) methods)
+          (map (λ (l) (list (first l) (Rep-seq (second l)))) augments)
+          (and init-rest (Rep-seq init-rest)))]
   [#:frees (λ (f) (combine-frees
                    (map f (append (map cadr inits)
                                   (map cadr fields)
@@ -531,11 +537,9 @@
                            '())
                      ,(f row))))]
   [#:key 'class]
-  [#:fold-rhs (match (list row-ext row)
-                [(list row-ext row)
-                 (*Class
-                  (and row-ext (type-rec-id row-ext))
-                  (type-rec-id row))])])
+  [#:fold-rhs (*Class
+                (and row-ext (type-rec-id row-ext))
+                (type-rec-id row))])
 
 ;; cls : Class
 (def-type Instance ([cls Type/c]) [#:key 'instance])

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-below.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-below.rkt
@@ -114,7 +114,7 @@
 (define (check-below tr1 expected)
   (define (filter-set-better? f1 f2)
     (match* (f1 f2)
-      [(f f) #t]
+      [(f1 f2) #:when (filter-equal? f1 f2) #t]
       [(f (NoFilter:)) #t]
       [((FilterSet: f1+ f1-) (FilterSet: f2+ f2-))
        (and (implied-atomic? f2+ f1+)
@@ -122,7 +122,7 @@
       [(_ _) #f]))
   (define (object-better? o1 o2)
     (match* (o1 o2)
-      [(o o) #t]
+      [(o1 o2) #:when (object-equal? o1 o2) #t]
       [(o (or (NoObject:) (Empty:))) #t]
       [(_ _) #f]))
   (define (filter-better? f1 f2)
@@ -210,7 +210,10 @@
        (expected-but-got (stringify t2) (stringify t1)))
      (fix-results expected)]
 
-    [((tc-results: t1 fs os) (tc-results: t2 fs os))
+    [((tc-results: t1 fs1 os1) (tc-results: t2 fs2 os2)) (=> continue)
+     (when (= (length t1) (length t2))
+       (unless (and (andmap filter-equal? fs1 fs2) (andmap object-equal? os1 os2))
+         (continue)))
      (unless (= (length t1) (length t2))
        (value-mismatch expected tr1))
      (unless (for/and ([t (in-list t1)] [s (in-list t2)]) (subtype t s))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/check-class-unit.rkt
@@ -569,7 +569,7 @@
 ;; return true if the class member is already annotated
 (define (check-duplicate-member table name type)
   (and (hash-has-key? table name)
-       (not (equal? (hash-ref table name) type))
+       (not (type-equal? (hash-ref table name) type))
        (tc-error/expr/fields
         "duplicate type annotation in class"
         #:stx #`#,name
@@ -734,11 +734,11 @@
       (define maybe-type (dict-ref type-map external #f))
       (->* (list (make-Univ))
            (cond [(and maybe-type
-                       (not (equal? (car maybe-type) top-func))
+                       (not (type-equal? (car maybe-type) top-func))
                        (not inner?))
                   (function->method (car maybe-type) self-type)]
                  [(and maybe-type
-                       (not (equal? (car maybe-type) top-func)))
+                       (not (type-equal? (car maybe-type) top-func)))
                   (Un (-val #f)
                       (function->method (car maybe-type) self-type))]
                  [else (make-Univ)]))))
@@ -788,7 +788,7 @@
       (define pre-type (dict-ref type-map f #f))
       (define maybe-type (if (pair? pre-type) (car pre-type) pre-type))
       (or (and maybe-type
-               (not (equal? maybe-type top-func))
+               (not (type-equal? maybe-type top-func))
                (function->method maybe-type self-type))
           (make-Univ))))
 
@@ -869,7 +869,7 @@
     (cond [(and maybe-expected
                 ;; fall back to tc-expr/t if the annotated type
                 ;; was the default type (Procedure)
-                (not (equal? (car maybe-expected) top-func))
+                (not (type-equal? (car maybe-expected) top-func))
                 (set-member? names-to-check external-name))
            (define pre-method-type (car maybe-expected))
            (define method-type

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app-helper.rkt
@@ -289,7 +289,7 @@
                ([c (in-list fun-tys-ret-any)]
                 [p (in-list parts-acc)]
                 ;; if a case is a supertype of another, we discard it
-                #:unless (is-subsumed-in? c (remove c fun-tys-ret-any)))
+                #:unless (is-subsumed-in? c (remove c fun-tys-ret-any type-equal?)))
 
              (cons p parts-res)))
 

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-app/tc-app-main.rkt
@@ -91,7 +91,7 @@
                     (in-sequences (in-list dom) (in-cycle (in-value rest)))))))
             (for/list ([a (in-list args*)] [types matching-domains])
               (match-define (cons t ts) types)
-              (if (for/and ((t2 (in-list ts))) (equal? t t2))
+              (if (for/and ((t2 (in-list ts))) (type-equal? t t2))
                   (tc-expr/check a (ret t))
                   (single-value a)))]
            [_ (map single-value args*)]))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-metafunctions.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-metafunctions.rkt
@@ -112,7 +112,7 @@
      (tc-result
        (Un t1 t2)
        (-FS (-or f1+ f2+) (-or f1- f2-))
-       (if (equal? o1 o2) o1 -empty-obj))])
+       (if (object-equal? o1 o2) o1 -empty-obj))])
 
   (define/match (same-dty? r1 r2)
     [(#f #f) #t]
@@ -131,8 +131,8 @@
 
 
   (define/match (merge-two-results res1 res2)
-    [((tc-result1: (== -Bottom)) res2) res2]
-    [(res1 (tc-result1: (== -Bottom))) res1]
+    [((tc-result1: (== -Bottom type-equal?)) res2) res2]
+    [(res1 (tc-result1: (== -Bottom type-equal?))) res1]
     [((tc-any-results: f1) res2)
      (tc-any-results (-or f1 (unconditional-prop res2)))]
     [(res1 (tc-any-results: f2))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-toplevel.rkt
@@ -5,7 +5,7 @@
          racket/list unstable/list racket/dict racket/match unstable/sequence
          (prefix-in c: (contract-req))
          (rep type-rep free-variance)
-         (types utils abbrev type-table struct-table)
+         (types subtype utils abbrev type-table struct-table)
          (private parse-type type-annotation type-contract syntax-properties)
          (env global-env init-envs type-name-env type-alias-env
               lexical-env env-req mvar-env scoped-tvar-env

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/base-abbrev.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/base-abbrev.rkt
@@ -105,7 +105,7 @@
 (define/cond-contract (-result t [f -top-filter] [o -empty-obj])
   (c:->* (Type/c) (FilterSet? Object?) Result?)
   (cond
-    [(or (equal? t -Bottom) (equal? f -bot-filter))
+    [(or (type-equal? t -Bottom) (filter-equal? f -bot-filter))
      (make-Result -Bottom -bot-filter o)]
     [else
      (make-Result t f o)]))
@@ -144,8 +144,8 @@
   (cond
     [(and (identifier? i) (is-var-mutated? i)) -top]
     [(Empty? o) -top]
-    [(equal? Univ t) -top]
-    [(equal? -Bottom t) -bot]
+    [(Univ? t) -top]
+    [(type-equal? -Bottom t) -bot]
     [else (make-TypeFilter t o)]))
 
 
@@ -162,8 +162,8 @@
   (cond
     [(and (identifier? i) (is-var-mutated? i)) -top]
     [(Empty? o) -top]
-    [(equal? -Bottom t) -top]
-    [(equal? Univ t) -bot]
+    [(Univ? t) -bot]
+    [(type-equal? -Bottom t) -top]
     [else (make-NotTypeFilter t o)]))
 
 

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/kw-types.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/kw-types.rkt
@@ -4,6 +4,7 @@
          "../utils/tc-utils.rkt"
          "../base-env/annotate-classes.rkt"
          "tc-result.rkt"
+         "../rep/rep-utils.rkt"
          racket/list racket/set racket/dict racket/match
          racket/format racket/string
          syntax/parse)
@@ -68,7 +69,7 @@
     (if split?
         (remove-duplicates
           (list (make-arr* ts/true rng #:drest drest)
-                (make-arr* ts/false rng #:drest drest)))
+                (make-arr* ts/false rng #:drest drest)) type-equal?)
         (list (make-arr* ts rng #:rest rest #:drest drest)))))
 
 
@@ -170,7 +171,9 @@
 (define (kw-convert ft actual-kws #:split [split? #f])
   (match ft
     [(Function: arrs)
-     (inner-kw-convert arrs actual-kws split?)]
+     ;; TODO revert
+     (parameterize ([raise-error #f])
+       (inner-kw-convert arrs actual-kws split?))]
     [(Poly-names: names f)
      (make-Poly names (kw-convert f actual-kws #:split split?))]
     [(PolyDots-names: names f)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/printer.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/printer.rkt
@@ -241,12 +241,12 @@
          (list (type->sexp t))]
         [(Values: (list (Result: t
                                  (FilterSet: (TypeFilter: ft (Path: pth (list 0 0)))
-                                             (NotTypeFilter: ft (Path: pth (list 0 0))))
+                                             (NotTypeFilter: ft* (Path: pth* (list 0 0))))
                                  (Empty:))))
          ;; Only print a simple filter for single argument functions,
          ;; since parse-type only accepts simple latent filters on single
          ;; argument functions.
-         #:when (= 1 (length dom))
+         #:when (and (= 1 (length dom)) (type-equal? ft ft*) (andmap object-equal? pth pth*))
          (if (null? pth)
              `(,(type->sexp t) : ,(type->sexp ft))
              `(,(type->sexp t) : ,(type->sexp ft) @
@@ -489,7 +489,7 @@
     [(ValuesDots: v dty dbound)
      (cons 'values (append (map t->s v) (list (t->s dty) '... dbound)))]
     [(Param: in out)
-     (if (equal? in out)
+     (if (type-equal? in out)
          `(Parameterof ,(t->s in))
          `(Parameterof ,(t->s in) ,(t->s out)))]
     [(Hashtable: k v) `(HashTable ,(t->s k) ,(t->s v))]

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/remove-intersect.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/remove-intersect.rkt
@@ -103,7 +103,7 @@
          [(list (and t1 (Struct: _ _ _ _ _ _))
                 (and t2 (Struct: _ _ _ _ _ _)))
           (or (subtype t1 t2) (subtype t2 t1))]
-         [(list (== (-val eof))
+         [(list (== (-val eof) type-equal?)
                 (Function: _))
           #f]
          [else #t])])))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/subtype.rkt
@@ -139,7 +139,7 @@
 ;; check subtyping of filters, so that predicates subtype correctly
 (define (filter-subtype* A0 s t)
   (match* (s t)
-   [(f f) A0]
+   [(f1 f2) #:when (filter-equal? f1 f2) A0]
    [((Bot:) t) A0]
    [(s (Top:)) A0]
    [(_ _) #f]))
@@ -553,7 +553,7 @@
          [((Struct: nm (? Type/c? parent) _ _ _ _) other)
           (subtype* A0 parent other)]
          ;; subtyping on values is pointwise, except special case for Bottom
-         [((Values: (list (Result: (== -Bottom) _ _))) _)
+         [((Values: (list (Result: (== -Bottom type-equal?) _ _))) _)
           A0]
          [((Values: vals1) (Values: vals2)) (subtypes* A0 vals1 vals2)]
          [((ValuesDots: s-rs s-dty dbound) (ValuesDots: t-rs t-dty dbound))
@@ -571,7 +571,8 @@
                (subtype-seq A0
                             (filter-subtype* f+ t-f)
                             (filter-subtype* f- t-f))]))]
-         [((Result: t (FilterSet: ft ff) o) (Result: t* (FilterSet: ft* ff*) o))
+         [((Result: t (FilterSet: ft ff) o1) (Result: t* (FilterSet: ft* ff*) o2))
+          #:when (object-equal? o1 o2)
           (subtype-seq A0
                        (subtype* t t*)
                        (filter-subtype* ft ft*)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/utils.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/utils.rkt
@@ -93,10 +93,17 @@
       ;; Keyword args, range and rest specs all the same.
       (let* ([xs (map (match-lambda [(arr: _ rng rest-spec _ kws)
                                 (list rng rest-spec kws)])
-                      arrs)]
-             [first-x (first xs)])
-        (for/and ([x (in-list (rest xs))])
-          (equal? x first-x)))
+                      arrs)])
+        (match (first xs)
+          [(list rng1 rest1 kws1)
+           (for/and ([x (in-list (rest xs))])
+             (match x
+               [(list rng2 rest2 kws2)
+                (and (type-equal? rng1 rng2)
+                     (if rest1
+                         (and rest2 (type-equal? rest1 rest2))
+                         (not rest2))
+                     (andmap type-equal? kws1 kws2))]))]))
       ;; Positionals are monotonically increasing by at most one.
       (let-values ([(_ ok?)
                     (for/fold ([positionals (arr-dom (first arrs))]
@@ -110,7 +117,7 @@
                                  (and ok-so-far?
                                       (or (= ldom lpositionals)
                                           (= ldom (add1 lpositionals)))
-                                      (equal? positionals (take dom lpositionals))))]))])
+                                      (andmap type-equal? positionals (take dom lpositionals))))]))])
         ok?)))
 
 (provide/cond-contract

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/check-below-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/check-below-tests.rkt
@@ -5,7 +5,7 @@
          syntax/srcloc syntax/location
          (types abbrev union tc-result)
          (utils tc-utils)
-         (rep filter-rep object-rep type-rep)
+         (rep filter-rep object-rep type-rep rep-utils)
          (typecheck check-below)
          (for-syntax racket/base syntax/parse))
 
@@ -47,7 +47,7 @@
            (define result (check-below t1 t2))
            (with-check-info (['actual result])
              (check-result result)
-             (unless (equal? expected-result result)
+             (unless ((if (Type? expected-result) type-equal? tc-result-equal?) expected-result result)
                (fail-check "Check below did not return expected result.")))))]
     [(_ #:fail (~optional message:expr #:defaults [(message #'#rx"type mismatch")])
         t1:expr t2:expr
@@ -66,7 +66,7 @@
                    (report-all-errors)
                    (fail-check "Check below did not fail."))))
              (check-result result)
-             (unless (equal? expected-result result)
+             (unless ((if (Type? expected-result) type-equal? tc-result-equal?) expected-result result)
                (fail-check "Check below did not return expected result."))
              (check-regexp-match message (exn-message exn)))))]))
 


### PR DESCRIPTION
This is not ready for merge, but I wanted to put it out for comment. I found may places where we were using generic equals and replaced them with type specific ones. I found a small (2-3%) improvement in timing of for-vector. I think that it is worth keeping the changes that do not make the code harder to read, but not on the others. Thoughts?
