### PR TITLE
syntax/parse: disarm the result of expanding patterns

### DIFF
--- a/pkgs/racket-test/tests/stxparse/test.rkt
+++ b/pkgs/racket-test/tests/stxparse/test.rkt
@@ -618,6 +618,17 @@
                                       (+ x y z))))
                   (syntax->datum #'(let ([x 1] [y 2] [z 3])
                                      (+ x y z))))
+
+    (define-syntax ~maybe
+      (pattern-expander
+       (syntax-rules ()
+        [(~maybe pat ...)
+         (~optional (~seq pat ...))])))
+
+    (check-equal? (syntax-parse #'(1 2 3 4 5 6)
+                    [((~maybe a b) ...)
+                     (syntax->datum #'(a ...))])
+                  '(1 3 5))
     ))
 
 (test-case "this-syntax"

--- a/racket/collects/syntax/parse/private/rep.rkt
+++ b/racket/collects/syntax/parse/private/rep.rkt
@@ -475,7 +475,7 @@
             [mstx (introducer (syntax-local-introduce stx))]
             [mresult (parameterize ([current-syntax-parse-pattern-introducer introducer])
                        (proc mstx))]
-            [result (syntax-local-introduce (introducer mresult))])
+            [result (syntax-local-introduce (introducer (syntax-disarm mresult #f)))])
        (disappeared! #'id)
        (recur result))]
     [(id . rst)
@@ -487,7 +487,7 @@
             [mstx (introducer (syntax-local-introduce stx))]
             [mresult (parameterize ([current-syntax-parse-pattern-introducer introducer])
                        (proc mstx))]
-            [result (syntax-local-introduce (introducer mresult))])
+            [result (syntax-local-introduce (introducer (syntax-disarm mresult #f)))])
        (disappeared! #'id)
        (recur result))]
     [wildcard


### PR DESCRIPTION
Fixes the bug pointed out in https://groups.google.com/d/msg/racket-users/YIYOVPo7W9Y/CEQCejGVBAAJ
