### PR TITLE
add @history[] lines for typed/racket/async-channel

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
+++ b/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/libraries.scrbl
@@ -72,6 +72,7 @@ The following libraries are included with Typed Racket in the
 @defmodule/incl[typed/openssl/sha1]
 @defmodule/incl[typed/pict]
 @defmodule/incl[typed/racket/async-channel]
+@history[#:added "6.0.1.13"]
 @defmodule/incl[typed/rackunit]
 @defmodule/incl[typed/srfi/14]
 @defmodule/incl[typed/syntax/stx]

--- a/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
+++ b/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/types.scrbl
@@ -418,6 +418,7 @@ corresponding to @racket[trest], where @racket[bound]
 (require typed/racket/async-channel)
 (ann (make-async-channel) (Async-Channelof Symbol))
 ]
+@history[#:added "6.0.1.13"]
 }
 
 @defidform[Async-ChannelTop]{is the type of an @rtech{asynchronous channel} with unknown
@@ -426,6 +427,7 @@ corresponding to @racket[trest], where @racket[bound]
   @racket[async-channel?].
 @ex[(require typed/racket/async-channel)
     (lambda: ([x : Any]) (if (async-channel? x) x (error "not an async-channel!")))]
+@history[#:added "6.0.1.13"]
 }
 
 @defform*[[(Parameterof t)


### PR DESCRIPTION
Don't merge, but wanted to check that I'm using the `@history[]` form properly.

In particular, the note in `libraries.scrbl` gets compiled to

```
Added in version 6.0.1.13 of package typed-racket-lib.
```

even though the library is part of `typed-racket-more`. But I'm not sure how to change that.
