### PR TITLE
added bytes->number

### DIFF
--- a/racket/collects/racket/bytes.rkt
+++ b/racket/collects/racket/bytes.rkt
@@ -1,12 +1,13 @@
 #lang racket/base
 
-(provide bytes-append* bytes-join)
+(provide bytes-append* bytes-join bytes->number)
 
 (define bytes-append*
   (case-lambda [(strs) (apply bytes-append strs)] ; optimize common case
                [(str . strss) (apply bytes-append (apply list* str strss))]))
 
-(require (only-in racket/list add-between))
+(require (only-in racket/list add-between)
+         (only-in file/sha1 bytes->hex-string))
 
 (define (bytes-join strs sep)
   (cond [(not (and (list? strs) (andmap bytes? strs)))
@@ -16,3 +17,5 @@
         [(null? strs) #""]
         [(null? (cdr strs)) (car strs)]
         [else (apply bytes-append (add-between strs sep))]))
+
+(define bytes->number (compose (lambda (s) (string->number s 16)) bytes->hex-string))


### PR DESCRIPTION
A procedure that turns byte-strings into numbers would be useful, especially when dealing with the proposed `crypto-random-bytes` function. This patch adds such a procedure.