### PR TITLE
XFORM_END_SKIP -> XFORM_SKIP_PROC in example.

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/inside/memory.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/inside/memory.scrbl
@@ -584,7 +584,7 @@ The following macros can be used (with care!) to navigate
     Example:
 
   @verbatim[#:indent 2]{
-    int foo(int c, ...) XFORM_END_SKIP {
+    int foo(int c, ...) XFORM_SKIP_PROC {
     }
   }}
 


### PR DESCRIPTION
The XFORM_SKIP_PROC example incorrectly used XFORM_END_SKIP,
it should have used XFORM_SKIP_PROC instead.
