### PR TITLE
adding unicode-lambda forms for match

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -460,17 +460,25 @@ many values to expect from @racket[expr].
   ]
 }
 
-@defform[(match-lambda clause ...)]{
+@deftogether[(
+@defform[(match-lambda clause ...)]
+@defform[(match-λ clause ...)]
+)]{
 
 Equivalent to @racket[(lambda (id) (match id clause ...))].
 }
-
-@defform[(match-lambda* clause ...)]{
+@deftogether[(
+@defform[(match-lambda* clause ...)]
+@defform[(match-λ* clause ...)]
+)]{
 
 Equivalent to @racket[(lambda lst (match lst clause ...))].
 }
 
-@defform[(match-lambda** clause* ...)]{
+@deftogether[(
+@defform[(match-lambda** clause* ...)]
+@defform[(match-λ** clause ...)]
+)]{
 
 Equivalent to @racket[(lambda (args ...) (match* (args ...) clause* ...))],
 where the number of @racket[args ...] is computed from the number of patterns

--- a/racket/collects/racket/match/define-forms.rkt
+++ b/racket/collects/racket/match/define-forms.rkt
@@ -16,8 +16,9 @@
 (provide define-forms)
 
 (define-syntax-rule (define-forms parse-id
-                      match match* match-lambda match-lambda*
-		      match-lambda** match-let match-let*
+                      match match* match-lambda match-λ 
+                      match-lambda* match-λ* match-lambda** match-λ** 
+                      match-let match-let* 
                       match-let-values match-let*-values
 		      match-define match-define-values
                       match-letrec match-letrec-values
@@ -25,7 +26,8 @@
                       define/match)
   (...
    (begin
-     (provide match match* match-lambda match-lambda* match-lambda**
+     (provide match match* match-lambda match-λ 
+              match-lambda* match-λ* match-lambda** match-λ**
 	      match-let match-let* match-let-values match-let*-values
               match-define match-define-values
               match-letrec match-letrec-values
@@ -59,27 +61,35 @@
               (let-values ([(ids ...) arg])
                 (match*/derived (ids ...) #,stx cl0 clauses ...))))]))
 
-     (define-syntax (match-lambda stx)
-       (syntax-parse stx
-         [(_ . clauses)
-          (with-syntax* ([arg (generate-temporary)]
-                         [body #`(match/derived arg #,stx . clauses)])
-            (syntax/loc stx (lambda (arg) body)))]))
+     (define-syntaxes (match-lambda match-λ)
+       (let [(match-lambda 
+               (lambda (stx)
+                 (syntax-parse stx
+                   [(_ . clauses)
+                    (with-syntax* ([arg (generate-temporary)]
+                                   [body #`(match/derived arg #,stx . clauses)])
+                      (syntax/loc stx (lambda (arg) body)))])))]
+         (values match-lambda match-lambda)))
 
-     (define-syntax (match-lambda* stx)
-       (syntax-parse stx
-         [(_ . clauses)
-          (with-syntax* ([arg (generate-temporary)]
-                         [body #`(match/derived arg #,stx . clauses)])
-            (syntax/loc stx (lambda arg body)))]))
+     (define-syntaxes (match-lambda* match-λ*)
+       (let ((match-lambda* 
+               (lambda (stx)
+                 (syntax-parse stx
+                   [(_ . clauses)
+                    (with-syntax* ([arg (generate-temporary)]
+                                   [body #`(match/derived arg #,stx . clauses)])
+                      (syntax/loc stx (lambda arg body)))]))))
+         (values match-lambda* match-lambda*)))
 
-     (define-syntax (match-lambda** stx)
-       (syntax-parse stx
-         [(_ (~and clauses [(pats ...) . rhs]) ...)
-          (with-syntax* ([vars (generate-temporaries (car (syntax-e #'((pats ...) ...))))]
-                         [body #`(match*/derived vars #,stx clauses ...)])
-            (syntax/loc stx (lambda vars body)))]))
-
+     (define-syntaxes (match-lambda** match-λ**)
+       (let ((match-lambda** 
+              (lambda (stx)
+                (syntax-parse stx
+                  [(_ (~and clauses [(pats ...) . rhs]) ...)
+                   (with-syntax* ([vars (generate-temporaries (car (syntax-e #'((pats ...) ...))))]
+                                  [body #`(match*/derived vars #,stx clauses ...)])
+                     (syntax/loc stx (lambda vars body)))]))))
+         (values match-lambda** match-lambda**)))
 
      (define-syntax (match-let-values stx)
        (syntax-parse stx

--- a/racket/collects/racket/match/legacy-match.rkt
+++ b/racket/collects/racket/match/legacy-match.rkt
@@ -15,7 +15,9 @@
          exn:misc:match?)
 
 (define-forms parse/legacy
-  match match* match-lambda match-lambda* match-lambda** match-let match-let*
+  match match* match-lambda match-λ 
+  match-lambda* match-λ* match-lambda** match-λ**
+  match-let match-let*
   match-let-values match-let*-values
   match-define match-define-values match-letrec match-letrec-values match/values match/derived match*/derived
   define/match)

--- a/racket/collects/racket/match/match.rkt
+++ b/racket/collects/racket/match/match.rkt
@@ -28,7 +28,9 @@
          exn:misc:match?)
 
 (define-forms parse
-  match match* match-lambda match-lambda* match-lambda** match-let match-let*
+  match match* match-lambda match-λ 
+  match-lambda* match-λ* match-lambda** match-λ**
+  match-let match-let*
   match-let-values match-let*-values
   match-define match-define-values match-letrec match-letrec-values match/values
   match/derived match*/derived


### PR DESCRIPTION
This adds forms `match-λ`, `match-λ*`, and `match-λ**`. Further reflecting upon #1295 the Racket docs pull up 141 entries for `lambda`. That's an awful lot to add. The three identifiers `match-lambda`, `match-lambda*`, and `match-lambda**` are the only ones by default in #lang racket that don't coincide with versions defined elsewhere (unlike `case-lambda`). 

Let's see how these go and maybe take others on an as-desired basis. First pull request to racket, so extra scrutiny warranted. 
