### PR TITLE
report locations in default error handler

### DIFF
--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -23,9 +23,8 @@
 
 (define (match:error val srclocs form-name)
   (raise (make-exn:misc:match
-          (format "~a: no matching clause for ~e\n  location: ~a"
-                  form-name val
-                  (srcloc->string (car srclocs)))
+          (format "~a: no matching clause for ~e"
+                  form-name val)
           (current-continuation-marks)
           val
           srclocs)))


### PR DESCRIPTION
Based on comments from @endobson in PR #1430 I threw together an initial, naive addition to the default error handler that displays source location info when available.

I'm not sure how close this is to whatever would be ideal, but perhaps this can generate some thoughts/comments/etc even if we scrap this initial attempt? =)


This initial change has the following effects on this program (ignoring the changes from #1430, which cause the location to be printed twice at the moment with this change).

Program:
```racket
#lang racket

(match 42
  [(cons a b) "success"])
````

Racket 6.6 command line:
```
% racket foo.rkt
match: no matching clause for 42
  context...:
   /Users/amk/Repos/plt/racket/racket/collects/racket/match/runtime.rkt:24:0: match:error
   /Users/amk/Desktop/foo.rkt: [running body]
```

Racket 6.6 w/ these changes, command line:
```
% racket foo.rkt
match: no matching clause for 42
  location:
   foo.rkt:3:0
  context...:
   /Users/amk/Repos/plt/racket/racket/collects/racket/match/runtime.rkt:24:0: match:error
   /Users/amk/Desktop/foo.rkt: [running body]
```

(Before I had mistakingly suggested DrRacket's printing was altered, but that is not the case fortunately)