### PR TITLE
fix documented contract ranges of `set-subtract!` and `set-symmetric-difference!`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -518,7 +518,7 @@ both @racket[set-clear] and @racket[set-add], and @supp{supports} @racket[set->s
 
 }
 
-@defproc[(set-subtract! [st0 generic-set?] [st generic-set?] ...) generic-set?]{
+@defproc[(set-subtract! [st0 generic-set?] [st generic-set?] ...) void?]{
 
 Removes every element from @racket[st0] that is contained by any of the
 @racket[st]s.
@@ -557,7 +557,7 @@ Supported for any @racket[st] that @impl{implements} @racket[set-remove] or both
 
 }
 
-@defproc[(set-symmetric-difference! [st0 generic-set?] [st generic-set?] ...) generic-set?]{
+@defproc[(set-symmetric-difference! [st0 generic-set?] [st generic-set?] ...) void?]{
 
 Adds and removes elements of @racket[st0] so that it includes all of the
 elements contained an odd number of times in the @racket[st]s and the


### PR DESCRIPTION
This pull request fixes the ranges of the remaining imperative set methods. Somehow I missed these last time...