### PR TITLE
Make struct overlap work correctly.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/restrict.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/infer/restrict.rkt
@@ -2,12 +2,41 @@
 
 (require "../utils/utils.rkt")
 (require (rep type-rep)
-         (types union subtype remove-intersect resolve)
+         (types union subtype remove-intersect resolve utils)
          "signatures.rkt"
+         unstable/sequence
          racket/match)
 
 (import infer^)
 (export restrict^)
+
+(define current-seen (make-parameter null))
+
+;; Type Type -> Pair<Seq, Seq>
+;; construct a pair for the set of seen type pairs
+(define (seen-before s t)
+  (cons (Type-seq s) (Type-seq t)))
+
+;; Type Type Seen -> Seen
+;; Add the type pair to the set of seen type pairs
+(define/cond-contract (remember s t A)
+  ((or/c AnyValues? Values/c ValuesDots?) (or/c AnyValues? Values/c ValuesDots?)
+   (listof (cons/c exact-nonnegative-integer?
+                   exact-nonnegative-integer?))
+   . -> .
+   (listof (cons/c exact-nonnegative-integer?
+                   exact-nonnegative-integer?)))
+ (cons (seen-before s t) A))
+
+;; Type Type -> Boolean
+;; Check if a given type pair have been seen before
+(define/cond-contract (seen? s t cs)
+  ((or/c AnyValues? Values/c ValuesDots?) (or/c AnyValues? Values/c ValuesDots?)
+   (listof (cons/c exact-nonnegative-integer?
+                   exact-nonnegative-integer?))
+   . -> . any/c)
+ (member (seen-before s t) cs))
+
 
 ;; we don't use union map directly, since that might produce too many elements
   (define (union-map f l)
@@ -16,22 +45,48 @@
        (let ([l (map f es)])
          (apply Un l))]))
 
