### PR TITLE
Fix error handling of parallel-compile-files.

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -456,8 +456,8 @@ result will not call @racket[proc] with @racket['unlock].)
 The @racketmodname[setup/parallel-build] library provides the parallel-compilation
 functionality of @exec{raco setup} and @exec{raco make}.}
 
-@defproc[(parallel-compile-files [list-of-files (listof path?)] 
-                                 [#:worker-count worker-count non-negative-integer? (processor-count)] 
+@defproc[(parallel-compile-files [list-of-files (listof path-string?)]
+                                 [#:worker-count worker-count exact-positive-integer? (processor-count)]
                                  [#:handler handler (->i ([handler-type symbol?]
                                                           [path path-string?]
                                                           [msg string?] 

--- a/pkgs/racket-pkgs/racket-test/tests/setup/parallel-build.rkt
+++ b/pkgs/racket-pkgs/racket-test/tests/setup/parallel-build.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+(require
+  rackunit
+  setup/parallel-build)
+
+(check-exn exn:fail:contract? (λ () (parallel-compile ".")))
+(check-exn exn:fail:contract? (λ () (parallel-compile-files (list) #:worker-count 2.5)))
+(check-exn exn:fail:contract? (λ () (parallel-compile-files (list) #:handler 5)))

--- a/racket/collects/setup/parallel-build.rkt
+++ b/racket/collects/setup/parallel-build.rkt
@@ -320,6 +320,12 @@
                                 #:worker-count [worker-count (processor-count)]
                                 #:handler [handler void]
                                 #:options [options '()])
+  (unless (exact-positive-integer? worker-count)
+    (raise-argument-error 'parallel-compile-files "exact-positive-integer?" worker-count))
+  (unless (and (list? list-of-files) (andmap path-string? list-of-files))
+    (raise-argument-error 'parallel-compile-files "(listof path-string?)" list-of-files))
+  (unless (and (procedure? handler) (procedure-arity-includes? handler 5))
+    (raise-argument-error 'parallel-compile-files "(procedure-arity-includes/c 5)" handler))
   (parallel-build (make-object file-list-queue% list-of-files handler options) worker-count))
 
 (define (parallel-compile worker-count setup-fprintf append-error collects-tree)


### PR DESCRIPTION
Related to PR 14809.

I couldn't find any tests for these files, do they exist? If not where should I put new tests and what can I rely on? Is rackunit ok, or should I avoid it for dependency reasons?
