### PR TITLE
use better url-regexp in string->url contract

### DIFF
--- a/racket/collects/net/url.rkt
+++ b/racket/collects/net/url.rkt
@@ -704,10 +704,7 @@
 (provide (struct-out url) (struct-out path/param))
 
 (provide/contract
- (string->url (-> (and/c string?
-                         (or/c #rx"^[a-zA-Z][a-zA-Z0-9+.-]*:"
-                               (not/c #rx"^[^:/?#]*:")))
-                  url?))
+ (string->url (-> (and/c string? url-regexp) url?))
  (path->url ((or/c path-string? path-for-some-system?) . -> . url?))
  (relative-path->relative-url-string ((and/c (or/c path-string? path-for-some-system?)
                                              relative-path?)


### PR DESCRIPTION
Any reason not to use this better url regexp?