### PR TITLE
Rename define-simple-macro from syntax/parse/define to define-syntax-parse-rule

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
@@ -12,7 +12,7 @@
 
 @defmodule[syntax/parse/define]
 
-@defform[(define-simple-macro (macro-id . pattern) pattern-directive ...
+@defform[(define-syntax-parse-rule (macro-id . pattern) pattern-directive ...
            template)]{
 
 Defines a macro named @racket[macro-id]; equivalent to the following:
@@ -25,11 +25,11 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 
 @(the-eval '(require syntax/parse/define))
 @examples[#:eval the-eval
-(define-simple-macro (fn x:id rhs:expr) (lambda (x) rhs))
+(define-syntax-parse-rule (fn x:id rhs:expr) (lambda (x) rhs))
 ((fn x x) 17)
 (fn 1 2)
 
-(define-simple-macro (fn2 x y rhs)
+(define-syntax-parse-rule (fn2 x y rhs)
   #:declare x id
   #:declare y id
   #:declare rhs expr
@@ -38,7 +38,7 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 (fn2 a #:b 'c)
 ]
 
-}
+@history[#:added "6.6.0.2"]}
 
 @defform[(define-syntax-parser macro-id parse-option ... clause ...+)]{
 
@@ -60,5 +60,11 @@ Defines a macro named @racket[macro-id]; equivalent to:
 (fn3 1 2)
 (fn3 a #:b 'c)
 ]}
+
+@defform[(define-simple-macro (macro-id . pattern) pattern-directive ...
+           template)]{
+Re-exports @racket[define-syntax-parse-rule] for backwards compatibility.
+
+@history[#:changed "6.6.0.2" @elem{deprecated in favor of @racket[define-syntax-parse-rule].}]}
 
 @(close-eval the-eval)

--- a/racket/collects/syntax/parse/define.rkt
+++ b/racket/collects/syntax/parse/define.rkt
@@ -2,19 +2,20 @@
 (require (for-syntax racket/base
                      syntax/parse
                      "private/sc.rkt"))
-(provide define-simple-macro
+(provide define-syntax-parse-rule
          define-syntax-parser
+         (rename-out [define-syntax-parse-rule define-simple-macro])
          (for-syntax (all-from-out syntax/parse)))
 
-(define-syntax (define-simple-macro stx)
+(define-syntax (define-syntax-parse-rule stx)
   (syntax-parse stx
-    [(define-simple-macro (~and (macro:id . _) pattern) . body)
+    [(_ (~and (macro:id . _) pattern) . body)
      #`(define-syntax macro
          (syntax-parser/template
           #,((make-syntax-introducer) stx)
           [pattern . body]))]))
 
-(define-simple-macro (define-syntax-parser macro:id option-or-clause ...)
+(define-syntax-parse-rule (define-syntax-parser macro:id option-or-clause ...)
   (define-syntax macro
     (syntax-parser option-or-clause ...)))
 


### PR DESCRIPTION
In [a mailing list thread from last year](https://groups.google.com/d/msg/racket-dev/e4WfuZ9JWUk/StzZW7lBCQAJ), it was mentioned that `define-simple-macro` might not be the best name for the `define-syntax-rule` analog exported from `syntax/parse/define`. I was not super satisfied with any of the proposed alternate names, but after considering it for a while, I think `define-syntax-pattern` is a fair one.
1. It is pretty close to `define-syntax-rule`, but distinct enough to not be any more confusing than `syntax-case` vs `syntax-parse`.
2. The term `pattern` is already used a lot within the `syntax/parse` docs, so it is a familiar term (probably more than `rule`, really).
3. Even in isolation, the name pretty accurately describes what the form does.

Obviously, I’ve left the old name in to avoid breaking backwards compatibility, but I’ve updated the docs to mention that the other name is preferred.
