### PR TITLE
fix cross compile on QNX

### DIFF
--- a/racket/src/racket/sconfig.h
+++ b/racket/src/racket/sconfig.h
@@ -883,7 +883,6 @@
 #if defined(i386)
 # define MZ_USE_JIT_I386
 # define MZ_JIT_USE_MPROTECT
-# define MZ_USE_DWARF_LIBUNWIND
 #endif
 #if defined(__x86_64__)
 # define MZ_USE_JIT_X86_64


### PR DESCRIPTION
got broken in 2e284cc78357ccc4a63aae7603682b0344bfc58f
The racket version of libunwind is not compatible with QNX but old-style stacktraces are still working with the default gcc version
