### PR TITLE
add define-pattern-expander

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -1061,9 +1061,27 @@ forms by rewriting them into existing pattern forms.
              character. Otherwise, @racket[syntax-parse] and other
              @racketmodname[syntax/parse] forms will not recognize it.}
 
+@defform*[[(define-pattern-expander name-id proc)
+           (define-pattern-expander (name-id . args) template)]
+          #:contracts ([proc (-> syntax? syntax?)]
+                       [name-id (and/c identifier? #rx"^~")])]{
+
+Defines @racket[name-id] as a @tech{pattern expander}. Use this form
+to define pattern expanders since it checks that the name is valid.
+
+@myexamples[
+(define-pattern-expander (~maybe pat ...)
+  (~optional (~seq pat ...)))
+(define-pattern-expander ~another-maybe
+   (syntax-parser
+     [(_ pat ...)
+      #'(~optional (~seq pat ...))]))
+]}
+
 @defproc[(pattern-expander [proc (-> syntax? syntax?)]) pattern-expander?]{
 
-Returns a @tech{pattern expander} that uses @racket[proc] to transform the pattern.
+This is the @tech{pattern expander} constructor function.
+Uses @racket[proc] to transform the pattern.
 
 @myexamples[
 (define-syntax ~maybe

--- a/pkgs/racket-test/tests/stxparse/test.rkt
+++ b/pkgs/racket-test/tests/stxparse/test.rkt
@@ -2,7 +2,7 @@
 (require rackunit
          syntax/parse
          syntax/parse/debug
-         syntax/parse/define
+         (except-in syntax/parse/define define-pattern-expander)
          "setup.rkt"
          (for-syntax syntax/parse))
 
@@ -547,9 +547,9 @@
 ;; from http://lists.racket-lang.org/users/archive/2014-June/063095.html
 (test-case "pattern-expanders"
   (let ()
-      (define-splicing-syntax-class binding #:literals (=)
-        [pattern (~seq name:id = expr:expr)])
-      
+    (define-splicing-syntax-class binding #:literals (=)
+      [pattern (~seq name:id = expr:expr)])
+    (let ()
       (define-syntax ~separated
         (pattern-expander
          (lambda (stx)
@@ -575,7 +575,58 @@
                    (parse-my-let #'(my-let (x = 1 / y = 2 / z = 3)
                                      (+ x y z))))
                   (syntax->datum #'(let ([x 1] [y 2] [z 3])
+                                     (+ x y z)))))
+    (let () ; define-pattern-expander1
+      (define-pattern-expander ~separated
+        (lambda (stx)
+          (syntax-case stx ()
+            [(separated sep pat)
+             (with-syntax ([ooo '...])
+               #'((~seq pat (~or (~peek-not _)
+                                 (~seq sep (~peek _))))
+                  ooo))])))
+      
+      (define-splicing-syntax-class bindings
+        [pattern (~separated (~datum /) b:binding)
+                 #:with (name ...) #'(b.name ...)
+                 #:with (expr ...) #'(b.expr ...)])
+    
+    (define (parse-my-let stx)
+      (syntax-parse stx
+        [(_ bs:bindings body)
+         #'(let ([bs.name bs.expr] ...)
+             body)]))
+    
+    (check-equal? (syntax->datum
+                   (parse-my-let #'(my-let (x = 1 / y = 2 / z = 3)
                                      (+ x y z))))
+                  (syntax->datum #'(let ([x 1] [y 2] [z 3])
+                                     (+ x y z)))))
+    (let () ; define-pattern-expander2
+      (define-pattern-expander (~binding name exp)
+        (~seq (~var name id) (~literal =) (~var exp expr)))
+      
+    (define (parse-my-let stx)
+      (syntax-parse stx
+        [(_ ((~binding name e)) body)
+         #'(let ([name e]) body)]))
+    
+    (check-equal? (syntax->datum
+                   (parse-my-let #'(my-let (x = 1)
+                                     (+ x x x))))
+                  (syntax->datum #'(let ([x 1])
+                                     (+ x x x)))))
+    ; define-pattern-expander errors
+    (check-exn
+            (lambda (exn)
+              (regexp-match #rx"pattern expander name must begin with ~" (exn-message exn)))
+            (lambda ()
+              (expand #'(define-pattern-expander (s x) (~seq x)))))
+    (check-exn
+            (lambda (exn)
+              (regexp-match #rx"pattern expander name must begin with ~" (exn-message exn)))
+            (lambda ()
+              (expand #'(define-pattern-expander s (syntax-parser [x #'x])))))
     ))
 
 (test-case "this-syntax"

--- a/racket/collects/syntax/parse.rkt
+++ b/racket/collects/syntax/parse.rkt
@@ -13,7 +13,8 @@
 (begin-for-syntax
   (require racket/contract/base
            "parse/private/pattern-expander-prop.rkt"
-           "parse/private/pattern-expander.rkt")
+           "parse/private/pattern-expander.rkt"
+           "parse/pre.rkt")
   (provide pattern-expander?
            (contract-out
             [pattern-expander
@@ -22,3 +23,5 @@
              (struct-type-property/c (-> pattern-expander? (-> syntax? syntax?)))]
             [syntax-local-syntax-parse-pattern-introduce
              (-> syntax? syntax?)])))
+(require "parse/private/define-pattern-expander.rkt")
+(provide define-pattern-expander)

--- a/racket/collects/syntax/parse/private/define-pattern-expander.rkt
+++ b/racket/collects/syntax/parse/private/define-pattern-expander.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+(require
+  (for-syntax racket/base "parse.rkt" "keywords.rkt" "pattern-expander.rkt"))
+(provide define-pattern-expander)
+
+(define-syntax (define-pattern-expander stx)
+  (syntax-parse stx
+    [(_ (pe x ...) ~! body)
+     #:fail-unless (and (identifier? #'pe)
+                        (regexp-match "^~" (symbol->string (syntax-e #'pe))))
+                   (format "pattern expander name must begin with ~~, given: ~a"
+                           (syntax->datum #'pe))
+     #'(define-syntax pe
+         (pattern-expander (syntax-parser [(_ x ...) #'body])))]
+    [(_ pe proc)
+     #:when (identifier? #'pe)
+     #:fail-unless (regexp-match "^~" (symbol->string (syntax-e #'pe)))
+                   (format "pattern expander name must begin with ~~, given: ~a"
+                           (syntax->datum #'pe))
+     #'(define-syntax pe (pattern-expander proc))]))


### PR DESCRIPTION
There should be a special form to define `pattern-expander`s, to check that the name is valid.