### PR TITLE
not sort xml attributes

### DIFF
--- a/pkgs/racket-test/tests/xml/test.rkt
+++ b/pkgs/racket-test/tests/xml/test.rkt
@@ -462,6 +462,12 @@ END
      (test-syntax:read-xml/element
       "<a href=\"#\">inner</a>"
       '(a ([href "#"]) "inner"))
+
+     (test-syntax:read-xml/element
+      "<a c=\"1\" a=\"2\" b=\"3\">inner</a>"
+      '(a ([c "1"] [a "2"] [b "3"]) "inner"))
+
+     (test-syntax:read-xml/element/exn "<a c=\"1\" a=\"2\" c=\"3\">inner</a>" "read-xml: lex-error: at position 1.20/21: duplicated attribute name c")
      
      (test-syntax:read-xml/element
       "<root>&nbsp;</root>"

--- a/racket/collects/xml/private/reader.rkt
+++ b/racket/collects/xml/private/reader.rkt
@@ -270,17 +270,16 @@
 
 ;; lex-attributes : Input-port (-> Location) -> (listof Attribute)
 (define (lex-attributes in pos)
-  (sort (let loop ()
-          (skip-space in)
-          (cond [(name-start? (peek-char-or-special in))
-                 (cons (lex-attribute in pos) (loop))]
-                [else null]))
-        (lambda (a b)
-          (let ([na (attribute-name a)]
-                [nb (attribute-name b)])
-            (cond
-              [(eq? na nb) (lex-error in pos "duplicated attribute name ~a" na)]
-              [else (string<? (symbol->string na) (symbol->string nb))])))))
+  (let* ([result_list 
+          (let loop ()
+            (skip-space in)
+            (cond [(name-start? (peek-char-or-special in))
+                   (cons (lex-attribute in pos) (loop))]
+                  [else null]))]
+         [check_dup (check-duplicates result_list (lambda (a b) (eq? (attribute-name a) (attribute-name b))))])
+    (if check_dup
+        (lex-error in pos "duplicated attribute name ~a" (attribute-name check_dup))
+        result_list)))
 
 ;; lex-attribute : Input-port (-> Location) -> Attribute
 (define (lex-attribute in pos)


### PR DESCRIPTION
When I use:
 ```
(xml->xexpr 
  (document-element 
    (read-xml (open-input-string 
      "<a c=\"1\" a=\"2\" b=\"3\">inner</a>"))))
```
I expected the result is:
      `'(a ((c "1") (a "2") (b "3")) "inner"))`

but I found the actual result is:
    ` '(a ((a "2") (b "3") (c "1")) "inner")`
attibutes list is sorted.

I want attibutes list order is the original order in xml.

So I change the lex-attributes func, use check-duplicates to find duplicate attributes, then return the original order attributes list.