### PR TITLE
make cdot reader left associative

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/reader.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/reader.scrbl
@@ -955,13 +955,19 @@ equivalent prefix as discussed in @secref["parse-number"]. If these
 numbers are followed by a @litchar{.} intended to be read as a C-style
 infix dot, then there must be separating whitespace.
 
-Finally, after reading any value, @racket[_x], the reader will seek
-over whitespace until it reaches a non-whitespace character. If the
-character is not @litchar{.}, then the value, @racket[_x], is returned
-as usual. If the character is @litchar{.}, then another value,
-@racket[_y], is read and the result @racket[(list '#%dot _x _y)] is
-returned. In @racket[read-syntax] mode, the @racket['#%dot] symbol has
-the source location information of the @litchar{.} character and the
+Finally, after reading any datum @racket[_x], the reader will seek
+through whitespace and look for zero or more sequences of a
+@litchar{.} followed by another datum @racket[_y]. It will then group
+@racket[_x] and @racket[_y] together in a @racket[#%dot] form so that
+@racket[_x.y] reads equal to @racket[(#%dot _x _y)].
+
+If @racket[_x.y] has another @litchar{.} after it, the reader will
+accumulate more @litchar{.}-separated datums, grouping them from
+left-to-right. For example, @racket[_x.y.z] reads equal to
+@racket[(#%dot (#%dot _x _y) _z)].
+
+In @racket[read-syntax] mode, the @racket[#%dot] symbol has the
+source location information of the @litchar{.} character and the
 entire list has the source location information spanning from the
 start of @racket[_x] to the end of @racket[_y].
 

--- a/pkgs/racket-test-core/tests/racket/read.rktl
+++ b/pkgs/racket-test-core/tests/racket/read.rktl
@@ -1242,6 +1242,27 @@
   (test 17t0 readstr "#x11.0t0"))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; read-cdot
+
+(parameterize ([read-cdot #true])
+  (test '(#%dot a b)                     readstr "a.b")
+  (test '(#%dot (#%dot a b) c)           readstr "a.b.c")
+  (test '(#%dot (#%dot (#%dot a b) c) d) readstr "a.b.c.d")
+  (test '(#%dot a (#%dot b c))           readstr "a.(#%dot b c)")
+  (test '(#%dot a (m b c))               readstr "a.(m b c)")
+  (test '(#%dot (#%dot a (m b c)) (n d e)) readstr "a.(m b c).(n d e)")
+  (test '(#%dot (#%dot (#%dot (#%dot (#%dot a (m b c)) x) (n d e)) y) z)
+        readstr "a.(m b c).x.(n d e).y.z")
+  (test '(#%dot (f a) b)                     readstr "(f a).b")
+  (test '(#%dot (#%dot (f a) b) c)           readstr "(f a).b.c")
+  (test '(#%dot (#%dot (#%dot (f a) b) c) d) readstr "(f a).b.c.d")
+  (test '(#%dot (f a) (#%dot b c))           readstr "(f a).(#%dot b c)")
+  (test '(#%dot (f a) (m b c))               readstr "(f a).(m b c)")
+  (test '(#%dot (#%dot (f a) (m b c)) (n d e)) readstr "(f a).(m b c).(n d e)")
+  (test '(#%dot (#%dot (#%dot (#%dot (#%dot (f a) (m b c)) x) (n d e)) y) z)
+        readstr "(f a).(m b c).x.(n d e).y.z"))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; srcloc->string
 
 (test "x.rkt:10:11" srcloc->string (make-srcloc "x.rkt" 10 11 100 8))


### PR DESCRIPTION
So that with the `read-cdot` option turned on,
```racket
X.Y.Z
```
Reads equal to 
```racket
(#%dot (#%dot X Y) Z)
```
This is what most language implementers will expect when they are writing their `#%dot` macros.

Resolves https://github.com/racket/racket/issues/1443.