### PR TITLE
change syntax/modcode signatures

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/modcode.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/modcode.scrbl
@@ -110,7 +110,7 @@ provide submodules.
 }
 
 @defproc[(get-metadata-path [path path-string?]
-                            [#:roots roots (listof (or/c path? 'same)) 
+                            [#:roots roots (listof (or/c path-string? 'same))
                                            (current-compiled-file-roots)]
                             [sub-path (or/c path-string? 'same)]
                             ...+)

--- a/pkgs/racket-test/tests/syntax/modcode.rkt
+++ b/pkgs/racket-test/tests/syntax/modcode.rkt
@@ -89,6 +89,22 @@
                                   (test zo? file-exists? zo)
                                   (test so? file-exists? so)
                                   #f)))
+     ;; test calling functions with path-strings instead of paths
+     (let ([== (lambda (x) x)]
+           [roots '("compiled" same)]
+           [to-list (lambda (thunk) (call-with-values thunk list))])
+       (test
+        (module-compiled-name (get-module-code file.sfx #:roots roots))
+        module-compiled-name
+        (get-module-code (path->string file.sfx)))
+       (test
+        (to-list (lambda () (get-module-path file.sfx #:roots roots)))
+        ==
+        (to-list (lambda () (get-module-path (path->string file.sfx) #:roots roots))))
+       (test
+        (get-metadata-path file.sfx #:roots roots)
+        ==
+        (get-metadata-path (path->string file.sfx) #:roots roots)))
      (void))
    (lambda ()
      (when src? (delete-file file.sfx))


### PR DESCRIPTION
Alternative to #1378. Instead of changing the docs, this changes the functions to take `path-string?` instead of `path?`.