### PR TITLE
remove bad srcloc from define-runtime-path

### DIFF
--- a/racket/collects/racket/runtime-path.rkt
+++ b/racket/collects/racket/runtime-path.rkt
@@ -186,8 +186,7 @@
                                         (path-of
                                          #,(datum->syntax
                                             #'orig-stx
-                                            `(,#'this-expression-source-file)
-                                            #'orig-stx)))
+                                            `(,#'this-expression-source-file))))
                                     #'void)])
                  (apply to-values (resolve-paths (#%variable-reference)
                                                  get-dir


### PR DESCRIPTION
Changes how `define-runtime-path` leaves srclocs around to give more useful information errortrace and cover. `(define-runtime-path a '(lib <something))` currently leaves much of that expression uncovered.