### PR TITLE
Correct shown portion of error message

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/contracts/simple-function.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/contracts/simple-function.scrbl
@@ -447,4 +447,4 @@ In general, each contract error message consists of six sections:
           @item{the complete contract plus a path into it showing which aspect was violated, @lines[3 2]}
           @item{the module where the contract was put (or, more generally, the boundary that the contract mediates), @lines[5 1]}
           @item{who was blamed, @lines[6 1]}
-          @item{and the source location where the contract appears. @lines[7 1]}]
+          @item{and the source location where the contract appears. @lines[8 1]}]


### PR DESCRIPTION
Currently this documentation page [1] ends with the unexpected

> and the source location where the contract appears.
>> (assuming the contract is correct)

Please see the original at http://docs.racket-lang.org/guide/contract-func.html to see the above in context.

With this change, it ends with the more sensible:
> and the source location where the contract appears.
>> at: eval:5.0

I suspect that this was the original output, but that the message changed and the docs weren't updated.

[1] http://docs.racket-lang.org/guide/contract-func.html