### PR TITLE
add prop:constructor-style-printer

### DIFF
--- a/racket/collects/racket/private/set-types.rkt
+++ b/racket/collects/racket/private/set-types.rkt
@@ -557,23 +557,27 @@
          (fprintf port "#<~acustom-set>" key-str)]
         [else (write-hash-set s port mode)]))
 
+(define (hash-set-constructor s)
+  (define table (custom-set-table s))
+  (define key-str
+    (cond [(immutable? table) ""]
+          [(hash-weak? table) "weak-"]
+          [else "mutable-"]))
+  (cond [(custom-set-spec s)
+         (string-append key-str "custom-set")]
+        [else
+         (define cmp-str
+           (cond [(hash-equal? table) "set"]
+                 [(hash-eqv? table) "seteqv"]
+                 [(hash-eq? table) "seteq"]))
+         (string-append key-str cmp-str)]))
+(define (hash-set-contents s)
+  (hash-keys (custom-set-table s)))
+
 (define write-hash-set
   (make-constructor-style-printer
-   (lambda (s)
-     (define table (custom-set-table s))
-     (define key-str
-       (cond [(immutable? table) ""]
-             [(hash-weak? table) "weak-"]
-             [else "mutable-"]))
-     (cond [(custom-set-spec s)
-            (string-append key-str "custom-set")]
-           [else
-            (define cmp-str
-              (cond [(hash-equal? table) "set"]
-                    [(hash-eqv? table) "seteqv"]
-                    [(hash-eq? table) "seteq"]))
-            (string-append key-str cmp-str)]))
-   (lambda (s) (hash-keys (custom-set-table s)))))
+   hash-set-constructor
+   hash-set-contents))
 
 (define (custom-in-set s)
   (define keys (in-hash-keys (custom-set-table s)))
@@ -680,6 +684,8 @@
 (define mk-not-allowed/mut (mk-not-allowed #:immut #t))
 
 (serializable-struct immutable-custom-set custom-set []
+  #:property prop:constructor-style-printer
+  (list hash-set-constructor hash-set-contents)
   #:methods gen:stream
   [(define stream-empty? custom-set-empty?)
    (define stream-first custom-set-first)
@@ -748,9 +754,13 @@
    (define set-symmetric-difference (mk-not-allowed/mut 'set-symmetric-difference))
    (define set-symmetric-difference! custom-set-symmetric-difference!)])
 
-(serializable-struct weak-custom-set imperative-custom-set [])
+(serializable-struct weak-custom-set imperative-custom-set []
+  #:property prop:constructor-style-printer
+  (list hash-set-constructor hash-set-contents))
 
-(serializable-struct mutable-custom-set imperative-custom-set [])
+(serializable-struct mutable-custom-set imperative-custom-set []
+  #:property prop:constructor-style-printer
+  (list hash-set-constructor hash-set-contents))
 
 (define-syntax (define-custom-set-types stx)
   (parameterize ([current-syntax-context stx])

--- a/racket/collects/racket/struct.rkt
+++ b/racket/collects/racket/struct.rkt
@@ -5,7 +5,17 @@
           [make-constructor-style-printer
            (-> (-> any/c (or/c symbol? string?))
                (-> any/c sequence?)
-               (-> any/c output-port? (or/c #t #f 0 1) void?))])
+               (-> any/c output-port? (or/c #t #f 0 1) void?))]
+          [prop:constructor-style-printer
+           (struct-type-property/c
+            (list/c (-> constructor-style-printer? (or/c symbol? string?))
+                    (-> constructor-style-printer? sequence?)))]
+          [constructor-style-printer?
+           (-> any/c boolean?)]
+          [constructor-style-printer-constructor
+           (-> constructor-style-printer? (or/c symbol? string?))]
+          [constructor-style-printer-contents
+           (-> constructor-style-printer? sequence?)])
          struct->list)
 
 (define dummy-value (box 'dummy))


### PR DESCRIPTION
This struct-type property allows structs to specify how they should by printed by constructor-style printing. I'm also submitting a pull request to pconvert-lib to recognize this property and use it when converting structs into s-expressions.
```racket
> (require racket/struct)
> (struct point (x y) ; this struct is opaque and wouldn't print like this otherwise
    #:property prop:constructor-style-printer
    (list
     (lambda (p) 'point)
     (lambda (p) (list (point-x p) (point-y p)))))
> (print (point 1 2))
(point 1 2)
> (parameterize ([pretty-print-columns 10])
    (pretty-print (point 3000000 4000000)))
(point
 3000000
 4000000)
> (require mzlib/pconvert)
> (print-convert (point 1 2)) ; with my other pull request to pconvert-lib
(list 'point 1 2)
```