### PR TITLE
Support `++args <arg>` in `raco test`.

### DIFF
--- a/pkgs/compiler-test/tests/compiler/test/args.rkt
+++ b/pkgs/compiler-test/tests/compiler/test/args.rkt
@@ -1,0 +1,6 @@
+#lang racket
+
+(module+ test
+  (match (current-command-line-arguments)
+    [(vector "1") 1]
+    [_ (void)]))

--- a/pkgs/compiler-test/tests/compiler/test/runtime.rkt
+++ b/pkgs/compiler-test/tests/compiler/test/runtime.rkt
@@ -4,12 +4,12 @@
 
 (define exe (find-exe))
 
-(define (try mode mod expect)
+(define (try mode mod expect . extra-args)
   (printf "trying ~s ~s\n" mod mode)
   (define s (open-output-bytes))
   (parameterize ([current-output-port s])
-    (system* exe "-l-" "raco" "test"
-             mode "-l" (string-append "tests/compiler/test/" mod)))
+    (apply system* exe "-l-" "raco" "test"
+           mode (append extra-args (list "-l" (string-append "tests/compiler/test/" mod)))))
   (define last-line
     (for/fold ([prev #f]) ([s (in-lines (open-input-bytes (get-output-bytes s)))])
       (if (or (eof-object? s)
@@ -17,12 +17,16 @@
           prev
           s)))
   (unless (equal? expect last-line)
-    (error 'runtime "test failed\n  module: ~s\n  expected: ~s\n  got: ~s"
-           mod expect last-line)))
+    (error 'runtime "test failed\n  module: ~s~a\n  expected: ~s\n  got: ~s"
+           mod
+           (if (null? extra-args) "" (format "\n  extra args: ~s" extra-args))
+           expect
+           last-line)))
 
 (for ([mod '("--direct" "--place" "--process")])
   (try mod "racket.rkt" "'(1 2)")
-  (try mod "scheme.rkt" "(1 2)"))
+  (try mod "scheme.rkt" "(1 2)")
+  (try mod "args.rkt" "1" "-q" "++args" "1"))
 
 
 


### PR DESCRIPTION
Moved from https://github.com/racket/compiler/pull/11
