### PR TITLE
Skip superfluous whitespace in PLTSTDERR environment variable contents

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/logging.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/logging.scrbl
@@ -41,25 +41,17 @@ through environment variables:
        @litchar{none}, @litchar{fatal}, @litchar{error},
        @litchar{warning}, @litchar{info}, or @litchar{debug}; all
        events the corresponding level of higher are printed. After an
-       initial @nonterm{level}, the value can contain space-separated
-       specifications of the form
-       @nonterm{level}@litchar["@"]@nonterm{topic}, which prints events
-       whose topics match @nonterm{topic} only at the given
+       initial @nonterm{level}, the value can contain
+       whitespace-separated specifications of the form
+       @nonterm{level}@litchar["@"]@nonterm{topic}, which prints
+       events whose topics match @nonterm{topic} only at the given
        @nonterm{level} or higher (where a @nonterm{topic} contains any
-       character other than a space or @litchar["@"]). For example,
-       the value @racket["error debug@GC"] prints all events at the
+       character other than whitespace or @litchar["@"]). Leading and
+       trailing whitespace is ignored. For example, the value
+       @racket["error debug@GC"] prints all events at the
        @racket['error] level and higher, but prints events for the
-       topic @racket['GC] at the @racket['debug] level and
-       higher (which includes all levels).
-
-       In versions of Racket up to and including 6.6, parsing of
-       @indexed-envvar{PLTSTDERR} and similar log-level specifications
-       was very strict. Leading and trailing whitespace was forbidden,
-       and anything other than exactly one space character separating
-       two specifications was rejected. This has since been relaxed,
-       starting with version 6.6.0.2. The new behaviour is to ignore
-       leading and trailing whitespace, and to accept any non-zero
-       number of whitespace characters between specifications.
+       topic @racket['GC] at the @racket['debug] level and higher
+       (which includes all levels).
 
        The default is @racket["error"].}
 
@@ -81,6 +73,12 @@ is the initial logger. The run-time system sometimes uses the current
 logger to report events. For example, the bytecode compiler sometimes
 reports @racket['warning] events when it detects an expression that
 would produce a run-time error if evaluated.
+
+@history[#:changed "6.6.0.2" @elem{Prior to version 6.6.0.2, parsing
+    of @envvar{PLTSTDERR} and @envvar{PLTSYSLOG} was very strict.
+    Leading and trailing whitespace was forbidden, and anything other
+    than exactly one space character separating two specifications was
+    rejected.}]
 
 @; ----------------------------------------
 @section{Creating Loggers}

--- a/pkgs/racket-doc/scribblings/reference/logging.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/logging.scrbl
@@ -48,7 +48,7 @@ through environment variables:
        @nonterm{level} or higher (where a @nonterm{topic} contains any
        character other than a space or @litchar["@"]). For example,
        the value @racket["error debug@GC"] prints all events at the
-       @racket['error] level and higher, but prints events for the topic
+       @racket['error] level and higher, but prints events for the
        topic @racket['GC] at the @racket['debug] level and
        higher (which includes all levels).
 

--- a/pkgs/racket-doc/scribblings/reference/logging.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/logging.scrbl
@@ -52,6 +52,15 @@ through environment variables:
        topic @racket['GC] at the @racket['debug] level and
        higher (which includes all levels).
 
+       In versions of Racket up to and including 6.6, parsing of
+       @indexed-envvar{PLTSTDERR} and similar log-level specifications
+       was very strict. Leading and trailing spaces were forbidden,
+       and anything other than exactly one space separating two
+       specifications was rejected. This has since been relaxed,
+       starting with version 6.6.0.2. The new behaviour is to ignore
+       leading and trailing spaces, and to accept any non-zero number
+       of spaces between specifications.
+
        The default is @racket["error"].}
 
  @item{If the @indexed-envvar{PLTSYSLOG} environment variable is

--- a/pkgs/racket-doc/scribblings/reference/logging.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/logging.scrbl
@@ -54,12 +54,12 @@ through environment variables:
 
        In versions of Racket up to and including 6.6, parsing of
        @indexed-envvar{PLTSTDERR} and similar log-level specifications
-       was very strict. Leading and trailing spaces were forbidden,
-       and anything other than exactly one space separating two
-       specifications was rejected. This has since been relaxed,
+       was very strict. Leading and trailing whitespace was forbidden,
+       and anything other than exactly one space character separating
+       two specifications was rejected. This has since been relaxed,
        starting with version 6.6.0.2. The new behaviour is to ignore
-       leading and trailing spaces, and to accept any non-zero number
-       of spaces between specifications.
+       leading and trailing whitespace, and to accept any non-zero
+       number of whitespace characters between specifications.
 
        The default is @racket["error"].}
 

--- a/racket/src/racket/cmdline.inc
+++ b/racket/src/racket/cmdline.inc
@@ -755,6 +755,10 @@ static Scheme_Object *get_log_level(char *prog, char *real_switch, const char *e
   l =  scheme_make_null();
 
   while (1) {
+    while (*str && *str == ' ') {
+      str++;
+    }
+
     if (!*str) {
       if (default_lvl == -1) default_lvl = 0;
       if (last)

--- a/racket/src/racket/cmdline.inc
+++ b/racket/src/racket/cmdline.inc
@@ -746,6 +746,8 @@ static Scheme_Object *reverse_path_list(Scheme_Object *l, int rel_to_cwd)
 # define GC_CAN_IGNORE /**/
 #endif
 
+#include <ctype.h>
+
 static Scheme_Object *get_log_level(char *prog, char *real_switch, const char *envvar, const char *what, GC_CAN_IGNORE char *str)
 {
   int k, len, default_lvl = -1;
@@ -755,7 +757,7 @@ static Scheme_Object *get_log_level(char *prog, char *real_switch, const char *e
   l =  scheme_make_null();
 
   while (1) {
-    while (*str && *str == ' ') {
+    while (*str && isspace(*str)) {
       str++;
     }
 
@@ -796,13 +798,13 @@ static Scheme_Object *get_log_level(char *prog, char *real_switch, const char *e
     if (k != -1) {
       if (*str == '@') {
         str++;
-        for (s = str; *s && *s != ' '; s++) {
+        for (s = str; *s && !isspace(*s); s++) {
         }
         l = scheme_make_pair(scheme_make_sized_byte_string(str, s - str, 1), l);
         if (!last) last = l;
         l = scheme_make_pair(scheme_make_integer(k), l);
         str = s;
-      } else if ((*str == ' ') || !*str) {
+      } else if (isspace(*str) || !*str) {
         if (default_lvl == -1)
           default_lvl = k;
         else


### PR DESCRIPTION
Of the following commands,

    PLTSTDERR=" " racket
    PLTSTDERR="  " racket
    PLTSTDERR="debug" racket
    PLTSTDERR=" debug" racket
    PLTSTDERR="  debug" racket
    PLTSTDERR="debug " racket
    PLTSTDERR="debug  " racket
    PLTSTDERR="debug@foo info@bar" racket
    PLTSTDERR="debug@foo  info@bar" racket
    PLTSTDERR=" debug@foo  info@bar" racket

only numbers 3, 6 and 8 run without a printed warning. All should be acceptable. This pull request skips the superfluous whitespace, allowing all to be accepted without warning.