### PR TITLE
More reductions uing types

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1228,6 +1228,27 @@
            '(lambda (w z) (list w z))
            #f)
 
+(test-comp '(lambda (u v) (car (cons u v)))
+           '(lambda (u v) u))
+(test-comp '(lambda (u v) (unsafe-car (cons u v)))
+           '(lambda (u v) u))
+(test-comp '(lambda (u v) (car (unsafe-cons-list u v)))
+           '(lambda (u v) u))
+
+(test-comp '(lambda (u v) (cdr (cons u v)))
+           '(lambda (u v) v))
+(test-comp '(lambda (u v) (unsafe-cdr (cons u v)))
+           '(lambda (u v) v))
+(test-comp '(lambda (u v) (cdr (unsafe-cons-list u v)))
+           '(lambda (u v) v))
+
+(test-comp '(lambda (v) (unbox (box v)))
+           '(lambda (v) v))
+(test-comp '(lambda (v) (unsafe-unbox (box v)))
+           '(lambda (v) v))
+(test-comp '(lambda (v) (unsafe-unbox* (box v)))
+           '(lambda (v) v))
+
 (test-comp '(lambda (w z) (pair? (list)))
            '(lambda (w z) #f))
 (test-comp '(lambda (w z) (null? (list)))
@@ -2316,13 +2337,13 @@
              (+ (unsafe-car z) (car z)))
            #f)
 
-(test-comp '(lambda (z)
+(test-comp '(lambda (z v)
              ;; It's ok to move an unsafe operation past a
              ;; safe one:
-             (let ([x (unsafe-car void)])
+             (let ([x (unsafe-car v)])
                (+ (car z) x)))
-           '(lambda (z)
-             (+ (car z) (unsafe-car void))))
+           '(lambda (z v)
+             (+ (car z) (unsafe-car v))))
 
 ;; Ok to reorder arithmetic that will not raise an error:
 (test-comp '(lambda (x y)
@@ -2339,7 +2360,7 @@
 (parameterize ([compile-context-preservation-enabled
                 ;; Avoid different amounts of unrolling
                 #t])
-  ;; Inferece of loop variable as number should allow
+  ;; Inference of loop variable as number should allow
   ;; additions to be reordered:
   (test-comp '(lambda ()
                (let loop ([n 0] [m 9])


### PR DESCRIPTION
**First commit:** Only wrap the argument `x` as `(values x)` when the optimizer is not sure that `x` is a single valued expression. This allows to remove the checks in the calling sites.

**Second commit:** Reduce `(unbox (box x)) => (values x)`. And extend the reductions for `cXr` to the unsafe versions, for example reduce `(unsafe-car (cons x y)) => x`.

**Third commit:** _(don't merge)_ check and save types in unsafe operations. I think this is technicaly correct, but it enables many surprising unexpected reductions, so I think it's better to not merge this. Also, it's very difficult to find examples where this aditional information is useful.
 
For example reduce:

    (lambda (x) (unsafe-car x) (pair? x)) ;infer type
    => (lambda (x) (unsafe-car x) #t)
    => (lambda (x) #t)

and

    (lambda (y) (+ (unsafe-car y) (unbox y)) ;infer error
    => (lambda (y) (unsafe-car y) (unbox y))
    => (lambda (y) (unbox y))

**Fouth commit:** The previous commit breaks one test that uses `(unsafe-car void)`. It's not clear whether  the optimizer is allowed to realize that it's undefined behavior and do strange things after it, but just in case I propose to change the test to `(unsafe-car var)`.