### PR TITLE
Remove typo in docs for expand-syntax-top-level-with-compile-time-evals

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/toplevel.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/toplevel.scrbl
@@ -12,7 +12,7 @@ Expands @racket[stx] as a top-level expression, and evaluates its
 compile-time portion for the benefit of later expansions.
 
 The expander recognizes top-level @racket[begin] expressions, and
-interleaves the evaluation and expansion of of the @racket[begin]
+interleaves the evaluation and expansion of the @racket[begin]
 body, so that compile-time expressions within the @racket[begin] body
 affect later expansions within the body. (In other words, it ensures
 that expanding a @racket[begin] is the same as expanding separate


### PR DESCRIPTION
Duplicate 'of' words.