### PR TITLE
Propagate srcloc information in wrap-expr/c from syntax/contract

### DIFF
--- a/racket/collects/syntax/contract.rkt
+++ b/racket/collects/syntax/contract.rkt
@@ -56,12 +56,13 @@
                           #:source [source #f])
   (let ([expr-name (or expr-name #'#f)]
         [source (or source #'#f)])
-    #`(contract #,ctc-expr
+    (quasisyntax/loc expr
+      (contract #,ctc-expr
                 #,expr
                 #,positive
                 #,negative
                 #,expr-name
-                #,source)))
+                #,source))))
 
 (define (get-source-expr source ctx)
   (cond [(eq? source 'use-site)


### PR DESCRIPTION
The source location of syntax objects produced by `wrap-expr/c` from `syntax/contract` was not properly chosen based on the provided expression, and the `contract` form from `racket/contract` reports errors using the source location information of the overall form. This adjusts `wrap-expr/c` to use the right source location information.