### PR TITLE
Include syntax/parse in defmacro.scrbl

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/compatibility/scribblings/defmacro.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/compatibility/scribblings/defmacro.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/doc
 @(require scribblings/reference/mz
-          (for-label compatibility/defmacro))
+          (for-label compatibility/defmacro
+                     syntax/parse))
 
 @title[#:tag "defmacro"]{Legacy macro support}
 


### PR DESCRIPTION
So that can be hyperlinked
