### PR TITLE
margin-note for gregor & srfi-19

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/time.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/time.scrbl
@@ -165,6 +165,9 @@ result is the result of  the last @racket[body].}
 @; ----------------------------------------------------------------------
 
 @section[#:tag "date-string"]{Date Utilities}
+@margin-note{For more date & time operations, see
+  @other-doc['(lib "gregor/scribblings/gregor.scrbl") #:indirect "Gregor: Date and Time"]
+  or @link["../srfi/srfi-19.html"]{srfi/19}}
 
 @note-lib-only[racket/date]
 


### PR DESCRIPTION
For #1212, until `gregor` is part of a main distribution :smile: 

Should we add an adjective to discourage srfi-19? 