### PR TITLE
fix procedure-rename to not convert procedures into methods or methods into normal procedures

### DIFF
--- a/racket/collects/racket/private/kw.rkt
+++ b/racket/collects/racket/private/kw.rkt
@@ -1559,8 +1559,8 @@
                  (cond
                   [(okp? proc)
                    ((if (okm? proc)
-                        make-optional-keyword-procedure
-                        make-optional-keyword-method)
+                        make-optional-keyword-method
+                        make-optional-keyword-procedure)
                     (keyword-procedure-checker proc)
                     (keyword-procedure-proc proc)
                     (keyword-procedure-required proc)


### PR DESCRIPTION
So that programs like
```racket
#lang racket
(define (f a b c d e #:x [x 5]) a)
(define f* (procedure-rename f 'f))
(f*)
```
Report
```
. f: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 5 plus an optional argument with keyword #:x
  given: 0
```
Instead of
```
. f: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 4 plus an optional argument with keyword #:x
  given: 0
```

Fixes https://github.com/AlexKnauth/kw-utils/issues/3