### PR TITLE
Link to the guide and reference source locations

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/guide.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/guide.scrbl
@@ -15,6 +15,9 @@ Racket. From @seclink["datatypes"]{Chapter 3} on, this guide dives
 into details---covering much of the Racket toolbox, but leaving
 precise details to @|Racket| and other reference manuals.
 
+If you would like to contribute to the maintenance of this guide,
+you can find it the source on @hyperlink[https://github.com/plt/racket/tree/master/pkgs/racket-doc/scribblings/guide]{GitHub}.
+
 @table-of-contents[]
 
 @include-section["welcome.scrbl"]

--- a/pkgs/racket-doc/scribblings/reference/reference.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/reference.scrbl
@@ -49,6 +49,9 @@ Unless otherwise noted, the bindings defined in this manual are
 exported by the @racketmodname[racket/base] and @racketmodname[racket]
 languages.}
 
+If you would like to contribute to the maintenance of this reference,
+you can find it the source on @hyperlink[https://github.com/plt/racket/tree/master/pkgs/racket-doc/scribblings/reference]{GitHub}.
+
 @margin-note{The @racketmodname[racket/base] library is much smaller than
 the @racketmodname[racket] library and will typically load faster.
 


### PR DESCRIPTION
I had a lot of trouble figuring out how to modify the guide to fix a typo, so I figured a link in the guide itself would help others.  I added one to the reference too!
