### PR TITLE
Fix bug in shifting of types during inlining

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -3630,6 +3630,30 @@
            #f)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Check that the type information is shifted in the
+;; right direction while inlining.
+;; The first example triggered a bug in 6.3.
+
+(test-comp '(let ([zz (lambda (x) (lambda (y) 0))])
+              (lambda (a b c)
+                ((zz (let ([loop (lambda () 0)]) loop)) (car a))
+                (list c (pair? c))))
+           '(let ([zz (lambda (x) (lambda (y) 0))])
+              (lambda (a b c)
+                ((zz (let ([loop (lambda () 0)]) loop)) (car a))
+                (list c #t)))
+           #f)
+
+(test-comp '(let ([zz (lambda (x) (lambda (y) 0))])
+              (lambda (a b c)
+                ((zz (let ([loop (lambda () 0)]) loop)) (car a))
+                (list a (pair? a))))
+           '(let ([zz (lambda (x) (lambda (y) 0))])
+              (lambda (a b c)
+                ((zz (let ([loop (lambda () 0)]) loop)) (car a))
+                (list a #t))))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check that the unused continuations are removed
 
 (test-comp '(call-with-current-continuation (lambda (ignored) 5))
@@ -4179,9 +4203,9 @@
     (test-values '(-100001.0t0 100001.0t0) tail)))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Check for corect fixpoint calculation when lifting
+;; Check for correct fixpoint calculation when lifting
 
-;; This test is especilly fragile. It's a minimized(?) variant
+;; This test is especially fragile. It's a minimized(?) variant
 ;; of PR 12910, where just enbought `with-continuation-mark's
 ;; are needed to thwart inlining, and enough functions are 
 ;; present in the right order to require enough fixpoint

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -1959,7 +1959,7 @@ Scheme_Object *optimize_for_inline(Optimize_Info *info, Scheme_Object *le, int a
                              id_offset, orig_le, prev);
           if (id_offset) {
             optimize_info_done(sub_info, NULL);
-            merge_types(sub_info, info, id_offset);
+            merge_types(sub_info, info, -id_offset);
           }
           return le;
 	} else {
@@ -5922,7 +5922,7 @@ scheme_optimize_lets(Scheme_Object *form, Optimize_Info *info, int for_inline, i
             info->single_result = sub_info->single_result;
             info->preserves_marks = sub_info->preserves_marks;
             optimize_info_done(sub_info, NULL);
-            merge_types(sub_info, info, 1);
+            merge_types(sub_info, info, -1);
           }
 
           return form;
@@ -5948,7 +5948,7 @@ scheme_optimize_lets(Scheme_Object *form, Optimize_Info *info, int for_inline, i
           info->single_result = sub_info->single_result;
           info->preserves_marks = sub_info->preserves_marks;
           optimize_info_done(sub_info, NULL);
-          merge_types(sub_info, info, 1);
+          merge_types(sub_info, info, -1);
           return body;
 	}
       }


### PR DESCRIPTION
I think this fix the crash that appeared in https://github.com/racket/racket/pull/1076. I also found an example that shows a bug in 6.3.

During inlining, the type information gathered in code that was inside the lambda is copied to the outer context. But the coordinates of the type information were shifted in the wrong direction, so the type was
assigned to the wrong variable.

The important change is the sign in line 1962. With this change the problem is fixed.

I also review all the other uses of `merge_types`, and I found two places where I think it should say `-1` instead of `1`. But both of the versions with `-1` and `1` compile without problems, and I coudn't make an example where this difference causes a problem. Moreover, using `printf` in those places, it looks like it's dead code (or they are used only in very weird code).