### PR TITLE
Make managed-compile-zo fail if the file doesn't exist.

### DIFF
--- a/pkgs/racket-pkgs/racket-test/tests/compiler/cm.rkt
+++ b/pkgs/racket-pkgs/racket-test/tests/compiler/cm.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+(require
+  rackunit
+  compiler/cm)
+
+(check-exn
+  (λ (exn) (and (exn:fail? exn) (regexp-match #rx"does not exist" (exn-message exn))))
+  (λ () (managed-compile-zo "a-directory-that-doesnt-exist/file.rkt")))

--- a/racket/collects/compiler/cm.rkt
+++ b/racket/collects/compiler/cm.rkt
@@ -605,14 +605,7 @@
                path)
         #f]
        [(not path-time)
-        (trace-printf "~a does not exist" orig-path)
-        (or (hash-ref up-to-date orig-path #f)
-            (let ([stamp (cons (or path-zo-time +inf.0)
-                               (delay (get-compiled-sha1 mode roots path)))])
-              (hash-set! up-to-date main-path stamp)
-              (unless (eq? main-path alt-path)
-                (hash-set! up-to-date alt-path stamp))
-              stamp))]
+        (error 'compile-zo "~a does not exist" orig-path)]
        [else
         (let ([deps (read-deps path)]
               [new-seen (hash-set seen path #t)])


### PR DESCRIPTION
Closes PR 14830.

This didn't break anything that I could tell, but again there are no tests as far as I can tell. Also is there a better way to get a nonexistent path in a test?
