### PR TITLE
Fix _date to allow dates before 1970 year

### DIFF
--- a/racket/collects/ffi/unsafe/com.rkt
+++ b/racket/collects/ffi/unsafe/com.rkt
@@ -1447,13 +1447,16 @@
                 (define s (make-SYSTEMTIME 0 0 0 0 0 0 0 0))
                 (unless (not (zero? (VariantTimeToSystemTime d s)))
                   (error 'date "error converting date from COM date"))
-                (seconds->date
-                 (find-seconds (SYSTEMTIME-wSecond s)
-                               (SYSTEMTIME-wMinute s)
-                               (SYSTEMTIME-wHour s)
-                               (SYSTEMTIME-wDay s)
-                               (SYSTEMTIME-wMonth s)
-                               (SYSTEMTIME-wYear s))))))
+                (date (SYSTEMTIME-wSecond s)
+                      (SYSTEMTIME-wMinute s)
+                      (SYSTEMTIME-wHour s)
+                      (SYSTEMTIME-wDay s)
+                      (SYSTEMTIME-wMonth s)
+                      (SYSTEMTIME-wYear s)
+                      (SYSTEMTIME-wDayOfWeek s)
+                      0
+                      #f
+                      0))))
 
 (define _currency
   (make-ctype _CY


### PR DESCRIPTION
In current version one cannot get date before 1970, because seconds->date doesn't allow such dates.
But `date' struct doesn't have such restriction, so it is better to drop day-of-year (one can calculate it if needed), than disallow all dates before 1970
