### PR TITLE
clarify role of empty `stop-ids` list in `local-expand`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
@@ -231,7 +231,7 @@ identifier, the @racket[exn:fail:contract] exception is raised.
 
 @defproc[(local-expand [stx any/c]
                        [context-v (or/c 'expression 'top-level 'module 'module-begin list?)]
-                       [stop-ids (or/c (listof identifier?) #f)]
+                       [stop-ids (or/c (listof identifier?) empty #f)]
                        [intdef-ctx (or/c internal-definition-context? 
                                          (and/c pair? 
                                                 (listof internal-definition-context?))
@@ -260,10 +260,17 @@ in a sub-expression, expansions stops for the sub-expression. If
 @racket[stop-ids], then application and
 literal data expressions without the respective explicit form are not
 wrapped with the explicit form, and @racket[#%top] wrappers are
-never added (even with an empty @racket[stop-ids] list). If @racket[stop-ids] is @racket[#f]
+never added (even with an empty @racket[stop-ids] list).
+
+If @racket[stop-ids] is an empty list, then @racket[stx] is expanded
+recursively (i.e., expansion proceeds to sub-expressions).
+
+If @racket[stop-ids] is @racket[#f]
 instead of a list, then @racket[stx] is expanded only as long as the
 outermost form of @racket[stx] is a macro (i.e., expansion does not
-proceed to sub-expressions). A fully expanded form can include the
+proceed to sub-expressions).
+
+A fully expanded form can include the
 bindings listed in @secref["fully-expanded"] plus the
 @racket[letrec-syntaxes+values] form and @racket[#%expression]
 in any expression position.


### PR DESCRIPTION
Make it clear that using an empty list for `stop-ids` will produce a recursive expansion.