### PR TITLE
Add %F to drracket desktop file

### DIFF
--- a/pkgs/drracket-pkgs/drracket/drracket/drracket.desktop
+++ b/pkgs/drracket-pkgs/drracket/drracket/drracket.desktop
@@ -5,4 +5,4 @@ Comment=DrRacket is an interactive, integrated, graphical programming environmen
 Terminal=false
 Type=Application
 Categories=Development;Education;
-Exec=drracket -singleInstance
+Exec=drracket -singleInstance %F


### PR DESCRIPTION
Add %F to the exec key of the Dr. Racket desktop file. The parameter is explained [here](http://standards.freedesktop.org/desktop-entry-spec/desktop-entry-spec-latest.html#exec-variables).

Among other things, this lets Dr. Racket appear in Gnome 3's Open With dialog (at least on my system), allowing .rkt files to open by double clicking them.
