### PR TITLE
Make subst-gen not require having all constraints bound.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/constraints.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/constraints.rkt
@@ -14,12 +14,9 @@
 ;; Widest constraint possible
 (define no-constraint (make-c (Un) Univ))
 
-;; Create an empty constraint map from a set of type variables X and
-;; index variables Y.  For now, we add the widest constraints for
-;; variables in X to the cmap and create an empty dmap.
-(define (empty-cset X Y)
-  (make-cset (list (cons (for/hash ([x (in-list X)])
-                           (values x no-constraint))
+;; An empty constraint map.
+(define empty-cset 
+  (make-cset (list (cons (hash) 
                          (make-dmap (make-immutable-hash null))))))
 
 
@@ -62,7 +59,7 @@
 ;; returns #f for failure
 (define cset-meet
   (case-lambda
-    [() (empty-cset null null)]
+    [() empty-cset]
     [(x) x]
     [(x y)
      (match* (x y)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/signatures.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/signatures.rkt
@@ -13,7 +13,7 @@
   ([cond-contracted cset-meet ((cset? cset?) #:rest (listof cset?) . ->* . (or/c #f cset?))]
    [cond-contracted cset-meet* ((listof cset?) . -> . (or/c #f cset?))]
    [cond-contracted no-constraint c?]
-   [cond-contracted empty-cset ((listof symbol?) (listof symbol?) . -> . cset?)]
+   [cond-contracted empty-cset cset?]
    [cond-contracted insert (cset? symbol? Type/c Type/c . -> . cset?)]
    [cond-contracted cset-join ((listof cset?) . -> . cset?)]
    [cond-contracted c-meet ((c? c?) (symbol?) . ->* . (or/c #f c?))]))


### PR DESCRIPTION
Removing this requirement means that we can produce more minimal csets when adding expected csets in later changes.
