### PR TITLE
Enable some extra tests in Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,33 @@ env:
 compiler:
   - gcc
   - clang
+matrix:
+  include:
+    - os: osx
+      compiler: gcc
+      env: PATH=./racket/bin:$PATH
+    - os: osx
+      compiler: clang
+      env: PATH=./racket/bin:$PATH
+  exclude:
+    - os: osx
+      compiler: gcc
+      env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-places --disable-futures --disable-extflonum"
+    - os: osx
+      compiler: clang
+      env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-places --disable-futures --disable-extflonum"
+    - os: osx
+      compiler: gcc
+      env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-jit"
+    - os: osx
+      compiler: clang
+      env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-jit"
+    - os: osx
+      compiler: gcc
+      env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-jit --disable-places --disable-futures --disable-extflonum"
+    - os: osx
+      compiler: clang
+      env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-jit --disable-places --disable-futures --disable-extflonum"
 # Just run tests for the core
 script:
   - make CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test" CONFIGURE_ARGS_qq="$RACKET_CONFIGURE_ARGS"


### PR DESCRIPTION
I talked with @samth in the IRC channel a week ago and he agreed to test the code also with the jit disabled is a good idea. I've added some additional test to the initial proposal. My intention is to enable some tests with configurations not widely tested by the users.

If I understand the racket documentation correctly, places is emulated in systems without support for thread local storage. Travis CI uses an OS with support for that, so racket always uses real threads for places. I don't know how to force to racket to use the "emulated behavior" on Linux. Is it enough to disable places with configure to force to racket to emulate places?.

@mflatt Can you take a look to the options? I usually break things when I play with the configure option :)
