### PR TITLE
Add omit-define-syntaxes to secondary form of define-type-alias.

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/type-alias-omit-define-syntaxes.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/type-alias-omit-define-syntaxes.rkt
@@ -1,0 +1,7 @@
+#lang typed/racket
+(define-type (Type1 t) t #:omit-define-syntaxes)
+(define-type (Type1* t) t)
+(define-type Type2 (All (t) t) #:omit-define-syntaxes)
+(define-type Type2* (All (t) t))
+(define-type Type3 Symbol #:omit-define-syntaxes)
+(define-type Type3* Symbol)


### PR DESCRIPTION
Closes PR 14505.

I moved this to not trampoline back to the expander as I like to avoid that wherever possible.
