### PR TITLE
note: cdot reader is right associative

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/reader.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/reader.scrbl
@@ -955,6 +955,9 @@ equivalent prefix as discussed in @secref["parse-number"]. If these
 numbers are followed by a @litchar{.} intended to be read as a C-style
 infix dot, then there must be separating whitespace.
 
+@margin-note{Unlike C, Racket's dot notation is right associative.
+ Reading @racket[x.y.z] gives @racket[(list '#%dot _x (list '#%dot _y _z))].}
+
 Finally, after reading any value, @racket[_x], the reader will seek
 over whitespace until it reaches a non-whitespace character. If the
 character is not @litchar{.}, then the value, @racket[_x], is returned


### PR DESCRIPTION
re: #1443 

Screenshot:
![screen shot 2016-08-31 at 11 52 12](https://cloud.githubusercontent.com/assets/1731829/18135892/73b4aaa0-6f71-11e6-988e-243a2f73b292.png)

Any suggestions for fitting `@racket[(list '#%dot _x (list '#%dot _y _z))]` on 1 line in the margin note?