### PR TITLE
fixing git-checkout permissions for windows

### DIFF
--- a/racket/collects/net/git-checkout.rkt
+++ b/racket/collects/net/git-checkout.rkt
@@ -955,8 +955,9 @@
     (copy-file (build-path (tmp-info-dir tmp) location)
                dest-file
                #t)])
-  (unless (equal? 'windows (system-type 'os))
-    (file-or-directory-permissions dest-file perms)))
+  (if (equal? 'windows (system-type 'os))
+      (file-or-directory-permissions dest-file #o777)
+      (file-or-directory-permissions dest-file perms)))
 
 ;; object->bytes : tmp-info location -> bytes
 (define (object->bytes tmp location)


### PR DESCRIPTION
Follow up to #1060, in which this finally works for Windows.