### PR TITLE
Support an empty (values) range in ->i

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/arrow-i.rkt
+++ b/pkgs/racket-test/tests/racket/contract/arrow-i.rkt
@@ -140,6 +140,10 @@
   (contract-syntax-error-test
    '->i-stx23
    #'(->i ([f (f x) any/c]) (#:x [x any/c]) [res any/c]))
+
+  (test/spec-passed
+   '->i-stx24
+   '(->i () (values)))
   
   (test/spec-passed
    '->i1

--- a/racket/collects/racket/contract/private/arr-i.rkt
+++ b/racket/collects/racket/contract/private/arr-i.rkt
@@ -824,7 +824,8 @@ evaluted left-to-right.)
                                   indy-arg-vars ordered-args indy-res-vars ordered-ress 
                                   stx)
   (cond
-    [(and (istx-ress an-istx)
+    [(and (positive? (vector-length res-proj-vars))
+          (istx-ress an-istx)
           (andmap eres? (istx-ress an-istx)))
      (for/fold ([body stx])
        ([an-arg/res (in-list (reverse (istx-ress an-istx)))]


### PR DESCRIPTION
Without the `positive?` check, an empty vector gets through to a usage of `in-vector` that ends up raising a range error.

(Beyond having an explicit name, is there a big difference between `test/no-errors` and `test/spec-passed`?)