+(define (restrict-fields flds flds* f)
+  (for/list ([fld (in-sequence-forever (in-list flds) #f)]
+             [fld* (in-list flds*)])
+    (if fld
+        (match* (fld fld*)
+         [((fld: t _ _) (fld: t* acc mut))
+          (make-fld (restrict t t* f) acc mut)])
+        fld*)))
+
+
 ;; NEW IMPL
 ;; restrict t1 to be a subtype of t2
 ;; if `f' is 'new, use t2 when giving up, otherwise use t1
 (define (restrict* t1 t2 [f 'new])
-  (cond
-    [(subtype t1 t2) t1] ;; already a subtype
-    [(match t2 
-       [(Poly: vars t)
-        (and (infer vars null (list t1) (list t) #f) t1)]
-       [_ #f])]
-    [(Union? t1) (union-map (lambda (e) (restrict* e t2 f)) t1)]
-    [(Union? t2) (union-map (lambda (e) (restrict* t1 e f)) t2)]
-    [(needs-resolving? t1) (restrict* (resolve-once t1) t2 f)]
-    [(needs-resolving? t2) (restrict* t1 (resolve-once t2) f)]
-    [(subtype t2 t1) t2] ;; we don't actually want this - want something that's a part of t1
-    [(not (overlap t1 t2)) (Un)] ;; there's no overlap, so the restriction is empty
-    [else (if (eq? f 'new) t2 t1)])) ;; t2 and t1 have a complex relationship, so we punt
+  (define default (if (eq? f 'new) t2 t1))
+  (define cs (current-seen))
+
+  (if (seen? t1 t2 cs)
+      default
+      (parameterize ([current-seen (remember t1 t2 cs)])
+        (cond
+          [(subtype t1 t2) t1] ;; already a subtype
+          [(match t2
+             [(Poly: vars t)
+              (and (infer vars null (list t1) (list t) #f) t1)]
+             [_ #f])]
+          [(Union? t1) (union-map (lambda (e) (restrict* e t2 f)) t1)]
+          [(Union? t2) (union-map (lambda (e) (restrict* t1 e f)) t2)]
+          [(needs-resolving? t1) (restrict* (resolve-once t1) t2 f)]
+          [(needs-resolving? t2) (restrict* t1 (resolve-once t2) f)]
+          [(and (Struct? t1) (Struct? t2) (ancestor-struct-type? t1 t2))
+           (match* (t1 t2)
+            [((Struct: _ _ flds _ _ _) (Struct: name parent flds* proc poly pred-id))
+             (define new-flds (restrict-fields flds flds* f))
+             (make-Struct name (and parent (restrict* t1 parent f)) new-flds proc poly pred-id)])]
+          [(and (Struct? t1) (Struct? t2) (ancestor-struct-type? t2 t1))
+           (match* (t2 t1)
+            [((Struct: _ _ flds _ _ _) (Struct: name parent flds* proc poly pred-id))
+             (define new-flds (restrict-fields flds flds* (if (eq? f 'new) 'old 'new)))
+             (make-Struct name (and parent (restrict* parent t2 f)) new-flds proc poly pred-id)])]
+          [(subtype t2 t1) t2] ;; we don't actually want this - want something that's a part of t1
+          [(not (overlap t1 t2)) (Un)] ;; there's no overlap, so the restriction is empty
+          [else default])))) ;; t2 and t1 have a complex relationship, so we punt
 
 (define restrict restrict*)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/remove-intersect.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/remove-intersect.rkt
@@ -96,20 +96,11 @@
                 (StructTop: (Struct: n* #f _ _ _ _))) (=> nevermind)
           (unless (free-identifier=? n n*) (nevermind))
           #t]
-         ;; n and n* must be different, so there's no overlap
-         [(list (Struct: n #f flds _ _ _)
-                (Struct: n* #f flds* _ _ _))
-          #f]
-         [(list (Struct: n #f flds _ _ _)
-                (StructTop: (Struct: n* #f flds* _ _ _)))
-          #f]
-         [(list (and t1 (Struct: _ _ _ _ _ _))
-                (and t2 (Struct: _ _ _ _ _ _)))
-          (or (subtype t1 t2) (subtype t2 t1))]
+         [(list (or (StructTop: t1) (? Struct? t1))
+                (or (StructTop: t2) (? Struct? t2)))
+          (or (ancestor-struct-type? t1 t2)
+              (ancestor-struct-type? t2 t1))]
          [else #t])])))
-
-
-;(trace overlap)
 
 ;; also not yet correct
 ;; produces old without the contents of rem
@@ -128,5 +119,3 @@
           [(list (Poly: vs b) t) (make-Poly vs (*remove b rem))]
           [_ old])))
   (if (subtype old initial) old initial))
-
-;(trace *remove)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/utils.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/types/utils.rkt
@@ -113,6 +113,14 @@
                                       (equal? positionals (take dom lpositionals))))]))])
         ok?)))
 
+
+;; Determines if t2 is an ancestor of t1
+(define (ancestor-struct-type? t1 t2)
+  (match* (t1 t2)
+    [((Struct: n _ _ _ _ _) (Struct: n* p* _ _ _ _))
+     (or (free-identifier=? n n*)
+         (and p* (ancestor-struct-type? t1 p*)))]))
+
 (provide/cond-contract
  [unfold (Mu? . -> . Type/c)]
  [instantiate-poly ((or/c Poly? PolyDots? PolyRow?) (listof Type/c)
@@ -124,5 +132,6 @@
  [fv/list ((listof Type/c) . -> . (set/c symbol?))]
  [current-poly-struct (parameter/c (or/c #f poly?))]
  [has-optional-args? (-> (listof arr?) any)]
+ [ancestor-struct-type? (Struct? Struct? . -> . boolean?)]
  )
 

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/struct-overlap.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/struct-overlap.rkt
@@ -1,0 +1,11 @@
+#lang typed/racket
+
+
+(struct (A) foo ([x : A]))
+(struct (A) bar foo ())
+
+
+(: test 'b)
+(define test
+  (let ((x (ann (bar 3) (foo Number))))
+    (if (bar? x) 'a 'b)))


### PR DESCRIPTION
This does 3 things.
1. Make remove intersect handle overlapping structs correctly.
2. Fix resulting breakage in restrict, by making restrict understand how
to instantiate type variables when restricting to a substruct.
3. Prevent infinite loops that occur when trying to acheive #2.
