### PR TITLE
Use normalize-path instead of custom trailing slash remover

### DIFF
--- a/racket/collects/pkg/private/orig-pkg.rkt
+++ b/racket/collects/pkg/private/orig-pkg.rkt
@@ -19,7 +19,9 @@
     [(link static-link) `(,type
                           ,(path->string
                             (find-relative-path (pkg-installed-dir)
-                                                (simple-form-path src)
+                                                ;; normalize with ending slash
+                                                (path->directory-path
+                                                 (simple-form-path src))
                                                 #:more-than-root? #t)))]
     [(clone) 
      (define-values (transport host port repo branch path)

--- a/racket/collects/pkg/private/path.rkt
+++ b/racket/collects/pkg/private/path.rkt
@@ -15,9 +15,6 @@
     [(bytes? pkg)
      pkg]))
 
-(define (directory-path-no-slash pkg)
-  (bytes->path (regexp-replace* #rx#"/$" (path->bytes* pkg) #"")))
-
 (define (directory-list* d)
   (append-map
    (λ (pp)


### PR DESCRIPTION
This makes the following interaction not produce an internal error:

    raco pkg install -n foo /

I think normalizing the string does hit the filesystem, but the code right above checks if the directory exists anyway so I think it shouldn't error. All the pkg tests seem to pass.