### PR TITLE
export object/c-stronger helper functions

### DIFF
--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -65,6 +65,8 @@
             (struct-out exn:fail:object)
             make-primitive-class
             class/c ->m ->*m ->dm case->m object/c instanceof/c
+            base-object/c? build-object/c-type-name object/c-width-subtype?
+            object/c-common-methods-stronger? object/c-common-fields-stronger?
             dynamic-object/c
             class-seal class-unseal
            


### PR DESCRIPTION
So that Typed Racket can use them to implement object/c-opaque