### PR TITLE
JIT: Allow the jitter to reverse the arguments of string=?

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -4650,6 +4650,22 @@
            #f)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Special case of folding for string=? and bytes=?
+
+(test-comp '(lambda () (string=? "123" "123"))
+           '(lambda () #t))
+(test-comp '(lambda () (string=? "123" "123456"))
+           '(lambda () #f))
+(test-comp '(lambda () (string=? "123" "456"))
+           '(lambda () #f))
+(test-comp '(lambda () (bytes=? #"123" #"123"))
+           '(lambda () #t))
+(test-comp '(lambda () (bytes=? #"123" #"123456"))
+           '(lambda () #f))
+(test-comp '(lambda () (bytes=? #"123" #"456"))
+           '(lambda () #f))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check that the type information is shifted in the
 ;; right direction while inlining.
 ;; The first example triggered a bug in 6.3.

--- a/racket/src/racket/src/jit.h
+++ b/racket/src/racket/src/jit.h
@@ -358,7 +358,9 @@ struct scheme_jit_common_record {
   void *apply_to_list_tail_code, *apply_to_list_code, *apply_to_list_multi_ok_code;
   void *eqv_code, *eqv_branch_code;
   void *bad_string_eq_2_code;
+  void *bad_string_rev_eq_2_code;
   void *bad_bytes_eq_2_code;
+  void *bad_bytes_rev_eq_2_code;
   void *proc_arity_includes_code;
 
 #ifdef CAN_INLINE_ALLOC

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -4622,6 +4622,16 @@ static Scheme_Object *finish_optimize_application3(Scheme_App3_Rec *app, Optimiz
         info->size -= 1;
         return make_optimize_prim_application2(scheme_null_p_proc, app->rand1, info, context);
       }
+    } else if (IS_NAMED_PRIM(app->rator, "string=?")) {
+      if (SAME_TYPE(SCHEME_TYPE(app->rand1), scheme_char_string_type)
+          && SAME_TYPE(SCHEME_TYPE(app->rand2), scheme_char_string_type)) {
+        return scheme_string_eq_2(app->rand1, app->rand2);
+      }
+    } else if (IS_NAMED_PRIM(app->rator, "bytes=?")) {
+      if (SAME_TYPE(SCHEME_TYPE(app->rand1), scheme_byte_string_type)
+          && SAME_TYPE(SCHEME_TYPE(app->rand2), scheme_byte_string_type)) {
+        return scheme_byte_string_eq_2(app->rand1, app->rand2);
+      }
     }
   }
 


### PR DESCRIPTION
Also, make a few tweaks to the implementation of string=?/bytes=? in the JIT.

A posible alternative is that when one of the arguments is an explicit string, put it always as the second argument to simplify the code in jitinline.c (using if necesary the reversed version to raise the right errors).