### PR TITLE
Specify names of missing fields for match on structs

### DIFF
--- a/racket/collects/racket/match/parse-helper.rkt
+++ b/racket/collects/racket/match/parse-helper.rkt
@@ -37,8 +37,8 @@
                     (parse (quasisyntax/loc stx (quote #,e)))))]
     [(quote bx)
      (box? (syntax-e #'bx))
-     (make-Box (parse (quasisyntax/loc 
-                       stx 
+     (make-Box (parse (quasisyntax/loc
+                       stx
                        (quote #,(unbox (syntax-e #'bx))))))]
     [(quote v)
      (or (parse-literal (syntax-e #'v))
@@ -95,7 +95,7 @@
                                5)])
           (cond [(equal? super #t) (values #t '())] ;; no super type exists
                 [(equal? super #f) (values #f '())] ;; super type is unknown
-                [else 
+                [else
                  (let-values ([(complete? lineage) (get-lineage super)])
                    (values complete?
                            (cons super lineage)))])))
@@ -111,24 +111,43 @@
                           [(not (car acc)) (cdr acc)]
                           [else acc])])
           (make-Struct pred
-                       (syntax-property 
-                        pred 
+                       (syntax-property
+                        pred
                         'disappeared-use (list struct-name))
                        lineage (and (checked-struct-info? v) complete?)
                        acc
-                       (cond [(eq? '_ (syntax-e pats))                            
+                       (cond [(eq? '_ (syntax-e pats))
                               (map make-Dummy acc)]
                              [(syntax->list pats)
                               =>
                               (lambda (ps)
                                 (unless (= (length ps) (length acc))
-                                  (raise-syntax-error
-                                   'match
-                                   (format "~a structure ~a: expected ~a but got ~a"
-                                           "wrong number for fields for"
-                                           (syntax->datum struct-name) (length acc)
-                                           (length ps))
-                                   stx pats))
+                                  (when (< (length acc) (length ps))
+                                    (raise-syntax-error
+                                     'match
+                                     (format "~a structure ~a: expected ~a but got ~a"
+                                             "excess number of fields for"
+                                             (syntax->datum struct-name) (length acc)
+                                             (length ps))
+                                     stx pats))
+                                  (when (> (length acc) (length ps))
+                                     (raise-syntax-error
+                                       'match
+                                       (format
+                                         "~a structure ~a: expected ~a but got ~a; ~a ~a"
+                                         "insufficient number of fields for"
+                                         (syntax->datum struct-name) (length acc)
+                                         (length ps)
+                                         "missing fields"
+                                         (list-tail
+                                           (map (lambda (field)
+                                             (string->symbol
+                                               (substring (symbol->string (syntax->datum field))
+                                                 (add1 (string-length
+                                                   (symbol->string (syntax->datum struct-name)))))))
+                                             acc)
+                                           (length ps)))
+                                     stx pats)))
                                 (map parse ps))]
                              [else (raise-syntax-error
                                     'match
@@ -157,7 +176,7 @@
     (define introducer (make-syntax-introducer))
     (parameterize ([current-match-introducer introducer])
       (let* ([mstx (introducer (syntax-local-introduce stx))]
-             [mresult (if (procedure-arity-includes? transformer 2) 
+             [mresult (if (procedure-arity-includes? transformer 2)
                           (transformer expander* mstx)
                           (transformer mstx))]
              [result (syntax-local-introduce (introducer mresult))])
@@ -205,7 +224,7 @@
 ;; (listof pat) syntax -> void
 ;; ps is never null
 ;; check that all the ps bind the same set of variables
-(define (all-vars ps stx)  
+(define (all-vars ps stx)
   (let* ([first-vars (bound-vars (car ps))]
          [l (length ps)]
          [ht (make-free-identifier-mapping)])

--- a/racket/collects/racket/match/parse-helper.rkt
+++ b/racket/collects/racket/match/parse-helper.rkt
@@ -139,7 +139,7 @@
                                                (length ps)
                                                "missing fields"
                                                (list-tail
-                                                 (for/list [(i acc)]
+                                                 (for/list [(i (in-list acc))]
                                                            (symbol->string (syntax->datum i)))
                                                  (length ps)))
                                        stx pats)))

--- a/racket/collects/racket/match/parse-helper.rkt
+++ b/racket/collects/racket/match/parse-helper.rkt
@@ -133,21 +133,16 @@
                                   (when (> (length acc) (length ps))
                                      (raise-syntax-error
                                        'match
-                                       (format
-                                         "~a structure ~a: expected ~a but got ~a; ~a ~a"
-                                         "insufficient number of fields for"
-                                         (syntax->datum struct-name) (length acc)
-                                         (length ps)
-                                         "missing fields"
-                                         (list-tail
-                                           (map (lambda (field)
-                                             (string->symbol
-                                               (substring (symbol->string (syntax->datum field))
-                                                 (add1 (string-length
-                                                   (symbol->string (syntax->datum struct-name)))))))
-                                             acc)
-                                           (length ps)))
-                                     stx pats)))
+                                       (format "~a structure ~a: expected ~a but got ~a; ~a ~a"
+                                               "insufficient number of fields for"
+                                               (syntax->datum struct-name) (length acc)
+                                               (length ps)
+                                               "missing fields"
+                                               (list-tail
+                                                 (for/list [(i acc)]
+                                                           (symbol->string (syntax->datum i)))
+                                                 (length ps)))
+                                       stx pats)))
                                 (map parse ps))]
                              [else (raise-syntax-error
                                     'match


### PR DESCRIPTION
Addressing issue #888 - Better error message for matching structs.