### PR TITLE
optimizer: fix warning in merge_types in 32 bits

### DIFF
--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -3730,7 +3730,7 @@ static void merge_types(Optimize_Info *src_info, Optimize_Info *info, int delta)
 {
   Scheme_Hash_Tree *types = src_info->types;
   Scheme_Object *pos, *pred;
-  intptr_t i;
+  mzlonglong i;
 
   if (!types)
     return;


### PR DESCRIPTION
I get these warnings in Visual Studio Express (32 bits):

....\racket\src\optimize.c(3738): warning C4244: '=' : conversion from 'mzlonglong' to 'intptr_t', possible loss of data
....\racket\src\optimize.c(3742): warning C4244: '=' : conversion from 'mzlonglong' to 'intptr_t', possible loss of data
