### PR TITLE
Fixed a bug in `values` within file lazy.rkt.

### DIFF
--- a/pkgs/lazy/lazy.rkt
+++ b/pkgs/lazy/lazy.rkt
@@ -221,7 +221,7 @@
         x)))
 
   (define* ~values
-    (case-lambda [(x) x] [xs (multiple-values xs)]))
+    (lambda xs (multiple-values xs)))
 
   ;; Redefine multiple-value constructs so they split the results
   (defsubst (~define-values (v ...) body)

--- a/pkgs/lazy/tests/lang.rkt
+++ b/pkgs/lazy/tests/lang.rkt
@@ -24,6 +24,14 @@
    (! (= 1.0 1)) => #t
    (! (equal? (list 1.0) (list 1.0))) => #t
    (! (letrec ([zs (cons 0 zs)]) (equal? (list zs zs) (list zs zs)))) => #t
+   (! (let-values ([(x) (values (error "a"))]) 1)) => 1
+   (! (let-values ([(x y) (values (error "a") (error "b"))]) 1)) => 1
+   (! (let*-values ([(x0 x1) (values (error "a") (error "b"))] [(y) (values x0)]) 1)) => 1
+   ;(! (letrec ([x y] [y 1]) x)) => 1  ;; <- this does not pass due to variable references not being delayed
+   (! (letrec ([x (list y)] [y 1]) (car x))) => 1
+   (! (letrec-values ([(x) (values (list y))] [(y) (values 1)]) (car x))) => 1
+   (! (letrec-values ([(x0 x1) (values (list y0) (list y1))] [(y0 y1) (values 1 2)])
+        (+ (car x0) (car x1)))) => 3
    ))
 
 (define (list-tests)


### PR DESCRIPTION
The issue was that when `values` was used with a single input, that input was being forced too early.
Now code such as:
(! (letrec-values ([(x) (values (list y))] [(y) (values 1)]) (car x))  )
should produce 1 instead of #<undefined>.

Some simple test cases were also added.
