### PR TITLE
Fix parsing of 0e401 on USE_EXPLICT_FP_FORM_CHECK platforms.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -2727,6 +2727,8 @@
 (test (- (sub1 (expt 2 256))) string->number "-ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff" 16)
 (test #f string->number "144r" 10)
 (err/rt-test (string->number "10" 30))
+(test 0.0 string->number "0e401")
+(test 0.0 string->number "00000.00000e9999999999")
 
 (define (q-test quotient)
   (test 0 quotient 0 12345678909876532341)

--- a/racket/src/racket/src/numstr.c
+++ b/racket/src/racket/src/numstr.c
@@ -386,7 +386,7 @@ END_XFORM_ARITH;
 static double STRTOD(const char *orig_c, char **f, int extfl)
 {
   int neg = 0;
-  int found_dot = 0, is_infinity = 0, is_zero = 0;
+  int found_dot = 0, is_infinity = 0, is_zero = 0, is_nonzero = 0;
   const char *c = orig_c;
 
   *f = (char *)c;
@@ -410,7 +410,8 @@ static double STRTOD(const char *orig_c, char **f, int extfl)
     int ch = *c;
 
     if (isdigit(ch)) {
-      /* ok */
+      if (ch != '0')
+	is_nonzero = 1;
     } else if ((ch == 'e') || (ch == 'E')) {
       int e = 0, neg_exp = 0;
 
@@ -431,7 +432,7 @@ static double STRTOD(const char *orig_c, char **f, int extfl)
 	else {
 	  e = (e * 10) + (ch - '0');
 	  if (e > CHECK_INF_EXP_THRESHOLD(extfl)) {
-	    if (neg_exp)
+	    if (neg_exp || !is_nonzero)
 	      is_zero  = 1;
 	    else
 	      is_infinity  = 1;


### PR DESCRIPTION
This is a fix for #1140.

This does not fix `(string->number (string-append "0." (make-string 400 #\0) "1e400"))` (which will still parse as infinity on such Linux, Solaris, HP/UX, etc.), but the common cases should be correct.

(Also, "explict"? Eww. (I worried that I had made a typo, but realised that I actually cut and pasted the macro name which was misspelled.))