### PR TITLE
make match exception transparent

### DIFF
--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -17,7 +17,8 @@
 (define match-equality-test (make-parameter equal?))
 
 (define-struct (exn:misc:match exn:fail) (value srclocs)
- #:property prop:exn:srclocs (lambda (ex) (exn:misc:match-srclocs ex)))
+  #:property prop:exn:srclocs (lambda (ex) (exn:misc:match-srclocs ex))
+  #:transparent)
 
 
 (define (match:error val srclocs form-name)


### PR DESCRIPTION
Per discussion on racket-users mailing list, making exn:misc:match transparent to better match other exceptions raised by racket.