### PR TITLE
Fix small typo in jit.h

### DIFF
--- a/racket/src/racket/src/jit.h
+++ b/racket/src/racket/src/jit.h
@@ -155,7 +155,7 @@ END_XFORM_ARITH;
 /* These flags are set post-JIT: */
 #define NATIVE_PRESERVES_MARKS 0x1
 #define NATIVE_IS_SINGLE_RESULT 0x2
-/* Pre-JIT flags rae in "schpriv.h" */
+/* Pre-JIT flags are in "schpriv.h" */
 
 #if defined(MZ_PRECISE_GC) && !defined(USE_COMPACT_3M_GC)
 # define CAN_INLINE_ALLOC


### PR DESCRIPTION
Just noticed it while reading db0a6de1d2d5d3059ec971275b287860c5bda6e2

edit: whoops, didn't meant to have the CI run. Not sure if there's a way to avoid that for such small PRs?