### PR TITLE
CSS patches: make fileboxed racketblocks & codeblocks look neater

### DIFF
--- a/pkgs/scribble-pkgs/scribble-lib/scribble/manual-racket.css
+++ b/pkgs/scribble-pkgs/scribble-lib/scribble/manual-racket.css
@@ -240,6 +240,30 @@ tbody > tr:first-child > td > .together {
  margin-right: 1em;
 }
 
+/* style patches: make fileboxed racketblocks & codeblocks look neater */
+
+blockquote.Rfilebox, blockquote.Rfilebox > blockquote.Rfilecontent {
+  margin-left: 0;
+}
+
+blockquote.Rfilebox > blockquote.Rfilecontent, 
+blockquote.Rfilebox > blockquote.Rfilecontent > blockquote.SCodeFlow {
+  margin-top: 0;
+}
+
+blockquote.Rfilebox > blockquote.Rfilecontent > blockquote.SCodeFlow {
+  padding-top: 0.7em;
+}
+
+blockquote.Rfilebox > p.Rfiletitle {
+  border-top: 1px dotted gray;
+  border-right: 1px dotted gray;
+  border-left: 1px dotted gray;
+}
+
+/* end style patches */
+
+
 .SCodeFlow .Rfilebox {
     margin-left: -1em; /* see 17.2 of guide, module languages */
 }


### PR DESCRIPTION
In #lang scribble/manual, when @filebox is wrapped around @racketblock or @codeblock, it looks broken compared to, say, @racketmod. This is due to the HTML rendering being different. This CSS patch smooths over the differences. 

Example: this code

@codeblock|{
# lang pollen

◊define[greeting]{Hi there}.
}|

@filebox["foo.html"]{
@codeblock|{
# lang pollen

◊define[greeting]{Hi there}.
}|}

@racketblock[
(define greeting
  "Hi there")
]

@filebox["foo.html"]{
@racketblock[
(define greeting
  "Hi there")
]}

Under the current CSS, looks like this:

![screen shot 2014-09-01 at sep 01 12 14 27 pm](https://cloud.githubusercontent.com/assets/1425051/4111597/d866aae2-320c-11e4-920a-92c5d64c3f77.gif)

But with this CSS patch, looks like this:

![screen shot 2014-09-01 at sep 01 12 14 40 pm](https://cloud.githubusercontent.com/assets/1425051/4111599/e2d45470-320c-11e4-9285-589ff9b01cf1.gif)
