### PR TITLE
Add H: search box option, to search for #lang providers

### DIFF
--- a/pkgs/racket-index/scribblings/main/private/make-search.rkt
+++ b/pkgs/racket-index/scribblings/main/private/make-search.rkt
@@ -168,7 +168,14 @@
           [(exported-index-desc? desc)
            (let ([libs (map lib->name (exported-index-desc-from-libs desc))])
              (string-append* `("[" ,@(add-between libs ",") "]")))]
-          [(module-path-index-desc? desc) "\"module\""]
+          [(module-path-index-desc? desc)
+            (cond
+             [(language-index-desc? desc)
+              "\"language\""]
+             [(reader-index-desc? desc)
+              "\"reader\""]
+             [else
+              "\"module\""])]
           [else "false"]))
       (and href
            (string-append "[" (quote-string text) ","


### PR DESCRIPTION
Adds two new search options:
- `H: str` shows only matches from a module `str` documented with `defmodulelang` 
- `R: str` same for `defmodulereader`

Searching for `H:` or `R:` alone lists all `#lang` and `#reader` modules.

Here's a screenshot:
![screen shot 2016-06-24 at 23 49 47](https://cloud.githubusercontent.com/assets/1731829/16354619/ce923918-3a67-11e6-8004-edc4bc149a63.png)
