### PR TITLE
fix how `output` handles byte strings

### DIFF
--- a/pkgs/scribble-pkgs/scribble-text-lib/scribble/text/output.rkt
+++ b/pkgs/scribble-pkgs/scribble-text-lib/scribble/text/output.rkt
@@ -44,7 +44,7 @@
   ;; the current mode for lists
   (define list=block? #t)
   ;; the low-level string output function (can change with `with-writer')
-  (define write write-string)
+  (define write (if (string? x) write-string write-bytes))
   ;; to get the output column
   (define (getcol) (let-values ([(line col pos) (port-next-location p)]) col))
   ;; total size of the two prefixes
@@ -87,7 +87,7 @@
     (define pfx (mcar pfxs))
     (if (not pfx) ; prefix disabled?
       (write x p)
-      (let ([len (string-length x)]
+      (let ([len ((if (string? x) string-length bytes-length) x)]
             [nls (regexp-match-positions* #rx"\n" x)])
         (let loop ([start 0] [nls nls] [lpfx (mcdr pfxs)] [col (getcol)])
           (cond [(pair? nls)
@@ -223,7 +223,7 @@
       [else
        (output-string
         (cond [(string?  x) x]
-              [(bytes?   x) (bytes->string/utf-8 x)]
+              [(bytes?   x) x]
               [(symbol?  x) (symbol->string      x)]
               [(path?    x) (path->string        x)]
               [(keyword? x) (keyword->string     x)]


### PR DESCRIPTION
Scribble’s `output` function seems to handle byte strings incorrectly.

The [docs say that](http://docs.racket-lang.org/guide/bytestrings.html) “display of a byte string ... writes the raw bytes **with no encoding**” (emphasis mine).

The [docs also say that](http://docs.racket-lang.org/reference/printing.html?q=printing#%28part._print-string%29) “All byte strings display as their literal byte sequence; this byte sequence **may not be a valid UTF-8 encoding**, so it may not correspond to a sequence of characters.” (emphasis mine again)

The current `output` function doesn’t conform to this specification. Instead, it assumes that every byte string can (and should) be converted to a UTF-8 string with `bytes->string/utf-8`. Thus it throws an error with other kinds of byte strings.
