### PR TITLE
fix doc typo

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/style/constructs.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/style/constructs.scrbl
@@ -209,7 +209,7 @@ racket
 (define (process f)
   (define (complex-step x)
     ... 10 lines ...)
-  (map complext-step
+  (map complex-step
        (to-list f)))
 ]
 @; -----------------------------------------------------------------------------


### PR DESCRIPTION
This is a typo fix for the example code in section ”Lambda vs Define” of ”How to Program Racket”.
