### PR TITLE
Flatten nested begin and begin0 forms after optimization

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1528,6 +1528,32 @@
 (test-comp '(lambda () (begin (random 1) (random 2)))
            '(lambda () (cdr (cons (random 1) (random 2)))))
 
+(test-comp '(lambda () (begin (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin (car (cons (random 1) (random 2))) (random 3) (random 4)))) ;
+(test-comp '(lambda () (begin (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin (cdr (cons (random 1) (random 2))) (random 3) (random 4))))
+(test-comp '(lambda () (begin (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin (random 1) (car (cons (random 2) (random 3))) (random 4)))) ;
+(test-comp '(lambda () (begin (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin (random 1) (cdr (cons (random 2) (random 3))) (random 4))))
+(test-comp '(lambda () (begin (random 1) (random 2) (begin0 (random 3) (random 4))))
+           '(lambda () (begin (random 1) (random 2) (car (cons (random 3) (random 4))))))
+(test-comp '(lambda () (begin (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin (random 1) (random 2) (cdr (cons (random 3) (random 4))))))
+
+(test-comp '(lambda () (begin0 (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin0 (car (cons (random 1) (random 2))) (random 3) (random 4))))
+(test-comp '(lambda () (begin0 (begin (random 1) (random 2)) (random 3) (random 4)))
+           '(lambda () (begin0 (cdr (cons (random 1) (random 2))) (random 3) (random 4))))
+(test-comp '(lambda () (begin0 (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin0 (random 1) (car (cons (random 2) (random 3))) (random 4)))) ;
+(test-comp '(lambda () (begin0 (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin0 (random 1) (cdr (cons (random 2) (random 3))) (random 4))))
+(test-comp '(lambda () (begin0 (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin0 (random 1) (random 2) (car (cons (random 3) (random 4)))))) ;
+(test-comp '(lambda () (begin0 (random 1) (random 2) (random 3) (random 4)))
+           '(lambda () (begin0 (random 1) (random 2) (cdr (cons (random 3) (random 4))))))
+
 (test-comp '(lambda (w)
               (begin (random) w))
            '(lambda (w)


### PR DESCRIPTION
The nested `begin`/`begin0` are flattened at read time, but some
optimizations may create new instances. So try again after optimizations. 

The main function is `flatten_sequence`. It has the same name than a function is `sfs.c` that is similar but not equivalent. This is not a problem for the c compiler, but I'm slightly worried about copy&paste errors in the future.

This commit has no tests, because `test-comp` uses the reader to see inside the compiled expressions, so (most?) of these `begins` are cleared. One possibility is to use `match` to inspect the compiled version. Another is to just add some test to ensure that the order is not messed. For example, reduce

    (begin (random 1) 0 (car (list (random 3) (random 3))) 0 (random 4))

to

    (begin (random 1) (random 2) (random 3) (random 4))

