### PR TITLE
Improve types of rest and cons.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -595,15 +595,9 @@
 [rest (-poly (a b)
              (cl->*
               (->acc (list (-pair a (-lst b))) (-lst b) (list -cdr))
-              (->* (list (-lst a)) (-lst a))))]
+              (->acc (list (-lst a)) (-lst a) (list -cdr))))]
 
-[cons (-poly (a b)
-             (cl->* [->* (list a (-lst a)) (-lst a)]
-                    [->* (list a b) (-pair a b)]))]
-#;[*cons (-poly (a b) (cl->
-                     [(a b) (-pair a b)]
-                     [(a (-lst a)) (-lst a)]))]
-#;[*list? (make-pred-ty (-lst Univ))]
+[cons (-poly (a b) (-> a b (-pair a b)))]
 
 [null? (make-pred-ty -Null)]
 [null -Null]

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/pr12985.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/pr12985.rkt
@@ -1,5 +1,5 @@
 #;
-(exn-pred 2)
+(exn-pred 1)
 #lang typed/racket/base
 
 (define-type T (Rec T (U (Pair String T) (Pair Char T))))

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/little-schemer.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/little-schemer.rkt
@@ -387,7 +387,7 @@
 (define: (lookup-in-entry [name : atom] [e : entry] [fail : (atom -> atom)]) : atom
   (lookup-in-entry-help name (car e) (car (cdr e)) fail))
 
-(define: extend-table : (entry table -> table) #{cons @ entry Any})
+(define: extend-table : (entry table -> table) cons)
 
 (define: (lookup-in-table [name : atom] [t : table] [fail : (atom -> atom)]) : atom
   (cond

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -440,7 +440,7 @@
         [tc-e/t (lambda () 3) (t:-> -PosByte : -true-filter)]
         [tc-e (values 3 4) #:ret (ret (list -PosByte -PosByte) (list -true-filter -true-filter))]
         [tc-e (cons 3 4) (-pair -PosByte -PosByte)]
-        [tc-e (cons 3 (ann '() : (Listof Integer))) (make-Listof -Integer)]
+        [tc-e (cons 3 (ann '() : (Listof Integer))) (-pair -PosByte (-lst -Integer))]
         [tc-e (void) -Void]
         [tc-e (void 3 4) -Void]
         [tc-e (void #t #f '(1 2 3)) -Void]
@@ -1872,7 +1872,7 @@
               (t:Un -Int (-val #f))]
         [tc-e (sequence-fold (lambda: ([y : (Listof Symbol)] [x : Symbol]) (cons x y))
                              null empty-sequence)
-              (-lst -Symbol)]
+              (unfold (-lst -Symbol))]
         [tc-e (sequence-count zero? (inst empty-sequence Integer))
               -Nat]
         [tc-e (sequence-filter zero? (inst empty-sequence Integer))
@@ -3133,6 +3133,19 @@
           (define (g x) (f x))
           (error "foo"))
         #:msg #rx"Polymorphic function `f' could not be applied"]
+
+       ;; PR 14457
+       [tc-e/t
+         (let ([xs : (Listof Symbol) (list 'a 'b 'c 'd)])
+           (if (or (empty? xs) (empty? (rest xs)) (empty? (rest (rest xs))))
+               (error 'bad)
+               xs))
+         (-pair -Symbol (-pair -Symbol (-pair -Symbol (-lst -Symbol))))]
+
+       [tc-e
+         (cons 'x (ann (list 'y 'z) (Listof Symbol)))
+         (-pair (-val 'x) (-lst -Symbol))]
+
         )
 
   (test-suite


### PR DESCRIPTION
Add accessor to second case in rest type.
Make cons not widen list types.
Introduces a slight backwards incombatibility in how cons can be
instantiated.

Closes PR 14457.

The backwards incombatibility of cons seems like it is unavoidable because the previous type of cons just ignored the second type argument and dropped all structure from list arguments. I think all necessary changes will be like for little schemer, where the instantiation is no longer needed.
