### PR TITLE
Add test for mu and invariant recursive calls.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/infer-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/infer-tests.rkt
@@ -257,6 +257,17 @@
       #:vars '(a)
       #:result [(-seq (-v a)) (-seq (-val 'b))]]
 
+    ;; Test that two -mu types check recursive variance constraints
+    [infer-l
+      (list
+        (-mu A (Un (-val 'b) (-vec A)))
+        (-vec -Symbol))
+      (list
+        (-mu C (Un (-v b2) (-vec C)))
+        (-vec (-v b2)))
+      #:vars '(b2)
+      #:fail]
+
     ;; Currently Broken
     ;(infer-t (make-ListDots -Symbol 'b) (-pair -Symbol (-lst -Symbol)) #:indices '(b))
     [i2-t (-v a) N ('a N)]


### PR DESCRIPTION
This case used to generate a substitution and now doesn't. I believe this is the correct behavior because the substitution generated before (b2 = Symbol) does not correctly unify with the first item because of the unfolding inside the vector.

Can someone doublecheck my reasoning?
