### PR TITLE
CSS patches: make fileboxed racketblocks & codeblocks look neater (v2)

### DIFF
--- a/pkgs/scribble-pkgs/scribble-lib/scribble/manual-racket.css
+++ b/pkgs/scribble-pkgs/scribble-lib/scribble/manual-racket.css
@@ -261,8 +261,17 @@ blockquote.Rfilebox > p.Rfiletitle {
   border-left: 1px dotted gray;
 }
 
-/* end style patches */
 
+.SCodeFlow > .Rfilebox > .Rfilecontent {
+  padding-top: 0.7em;
+  padding-left: 1em;
+}
+
+.SCodeFlow > .Rfilebox > .Rfiletitle {
+  border-left: none;
+}
+
+/* end style patches */
 
 .SCodeFlow .Rfilebox {
     margin-left: -1em; /* see 17.2 of guide, module languages */


### PR DESCRIPTION
In #lang scribble/manual, when `@filebox` is wrapped around `@racketblock` or `@codeblock`, it looks broken compared to, say, `@racketmod`. This is due to the HTML rendering being different. This CSS patch smooths over the differences. 

Example: this code

``` racket
#lang scribble/manual


@codeblock|{
#lang pollen

◊define[greeting]{Hi there}.
}|


@filebox["foo.html"]{
@codeblock|{
#lang pollen

◊define[greeting]{Hi there}.
}|}


@racketblock[
(define greeting
  "Hi there")
]

@filebox["foo.html"]{
@racketblock[
(define greeting
  "Hi there")
]}

@racketmod[racket/base
(define greeting
  "Hi there")
]

@racketmod[#:file "foo.html" racket/base
(define greeting
  "Hi there")
]
```

Under the current CSS, looks like this:

![screen shot 2014-09-01 at sep 01 12 58 05 pm](https://cloud.githubusercontent.com/assets/1425051/4111776/61c13532-3212-11e4-8a2a-671c9fdf7aef.gif)

But with this CSS patch, looks like this:

![screen shot 2014-09-01 at sep 01 12 58 25 pm](https://cloud.githubusercontent.com/assets/1425051/4111777/63741c14-3212-11e4-91a3-566313f82cef.gif)
