### PR TITLE
Generalize inferred names

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -984,6 +984,12 @@ property value of @|void-const| hides a name that would otherwise be
 inferred from context (perhaps because a binding identifier's was 
 automatically generated and should not be exposed).
 
+To support the propagation of properties during expansions, instead
+of a symbol it is possible to use a tree made of @racket[cons] where
+all the leaves are that symbol, for example @racket[('name . 'name)]
+is equivalent to @racket['name]. Similarly, @racket[(<void> . <void>)]
+is equivalent to @|void-const|.
+
 When an inferred name is not available, but a source location is
 available, a name is constructed using the source location
 information. Inferred and property-assigned names are also available

--- a/pkgs/racket-doc/syntax/scribblings/define.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/define.scrbl
@@ -27,7 +27,7 @@ If the definition is ill-formed, a syntax error is raised. If
 an expression context. The default value of @racket[check-context?] is
 @racket[#t].
 
-If @racket[opt-kws?] is @racket[#t], then arguments of the form
+If @racket[opt+kws?] is @racket[#t], then arguments of the form
 @racket[[id expr]], @racket[keyword id], and @racket[keyword [id
 expr]] are allowed, and they are preserved in the expansion.}
 

--- a/pkgs/racket-doc/syntax/scribblings/name.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/name.scrbl
@@ -8,12 +8,19 @@
 @defproc[(syntax-local-infer-name [stx syntax?] [use-local? any/c #t]) any/c]{
 
 Similar to @racket[syntax-local-name], except that @racket[stx] is
-checked for an @racket['inferred-name] property (which overrides any
-inferred name). If neither @racket[syntax-local-name] nor
+checked for an @racket['inferred-name] property that is a symbol 
+(which overrides any inferred name) or @|void-const|.
+If neither @racket[syntax-local-name] nor
 @racket['inferred-name] produce a name, or if the
 @racket['inferred-name] property value is @|void-const|, then a name
 is constructed from the source-location information in @racket[stx],
 if any. If no name can be constructed, the result is @racket[#f].
+
+To support the propagation of properties during expansions, instead
+of a symbol it is possible to use a tree made of @racket[cons] where
+all the leaves are that symbol, for example @racket[('name . 'name)]
+is equivalent to @racket['name]. Similarly, @racket[(<void> . <void>)]
+is equivalent to @|void-const|.
 
 If @racket[use-local?] is @racket[#f], then @racket[syntax-local-name] is
 not used. Provide @racket[use-local?] as @racket[#f] to construct a name

--- a/pkgs/racket-test-core/tests/racket/name.rktl
+++ b/pkgs/racket-test-core/tests/racket/name.rktl
@@ -131,4 +131,22 @@
                    5))
              #rx"^(?!.*unmentionable)")
 
+; Test use of the 'inferred-name syntax property
+(define-syntax (named-thunk1 stx)
+  (syntax-case stx ()
+    [(_ v)
+     (syntax-property #'(lambda () 1) 'inferred-name (eval #'v))]))
+
+(test 'one object-name (let ([tmp (named-thunk1 'one)]) tmp))
+(test #t src-name? (object-name (let ([tmp (named-thunk1 (void))]) tmp)))
+(test 'tmp object-name (let ([tmp (named-thunk1 #f)]) tmp))
+(test 'tmp object-name (let ([tmp (named-thunk1 1)]) tmp))
+(test 'tmp object-name (let ([tmp (named-thunk1 "one")]) tmp))
+
+(test 'one object-name (let ([tmp (named-thunk1 (cons 'one 'one))]) tmp))
+(test #t src-name? (object-name (let ([tmp (named-thunk1 (cons (void) (void)))]) tmp)))
+(test 'tmp object-name (let ([tmp (named-thunk1 (cons #f #f))]) tmp))
+(test 'tmp object-name (let ([tmp (named-thunk1 (cons 1 1))]) tmp))
+(test 'tmp object-name (let ([tmp (named-thunk1 (cons "one" "one"))]) tmp))
+
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/name.rktl
+++ b/pkgs/racket-test-core/tests/racket/name.rktl
@@ -3,8 +3,8 @@
 
 (load-relative "loadtest.rktl")
 
-(require scheme/class)
-(require scheme/unit)
+(require racket/class)
+(require racket/unit)
 
 (Section 'names)
 

--- a/racket/collects/racket/private/name.rkt
+++ b/racket/collects/racket/private/name.rkt
@@ -2,13 +2,21 @@
 (module name '#%kernel
   (#%require "define.rkt" "small-scheme.rkt")
   (#%provide syntax-local-infer-name)
+
+  (define (simplify-inferred-name name fuel)
+    (if (and (fuel . > . 0) (pair? name))
+        (let ([name-car (simplify-inferred-name (car name) (sub1 fuel))]
+              [name-cdr (simplify-inferred-name (cdr name) (sub1 fuel))])
+          (if (eq? name-car name-cdr)
+              name-car
+              name))
+        name))
   
   (define syntax-local-infer-name
     (case-lambda
      [(stx use-local?)
-      (let-values ([(prop) (syntax-property stx 'inferred-name)])
-        (or (and prop
-                 (not (void? prop))
+      (let-values ([(prop) (simplify-inferred-name (syntax-property stx 'inferred-name) 5)])
+        (or (and (symbol? prop)
                  prop)
             (let ([n (and use-local?
                           (not (void? prop))

--- a/racket/src/racket/src/compile.c
+++ b/racket/src/racket/src/compile.c
@@ -371,11 +371,24 @@ static void bad_form(Scheme_Object *form, int l)
 		      l - 1, (l != 2) ? "s" : "");
 }
 
+Scheme_Object *simplify_inferred_name(Scheme_Object *name, int fuel)
+{
+  if (fuel && SCHEME_PAIRP(name)) {
+    Scheme_Object *name_car = SCHEME_CAR(name), * name_cdr = SCHEME_CDR(name);
+    name_car = simplify_inferred_name(name_car, fuel-1);
+    name_cdr = simplify_inferred_name(name_cdr, fuel-1);
+    if (name_car && name_cdr && SAME_OBJ(name_car, name_cdr))
+      return name_car;
+  }
+  return name;  
+}
+
 Scheme_Object *scheme_check_name_property(Scheme_Object *code, Scheme_Object *current_val)
 {
   Scheme_Object *name;
 
   name = scheme_stx_property(code, inferred_name_symbol, NULL);
+  name = simplify_inferred_name(name, 5);
   if (name && SCHEME_SYMBOLP(name))
     return name;
   else
@@ -518,6 +531,7 @@ Scheme_Object *scheme_build_closure_name(Scheme_Object *code, Scheme_Compile_Inf
   Scheme_Object *name;
 
   name = scheme_stx_property(code, inferred_name_symbol, NULL);
+  name = simplify_inferred_name(name, 5);
   if (name && SCHEME_SYMBOLP(name)) {
     name = combine_name_with_srcloc(name, code, 0);
   } else if (name && SCHEME_VOIDP(name)) {


### PR DESCRIPTION
After some expansions, a expression with the syntax property `'inferred-name` of
`'x` is converted to one with ` ('x . 'x) `, so it's not useful to get the name of a
procedure. 

So we simplify the syntax property `'inferred-name` to handle
these cases, to trees deep <=5, where all the leaves are the same symbol. (In the wild, I only saw the 1-level case ` ('x . 'x) `).

The same simplification is useful for properties like ` (#<void> . #<void>)` that are simplified to `#<void>` and replace the local inferred name with the location.

This commit also changes `syntax-local-infer-name` in the case that the property is not a symbol. This is a small breaking change, but the new behavior is more consistent with the names of the procedures.

Some examples:

    #lang racket

    (define-syntax (thunk1 stx)
      (syntax-case stx ()
        [(_ v)
         (begin
           #;(displayln (eval #'v))
           (syntax-property
            #'(lambda () 1)
            'inferred-name
            (eval #'v)))]))


     (let ([tmp (thunk1 (cons 'one 'one))]) tmp)     ;==> #<procedure:tmp> 
                                                          ;changes to #<procedure:one>
     (let ([tmp (thunk1 (cons 1 1))]) tmp)           ;==> #<procedure:tmp>
     (let ([tmp (thunk1 (cons (void) (void)))]) tmp) ;==> #<procedure:tmp> 
                                                          ;changes to #<procedure:test.rkt:77:77>
     (let ([tmp (thunk1 (cons #f #f))]) tmp)         ;==> #<procedure:tmp>
     (let ([tmp (thunk1 (cons "one" "one"))]) tmp)   ;==> #<procedure:tmp>

TODO:
* Fix the documentation of `'inferred-name` and `syntax-local-infer-name`
* Add tests. (I'm not sure where I should to put them)
