### PR TITLE
Include racket/base for-label for the contracts intro in the guide

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/contracts/intro.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/contracts/intro.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/doc
 @(require scribble/manual scribble/eval "utils.rkt"
-          (for-label racket/contract))
+          (for-label racket/base
+                     racket/contract))
 
 @title[#:tag "contract-boundaries"]{Contracts and Boundaries}
 


### PR DESCRIPTION
Self-explanatory: the intro to contracts in the guide was missing a `racket/base` require `for-label`.