### PR TITLE
Add `recompile` option to `raco demod`.

### DIFF
--- a/pkgs/compiler-lib/compiler/demodularizer/batch.rkt
+++ b/pkgs/compiler-lib/compiler/demodularizer/batch.rkt
@@ -55,6 +55,8 @@ Here's the idea:
                  (output-file (string->path dest-filename))]
                 [("-g" "--garbage-collect") "Garbage-collect final module (unsound)"
                  (garbage-collect-toplevels-enabled #t)]                         
+                [("-r" "--recompile") "Recompile final module to re-run optimizations"
+                 (recompile-enabled #t)]                         
                 #:args (filename) 
                 (demodularize filename (output-file))))
 

--- a/pkgs/compiler-lib/compiler/demodularizer/main.rkt
+++ b/pkgs/compiler-lib/compiler/demodularizer/main.rkt
@@ -11,9 +11,11 @@
 
 (provide current-excluded-modules
          garbage-collect-toplevels-enabled
+         recompile-enabled
          demodularize)
 
 (define garbage-collect-toplevels-enabled (make-parameter #f))
+(define recompile-enabled (make-parameter #f))
 
 (define logger (make-logger 'demodularizer (current-logger)))
 
@@ -74,4 +76,16 @@
          merged-zo-path
        (lambda ()
          (zo-marshal-to batch-mod (current-output-port)))
-       #:exists 'replace))))
+       #:exists 'replace))
+  
+    (void
+      (when (recompile-enabled)
+        (define recomp
+          (compiled-expression-recompile 
+            (parameterize ([read-accept-compiled #t])
+              (call-with-input-file merged-zo-path read))))
+        (call-with-output-file merged-zo-path
+          (lambda (out)
+            (write recomp out))
+          #:exists 'replace)))))
+

--- a/pkgs/compiler-lib/compiler/demodularizer/nodep.rkt
+++ b/pkgs/compiler-lib/compiler/demodularizer/nodep.rkt
@@ -102,7 +102,12 @@
           (make-module-code modvar-rewrite lang-info ctop))))))
 
 (define (nodep/dir top pth phase)
-  (parameterize ([current-module-path pth])
+  (define pth*
+    (cond 
+      [(string? pth) (string->path pth)]
+      [(list? pth) (cadr pth)]
+      [else pth]))
+  (parameterize ([current-module-path pth*])
     (nodep top phase)))
 
 (define (nodep top phase)


### PR DESCRIPTION
Originally by @bdj in racket/compiler#7.