### PR TITLE
sizeof(char) is always 1

### DIFF
--- a/racket/src/foreign/foreign.c
+++ b/racket/src/foreign/foreign.c
@@ -26,12 +26,8 @@
 #endif /* WINDOWS_DYNAMIC_LOAD */
 
 #if !defined(WINDOWS_DYNAMIC_LOAD) || defined(__MINGW32__)
-# if SIZEOF_CHAR == 1
    typedef   signed char Tsint8;
    typedef unsigned char Tuint8;
-# else
-#  error "configuration error, please contact PLT (int8)"
-# endif
 
 # if SIZEOF_SHORT == 2
    typedef   signed short Tsint16;

--- a/racket/src/foreign/foreign.rktc
+++ b/racket/src/foreign/foreign.rktc
@@ -29,13 +29,6 @@ exec racket "$0" > `echo "$0" | sed 's/rktc$/c/'` "$0"
 }
 
 @@@IF{!defined(WINDOWS_DYNAMIC_LOAD) || defined(__MINGW32__)}{
-# if SIZEOF_CHAR == 1
-   typedef   signed char Tsint8;
-   typedef unsigned char Tuint8;
-# else
-#  error "configuration error, please contact PLT (int8)"
-# endif
-
 # if SIZEOF_SHORT == 2
    typedef   signed short Tsint16;
    typedef unsigned short Tuint16;

--- a/racket/src/racket/mzconfig.h.in
+++ b/racket/src/racket/mzconfig.h.in
@@ -4,9 +4,6 @@
 #ifndef __MZSCHEME_CONFIGURATION_INFO__
 #define __MZSCHEME_CONFIGURATION_INFO__
 
-/* The size of a `char', as computed by sizeof. */
-#undef SIZEOF_CHAR
-
 /* The size of a `int', as computed by sizeof. */
 #undef SIZEOF_INT
 

--- a/racket/src/worksp/mzconfig.h
+++ b/racket/src/worksp/mzconfig.h
@@ -10,9 +10,6 @@
 
 /* Undefined items are not used on Windows. */
 
-/* The size of a `char', as computed by sizeof. */
-#undef SIZEOF_CHAR
-
 /* The size of a `int', as computed by sizeof. */
 #undef SIZEOF_INT
 


### PR DESCRIPTION
POSIX and ANSI specify that char is always 1 byte, and I'm almost
certain that no systems violate this. Regardless, the SIZEOF_CHAR macro
is never used.