### PR TITLE
Implement class sealing/unsealing

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -2701,6 +2701,47 @@ a method that is not supplied by an object.
 
 }
 
+@defproc[(class-seal [class class?]
+                     [key symbol?]
+                     [unsealed-inits (listof symbol?)]
+                     [unsealed-fields (listof symbol?)]
+                     [unsealed-methods (listof symbol?)]
+                     [inst-proc (-> class? any)]
+                     [member-proc (-> class? (listof symbol?) any)])
+         class?]{
+
+Adds a seal to a given class keyed with the symbol @racket[key]. The
+given @racket[unsealed-inits], @racket[unsealed-fields], and
+@racket[unsealed-methods] list corresponding class members that are
+unaffected by sealing.
+
+When a class has any seals, the @racket[inst-proc] procedure is called
+on instantiation (normally, this is used to raise an error on
+instantiation) and the @racket[member-proc] function is called
+(again, this is normally used to raise an error) when a subclass
+attempts to add class members that are not listed in the unsealed lists.
+
+The @racket[inst-proc] is called with the class value on which an
+instantiation was attempted. The @racket[member-proc] is called with
+the class value and the list of initialization argument, field, or
+method names.
+}
+
+@defproc[(class-unseal [class class?]
+                       [key symbol?]
+                       [wrong-key-proc (-> class? any)])
+         class?]{
+
+Removes a seal on a class that has been previously sealed with the
+@racket[class-seal] function and the given @racket[key].
+
+If the unseal removed all of the seals in the class, the class
+value can be instantiated or subclassed freely. If the given
+class value does not contain or any seals or does not contain
+any seals with the given key, the @racket[wrong-key-proc] function
+is called with the class value.
+}
+
 @; ----------------------------------------------------------------------
 
 @include-section["surrogate.scrbl"]

--- a/racket/collects/racket/private/class-c-old.rkt
+++ b/racket/collects/racket/private/class-c-old.rkt
@@ -372,7 +372,7 @@
                    (super-go the-obj si_c si_inited? init-args null null)
                    (init the-obj super-go si_c si_inited? init-args init-args))))))
         
-        c))))
+        (copy-seals cls c)))))
 
 (define (internal-class/c-proj internal-ctc)
   (define dynamic-features
@@ -707,7 +707,7 @@
                  (super-go the-obj si_c si_inited? init-args null null)
                  (init the-obj super-go si_c si_inited? init-args init-args)))))
         
-        c))))
+        (copy-seals cls c)))))
 
 (define (blame-add-init-context blame name)
   (blame-add-context blame
@@ -1633,4 +1633,4 @@
           (define p-neg ((contract-projection c) (blame-add-field-context blame f #:swap? #t)))
           (hash-set! field-ht f (field-info-extend-external fi p-pos p-neg)))))
     
-    c))
+    (copy-seals cls c)))


### PR DESCRIPTION
This implements two class operations `class-seal` and `class-unseal` that are not tied to contracts, but are primarily intended to be used to implement polymorphic contracts on classes.

@rfindler I showed you a previous incarnation of this code, but I've basically re-written it from scratch since then. More specifically, I took your advice and separated the `make-seal/c` operation into two more primitive operations that aren't tied to contracts.

I also use the new feature of impersonator properties that lets a property be overriden by a chaperone/impersonator that does no redirection and just supplies a witness instead. This lets sealing/unsealing use memory proportional to the number of seals and the number of classes in the hierarchy, rather than proportional to the number of times something gets sealed and/or unsealed (even with the same seal). It also avoids allocating a whole class structure for each seal/unseal operation.

The client of this PR is this Typed Racket PR: https://github.com/racket/typed-racket/pull/80