### PR TITLE
~a #:limit-prefix?

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/format.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/format.scrbl
@@ -27,6 +27,7 @@ shorter than @racket[format] (with format string),
              [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
              [#:min-width min-width exact-nonnegative-integer? (or width 0)]
              [#:limit-marker limit-marker string? ""]
+             [#:limit-prefix? limit-prefix? boolean? #f]
              [#:align align (or/c 'left 'center 'right) 'left]
              [#:pad-string pad-string non-empty-string? " "]
              [#:left-pad-string left-pad-string non-empty-string? pad-string]
@@ -68,6 +69,8 @@ If @racket[_s] is longer than @racket[max-width] characters, it is
 truncated and the end of the string is replaced with
 @racket[limit-marker]. If @racket[limit-marker] is longer than
 @racket[max-width], an exception is raised.
+If @racket[limit-prefix?] is @racket[#t], the beginning of the string
+is truncated instead of the end.
 
 @examples[#:eval the-eval
 (~a "abcde" #:max-width 5)
@@ -76,6 +79,7 @@ truncated and the end of the string is replaced with
 (~a "abcde" #:max-width 4 #:limit-marker "...")
 (~a "The quick brown fox" #:max-width 15 #:limit-marker "")
 (~a "The quick brown fox" #:max-width 15 #:limit-marker "...")
+(~a "The quick brown fox" #:max-width 15 #:limit-marker "..." #:limit-prefix? #f)
 ]
 
 If @racket[_s] is shorter than @racket[min-width], it is padded to at
@@ -120,6 +124,7 @@ simultaneously, ensuring that the resulting string is exactly
              [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
              [#:min-width min-width exact-nonnegative-integer? (or width 0)]
              [#:limit-marker limit-marker string? "..."]
+             [#:limit-prefix? limit-prefix? boolean? #f]
              [#:align align (or/c 'left 'center 'right) 'left]
              [#:pad-string pad-string non-empty-string? " "]
              [#:left-pad-string left-pad-string non-empty-string? pad-string]
@@ -154,6 +159,7 @@ Use @racket[~v] to produce text that talks about Racket values.
              [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
              [#:min-width min-width exact-nonnegative-integer? (or width 0)]
              [#:limit-marker limit-marker string? "..."]
+             [#:limit-prefix? limit-prefix? boolean? #f]
              [#:align align (or/c 'left 'center 'right) 'left]
              [#:pad-string pad-string non-empty-string? " "]
              [#:left-pad-string left-pad-string non-empty-string? pad-string]
@@ -181,6 +187,7 @@ marker is @racket["..."].
              [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
              [#:min-width min-width exact-nonnegative-integer? (or width 0)]
              [#:limit-marker limit-marker string? "..."]
+             [#:limit-prefix? limit-prefix? boolean? #f]
              [#:align align (or/c 'left 'center 'right) 'left]
              [#:pad-string pad-string non-empty-string? " "]
              [#:left-pad-string left-pad-string non-empty-string? pad-string]
@@ -406,6 +413,7 @@ the resulting string is appended to the significand:
               [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
               [#:min-width min-width exact-nonnegative-integer? (or width 0)]
               [#:limit-marker limit-marker string? ""]
+              [#:limit-prefix? limit-prefix? boolean? #f]
               [#:align align (or/c 'left 'center 'right) 'left]
               [#:pad-string pad-string non-empty-string? " "]
               [#:left-pad-string left-pad-string non-empty-string? pad-string]
@@ -417,6 +425,7 @@ the resulting string is appended to the significand:
               [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
               [#:min-width min-width exact-nonnegative-integer? (or width 0)]
               [#:limit-marker limit-marker string? "..."]
+              [#:limit-prefix? limit-prefix? boolean? #f]
               [#:align align (or/c 'left 'center 'right) 'left]
               [#:pad-string pad-string non-empty-string? " "]
               [#:left-pad-string left-pad-string non-empty-string? pad-string]
@@ -428,6 +437,7 @@ the resulting string is appended to the significand:
               [#:max-width max-width (or/c exact-nonnegative-integer? +inf.0) (or width +inf.0)]
               [#:min-width min-width exact-nonnegative-integer? (or width 0)]
               [#:limit-marker limit-marker string? "..."]
+              [#:limit-prefix? limit-prefix? boolean? #f]
               [#:align align (or/c 'left 'center 'right) 'left]
               [#:pad-string pad-string non-empty-string? " "]
               [#:left-pad-string left-pad-string non-empty-string? pad-string]

--- a/pkgs/racket-test/tests/racket/format.rkt
+++ b/pkgs/racket-test/tests/racket/format.rkt
@@ -47,6 +47,10 @@
     "abc*")
 (tc (~a "abcde" #:max-width 4 #:limit-marker "")
     "abcd")
+(tc (~a "abcde" #:max-width 4 #:limit-marker "..." #:limit-prefix? #f)
+    "a...")
+(tc (~a "abcde" #:max-width 4 #:limit-marker "..." #:limit-prefix? #t)
+    "...e")
 (tc (~a "The quick brown fox" #:max-width 15 #:limit-marker "")
     "The quick brown")
 (tc (~a "The quick brown fox" #:max-width 15 #:limit-marker "...")
@@ -66,6 +70,8 @@
     "short ")
 (tc (~a "loquacious" #:width 6 #:limit-marker "...")
     "loq...")
+(tc (~a "ostentatious" #:align 'right #:width 5 #:limit-marker "..." #:limit-prefix? #t)
+    "...us")
 
 ;; ~v
 
@@ -82,6 +88,8 @@
 
 (tc (~v '(123456) #:max-width 5)
     "'(...")
+(tc (~v '(123456) #:max-width 5 #:limit-prefix? #t)
+    "...6)")
 
 ;; ~s
 
@@ -98,6 +106,8 @@
 
 (tc (~s 123456 #:max-width 5)
     "12...")
+(tc (~s 123456 #:max-width 5 #:limit-prefix? #t)
+    "...56")
 
 ;; ~r
 

--- a/racket/collects/racket/format.rkt
+++ b/racket/collects/racket/format.rkt
@@ -44,6 +44,7 @@
         #:max-width (or/c exact-nonnegative-integer? +inf.0)
         #:min-width exact-nonnegative-integer?
         #:limit-marker string?
+        #:limit-prefix? boolean?
         #:align align-mode/c
         #:pad-string padding/c
         #:left-pad-string padding/c
@@ -74,10 +75,15 @@
 
 (define (%limit #:limit limit
                 #:limit-marker limit-marker
+                #:limit-prefix? limit-prefix?
                 s)
-  (cond [(> (string-length s) limit)
-         (string-append (substring s 0 (- limit (string-length limit-marker)))
-                        limit-marker)]
+  (define len (string-length s))
+  (cond [(> len limit)
+         (if limit-prefix?
+           (string-append limit-marker
+                          (substring s (+ (- len limit) (string-length limit-marker))))
+           (string-append (substring s 0 (- limit (string-length limit-marker)))
+                          limit-marker))]
         [else s]))
 
 (define (%pad #:pad-to pad-to
@@ -141,6 +147,7 @@
      (let ([who (λ (#:width            [width         #f]
                     #:max-width        [limit         (or width +inf.0)]
                     #:limit-marker     [limit-marker  default-limit-marker]
+                    #:limit-prefix?    [limit-prefix? #f]
                     #:min-width        [pad-to        (or width 0)]
                     #:align            [align         'left]
                     #:pad-string       [padding       " "]
@@ -150,6 +157,7 @@
                     . s)
                   (do-checks 'who limit limit-marker pad-to)
                   (%pad (%limit #:limit limit #:limit-marker limit-marker
+                                #:limit-prefix? limit-prefix?
                                 (if (and (pair? s) (null? (cdr s)))
                                   (fmt (car s))
                                   (apply string-append


### PR DESCRIPTION
Currently `(~a ... #:max-width w #:limit-marker m)` truncates the end (suffix) of the string. This PR adds an optional boolean argument `#:limit-prefix?` to change this default & truncate the beginning of the string.

```
-> (~a "racket" #:max-width 5 #:limit-marker "...")
"ra..."
-> (~a "racket" #:max-width 5 #:limit-marker "..." #:limit-prefix? #t)
"...et"
```

Any opinion on the name `limit-prefix?` ?