### PR TITLE
optimizer: more types anotations related with list?

### DIFF
--- a/racket/src/racket/src/list.c
+++ b/racket/src/racket/src/list.c
@@ -324,7 +324,8 @@ scheme_init_list (Scheme_Env *env)
   scheme_add_global_constant("immutable?", p, env);
 
   p = scheme_make_immed_prim(length_prim, "length", 1, 1);
-  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED);
+  SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
+                                                            | SCHEME_PRIM_PRODUCES_FIXNUM);
   scheme_add_global_constant("length", p, env);
 
   scheme_add_global_constant ("append",


### PR DESCRIPTION
**First commit:**
The original idea was to refactor the latest test for the type inference of the arguments in some popular functions that use `vector?`, `string?` or `bytes?`. But the easy to write test make more visible the missing cases. In particular, many of the popular functions that use `list?` were added to the optimizer before it can recognize `list?`. (For example in an application of `map `the optimizer could recognize that the first argument was a `procedure?` but not that the second was a `list?` neither that the result is a `list?`.)

So this grows out of scope, and I think most of the changes involve `list?` but there are a few small changes related to other types.

I also added a prefix for the identifiers in `#%kernel` to make it easy to test `map` from _map.krt_ and `k:map` from the `#%kernel`.

**Second commit:**

The second commit is smaller, and I'm not sure it is correct.

In the documentation, some arguments like the position in  `(vector-ref <vector> <position>)` are documented as `exact-nonnegative-integer?` but due to the implementation details they are in a subset of `fixnum?`. 

In particular I'm worried about `length`. How long can be a list?

In the first commit I left them as `real?` because it's the smaller type that the optimizer recognizes that include `exact-nonnegative-integer?`. But I think they can be hanged to `fixnum?`
