### PR TITLE
fix typo in documented contracts for `extfl->exact` and `extfl->inexact`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/extflonums.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/extflonums.scrbl
@@ -109,8 +109,8 @@ Like @racket[flsin], @racket[flcos], @racket[fltan], @racket[flasin],
 @defproc[(->extfl [a exact-integer?]) extflonum?]
 @defproc[(extfl->exact-integer [a extflonum?]) exact-integer?]
 @defproc[(real->extfl [a real?]) extflonum?]
-@defproc[(extfl->exact [a real?]) (and/c real? exact?)]
-@defproc[(extfl->inexact [a real?]) flonum?]
+@defproc[(extfl->exact [a extflonum?]) (and/c real? exact?)]
+@defproc[(extfl->inexact [a extflonum?]) flonum?]
 )]{
 
 The first four are like @racket[->fl], @racket[fl->exact],


### PR DESCRIPTION
Fix typo in documented contracts for `extfl->exact` and `extfl->inexact`.