### PR TITLE
Improve Guide example on `flat-named-contract'

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/contracts/simple-function.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/contracts/simple-function.scrbl
@@ -404,11 +404,14 @@ the contract so that error messages become intelligible:
 @interaction[#:eval 
              contract-eval
              (module improved-bank-server racket
-               (define (amount? x) (and (number? x) (integer? x) (>= x 0)))
-               (define amount (flat-named-contract 'amount amount?))
-  
-               (provide (contract-out [deposit (amount . -> . any)]))
-  
+               (provide
+                (contract-out
+                 [deposit (-> (flat-named-contract
+                               'amount
+                               (λ (x)
+                                 (and (number? x) (integer? x) (>= x 0))))
+                              any)]))
+
                (define total 0)
                (define (deposit a) (set! total (+ a total))))]
 


### PR DESCRIPTION
Previously, on the example, the function was not anonymous, so no
`tempN` would appear on the error message.

The fixed example makes use of `flat-named-contract` on an anonymous
function, which resembles the snippet above it and demonstrates the
purpose of `flat-named-contract` better.