### PR TITLE
Link to reference from reader extensions guide

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/reader-extension.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/reader-extension.scrbl
@@ -5,6 +5,8 @@
 
 @title[#:tag "hash-reader"]{Reader Extensions}
 
+@refdetails["parse-reader"]{reader extensions}
+
 The @tech{reader} layer of the Racket language can be extended through
 the @racketmetafont{#reader} form. A reader extension is implemented
 as a module that is named after @racketmetafont{#reader}. The module


### PR DESCRIPTION
This adds a link to the Reading via an Extension section of the racket reference from the Reader Extensions section of the guide.