### PR TITLE
edit: make object/c-helpers private

### DIFF
--- a/racket/collects/racket/private/class-c-old.rkt
+++ b/racket/collects/racket/private/class-c-old.rkt
@@ -22,9 +22,10 @@
          just-check-existence just-check-existence?
          build-internal-class/c internal-class/c-late-neg-proj
          class/c-internal-name-clauses
+         dynamic-object/c
+         ;; needed by TR
          base-object/c? build-object/c-type-name object/c-width-subtype?
-         object/c-common-methods-stronger? object/c-common-fields-stronger?
-         dynamic-object/c)
+         object/c-common-methods-stronger? object/c-common-fields-stronger?)
 
 ;; Shorthand contracts that treat the implicit object argument as if it were
 ;; contracted with any/c.

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -65,8 +65,6 @@
             (struct-out exn:fail:object)
             make-primitive-class
             class/c ->m ->*m ->dm case->m object/c instanceof/c
-            base-object/c? build-object/c-type-name object/c-width-subtype?
-            object/c-common-methods-stronger? object/c-common-fields-stronger?
             dynamic-object/c
             class-seal class-unseal
            


### PR DESCRIPTION
Remove `object/c` helpers from `class-internal.rkt`.
(And add a comment that TR needs these helpers in their defining file: `class-c-old.rkt`)

Fixes the TR "undocumented public identifiers" DrDr error
http://drdr.racket-lang.org/35945/racket/share/pkgs/typed-racket-test/test-docs-complete.rkt