### PR TITLE
Fix description of the `#x20` X-expression

### DIFF
--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -168,7 +168,7 @@ A @racket[_symbol] represents a symbolic entity. For example,
 @racket['nbsp] represents @litchar{&nbsp;}.
 
 An @racket[valid-char?] represents a numeric entity. For example,
-@racketvalfont{#x20} represents @litchar{&#20;}.
+@racketvalfont{#x20} represents @litchar{&#x20;}.
 
 A @racket[_cdata] is an instance of the @racket[cdata] structure type,
 and a @racket[_misc] is an instance of the @racket[comment] or


### PR DESCRIPTION
An X-expression of `#x20` converts to `&#x20;` (actually `&#32;`), not `&#20;`. An X-expression of `20` would indeed convert to `&#20;`, however.