### PR TITLE
Add optional failure thunk for regexp and friends

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -198,7 +198,9 @@ Returns @racket[#t] if @racket[v] is a @tech{regexp value} created by
 otherwise.}
 
 
-@defproc[(regexp [str string?]) regexp?]{
+@defproc[(regexp [str string?]
+                 [handler (-> any) (λ () (raise (exn:fail:contract ....)))])
+         regexp?]{
 
 Takes a string representation of a regular expression (using the
 syntax in @secref["regexp-syntax"]) and compiles it into a @tech{regexp
@@ -208,15 +210,21 @@ is used multiple times, it is faster to compile the string once to a
 @tech{regexp value} and use it for repeated matches instead of using the
 string each time.
 
+If @racket[handler] is provided, it is called and its result is returned
+if @racket[str] is not a valid representation of a regular expression.
+
 The @racket[object-name] procedure returns
 the source string for a @tech{regexp value}.
 
 @examples[
 (regexp "ap*le")
 (object-name #rx"ap*le")
+(regexp "+" (λ () #f))
 ]}
 
-@defproc[(pregexp [string string?]) pregexp?]{
+@defproc[(pregexp [string string?]
+                  [handler (-> any) (λ () (raise (exn:fail:contract ....)))])
+         pregexp?]{
 
 Like @racket[regexp], except that it uses a slightly different syntax
 (see @secref["regexp-syntax"]). The result can be used with
@@ -226,13 +234,19 @@ Like @racket[regexp], except that it uses a slightly different syntax
 @examples[
 (pregexp "ap*le")
 (regexp? #px"ap*le")
+(pregexp "+" (λ () #f))
 ]}
 
-@defproc[(byte-regexp [bstr bytes?]) byte-regexp?]{
+@defproc[(byte-regexp [bstr bytes?]
+                      [handler (-> any) (λ () (raise (exn:fail:contract ....)))])
+         byte-regexp?]{
 
 Takes a byte-string representation of a regular expression (using the
 syntax in @secref["regexp-syntax"]) and compiles it into a
 byte-@tech{regexp value}.
+
+If @racket[handler] is provided, it is called and its result is returned
+if @racket[str] is not a valid representation of a regular expression.
 
 The @racket[object-name] procedure
 returns the source byte string for a @tech{regexp value}.
@@ -241,9 +255,12 @@ returns the source byte string for a @tech{regexp value}.
 (byte-regexp #"ap*le")
 (object-name #rx#"ap*le")
 (eval:error (byte-regexp "ap*le"))
+(byte-regexp #"+" (λ () #f))
 ]}
 
-@defproc[(byte-pregexp [bstr bytes?]) byte-pregexp?]{
+@defproc[(byte-pregexp [bstr bytes?]
+                       [handler (-> any) (λ () (raise (exn:fail:contract ....)))])
+         byte-pregexp?]{
 
 Like @racket[byte-regexp], except that it uses a slightly different
 syntax (see @secref["regexp-syntax"]). The result can be used with
@@ -252,6 +269,7 @@ syntax (see @secref["regexp-syntax"]). The result can be used with
 
 @examples[
 (byte-pregexp #"ap*le")
+(byte-pregexp #"+" (λ () #f))
 ]}
 
 @defproc*[([(regexp-quote [str string?] [case-sensitive? any/c #t]) string?]

--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -1356,7 +1356,7 @@
                                     o))
     (test (- N M) string-length (get-output-string o)))))
 
-(arity-test regexp 1 1)
+(arity-test regexp 1 2)
 (arity-test regexp? 1 1)
 (arity-test regexp-match 2 6)
 (arity-test regexp-match-positions 2 6)

--- a/pkgs/racket-test-core/tests/racket/rx.rktl
+++ b/pkgs/racket-test-core/tests/racket/rx.rktl
@@ -1785,5 +1785,17 @@
              (lambda () (regexp-match-peek-positions-immediate/end #rx".*" (open-input-string "abc"))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Test failure handlers
+
+(test #f regexp "+" (λ () #f))
+(test #f pregexp "+" (λ () #f))
+(test #f byte-regexp #"+" (λ () #f))
+(test #f byte-pregexp #"+" (λ () #f))
+(test 3 regexp "+" (λ () (+ 1 2)))
+(test 3 pregexp "+" (λ () (+ 1 2)))
+(test 3 byte-regexp #"+" (λ () (+ 1 2)))
+(test 3 byte-pregexp #"+" (λ () (+ 1 2)))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (report-errs)

--- a/racket/src/racket/include/schthread.h
+++ b/racket/src/racket/include/schthread.h
@@ -229,6 +229,8 @@ typedef struct Thread_Local_Variables {
   rxpos regcodesize_;
   rxpos regcodemax_;
   intptr_t regmaxlookback_;
+  Scheme_Object *regerrorproc_;
+  Scheme_Object *regerrorval_;
   intptr_t rx_buffer_size_;
   rxpos *startp_buffer_cache_;
   rxpos *endp_buffer_cache_;
@@ -624,6 +626,8 @@ XFORM_GC_VARIABLE_STACK_THROUGH_THREAD_LOCAL;
 #define regcodesize XOA (scheme_get_thread_local_variables()->regcodesize_)
 #define regcodemax XOA (scheme_get_thread_local_variables()->regcodemax_)
 #define regmaxlookback XOA (scheme_get_thread_local_variables()->regmaxlookback_)
+#define regerrorproc XOA (scheme_get_thread_local_variables()->regerrorproc_)
+#define regerrorval XOA (scheme_get_thread_local_variables()->regerrorval_)
 #define rx_buffer_size XOA (scheme_get_thread_local_variables()->rx_buffer_size_)
 #define startp_buffer_cache XOA (scheme_get_thread_local_variables()->startp_buffer_cache_)
 #define endp_buffer_cache XOA (scheme_get_thread_local_variables()->endp_buffer_cache_)


### PR DESCRIPTION
I noticed that the regexp API doesn't provide any easy way to test if a string input is actually a valid regular expression (i.e., without installing an exception handler). This PR adds a failure thunk to the constructors for this purpose.

I ended up adding some new thread local variables to track the failure thunk and also its result. Is this a reasonable approach or is it discouraged to add more data to threads?

Also does the API addition seem reasonable? Or is there a better interface?