### PR TITLE
Typecheck the #:guard clause of typed structs

### DIFF
--- a/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
+++ b/pkgs/typed-racket-pkgs/typed-racket-doc/typed-racket/scribblings/reference/special-forms.scrbl
@@ -375,7 +375,8 @@ those functions.
 (struct maybe-type-vars name-spec ([f : t] ...) options ...)
 ([maybe-type-vars code:blank (v ...)]
  [name-spec name (code:line name parent)]
- [options #:transparent #:mutable])]{
+ [options #:transparent #:mutable
+          (code:line #:guard guard-expr)])]{
  Defines a @rtech{structure} with the name @racket[name], where the
  fields @racket[f] have types @racket[t], similar to the behavior of @|struct-id|
  from @racketmodname[racket/base].
@@ -395,7 +396,9 @@ from @racketmodname[racket/base].}
 (define-struct maybe-type-vars name-spec ([f : t] ...) options ...)
 ([maybe-type-vars code:blank (v ...)]
  [name-spec name (name parent)]
- [options #:transparent #:mutable])]{Legacy version of @racket[struct],
+ [options #:transparent #:mutable
+          (code:line #:guard guard-expr)])]
+{Legacy version of @racket[struct],
 corresponding to @|define-struct-id| from @racketmodname[racket/base].}
 
 @defform/subs[

--- a/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-lib/typed-racket/typecheck/tc-lambda-unit.rkt
@@ -293,6 +293,12 @@
          (match t
            [(Mu: _ _) (loop (unfold t))]
            [(Function/arrs: _ _ _ _ '()) t]
+           ;; if it's a union and there's only a single function type
+           ;; in there, use that (this helps for struct guard checking)
+           [(Union: ts)
+            (define subs (filter values (map loop ts)))
+            (and (= (length subs) 1)
+                 (car subs))]
            [_ #f]))]
       [_ #f]))
 

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/struct-guard.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/fail/struct-guard.rkt
@@ -1,0 +1,12 @@
+#;(exn-pred #rx"wrong arity")
+#lang typed/racket/base
+
+(struct foo ([x : Integer] [y : Integer])
+        #:guard (λ (x y) (values x y)))
+
+(struct bar ([x : Integer] [y : Integer])
+        #:guard (lambda: ([x : String] [y : String] [name : String])
+                  (values x y)))
+
+(struct baz ([x : Integer] [y : Integer])
+        #:guard 3)

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/struct-guard.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/succeed/struct-guard.rkt
@@ -1,0 +1,13 @@
+#lang typed/racket/base
+
+(require typed/rackunit)
+
+(struct foo ([x : Integer] [y : Integer])
+        #:guard (λ (x y name)
+                  (values (add1 x) (add1 y))))
+
+(struct bar ([x : Integer] [y : Integer])
+        #:guard #f)
+
+(check-equal? (foo-y (foo 1 2)) 3)
+(check-equal? (bar-y (bar 1 2)) 2)

--- a/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
+++ b/pkgs/typed-racket-pkgs/typed-racket-test/tests/typed-racket/unit-tests/typecheck-tests.rkt
@@ -3350,6 +3350,14 @@
                  (ann (values a a) (Values Symbol Symbol)))
                (void))
              -Void]
+
+       ;; Expected type for lambda should work if the Union has
+       ;; only one function type
+       [tc-e (let ()
+               (: f (Option (-> String String)))
+               (define f (lambda (x) (string-append x "foo")))
+               ((assert f) "bar"))
+             -String]
         )
 
   (test-suite


### PR DESCRIPTION
This PR turns on typechecking for the `#:guard` clause of structs which were silently ignored before.

It's a fairly minimal change that primarily only required changes at the frontend macro level. The limitation of this approach is that it doesn't let the guard expression change the type of the struct fields, which you could potentially support by making the typechecker aware of struct guards (use the result type of the guard as the field types basically). I doubt that that's a common use case.

Also, there's a lot of code duplication in the implementation of `define-struct` that I intend to eventually factor out.
