### PR TITLE
Documentation for scheme_register_process_global is fixed.

### DIFF
--- a/pkgs/racket-doc/scribblings/inside/misc.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/misc.scrbl
@@ -365,9 +365,11 @@ any place.}
 
 Gets or sets a value in a process-global table (i.e., shared across
 multiple places, if any). If @var{val} is NULL, the current mapping
-for @var{key} is given, otherwise @var{val} is installed as the value
-for @var{key} and @cpp{NULL} is returned. The given @var{val} must not
-refer to garbage-collected memory.
+for @var{key} is given. If @var{val} is not NULL, and no value has been
+installed for that @var{key}, then the value is installed and NULL is returned. If a
+value has already been installed, then no new value is installed and the old
+value is returned. The given @var{val} must not refer to garbage-collected
+memory.
 
 This function is intended for infrequent use with a small number of
 keys.}


### PR DESCRIPTION
It was previously both incomplete, and incorrect.