### PR TITLE
Add a true? predicate to racket/bool

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/booleans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/booleans.scrbl
@@ -265,6 +265,9 @@ Returns @racket[(equal? a b)] (if @racket[a] and @racket[b] are symbols).}
 
 Returns @racket[(equal? a b)] (if @racket[a] and @racket[b] are booleans).}
 
+@defproc[(true? [v any/c]) boolean?]{
+Returns @racket[#f] if @racket[v] is @racket[#f], @racket[#t] otherwise.}
+
 @defproc[(false? [v any/c]) boolean?]{
 
 Returns @racket[(not v)].}

--- a/pkgs/racket-test/tests/racket/bool.rkt
+++ b/pkgs/racket-test/tests/racket/bool.rkt
@@ -18,6 +18,10 @@
 (check-false (false? #t))
 (check-false (false? "11"))
 
+(check-false (true? #f))
+(check-true (true? #t))
+(check-true (true? "11"))
+
 (for ([x (in-list '(#f #t))])
   (for ([y (in-list '(#f #t))])
     (check-equal? (implies x y)

--- a/racket/collects/racket/bool.rkt
+++ b/racket/collects/racket/bool.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(provide true false false?
+(provide true false true? false?
          boolean=?
          symbol=?
          implies nand nor xor)
@@ -9,6 +9,7 @@
 (define true #t)
 (define false #f)
 
+(define (true? v) (if v #t #f))
 (define (false? v) (eq? v #f))
 
 (define (boolean=? x y)


### PR DESCRIPTION
So, `racket/bool` already has `false?`. This is an utterly useless function for everything besides clarity—it is identical in every way to `not`. Yet for whatever reason, it does not include `true?`, which would actually be *useful*.

This has been disputed a few times on IRC, so let me explain. Racket, like Scheme, uses the concept of truthiness. Most of the time, there's no need to cast a value to a boolean explicitly; instead of `boolean?`, the Racketeer uses `any/c`. Constructs like `if` handle these values appropriately.

I know this, but a `true?` function is still sometimes useful. Why? Well, sometimes you want to return a value from a function, but you don't want to return some truthy value that exposes some internal implementation details. There are various ways around this, the most common being `(not (not ...))` or `(and ... #t)`.

Don't believe me? Run `git grep -E "\\(and \\S+ #t\\)"`. This is a real pattern. It's also a bad one, and considering we have `false?`, there's no reason to not also include `true?`.