### PR TITLE
optimizer: allow to move once_used to test position

### DIFF
--- a/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
+++ b/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
@@ -1361,9 +1361,13 @@
                               (if r r (something-else)))
                             (a1)
                             (a2)))
-           '(lambda (x)  (if (if (something) #t (something-else))
-                             (a1)
-                             (a2))))
+           '(lambda (x) (if (if (something) #t (something-else))
+                            (a1)
+                            (a2))))
+
+(test-comp '(lambda (x) (let ([r (something)])
+                          (if r #t (something-else))))
+           '(lambda (x) (if (something) #t (something-else))))
 
 (test-comp '(if (let ([z (random)]) null) 1 2)
            '(if (let ([z (random)]) #t) 1 2))

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -6694,7 +6694,8 @@ Scheme_Object *scheme_optimize_expr(Scheme_Object *expr, Optimize_Info *info, in
         if (SAME_TYPE(SCHEME_TYPE(val), scheme_once_used_type)) {
           Scheme_Once_Used *o = (Scheme_Once_Used *)val;
           if (((o->vclock == info->vclock)
-               && single_valued_noncm_expression(o->expr, 5))
+               && ((context & OPT_CONTEXT_BOOLEAN)
+                   || single_valued_noncm_expression(o->expr, 5)))
               || movable_expression(o->expr, info, o->delta, o->cross_lambda,
                                     o->kclock != info->kclock,
                                     0, 5)) {


### PR DESCRIPTION
Allow the optimizer to move the once_used expressions to test position, because the if will check that the expression returns a single value.  

This pass all the tests, but I’m still not 100% sure that this changes doesn’t create a problem with the captured continuations.
