### PR TITLE
make sure git checkouts have correct file perms

### DIFF
--- a/racket/collects/net/git-checkout.rkt
+++ b/racket/collects/net/git-checkout.rkt
@@ -676,6 +676,7 @@
             #"100755" #"755")
            (copy-object tmp
                         (this-object-location)
+                        mode
                         (build-path dest-dir fn))]
           [(#"40000" #"040000")
            (extract-tree id obj-ids tmp (build-path dest-dir fn))]
@@ -938,8 +939,8 @@
    [else
     (call-with-input-file* (build-path (tmp-info-dir tmp) location) proc)]))
 
-;; copy-object : tmp-info location path -> void
-(define (copy-object tmp location dest-file)
+;; copy-object : tmp-info location bytes path -> void
+(define (copy-object tmp location mode dest-file)
   (cond
    [(pair? location)
     (define bstr (object->bytes tmp location))
@@ -950,7 +951,12 @@
    [else
     (copy-file (build-path (tmp-info-dir tmp) location)
                dest-file
-               #t)]))
+               #t)])
+  (define perms
+    (case mode
+      [(#"755" #"100755") #o755]
+      [(#"644" #"100644") #o644]))
+  (file-or-directory-permissions dest-file perms))
 
 ;; object->bytes : tmp-info location -> bytes
 (define (object->bytes tmp location)

--- a/racket/collects/net/git-checkout.rkt
+++ b/racket/collects/net/git-checkout.rkt
@@ -671,13 +671,16 @@
        (when id
          (define (this-object-location)
            (object-location (hash-ref obj-ids id)))
-         (case (datum-intern-literal mode)
-          [(#"100644" #"644"
-            #"100755" #"755")
+         (define (copy-this-object perms)
            (copy-object tmp
                         (this-object-location)
-                        mode
-                        (build-path dest-dir fn))]
+                        perms
+                        (build-path dest-dir fn)))
+         (case (datum-intern-literal mode)
+          [(#"100755") #"755"
+           (copy-this-object #o755)]
+          [(#"100644" #"644")
+           (copy-this-object #o644)]
           [(#"40000" #"040000")
            (extract-tree id obj-ids tmp (build-path dest-dir fn))]
           [(#"120000")
@@ -939,8 +942,8 @@
    [else
     (call-with-input-file* (build-path (tmp-info-dir tmp) location) proc)]))
 
-;; copy-object : tmp-info location bytes path -> void
-(define (copy-object tmp location mode dest-file)
+;; copy-object : tmp-info location integer path -> void
+(define (copy-object tmp location perms dest-file)
   (cond
    [(pair? location)
     (define bstr (object->bytes tmp location))
@@ -952,10 +955,6 @@
     (copy-file (build-path (tmp-info-dir tmp) location)
                dest-file
                #t)])
-  (define perms
-    (case mode
-      [(#"755" #"100755") #o755]
-      [(#"644" #"100644") #o644]))
   (file-or-directory-permissions dest-file perms))
 
 ;; object->bytes : tmp-info location -> bytes

--- a/racket/collects/net/git-checkout.rkt
+++ b/racket/collects/net/git-checkout.rkt
@@ -955,7 +955,9 @@
     (copy-file (build-path (tmp-info-dir tmp) location)
                dest-file
                #t)])
-  (file-or-directory-permissions dest-file perms))
+  (if (eq? 'windows (system-type 'os))
+      (file-or-directory-permissions dest-file #o755)
+      (file-or-directory-permissions dest-file perms)))
 
 ;; object->bytes : tmp-info location -> bytes
 (define (object->bytes tmp location)


### PR DESCRIPTION
This fixes and issue where package installs sometimes have the wrong permissions a file.

I don't quite know how to tests this. I did check locally on the package that was having issues (https://github.com/rpless/cover-coveralls)