### PR TITLE
optimizer: fix do_make_discarding_sequence

### DIFF
--- a/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
+++ b/pkgs/racket-pkgs/racket-test/tests/racket/optimize.rktl
@@ -1340,10 +1340,32 @@
 (test-comp '(lambda (w z) (box? (list (cons (random w) z))))
            '(lambda (w z) (random w) #f))
 
+(test-comp '(lambda () (begin0 (random 1) (random 2)))
+           '(lambda () (car (cons (random 1) (random 2)))))
+(test-comp '(lambda () (begin (random 1) (random 2)))
+           '(lambda () (cdr (cons (random 1) (random 2)))))
+
 (test-comp '(lambda (w)
-              (car (cons w (random))))
+              (begin (random) w))
            '(lambda (w)
-              (begin (random) w)))
+              (car (cons w (random)))))
+;don't exchange if it may capture a continuation
+(test-comp '(lambda (f) 
+              (begin (values (f)) (list 7)))
+           '(lambda (f) 
+              (car (cons (list 7) (values (f)))))
+           #f)
+;don't exchange if it may be not safe for space
+(test-comp '(lambda (f)
+              (let ([big (cons (f) (make-vector 10))])
+                (display big) 
+                (begin (make-vector 20) (car big))))
+           '(lambda (f)
+              (let ([big (cons (f) (make-vector 10))])
+                (display big) 
+                (car (cons (car big) (make-vector 20)))))
+           #f)
+
 (test-comp '(lambda (w)
               (begin
                 (list (random) w)

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -550,7 +550,7 @@ static Scheme_Object *do_make_discarding_sequence(Scheme_Object *e1, Scheme_Obje
     return e1;
 
   /* use `begin` instead of `begin0` if we can swap the order: */
-  if (rev && movable_expression(e2, info, -id_offset, 0, 0, 0, 0, 50))
+  if (rev && movable_expression(e2, info, -id_offset, 0, 1, 1, 0, 50))
     rev = 0;
 
   return scheme_make_sequence_compilation(scheme_make_pair((rev ? e2 : e1),


### PR DESCRIPTION
The optimizer converts (car (cons X Y)) to (begin0 X Y) and then reduces it to (begin Y X) if X is movable.
Check that the movement is safe for space and for continuation captures.
