### PR TITLE
fix typo in the syntax-arm docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-taints.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-taints.scrbl
@@ -129,9 +129,9 @@ inspector that depends on the current dynamic context:
 
 @itemlist[
 
- @item{when applying a syntax transformer is being applied, the
-       declaration-time code inspector of the module in which a syntax
-       transformer was bound;}
+ @item{when a syntax transformer is being applied, the declaration-time
+       code inspector of the module in which a syntax transformer was
+       bound;}
 
  @item{when a module is being visited, the module's declaration-time
        code inspector;}


### PR DESCRIPTION
"when applying a syntax transformer is being applied"
->
"when a syntax transformer is being applied"