### PR TITLE
fix tiny typo in `arith.rkt` in racket guide

### DIFF
--- a/pkgs/racket-pkgs/racket-doc/scribblings/guide/arith.rkt
+++ b/pkgs/racket-pkgs/racket-doc/scribblings/guide/arith.rkt
@@ -40,9 +40,9 @@
        (define op (to-syntax (string->symbol op-str)
                              (+ delta a-len) op-str))
        (to-syntax (list op a b) delta s)]
-      [else (to-syntax (or (string->number s) 
-                           (string->symbol s))
-                       delta s)]))
+      [_ (to-syntax (or (string->number s) 
+                        (string->symbol s))
+                    delta s)]))
 
   (unless expr-match
     (raise-read-error "bad arithmetic syntax" 


### PR DESCRIPTION
Just a small typo in the guide, where `else` is used in `match` to mean ignored default pattern.
