### PR TITLE
unsafe-{chaperone,impersonate}-procedure: fix name on bad arity

### DIFF
--- a/pkgs/racket-test-core/tests/racket/chaperone.rktl
+++ b/pkgs/racket-test-core/tests/racket/chaperone.rktl
@@ -2380,6 +2380,12 @@
     (struct s (f) #:property prop:procedure 0)
     (test #t s? (unsafe-chaperone-procedure (s add1) (λ (x) x)))))
 
+;; Check name in arity error message:
+(let ()
+  (define (pf x) x)
+  (define cf (unsafe-chaperone-procedure pf (lambda (x) x)))
+  (err/rt-test (cf) (λ (x) (regexp-match #rx"^pf:" (exn-message x)))))
+
 ;; ----------------------------------------
 
 (let ()

--- a/racket/src/racket/src/schnapp.inc
+++ b/racket/src/racket/src/schnapp.inc
@@ -62,10 +62,13 @@ Scheme_Object *PRIM_APPLY_NAME(Scheme_Object *rator,
 
     if ((t == scheme_proc_chaperone_type)
         && SCHEME_VECTORP(((Scheme_Chaperone *)rator)->redirects)
-        && (SCHEME_VEC_SIZE(((Scheme_Chaperone *)rator)->redirects) & 0x1)) {
-      if (SCHEME_BOOLP(SCHEME_VEC_ELS(((Scheme_Chaperone *)rator)->redirects)[1])) {
+        && (SCHEME_VEC_SIZE(((Scheme_Chaperone *)rator)->redirects) & 0x1)
+        && (SCHEME_CHAPERONE_FLAGS((Scheme_Chaperone *)rator) == SCHEME_PROC_CHAPERONE_CALL_DIRECT)) {
+      if (SCHEME_FALSEP(SCHEME_VEC_ELS(((Scheme_Chaperone *)rator)->redirects)[1])
+          || SCHEME_INT_VAL(SCHEME_VEC_ELS(((Scheme_Chaperone *)rator)->redirects)[1]) == argc) {
         /* No redirection proc, i.e, chaperone is just for
-	   properties or unsafe-chaperone-procedure result */
+	   properties or produced by unsafe-chaperone-procedure result -- and in the
+           latter case, the arity is right.. */
         rator = SCHEME_VEC_ELS(((Scheme_Chaperone *)rator)->redirects)[0];
         t = _SCHEME_TYPE(rator);
       } else

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -1063,6 +1063,7 @@ typedef struct Scheme_Chaperone {
 
 #define SCHEME_CHAPERONE_FLAGS(c) MZ_OPT_HASH_KEY(&(c)->iso)
 #define SCHEME_CHAPERONE_IS_IMPERSONATOR 0x1
+#define SCHEME_PROC_CHAPERONE_CALL_DIRECT 0x2
 
 #define SCHEME_CHAPERONE_VAL(obj) (((Scheme_Chaperone *)obj)->val)
 


### PR DESCRIPTION
When a procedure created by `unsafe-{chaperone,impersonate}-procedure`
is given the wrong number of arguments, the original procedure's name
should be used in the error message.