### PR TITLE
scalinger -> scaliger

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/time.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/time.scrbl
@@ -224,16 +224,16 @@ local time by default or UTC if @racket[local-time?] is
 error is signaled, otherwise an integer is returned.}
 
 
-@defproc[(date->julian/scalinger [date date?]) exact-integer?]{
+@defproc[(date->julian/scaliger [date date?]) exact-integer?]{
 
 Converts a date structure (up to 2099 BCE Gregorian) into a Julian
 date number. The returned value is not a strict Julian number, but
-rather Scalinger's version, which is off by one for easier
+rather Scaliger's version, which is off by one for easier
 calculations.}
 
 
-@defproc[(julian/scalinger->string [date-number exact-integer?])
+@defproc[(julian/scaliger->string [date-number exact-integer?])
          string?]{
 
-Converts a Julian number (Scalinger's off-by-one version) into a
+Converts a Julian number (Scaliger's off-by-one version) into a
 string.}

--- a/pkgs/racket-test-core/tests/racket/date.rktl
+++ b/pkgs/racket-test-core/tests/racket/date.rktl
@@ -72,9 +72,13 @@
   (test-string 'rfc2822 #t "Thu, 4 May 2006 03:02:01 -0600")
   (test-string 'julian #f "JD 2 453 860")
   (test-string 'julian #t "JD 2 453 860, 03:02:01")
-  
+
+  ;; In the off chance that one of these changes and not the other,
+  ;; both are provided for tests.
   (test 2453860 date->julian/scalinger d)
-  (test "JD 2 453 860" julian/scalinger->string 2453860))
+  (test 2453860 date->julian/scaliger d)
+  (test "JD 2 453 860" julian/scalinger->string 2453860)
+  (test "JD 2 453 860" julian/scaliger->string 2453860))
 
 ;; Bad dates
 (err/rt-test (find-seconds 0 0 0 0 0 1990) exn:fail?)
@@ -106,9 +110,14 @@
       ;;  one of the two possible values, though:
       (test-find 0 30 1 7 11 2010))))
 
+
+;; In the off chance that one of these changes and not the other,
+;; both are provided for tests.
 ;; bug fixes
 (test "JD 12" julian/scalinger->string 12)
+(test "JD 12" julian/scaliger->string 12)
 (test "JD 123" julian/scalinger->string 123)
+(test "JD 123" julian/scaliger->string 123)
 
 ;; make sure that date* has the correct parent info
 (test #t date*?

--- a/racket/collects/racket/date.rkt
+++ b/racket/collects/racket/date.rkt
@@ -18,7 +18,9 @@
                 . ->* .
                 exact-integer?)]
  [date->julian/scalinger (date? . -> . exact-integer?)]
- [julian/scalinger->string (exact-integer? . -> . string?)])
+ [date->julian/scaliger (date? . -> . exact-integer?)]
+ [julian/scalinger->string (exact-integer? . -> . string?)]
+ [julian/scaliger->string (exact-integer? . -> . string?)])
 
 (define (current-date)
   (seconds->date (* #i1/1000 (current-inexact-milliseconds))))
@@ -348,6 +350,8 @@
        gregorian-adjustment))
   final-date)
 
+(define date->julian/scaliger date->julian/scalinger)
+
 ;; julian/scalinger->string :
 ;; number [julian-day] -> string [julian-day-format]
 
@@ -372,3 +376,5 @@
                                              (cadr reversed-digits)
                                              (car reversed-digits)))
                                 (loop (cdr (cdr (cdr reversed-digits))))))))))))
+
+(define julian/scaliger->string julian/scalinger->string)


### PR DESCRIPTION
This fixes racket/racket#757. Tests are included for both versions,
and documentation now only references the new, correctly named,
procedures.