### PR TITLE
Binding for OpenSSL SHA-256

### DIFF
--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -4,7 +4,8 @@
           (for-label openssl
                      racket
                      openssl/sha1
-                     openssl/md5))
+                     openssl/md5
+                     openssl/sha256))
 
 @title{OpenSSL: Secure Communication}
 
@@ -793,6 +794,29 @@ representation in the resulting string.}
 @defproc[(hex-string->bytes [str string?]) bytes?]{
 
 The inverse of @racket[bytes->hex-string].}
+
+@; ----------------------------------------------------------------------
+
+@section{SHA-256 Hashing}
+
+@defmodule[openssl/sha256]{The @racketmodname[openssl/sha256] library
+provides a Racket wrapper for the OpenSSL library's SHA-256 hashing
+function. OpenSSL is required to use this module, as there currently is no fallback implementation.
+}
+@defproc[(sha256 [in input-port?]) string?]{
+
+Returns a 64-character string that represents the SHA-256 hash (in
+hexadecimal notation) of the content from @racket[in], consuming all
+of the input from @racket[in] until an end-of-file.
+
+The @racket[sha256] function composes @racket[bytes->hex-string] with
+@racket[sha256-bytes].}
+
+@defproc[(sha256-bytes [in input-port?]) bytes?]{
+
+Returns a 32-byte byte string that represents the SHA-256 hash of the
+content from @racket[in], consuming all of the input from @racket[in]
+until an end-of-file.}
 
 @; ----------------------------------------------------------------------
 

--- a/racket/collects/openssl/sha256.rkt
+++ b/racket/collects/openssl/sha256.rkt
@@ -1,0 +1,41 @@
+#lang racket/base
+(require ffi/unsafe
+         racket/runtime-path
+         (for-syntax racket/base)
+         (prefix-in r: file/sha1)
+         "libcrypto.rkt")
+
+(provide sha256
+         sha256-bytes)
+
+(define _SHA256_CTX-pointer _pointer)
+
+(define SHA256_Init 
+  (and libcrypto
+       (get-ffi-obj 'SHA256_Init libcrypto (_fun _SHA256_CTX-pointer -> _int) (lambda () #f))))
+(define SHA256_Update 
+  (and libcrypto
+       (get-ffi-obj 'SHA256_Update libcrypto (_fun _SHA256_CTX-pointer _pointer _long -> _int) (lambda () #f))))
+(define SHA256_Final
+  (and libcrypto
+       (get-ffi-obj 'SHA256_Final libcrypto (_fun _pointer _SHA256_CTX-pointer -> _int) (lambda () #f))))
+
+(define (sha256-bytes in)
+  (unless (input-port? in) (raise-argument-error 'sha256-bytes "input-port?" in))
+  (if SHA256_Init
+      (let ([ctx (malloc 256)]
+            [tmp (make-bytes 4096)]
+            [result (make-bytes 32)])
+        (SHA256_Init ctx)
+        (let loop ()
+          (let ([n (read-bytes-avail! tmp in)])
+            (unless (eof-object? n)
+              (SHA256_Update ctx tmp n)
+              (loop))))
+        (SHA256_Final result ctx)
+        result)
+      (lambda () #f)))
+
+(define (sha256 in)
+  (unless (input-port? in) (raise-argument-error 'sha256 "input-port?" in))
+  (r:bytes->hex-string (sha256-bytes in)))


### PR DESCRIPTION
Figured it would be nice if people could easily use SHA-256, so I wrapped openssl's implementation.
The first commit adds the wrapper itself, while the second consists of the documentation.