### PR TITLE
Add 'fallback key to config.rktd files.

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/config.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/config.scrbl
@@ -153,6 +153,16 @@ directory}:
        @racket[#t] if the installation uses absolute path names,
        @racket[#f] otherwise.}
 
+ @item{@indexed-racket['fallback] --- a path, string, or byte string
+       for a directory containing an additional @filepath{config.rktd}
+       file. The procedures provided by @racketmodname[setup/dirs]
+       automatically consult this file for keys not found in the
+       @filepath{config.rktd} file in the @tech{configuration
+       directory}. The additional @filepath{config.rktd} file may have
+       a @racket['fallback] entry, which is also consulted as needed.
+
+       @history[#:added "6.4.0.1"]}
+
  @item{@indexed-racket['cgc-suffix] --- a string used as the suffix (before
        the actual suffix, such as @filepath{.exe}) for a
        @filepath{CGC} executable. Use Windows-style casing, and the

--- a/pkgs/racket-doc/scribblings/raco/setup.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/setup.scrbl
@@ -1409,6 +1409,15 @@ function for installing a single @filepath{.plt} file.
   absolute path names for executable and library references, 
   @racket[#f] otherwise.}
 
+@defprof[(find-fallback-dir) (or/c path? #f)]{
+  Returns a path to the directory used to find a fallback @filepath{config.rktd}
+  file, used when the @filepath{config.rktd} file via @racket[(find-config-dir)]
+  does not specify a value for a given key. The result is @racket[#f] if no such
+  fallback directory is specified. 
+
+  @history[#:added "6.4.0.1"]
+}
+
 @; ------------------------------------------------------------------------
 
 @section[#:tag "getinfo"]{API for Reading @filepath{info.rkt} Files}


### PR DESCRIPTION
The 'fallback key points to a directory to find another config.rktd file which
is used if no key is found.