### PR TITLE
Fix documentation error in net/sendurl

### DIFF
--- a/pkgs/net-pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -12,7 +12,7 @@ browser preference is set.
 
 
 @defproc[(send-url [str string?] [separate-window? any/c #t]
-                   [#:escape escape? any/c #t])
+                   [#:escape? escape? any/c #t])
          void?]{
 
 Opens @racket[str], which represents a URL, in a platform-specific


### PR DESCRIPTION
Documentation for the function send-url lists it as accepting the keyword parameter #:escape, when it is actually #:escape?
