### PR TITLE
Fix for-label requires for some struct documentation

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
@@ -1,5 +1,5 @@
 #lang scribble/doc
-@(require "mz.rkt" (for-label racket/struct-info))
+@(require "mz.rkt" (for-label racket/struct))
 
 @title{Printer Extension}
 

--- a/pkgs/racket-doc/scribblings/reference/struct.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/struct.scrbl
@@ -1,5 +1,5 @@
 #lang scribble/doc
-@(require "mz.rkt" (for-label racket/struct))
+@(require "mz.rkt" (for-label racket/struct racket/struct-info))
 
 @(define struct-eval (make-base-eval))
 @(define struct-copy-eval (make-base-eval))


### PR DESCRIPTION
Commit f549724e36c141989f4d1d2d103f5b65e740865e accidentally incorrectly updated the `for-label` requires for a couple places in the documentation; this adjusts them to be correct.