### PR TITLE
add `in-hash-set` fast path for hash sets

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -153,16 +153,20 @@ Analogous to @racket[for/list] and @racket[for*/list], but to
 construct a @tech{hash set} instead of a list.
 }
 
-@defproc[(in-hash-set [st (or/c set? set-mutable? set-weak?)]) sequence?]{
+@deftogether[(
+@defproc[(in-immutable-set [st set?]) sequence?]
+@defproc[(in-mutable-set [st set-mutable?]) sequence?]
+@defproc[(in-weak-set [st set-weak?]) sequence?]
+)]{
 
-Explicitly converts a @tech{hash set} to a sequence for use with @racket[for] and
-other forms.
+Explicitly converts a specific kind of @tech{hash set} to a sequence for 
+use with @racket[for] forms.
 
 As with @racket[in-list] and some other sequence constructors,
-@racket[in-hash-set] is more performant when it appears directly in a
+@racket[in-immutable-set] is more performant when it appears directly in a
 @racket[for] clause.
 
-The @racket[in-hash-set] constructor is compatible with
+These sequence constructors are compatible with
 @secref["Custom_Hash_Sets" #:doc '(lib "scribblings/reference/reference.scrbl")].
 
 }

--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -153,6 +153,20 @@ Analogous to @racket[for/list] and @racket[for*/list], but to
 construct a @tech{hash set} instead of a list.
 }
 
+@defproc[(in-hash-set [st (or/c set? set-mutable? set-weak?)]) sequence?]{
+
+Explicitly converts a @tech{hash set} to a sequence for use with @racket[for] and
+other forms.
+
+As with @racket[in-list] and some other sequence constructors,
+@racket[in-hash-set] is more performant when it appears directly in a
+@racket[for] clause.
+
+The @racket[in-hash-set] constructor is compatible with
+@secref["Custom_Hash_Sets" #:doc '(lib "scribblings/reference/reference.scrbl")].
+
+}
+
 @section{Set Predicates and Contracts}
 
 @defproc[(generic-set? [v any/c]) boolean?]{

--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -549,5 +549,36 @@
 ;; for/fold syntax checking
 (syntax-test #'(for/fold () bad 1) #rx".*bad sequence binding clauses.*")
 
+;; in-hash-set
+(err/rt-test (for/sum ([x (in-hash-set '(1 2))]) x)
+             exn:fail:contract?
+             #rx"not a hash set")
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (set 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (mutable-set 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (weak-set 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (seteqv 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (mutable-seteqv 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (weak-seteqv 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (seteq 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (mutable-seteq 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (weak-seteq 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-hash-set (list->set '(1 2 3 4)))]) x))
+(test 30 'custom-in-hash-set
+      (let ()
+        (define-custom-set-types pos-set
+          #:elem? positive?
+          (λ (x y recur) (+ x y))
+          (λ (x recur) x))
+        (define imm
+          (make-immutable-pos-set '(1 2 3 4)))
+        (define m
+          (make-mutable-pos-set '(1 2 3 4)))
+        (define w
+          (make-weak-pos-set '(1 2 3 4)))
+        (+ (for/sum ([x (in-hash-set imm)]) x)
+           (for/sum ([x (in-hash-set m)]) x)
+           (for/sum ([x (in-hash-set w)]) x))))
+
+
 
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -549,20 +549,28 @@
 ;; for/fold syntax checking
 (syntax-test #'(for/fold () bad 1) #rx".*bad sequence binding clauses.*")
 
-;; in-hash-set
-(err/rt-test (for/sum ([x (in-hash-set '(1 2))]) x)
+;; specific hash set iterators
+(err/rt-test (for/sum ([x (in-immutable-set '(1 2))]) x)
              exn:fail:contract?
              #rx"not a hash set")
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (set 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (mutable-set 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (weak-set 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (seteqv 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (mutable-seteqv 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (weak-seteqv 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (seteq 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (mutable-seteq 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (weak-seteq 1 2 3 4))]) x))
-(test 10 'in-hash-set (for/sum ([x (in-hash-set (list->set '(1 2 3 4)))]) x))
+(err/rt-test (for/sum ([x (in-mutable-set '(1 2))]) x)
+             exn:fail:contract?
+             #rx"not a hash set")
+(err/rt-test (for/sum ([x (in-weak-set '(1 2))]) x)
+             exn:fail:contract?
+             #rx"not a hash set")
+(test 10 'in-hash-set (for/sum ([x (in-immutable-set (set 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-mutable-set (mutable-set 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-weak-set (weak-set 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-immutable-set (seteqv 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-mutable-set (mutable-seteqv 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-weak-set (weak-seteqv 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-immutable-set (seteq 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-mutable-set (mutable-seteq 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-weak-set (weak-seteq 1 2 3 4))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-immutable-set (list->set '(1 2 3 4)))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-mutable-set (list->mutable-set '(1 2 3 4)))]) x))
+(test 10 'in-hash-set (for/sum ([x (in-weak-set (list->weak-set '(1 2 3 4)))]) x))
 (test 30 'custom-in-hash-set
       (let ()
         (define-custom-set-types pos-set
@@ -575,9 +583,9 @@
           (make-mutable-pos-set '(1 2 3 4)))
         (define w
           (make-weak-pos-set '(1 2 3 4)))
-        (+ (for/sum ([x (in-hash-set imm)]) x)
-           (for/sum ([x (in-hash-set m)]) x)
-           (for/sum ([x (in-hash-set w)]) x))))
+        (+ (for/sum ([x (in-immutable-set imm)]) x)
+           (for/sum ([x (in-mutable-set m)]) x)
+           (for/sum ([x (in-weak-set w)]) x))))
 
 
 

--- a/racket/collects/racket/set.rkt
+++ b/racket/collects/racket/set.rkt
@@ -21,6 +21,7 @@
          set-union! set-intersect! set-subtract! set-symmetric-difference!
 
          in-set
+         in-hash-set
          set-implements/c
 
          set seteq seteqv

--- a/racket/collects/racket/set.rkt
+++ b/racket/collects/racket/set.rkt
@@ -21,7 +21,9 @@
          set-union! set-intersect! set-subtract! set-symmetric-difference!
 
          in-set
-         in-hash-set
+         in-immutable-set
+         in-mutable-set
+         in-weak-set
          set-implements/c
 
          set seteq seteqv


### PR DESCRIPTION
This is a pull request because I'm unsure about the name. 

`in-hash-set` creates a sequence from a hash-table-based set. But is the name confusing? Maybe `in-hashset` as another alternative?