### PR TITLE
optimizer: don't mark (-) as omittable

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -4339,6 +4339,13 @@
   (check-number-op-unary 'sub1)
   (check-number-op-unary 'abs))
 
+(test-comp '(lambda () (-) (void))
+           '(lambda () (void))
+           #f)
+(test-comp '(lambda () (/) (void))
+           '(lambda () (void))
+           #f)
+
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check elimination of dead code after error
 (test-comp '(lambda () (random) (error 'error))

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -3431,7 +3431,9 @@ static Scheme_Object *finish_optimize_application(Scheme_App_Rec *app, Optimize_
     info->single_result = -info->single_result;
   }
     
-  if (SCHEME_PRIMP(app->args[0])) {
+  if (SCHEME_PRIMP(app->args[0])
+      && (app->num_args >= ((Scheme_Primitive_Proc *)app->args[0])->mina)
+      && (app->num_args <= ((Scheme_Primitive_Proc *)app->args[0])->mu.maxa)) {
     Scheme_Object *app_o = (Scheme_Object *)app, *rator = app->args[0];
     Scheme_Object *rand1 = NULL, *rand2 = NULL;
 


### PR DESCRIPTION
The application of some procedures are omittables only when the arguments have
certain properties. Check the arity of the procedure before marking the application as omittable.
The only case that appears to be relevant is the expression `(-)`.

This fix the bug reported by @samth in 
https://github.com/racket/racket/pull/1379#commitcomment-18285342
