### PR TITLE
Special case for small hashes in scheme_unsafe_hash_tree_start/next

### DIFF
--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -212,6 +212,27 @@
   (test-hash-iters-generic lst3 lst4)
   (test-hash-iters-specific lst3 lst4))
 
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+; Use keys that are a multile of a power of 2 to
+; get "almost" collisions that force the hash table
+; to use a deeper tree.
+
+(let ()
+  (define vals (for/list ([j (in-range 100)]) (add1 j)))
+  (define sum-vals (for/sum ([v (in-list vals)]) v))
+  (for ([shift (in-range 150)])
+    (define keys (for/list ([j (in-range 100)])
+                   (arithmetic-shift j shift)))
+    ; test first the weak table to ensure the keys are not collected
+    (define ht/weak (make-weak-hash (map cons keys vals)))
+    (define sum-ht/weak (for/sum ([v (in-weak-hash-values ht/weak)]) v))
+    (define ht/mut (make-hash (map cons keys vals)))
+    (define sum-ht/mut (for/sum ([v (in-mutable-hash-values ht/mut)]) v))
+    (define ht/immut (make-immutable-hash (map cons keys vals)))
+    (define sum-ht/immut (for/sum ([v (in-immutable-hash-values ht/immut)]) v))
+    (test #t = sum-vals sum-ht/weak sum-ht/mut sum-ht/immut)))
+
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (let ()

--- a/racket/src/racket/src/list.c
+++ b/racket/src/racket/src/list.c
@@ -4118,30 +4118,34 @@ Scheme_Object *unsafe_scheme_hash_tree_iterate_next(int argc, Scheme_Object *arg
   
   if (SCHEME_NP_CHAPERONEP(o)) o = SCHEME_CHAPERONE_VAL(o);
 
-  return scheme_unsafe_hash_tree_next(argv[1]);
+  return scheme_unsafe_hash_tree_next((Scheme_Hash_Tree *)o, argv[1]);
 }
 Scheme_Object *unsafe_scheme_hash_tree_iterate_key(int argc, Scheme_Object *argv[])
 {
   Scheme_Object *obj = argv[0], *args = argv[1], *key;
-  Scheme_Hash_Tree *subtree = (Scheme_Hash_Tree *)SCHEME_CAR(args);
-  int i = SCHEME_INT_VAL(SCHEME_CADR(args));
+  Scheme_Hash_Tree *subtree;
+  int i;
+  
+  scheme_unsafe_hash_tree_subtree(obj, args, &subtree, &i);
   key = subtree->els[i];
   
   if (SCHEME_NP_CHAPERONEP(obj))
-    return chaperone_hash_key("unsafe-weak-hash-iterate-key", obj, key);
+    return chaperone_hash_key("unsafe-immutable-hash-iterate-key", obj, key);
   else
     return key;
 }
 Scheme_Object *unsafe_scheme_hash_tree_iterate_value(int argc, Scheme_Object *argv[])
 {
   Scheme_Object *obj = argv[0], *args = argv[1];
-  Scheme_Hash_Tree *subtree = (Scheme_Hash_Tree *)SCHEME_CAR(args);
-  int i = SCHEME_INT_VAL(SCHEME_CADR(args));
+  Scheme_Hash_Tree *subtree;
+  int i;
+
+  scheme_unsafe_hash_tree_subtree(obj, args, &subtree, &i);
 
   if (SCHEME_NP_CHAPERONEP(obj)) {
     Scheme_Object *chap_key, *chap_val;
-    chaperone_hash_key_value("unsafe-weak-hash-iterate-value",
-			     obj, subtree->els[i], &chap_key, &chap_val, 0);
+    chaperone_hash_key_value("unsafe-immutable-hash-iterate-value",
+                             obj, subtree->els[i], &chap_key, &chap_val, 0);
     return chap_val;
   } else {
     int popcount;
@@ -4151,15 +4155,17 @@ Scheme_Object *unsafe_scheme_hash_tree_iterate_value(int argc, Scheme_Object *ar
 }
 Scheme_Object *unsafe_scheme_hash_tree_iterate_pair(int argc, Scheme_Object *argv[])
 {
-  Scheme_Object *obj = argv[0], *args = argv[1];
-  Scheme_Hash_Tree *subtree = (Scheme_Hash_Tree *)SCHEME_CAR(args);
-  int i = SCHEME_INT_VAL(SCHEME_CADR(args));
-  Scheme_Object *key = subtree->els[i];
+  Scheme_Object *obj = argv[0], *args = argv[1], *key;
+  Scheme_Hash_Tree *subtree;
+  int i;
+
+  scheme_unsafe_hash_tree_subtree(obj, args, &subtree, &i);
+  key = subtree->els[i];
 
   if (SCHEME_NP_CHAPERONEP(obj)) {
     Scheme_Object *chap_key, *chap_val;
-    chaperone_hash_key_value("unsafe-weak-hash-iterate-pair",
-			     obj, subtree->els[i], &chap_key, &chap_val, 0);
+    chaperone_hash_key_value("unsafe-immutable-hash-iterate-pair",
+                             obj, subtree->els[i], &chap_key, &chap_val, 0);
     return scheme_make_pair(chap_key, chap_val);
   } else {
     Scheme_Object *val;
@@ -4171,14 +4177,16 @@ Scheme_Object *unsafe_scheme_hash_tree_iterate_pair(int argc, Scheme_Object *arg
 }
 Scheme_Object *unsafe_scheme_hash_tree_iterate_key_value(int argc, Scheme_Object *argv[])
 {
-  Scheme_Object *obj = argv[0], *args = argv[1], *res[2];
-  Scheme_Hash_Tree *subtree = (Scheme_Hash_Tree *)SCHEME_CAR(args);
-  int i = SCHEME_INT_VAL(SCHEME_CADR(args));
-  Scheme_Object *key = subtree->els[i];
+  Scheme_Object *obj = argv[0], *args = argv[1], *key, *res[2];
+  Scheme_Hash_Tree *subtree;
+  int i;
+
+  scheme_unsafe_hash_tree_subtree(obj, args, &subtree, &i);
+  key = subtree->els[i];
 
   if (SCHEME_NP_CHAPERONEP(obj)) {
-    chaperone_hash_key_value("unsafe-weak-hash-iterate-pair",
-			     obj, subtree->els[i], &res[0], &res[1], 0);
+    chaperone_hash_key_value("unsafe-immutable-hash-iterate-pair",
+                             obj, subtree->els[i], &res[0], &res[1], 0);
   } else {
     Scheme_Object *val;
     int popcount;

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -966,7 +966,9 @@ Scheme_Object *scheme_hash_tree_get(Scheme_Hash_Tree *tree, Scheme_Object *key);
 XFORM_NONGCING Scheme_Object *scheme_eq_hash_tree_get(Scheme_Hash_Tree *tree, Scheme_Object *key);
 XFORM_NONGCING mzlonglong scheme_hash_tree_next(Scheme_Hash_Tree *tree, mzlonglong pos);
 Scheme_Object *scheme_unsafe_hash_tree_start(Scheme_Hash_Tree *ht);
-Scheme_Object *scheme_unsafe_hash_tree_next(Scheme_Object *args);
+XFORM_NONGCING void scheme_unsafe_hash_tree_subtree(Scheme_Object *obj, Scheme_Object *args,
+                                                    Scheme_Hash_Tree **_subtree, int *_i);
+Scheme_Object *scheme_unsafe_hash_tree_next(Scheme_Hash_Tree *ht, Scheme_Object *args);
 Scheme_Object *scheme_hash_tree_next_pos(Scheme_Hash_Tree *tree, mzlonglong pos);
 XFORM_NONGCING int scheme_hash_tree_index(Scheme_Hash_Tree *tree, mzlonglong pos, Scheme_Object **_key, Scheme_Object **_val);
 int scheme_hash_tree_equal(Scheme_Hash_Tree *t1, Scheme_Hash_Tree *t2);


### PR DESCRIPTION
The index of the iteration is like a list of fixnums and internal hashes. The idea is to encode it using only integers to avoid allocations. This is useful for small hashes and makes the iteration ~50% faster. For long hashes, we should keep the index in the list representation because the additional searches make the code slower.

I didn't squash the commits, so each pass can be tested and benchmarked separately.

The first commit adds the change `(#hash i0) --> i0` so all the hashes with less than 32 elements should use only numbers without allocation.

The seccond ommit  adds the change `(#hash i1 #hash i0) --> (+ (<< i1 6) (<< 1 5) i0)`. This is useful for hashes of a few hundred elements, but the internal structure is more complicated, so an unlucky hash may need a deeper tree in spite it is not so big.

The third ommit adds the change `(#hash i2 #hash i1 #hash i0) --> (+ (<< i2 12) (<< 1 11) (<< i1 6) (<< 1 5) i0)`.

I could add more steps, but it's boring and the results are not promising. (See benchmark below.) I think it's better to add only the first two cases, and leave the trees that use `(#hash i2 #hash i1 #hash i0)` unchanged.

This still needs some cleanup and I'm not sure if all the chaperone cases are added in the right commit.

--

I'm using this benchmark. (The first loop is only a baseline to ensure that my machine is not doing something very strange between comparisons.) (I have the times with the internal `when` uncommented. The times are bigger, but the results are equivalent.)

    #lang racket/base
    
    (require racket/unsafe/ops)
    
    (define tot 100000000)
    
    (for ([z (in-range 1)])
      (printf "for ~a: " tot)
      (collect-garbage)(collect-garbage)(collect-garbage)
      (time
       (for/and ([j (in-range 10)])
         (for/and ([i (in-range tot)])
           (> i -1))))

      (for ([h-len (in-list '(10 100 1000 10000 100000 1000000))])
    
      (define old (build-list h-len (lambda (x) (cons x (number->string x)))))
      (define h (make-immutable-hash old))
    
      (printf "~a x ~a: " h-len (/ tot h-len))
      (collect-garbage)(collect-garbage)(collect-garbage)
      (time
       (for ([i (in-range (/ tot h-len))])
         (let loop ([h-idx (unsafe-immutable-hash-iterate-first h)])
           (when h-idx
             #;(when (eq? (unsafe-immutable-hash-iterate-key h h-idx)
                          (unsafe-immutable-hash-iterate-value h h-idx))
                 (display "*"))
             (loop (unsafe-immutable-hash-iterate-next h h-idx)))))))
    )

Results:
 
0 = Master

    for 100000000: cpu time: 16068 real time: 16193 gc time: 0
    10 x 10000000: cpu time: 21373 real time: 21856 gc time: 297
    100 x 1000000: cpu time: 24383 real time: 24554 gc time: 421
    1000 x 100000: cpu time: 30903 real time: 31262 gc time: 720
    10000 x 10000: cpu time: 24616 real time: 25163 gc time: 548
    100000 x 1000: cpu time: 25131 real time: 25506 gc time: 374
    1000000 x 100: cpu time: 26567 real time: 26926 gc time: 63

1 = only `(#hash i0) --> i0`

    for 100000000: cpu time: 16583 real time: 16848 gc time: 0
    10 x 10000000: cpu time: 9610 real time: 9844 gc time: 0
    100 x 1000000: cpu time: 25350 real time: 25724 gc time: 656
    1000 x 100000: cpu time: 32370 real time: 32885 gc time: 744
    10000 x 10000: cpu time: 25538 real time: 25989 gc time: 606
    100000 x 1000: cpu time: 26083 real time: 26598 gc time: 419
    1000000 x 100: cpu time: 27752 real time: 28252 gc time: 202

2 = add `(#hash i1 #hash i0) --> (+ (<< i1 6) (<< 1 5) i0)`

    for 100000000: cpu time: 16224 real time: 16583 gc time: 0
    10 x 10000000: cpu time: 9766 real time: 9874 gc time: 0
    100 x 1000000: cpu time: 10234 real time: 10389 gc time: 0
    1000 x 100000: cpu time: 33166 real time: 33868 gc time: 644
    10000 x 10000: cpu time: 25818 real time: 26286 gc time: 549
    100000 x 1000: cpu time: 26598 real time: 27051 gc time: 452
    1000000 x 100: cpu time: 27705 real time: 28096 gc time: 62

3 = add `(#hash i2 #hash i1 #hash i0) --> (+(<< i2 12) (<< 1 11) (<< i1 6) (<< 1 5) i0)`

    for 100000000: cpu time: 16972 real time: 17644 gc time: 0
    10 x 10000000: cpu time: 10311 real time: 11029 gc time: 0
    100 x 1000000: cpu time: 10905 real time: 11170 gc time: 0
    1000 x 100000: cpu time: 33883 real time: 34898 gc time: 856
    10000 x 10000: cpu time: 26957 real time: 27643 gc time: 669
    100000 x 1000: cpu time: 27612 real time: 28564 gc time: 294
    1000000 x 100: cpu time: 29765 real time: 30685 gc time: 173
