### PR TITLE
Don't burn fuel when a single use function is inlined (with error, don't merge)

### DIFF
--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -1631,7 +1631,8 @@ static Scheme_Object *no_potential_size(Scheme_Object *v)
 static Scheme_Object *apply_inlined(Scheme_Object *p, Scheme_Closure_Data *data, Optimize_Info *info,
 				    int argc, Scheme_App_Rec *app, Scheme_App2_Rec *app2, Scheme_App3_Rec *app3,
                                     int context,
-                                    int nested_count, Scheme_Object *orig, Scheme_Object *le_prev)
+                                    int nested_count, Scheme_Object *orig, Scheme_Object *le_prev,
+                                    int single_use)
 {
   Scheme_Let_Header *lh;
   Scheme_Compiled_Let_Value *lv, *prev = NULL;
@@ -1644,7 +1645,8 @@ static Scheme_Object *apply_inlined(Scheme_Object *p, Scheme_Closure_Data *data,
 
   if (!expected) {
     sub_info = optimize_info_add_frame(info, 0, 0, 0);
-    sub_info->inline_fuel >>= 1;
+    if (!single_use)
+      sub_info->inline_fuel >>= 1;
     p = scheme_optimize_expr(p, sub_info, context);
     info->single_result = sub_info->single_result;
     info->preserves_marks = sub_info->preserves_marks;
@@ -1713,7 +1715,8 @@ static Scheme_Object *apply_inlined(Scheme_Object *p, Scheme_Closure_Data *data,
     lh->body = p;
 
   sub_info = optimize_info_add_frame(info, 0, 0, 0);
-  sub_info->inline_fuel >>= 1;
+  if (!single_use)
+    sub_info->inline_fuel >>= 1;
 
   p = scheme_optimize_lets((Scheme_Object *)lh, sub_info, 1, context);
 
@@ -1937,7 +1940,7 @@ Scheme_Object *optimize_for_inline(Optimize_Info *info, Scheme_Object *le, int a
 		     threshold,
 		     scheme_optimize_context_to_string(info->context));
           le = apply_inlined(le, data, sub_info, argc, app, app2, app3, context,
-                             id_offset, orig_le, prev);
+                             id_offset, orig_le, prev, single_use);
           if (id_offset) {
             optimize_info_done(sub_info, NULL);
             merge_types(sub_info, info, id_offset);


### PR DESCRIPTION
Since this operation only moves the code and doesn't make the final
bytecode bigger, it's not necessary to decrease the fuel and then it
is available for further inlining.

With this change, the Racket build and tests complete without errors. But I tried a few additional changes and discovered a problem. [In particular, I was trying to burn less fuel when a function is small, there is a similar problem when increasing the initial fuel.]

The problem is that this program doesn't finish compiling:

    #lang racket/base
    (define ((proc))
      ((proc)))

And this neither:

    #lang racket/base
    (let ()
      (define ((proc))
        ((proc)))
      (void proc proc))

I think that the problem is the internal `lambda`s in `(lambda () (lambda () ...))`.

