### PR TITLE
Wait more time before of to abort the tests.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/quiet.rktl
+++ b/pkgs/racket-test-core/tests/racket/quiet.rktl
@@ -30,7 +30,7 @@
       (set! timeout-thread
             (thread
              (lambda ()
-               (sleep 1200)
+               (if (eval-jit-enabled) (sleep 1200) (sleep 1800))
                (fprintf errp "\n\n~aTIMEOUT -- ABORTING!\n" Section-prefix)
                (exit 3)
                ;; in case the above didn't work for some reason


### PR DESCRIPTION
For slow systems without JIT support (like sparc64), 20 minutes is not enough.
