### PR TITLE
improve vertical positioning & paren shaping in `syntax->string`

### DIFF
--- a/racket/collects/syntax/to-string.rkt
+++ b/racket/collects/syntax/to-string.rkt
@@ -3,7 +3,7 @@
            syntax/stx)
   
   (require racket/list)
-
+  
   (define (syntax->string c)
     (let* ([s (open-output-string)]
            [l (syntax->list c)]
@@ -14,7 +14,7 @@
         (let ([c (syntax-column c)]
               [l (syntax-line c)])
           (when (and l (l . > . line))
-            (newline)
+            (for-each (λ (_) (newline)) (range (- l line)))
             (set! line l)
             (init-line!))
           (when c
@@ -55,10 +55,14 @@
                  ((loop init-line!) i))]
               [(pair? (syntax-e c))
                (advance c init-line!)
-               (printf "(")
+               (define c-paren-shape (syntax-property c 'paren-shape))
+               (printf (format "~a" (or c-paren-shape #\()))
                (set! col (+ col 1))
                (map (loop init-line!) (syntax->list c))
-               (printf ")")
+               (printf (case c-paren-shape
+                         [(#\[) "]"]
+                         [(#\{) "}"]
+                         [else ")"]))
                (set! col (+ col 1))]
               [(vector? (syntax-e c))
                (advance c init-line!)

--- a/racket/collects/syntax/to-string.rkt
+++ b/racket/collects/syntax/to-string.rkt
@@ -56,7 +56,7 @@
               [(pair? (syntax-e c))
                (advance c init-line!)
                (define c-paren-shape (syntax-property c 'paren-shape))
-               (printf (format "~a" (or c-paren-shape #\()))
+               (printf "~a" (or c-paren-shape #\())
                (set! col (+ col 1))
                (map (loop init-line!) (syntax->list c))
                (printf (case c-paren-shape


### PR DESCRIPTION
Two improvements:

1) Currently, `syntax->string` collapses multiple newlines into one. But the docs say that it “Builds a string with newlines and indenting according to the source locations”. So it seems more accurate to preserve the newlines.

2) Currently, `syntax->string` ignores the `'paren-shape` property. (Perhaps it predates 'paren-shape.) It seems more accurate to observe it.