### PR TITLE
More reductions for (eq? var var) and (if expr var var)

### DIFF
--- a/racket/src/racket/src/symbol.c
+++ b/racket/src/racket/src/symbol.c
@@ -698,7 +698,7 @@ const char *scheme_symbol_name_and_size(Scheme_Object *sym, uintptr_t *length, i
       mzchar cbuf[100], *cs, *cresult;
       intptr_t clen;
       int p = 0;
-      uintptr_t i = 0;
+      intptr_t i = 0;
       intptr_t rlen;
 
       dz = 0;


### PR DESCRIPTION
These are many short commits, I'll probably squash all but the first. It's easier to discuss if they are separated.

**First commit: avoid compiler warning**
Totaly unrelated.

**Second commit: reduce `(if t v v) => (begin t v)` when `v` is a top level**
Is it necessary to check that both instances of the toplevel have the same flags? I think that currently all of them have the same flags in these cases.

**Third commit: reduce `(eq? var var) ==> #t`**
I'm reusing `equivalent_exprs`, I don't like this completely but it looks silly to make a copy of the implementation. (Perhaps, in the future, I'd like to extend this to more complex expressions like `(eq? (car x) (car x))`. But befor that, I want to see if expressions like this appear in real code and look carefully at the details. Because the second `car` would be transformed into a `unsafe-car` ...) Also, I reduced this to `(eq? var var) ==> (begin var var #t) ==> #t` just in case to be future proof.

**Fourth commit: reduce `(if v v #f) => v` when `v` is a top level**
I reused again `equivalent_exprs` but with another pattern. It's slightly different because it changes the number of times `v` is called in each branch and after the optimization.

**Sixth commit: comment (squash)**
I added a warning to `equivalent_exprs`. Is it necesary? Is this a good idea? 

**Fifth commit: move `(if x #t #f)` reduction after branch optimization**
It makes more sense to test this after the branches are optimized, instead of before. It catches more cases, but in some cases it generates a new unnecessary `#<void>`. For example in `(not (if (let ([r (random)]) #t) #t #f)))`.
