### PR TITLE
fix type signature of force for promises

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/base-env/base-env.rkt
@@ -1179,7 +1179,9 @@
 
 ;; Section 10.3 (Delayed Evaluation)
 [promise? (make-pred-ty (-Promise Univ))]
-[force (-poly (a) (->acc (list (-Promise a)) a (list -force)))]
+[force (-poly (a) (cl->*
+		   (->acc (list (-Promise a)) a (list -force))
+		   (-> a a)))]
 [promise-forced? (-poly (a) (-> (-Promise a) B))]
 [promise-running? (-poly (a) (-> (-Promise a) B))]
 

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/force-delay.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/force-delay.rkt
@@ -6,4 +6,6 @@
 
 (force (delay 3))
 
+(force 3)
+
 (call-with-values (lambda () 3) list)


### PR DESCRIPTION
force acts as the identity when given a non-promise; the previous type didn't allow it to accept non-promises.

for easy reference:
https://github.com/plt/racket/blob/master/racket/collects/racket/private/promise.rkt#L112

http://docs.racket-lang.org/reference/Delayed_Evaluation.html?q=force#%28def._%28%28lib._racket%2Fpromise..rkt%29._force%29%29
