### PR TITLE
Preserve syntax-original?-ness and syntax properties from splicing forms

### DIFF
--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -1643,6 +1643,23 @@
          (define-syntax (m stx) id)
          (m))))
 
+(test 'prop-value 'splicing+syntax-property
+      (eval
+       '(begin
+          (define-syntax (define-syntaxes/prop stx)
+            (syntax-case stx ()
+              [(_ . body)
+               (syntax-property #'(define-syntaxes . body) 'some-prop 'prop-value)]))
+          (define-syntax (inspect-prop stx)
+            (syntax-case stx ()
+              [(_ form)
+               (syntax-case (local-expand #'form (syntax-local-context) '()) ()
+                 [(_ definition)
+                  (with-syntax ([prop-value (syntax-property #'definition 'some-prop)])
+                    #''prop-value)])]))
+          (inspect-prop (splicing-let ()
+                          (define-syntaxes/prop [] (values)))))))
+
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check keyword & optionals for define-syntax 
 ;; and define-syntax-for-values:


### PR DESCRIPTION
This makes two changes to the forms in `racket/splicing` to adjust how syntax properties are propagated through expansion:

  1. Uses of `make-syntax-introducer` are passed `#t` as the first argument, which causes the introduced scope to be consider a use-site rather than macro-introduction scope. This prevents syntax objects from being unnecessarily marked as unoriginal, in the `syntax-original?` sense.

  2. Uses of `syntax/loc` have been adjusted to copy syntax properties from original syntax objects, which were previously discared. Forms that were spliced into the surrounding context, such as `begin`, `define-values`, and `define-syntaxes`, recreated the top-level syntax objects, which did not preserve syntax properties from the originals.

This is not a perfect solution, mostly because it potentially elides properties that may be associated with captured literals (that is, properties attached directly to `begin`, `define-values`, or `define-syntaxes` identifiers themselves). However, it seems to accommodate most of the common use-cases: propagation of `syntax-original?`-ness and forms like `struct`, which attach properties like `'sub-range-binders`.

Fixes #1410.