### PR TITLE
Update to the package template + small documentation changes

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
@@ -55,7 +55,7 @@ popular among Racketeers as well.
        name @tt{geiser}.}
 
  @item{Emacs ships with a major mode for Scheme, @tt{scheme-mode},
-       that while not as featureful as the above options, but works
+       that while not as featureful as the above options, works
        reasonably well for editing Racket code. However, this mode
        does not provide support for Racket-specific forms.}
 

--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -926,11 +926,13 @@ times in the entire repetition.
 
 If the pattern is matched too few times, then the ellipsis pattern
 fails with the message either @racket[too-few-message-expr] or
-@racketvalfont{"too few occurrences of @racket[name-expr]"}.
+@racketvalfont{"too few occurrences of @racket[name-expr]"}, when
+@racket[name-expr] is provided.
 
 If the pattern is chosen too many times, then the ellipsis pattern
 fails with the message either @racket[too-many-message-expr] or
-@racketvalfont{"too few occurrences of @racket[name-expr]"}.
+@racketvalfont{"too many occurrences of @racket[name-expr]"}, when
+@racket[name-expr] is provided.
 }
 
 

--- a/racket/collects/pkg/private/new.rkt
+++ b/racket/collects/pkg/private/new.rkt
@@ -87,7 +87,8 @@ EOS
 \#*
 .\#*
 .DS_Store
-compiled
+compiled/
+/doc/
 
 EOS
 )))
@@ -122,34 +123,33 @@ env:
     - RACKET_VERSION=6.1.1
     - RACKET_VERSION=6.2
     - RACKET_VERSION=6.3
+    - RACKET_VERSION=6.4
     - RACKET_VERSION=HEAD
 
 matrix:
   allow_failures:
-    env: RACKET_VERSION=HEAD
-    fast_finish: true
+#   - env: RACKET_VERSION=HEAD
+  fast_finish: true
 
 before_install:
-- git clone https://github.com/greghendershott/travis-racket.git
-- cat travis-racket/install-racket.sh | bash # pipe to bash not sh!
+- git clone https://github.com/greghendershott/travis-racket.git ~/travis-racket
+- cat ~/travis-racket/install-racket.sh | bash # pipe to bash not sh!
 - export PATH="${RACKET_DIR}/bin:${PATH}" #install-racket.sh can't set for us
 
 install:
+ - raco pkg install --deps search-auto
 
 before_script:
 
-# Here supply steps such as raco make, raco test, etc.  Note that you
-# need to supply /usr/racket/bin/ -- it's not in PATH. You can run
-# `raco pkg install --deps search-auto <<name>>` to install any required
+# Here supply steps such as raco make, raco test, etc.  You can run
+# `raco pkg install --deps search-auto` to install any required
 # packages without it getting stuck on a confirmation prompt.
 script:
- - raco pkg install --deps search-auto cover
  - raco test -x -p <<name>>
 
 after_success:
- - raco setup --check-deps <<name>>
- - raco pkg install --deps search-auto cover-coveralls
- - raco pkg install --deps search-auto
+ - raco setup --check-pkg-deps --pkgs <<name>>
+ - raco pkg install --deps search-auto cover cover-coveralls
  - raco cover -b -f coveralls -d $TRAVIS_BUILD_DIR/coverage .
 
 EOS
@@ -196,7 +196,7 @@ EOS
 ;; To uninstall:
 ;;   $ raco pkg remove <<name>>
 ;; To view documentation:
-;;   $ raco doc <<name>>
+;;   $ raco docs <<name>>
 ;;
 ;; For your convenience, we have included a LICENSE.txt file, which links to
 ;; the GNU Lesser General Public License.


### PR DESCRIPTION
Changes to the package template (mostly `.travis.yml`):
* Add 6.4 version, as this is now the default one to download on the website.
* `raco` is now on the PATH, remove obsolete warning
* Change `raco setup --check-deps <<name>>` to `raco setup --check-pkg-deps --pkgs <<name>>` (the former seems obsolete).
* Move `raco pkg install --deps search-auto` to the `install:` section, so that it is done before running the tests
* Move `raco pkg install --deps search-auto cover`, to the `after_success section`, since `raco cover` is run there.
* Fixed .travis.yml syntax (wrong indentation for fields under "matrix:")
** Since the old syntax for allowed_failures was ignored, I commented out the "- env: RACKET_VERSION: HEAD", to keep the same behaviour.
* Clone https://github.com/greghendershott/travis-racket.git to a separate directory, not a subdirectory of the current package, as this can cause problems (see https://travis-ci.org/jsmaniac/type-expander/jobs/121099218#L824)
* In the comments in the `main.rkt` file, `raco doc <<name>>` should be `raco docs <<name>>`

I applied by hand these changes on a brand-new package, and it compiled smoothly: https://travis-ci.org/jsmaniac/preexpanded/builds/121418630

I also included a few small changes to the documentation.
