### PR TITLE
Don't drop expressions with side effects in eq? reduction

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1494,6 +1494,12 @@
            '(lambda (x y) (car x) (unbox y) (eq? x y)))
 (test-comp '(lambda (x) (car x) #f)
            '(lambda (x) (car x) (eq? x (box 0))))
+(test-comp '(lambda (x) (car x) #f)
+           '(lambda (x) (car x) (eq? (begin (newline) x) (box 0)))
+           #f)
+(test-comp '(lambda (x) (car x) #f)
+           '(lambda (x) (car x) (eq? x (begin (newline) (box 0))))
+           #f)
 
 (test-comp '(lambda (w) (car w) (mcar w))
            '(lambda (w) (car w) (mcar w) (random)))

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -3698,7 +3698,13 @@ static Scheme_Object *finish_optimize_application3(Scheme_App3_Rec *app, Optimiz
         if (!SAME_OBJ(pred1, pred2)) {
           info->preserves_marks = 1;
           info->single_result = 1;
-          return scheme_false;
+          return do_make_discarding_sequence(app->rand1,
+                                             do_make_discarding_sequence(app->rand2,
+                                                                         scheme_false,
+                                                                         info, 0,
+                                                                         1, 0),
+                                             info, 0,
+                                             1, 0);
         }
       }
     }


### PR DESCRIPTION
The expression `(eq? x y)` is reduced to `#f` when the types of
`x` and `y` are known. Reduce this to `(begin x y #f)` when they
have side effects.