### PR TITLE
optimizer: split optimize_info_lookup

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1630,10 +1630,29 @@
            '(lambda (a b)
               (not (if a b #t))))
 
+;ensure that variable p is not marked as used in the lambda
+(test-comp '(let ([p (if (zero? (random 2)) 1 2)])
+              (list p p (lambda () (not p))))
+           '(let ([p (if (zero? (random 2)) 1 2)])
+              (list p p (lambda () #f))))
+(test-comp '(let ([p (lambda () 0)])
+              (list p p (lambda () (not p))))
+           '(let ([p (lambda () 0)])
+              (list p p (lambda () #f))))
+;this still doesn't work without the additional p
+#;(test-comp '(let ([p (lambda () 0)])
+                (list p p (lambda () (procedure? p))))
+             '(let ([p (lambda () 0)])
+                (list p p (lambda () #t))))
+(test-comp '(let ([p (lambda () 0)])
+              (list p p (lambda () (procedure? p))))
+           '(let ([p (lambda () 0)])
+              (list p p (lambda () p #t))))
+
 (test-comp '(lambda (w) (if (void (list w)) 1 2))
            '(lambda (w) 1))
 
-; Diferent number of argumets use different codepaths
+; Different number of arguments use different code paths
 (test-comp '(lambda (f x) (void))
            '(lambda (f x) (void (list))))
 (test-comp '(lambda (f x) (begin (values (f x)) (void)))
@@ -1810,6 +1829,19 @@
            '(lambda (x) x))
 (test-comp '(lambda (x) (not (if (null? x) #t x)))
            '(lambda (x) (not x)))
+
+(test-comp '(lambda (x) (let ([n (list 1)])
+                          (list n n (not (if x #t n)))))
+           '(lambda (x) (let ([n (list 1)])
+                          (list n n #f))))
+(test-comp '(lambda (x) (let ([n (if (zero? (random 2)) 1 -1)])
+                          (list n n (not (if x #t n)))))
+           '(lambda (x) (let ([n (if (zero? (random 2)) 1 -1)])
+                          (list n n #f))))
+(test-comp '(lambda (x) (let ([n (if (zero? (random 2)) 1 -1)])
+                          (list n n (not (if x #t n)))))
+           '(lambda (x) (let ([n (if (zero? (random 2)) 1 -1)])
+                          (list n n #f))))
 
 (test-comp '(lambda (x) (if (let ([r (something)])
                               (if r r (something-else)))


### PR DESCRIPTION
With the old representation of local variables, `optimize_info_lookup` had to search the stack for the frame with the information about the variable. This was complicated so it has many flags to be used in different situations and extract different kind of information.

With the new representation this process is easier, so it's possible to split the function into a few smaller functions with an easier control flow.

In particular, this is useful to avoid marking a variable as used inside a lambda when the reference in immediately reduced to a constant using the type information.

Three more subtle changes:

) `(set! v ...)` marks the variable as used, but not as `escapes_after_k_tick`

) When a local `v1` is propagated  in a single step to another local `v2` and then to another local `v3`, the code calls `increment_use_count(v3, 0)` if the `count_use` of `v1` is not `1`, but the previous code used the `count_use` of `v2`. (See [optimize.c#R8344](https://github.com/racket/racket/compare/master...gus-massa:16-2-Info-Lookup?expand=1#diff-5e09d7df9102fa81a4736e357a0c3e1aR8344)) I think it's more natural to use `v1` than `v2`.

Nevertheless, I think that the propagation chain is done before, so the code in `optimize_info_propagate_local` actually never loops to search the final local, but I'm not sure.

Moreover, for testing I removed in the third commit the check that `count_use` is not `1`, so some variables are unnecessarily marked as used multiple times, but none of the optimization tests raise an error. (It's not a bug, but it may prevent some optimizations.) I couldn't create a test that detects this problem. Any ideas?

) The second commit is very small and barely related. It detects explicit `case-lambdas` in `lookup_constant_proc`.