### PR TITLE
Use a more restricted log receiver in cm.rkt

### DIFF
--- a/racket/collects/compiler/cm.rkt
+++ b/racket/collects/compiler/cm.rkt
@@ -330,7 +330,7 @@
        (set! reader-deps (cons (path->bytes p) reader-deps)))))
 
   ;; Set up a logger to receive and filter accomplice events:
-  (define accomplice-logger (make-logger))
+  (define accomplice-logger (make-logger 'cm-accomplice (current-logger)))
   (define log-th
     (let ([orig-log (current-logger)]
           [receiver (make-log-receiver accomplice-logger 'debug)])
@@ -378,8 +378,7 @@
                                            p)])
                                (when (path? p) (reader-dep! p))))
                            d))
-                       rg))]
-                   [current-logger accomplice-logger])
+                       rg))])
       (get-module-code path mode compile
                        (lambda (a b) #f) ; extension handler
                        #:source-reader read-src-syntax)))


### PR DESCRIPTION
@mflatt can you take a look at this?

The problem I want to solve is to be able to conditionally send log messages from TR to DrRacket based on whether DrRacket is listening for tooltip messages.

Currently, the `cm-accomplice` logger will catch _all_ compile-time log messages (though it only cares about a subset of those) because the expression `(make-log-receiver accomplice-logger 'debug)` creates a log receiver that catches all messages `'debug` and higher (i.e., all of them) since the `accomplice-logger` is not restricted by name.

This PR restricts the logger to only listen for the relevant ones, so that TR can more reliably check if DrRacket is listening or not.
