### PR TITLE
read/contract

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1784,6 +1784,16 @@ The @racket[define-struct/contract] form only allows a subset of the
   
 }
 
+@defform[#:literals (current-input-port)
+         (read/contract contract-expr [in (current-input-port)])
+         #:contracts ([in input-port?])]{
+  Calls @racket[read] to retrieve a single @tech{datum} from @emph{in}, then applies
+  @racket[contract-expr] to the result.
+
+  @history[#:added "6.4.0.1"]
+
+}
+
 @defidform[current-contract-region]{
   Bound by @racket[define-syntax-parameter], this contains
   information about the current contract region, used by

--- a/pkgs/racket-test/tests/racket/contract/read.rkt
+++ b/pkgs/racket-test/tests/racket/contract/read.rkt
@@ -1,0 +1,38 @@
+#lang racket/base
+(require "test-util.rkt")
+(parameterize ([current-contract-namespace (make-basic-contract-namespace
+                                             'racket/contract
+                                             'racket/port)])
+
+  (test/spec-passed
+    'read/contract-1
+    '(with-input-from-string "1"
+       (lambda () (read/contract integer?))))
+
+  (test/spec-passed
+    'read/contract-2
+    '(with-input-from-string "(1 2 3)"
+       (lambda ()
+         (read/contract (listof (integer-in 1 3))))))
+
+
+  (test/spec-failed
+    'read/contract-3
+    '(with-input-from-string "1"
+       (lambda () (read/contract symbol?)))
+    "#<input-port:string>")
+
+  (test/spec-failed
+    'read/contract-4
+    '(with-input-from-string "(1 2 three)"
+       (lambda () (read/contract (listof integer?))))
+    "#<input-port:string>")
+
+  (test/spec-failed
+    'read/contract-5
+    '(with-input-from-string "#(a b c)"
+       (lambda ()
+         (let ([v (read/contract (vectorof symbol?))])
+           (vector-set! v 0 0))))
+    "top-level")
+)

--- a/racket/collects/racket/contract/base.rkt
+++ b/racket/collects/racket/contract/base.rkt
@@ -61,6 +61,7 @@
  contract
  recursive-contract
  invariant-assertion
+ read/contract
  
  flat-murec-contract
  and/c

--- a/racket/collects/racket/contract/private/base.rkt
+++ b/racket/collects/racket/contract/private/base.rkt
@@ -4,6 +4,7 @@
          (rename-out [-recursive-contract recursive-contract])
          current-contract-region
          invariant-assertion
+         read/contract
          (for-syntax lifted-key add-lifted-property))
 
 (require (for-syntax racket/base syntax/name syntax/srcloc)
@@ -86,6 +87,21 @@
                    me me
                    '#,(syntax-local-infer-name stx)
                    '#,(build-source-location-vector #'ctc))))]))
+
+(define-syntax (read/contract stx)
+  (with-syntax ([(ctc port)
+                 (syntax-case stx ()
+                  [(_read ctc) #'(ctc #f)]
+                  [(_read ctc in) #'(ctc in)])])
+    (quasisyntax/loc stx
+      (let* ([in (or port (current-input-port))]
+             [v (read in)])
+        (contract ctc
+                  v
+                  in
+                  (current-contract-region)
+                  '#,(syntax-local-infer-name stx)
+                  '#,(build-source-location-vector #'ctc))))))
 
 (define-syntax (-recursive-contract stx)
   (define (do-recursive-contract arg type name list-contract?)

--- a/racket/collects/racket/contract/region.rkt
+++ b/racket/collects/racket/contract/region.rkt
@@ -4,7 +4,8 @@
          define/contract
          with-contract
          current-contract-region
-         invariant-assertion)
+         invariant-assertion
+         read/contract)
 
 (require (for-syntax racket/base
                      racket/struct-info


### PR DESCRIPTION
(I'm trying to solve a specific use-case. This solution is maybe too general.)

### Goal

Parsing command-line arguments is a little awkward & error-prone right now.
```
(define my-n (make-parameter 0))
(command-line
  [("-n") arg "a number" (let ([n (number->string arg)]) (if n (my-n n) (error "expected number")))]
  ....)
```
I'd like an easy way to read values from a string, assert they match a specification, and raise a helpful message otherwise.

### This PR

Adds a general `read/contract` for reading one datum from an input port & applying a contract. This makes command-line parsing a little easier:

```
....
(with-input-from-string arg (lambda () (my-n (read/contract number?))))
....
```

