### PR TITLE
provide example for in-directory

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -384,7 +384,31 @@ each element in the sequence.
   content of a directory, use the result of @racket[directory-list] as
   a sequence.
 
-@history[#:changed "6.0.0.1" @elem{Added @racket[use-dir?] argument.}]}
+@history[#:changed "6.0.0.1" @elem{Added @racket[use-dir?] argument.}]
+
+Examples:
+
+    @racketblock[
+    (code:comment @#,t{Given a directory tree:})
+    (code:comment @#,t{})
+    (code:comment @#,t{ /example})
+    (code:comment @#,t{ ├── a})
+    (code:comment @#,t{ │   ├── alpha})
+    (code:comment @#,t{ │   └── apple})
+    (code:comment @#,t{ ├── b})
+    (code:comment @#,t{ │   └── beta})
+    (code:comment @#,t{ └── c})
+    (code:comment @#,t{})
+    (code:comment @#,t{Output:})
+    (code:comment @#,t{})
+    (code:comment @#,t{/example/c})
+    (code:comment @#,t{/example/b})
+    (code:comment @#,t{/example/b/beta})
+    (code:comment @#,t{/example/a})
+    (code:comment @#,t{})
+    (let ([f (lambda (path) (regexp-match? #rx"/example/b.*" (path->string path)))])
+      (for ([p (in-directory "/example" f)])
+      (printf "~a\n" p)))]}
 
 
 @defproc*[([(in-producer [producer procedure?])


### PR DESCRIPTION
Given  [in-directory](http://docs.racket-lang.org/reference/sequences.html?q=filesystem#%28def._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._in-directory%29%29) is a "start quickly" example on the [main site](http://racket-lang.org/), I thought might benefit from an example, especially considering the `use-dir?` parameter, which had me slightly confused (late) last night (I expected to see only `/example/b` and `/example/b/beta` in the output, but re-read the doc and saw **except for the CONTENTS of any directory for which**).