### PR TITLE
Fix or/sc optimization with non flat contracts.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/any.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/any.rkt
@@ -27,7 +27,8 @@
           [(define (sc-map v f) v)
            (define (sc-traverse v f) (void))
            (define (sc->contract v f) #'any/c)
-           (define (sc->constraints v f) (simple-contract-restrict 'flat))]
+           (define (sc->constraints v f) (simple-contract-restrict 'flat))
+           (define (sc-terminal-kind v) 'flat)]
         #:methods gen:custom-write [(define write-proc any-write-proc)])
 
 (define-match-expander any/sc:

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/none.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/none.rkt
@@ -27,7 +27,8 @@
           [(define (sc-map v f) v)
            (define (sc-traverse v f) (void))
            (define (sc->contract v f) #'none/c)
-           (define (sc->constraints v f) (simple-contract-restrict 'flat))]
+           (define (sc->constraints v f) (simple-contract-restrict 'flat))
+           (define (sc-terminal-kind v) 'flat)]
         #:methods gen:custom-write [(define write-proc none-write-proc)])
 
 (define-match-expander none/sc:

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/combinators/structural.rkt
@@ -10,7 +10,8 @@
          racket/set
          racket/format
          unstable/contract
-         (for-template racket/base
+         (for-template "../runtime-definitions.rkt"
+                       racket/base
                        racket/contract/base
                        racket/set
                        unstable/contract)
@@ -144,6 +145,7 @@
 (combinator-structs
   ((or/sc . (#:covariant)) or/c #:flat)
   ((and/sc . (#:covariant)) and/c #:flat)
+  ((if-first-order-passes/sc (#:covariant)) if-first-order-passes/c #:flat)
   ((list/sc . (#:covariant)) list/c #:flat)
   ((listof/sc (#:covariant)) listof #:flat)
   ((cons/sc (#:covariant) (#:covariant)) cons/c #:flat)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/optimize.rkt
@@ -55,7 +55,8 @@
      (match scs
       [(list) none/sc]
       [(list sc) sc]
-      [(? (λ (l) (member any/sc l))) any/sc]
+      [(? (λ (l) (member any/sc l)))
+       (if-first-order-passes/sc (apply or/sc (remove* (list any/sc) scs)))]
       [(? (λ (l) (member none/sc l)))
        (apply or/sc (remove* (list none/sc) scs))]
       [else sc])]
@@ -70,6 +71,8 @@
        (apply and/sc (remove* (list any/sc) scs))]
       [else sc])]
 
+    ;; if-first-order-passes/sc cases
+    [(if-first-order-passes/sc: (app sc-terminal-kind 'flat)) any/sc]
 
     ;; case->/sc cases
     [(case->/sc: arrs ...)

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/runtime-definitions.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/static-contracts/runtime-definitions.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+(require racket/contract
+         unstable/contract)
+
+(provide if-first-order-passes/c)
+
+(define (if-first-order-passes/c ctc)
+  (if/c (contract-first-order ctc)
+        ctc
+        any/c))

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typed-racket.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typed-racket.rkt
@@ -10,6 +10,7 @@
  (submod "private/type-contract.rkt" predicates)
  "utils/utils.rkt"
  (for-syntax "utils/utils.rkt")
+ "static-contracts/runtime-definitions.rkt"
  "utils/any-wrap.rkt" unstable/contract racket/contract/parametric)
 
 (provide (rename-out [module-begin #%module-begin]

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/static-contract-optimizer-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/static-contract-optimizer-tests.rkt
@@ -60,6 +60,7 @@
 ;; Ids with unique identity so that equals works
 (define foo-id #'foo)
 (define bar-id #'bar)
+(define chap/sc (chaperone/sc #'a-chaperone-ctc))
 
 (define syntax-tests
   (test-suite "Optimized Syntax Tests"
@@ -322,6 +323,11 @@
               (list
                 (arr/sc empty #f (list set?/sc))
                 (arr/sc (list any/sc) #f (list (listof/sc set?/sc))))))
+
+    ;; PR 14581
+    (check-optimize (or/sc identifier?/sc (listof/sc chap/sc))
+      #:pos (if-first-order-passes/sc (listof/sc chap/sc))
+      #:neg (or/sc identifier?/sc (listof/sc chap/sc)))
 
     ))
 

--- a/pkgs/unstable-contract-lib/unstable/contract.rkt
+++ b/pkgs/unstable-contract-lib/unstable/contract.rkt
@@ -37,12 +37,17 @@
         (let ([then-proj (contract-projection then-ctc)]
               [then-fo (contract-first-order then-ctc)]
               [else-proj (contract-projection else-ctc)]
-              [else-fo (contract-first-order else-ctc)])
+              [else-fo (contract-first-order else-ctc)]
+              [constructor
+                (if (and (chaperone-contract? then-ctc)
+                         (chaperone-contract? else-ctc))
+                    make-chaperone-contract
+                    make-contract)])
           (define ((proj blame) x)
             (if (predicate x)
                 ((then-proj blame) x)
                 ((else-proj blame) x)))
-          (make-contract
+          (constructor
            #:name name
            #:projection proj
            #:first-order


### PR DESCRIPTION
or/sc cannot optimize away all contracts if one is any/sc, because some
of the values passing through the contract barrier may still need the
protection of the other contracts.

Closes PR 14581.
