### PR TITLE
Fixes #1452 (syntax-parse discards the 'disappeared-uses property added by pattern-expanders)

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax-util.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-util.scrbl
@@ -164,19 +164,23 @@ does not satisfy the predicate, @racket[#f] is returned and the
 identifier is not recorded as a disappeared use.
 }
 
-@defproc[(record-disappeared-uses [id (or/c identifier? (listof identifier?))])
+@defproc[(record-disappeared-uses [id (or/c identifier? (listof identifier?))]
+                                  [intro? boolean? (syntax-transforming?)])
          void?]{
 
-Add @racket[id] to @racket[(current-recorded-disappeared-uses)] after calling
-@racket[syntax-local-introduce] on the identifier. If @racket[id] is a list,
-perform the same operation on all the identifiers.
+Add @racket[id] to @racket[(current-recorded-disappeared-uses)]. If
+@racket[id] is a list, perform the same operation on all the
+identifiers. If @racket[intro?] is true, then
+@racket[syntax-local-introduce] is first called on the identifiers.
 
 If not used within the extent of a @racket[with-disappeared-uses] 
 form or similar, has no effect.
 
 @history[#:changed "6.5.0.7"
          @elem{Added the option to pass a single identifier instead of
-               requiring a list.}]
+               requiring a list.}
+         #:changed "7.2.0.11"
+         @elem{Added the @racket[intro?] argument.}]
 }
 
 

--- a/pkgs/racket-test/tests/stxparse/manual/disappeared-uses.rkt
+++ b/pkgs/racket-test/tests/stxparse/manual/disappeared-uses.rkt
@@ -1,0 +1,26 @@
+#lang racket/base
+(require (for-syntax racket/base syntax/parse))
+
+(begin-for-syntax
+  (require (for-syntax racket/base))
+  (define-syntax => #f)  ;; DEF
+  (define-syntax ~thing
+    (pattern-expander
+     (lambda (stx)
+       (syntax-case stx (=>)
+         [(_ p1 => p2)
+          (with-syntax ([dots (quote-syntax ...)])
+            (syntax-property
+             #'((~and p1 ~!) dots . p2)
+             'disappeared-use
+             (syntax-local-introduce (caddr (syntax->list stx)))))])))))
+
+(define-syntax (mac stx)
+  (syntax-parse stx
+    [(_ (~thing x:id => rest))  ;; USE
+     #'(quote ((x ...) rest))]))
+
+(void (mac (a b 3)))
+
+;; Check Syntax should draw an arrow between the occurrence of `=>`
+;; marked USE and the occurrence of `=>` marked DEF.

--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -87,15 +87,15 @@
          (begin (record-disappeared-uses (list id))
                 value))))
 
-(define (record-disappeared-uses ids)
+(define (record-disappeared-uses ids [intro? (syntax-transforming?)])
   (cond
-    [(identifier? ids) (record-disappeared-uses (list ids))]
+    [(identifier? ids) (record-disappeared-uses (list ids) intro?)]
     [(and (list? ids) (andmap identifier? ids))
      (let ([uses (current-recorded-disappeared-uses)])
        (when uses
          (current-recorded-disappeared-uses 
           (append
-           (if (syntax-transforming?)
+           (if intro?
                (map syntax-local-introduce ids)
                ids)
            uses))))]

--- a/racket/collects/syntax/parse/private/rep.rkt
+++ b/racket/collects/syntax/parse/private/rep.rkt
@@ -168,8 +168,12 @@
 
 (define (disappeared! x)
   (cond [(identifier? x)
+         (when (syntax-property x 'disappeared-uses)
+           (record-disappeared-uses (syntax-property x 'disappeared-uses)))
          (record-disappeared-uses (list x))]
         [(and (stx-pair? x) (identifier? (stx-car x)))
+         (when (syntax-property (stx-car x) 'disappeared-uses)
+           (record-disappeared-uses (syntax-property (stx-car x) 'disappeared-uses)))
          (record-disappeared-uses (list (stx-car x)))]
         [else
          (raise-type-error 'disappeared!
@@ -252,7 +256,7 @@
     (append/check-lits+litsets lits datum-lits litsets))
   (define-values (convs-rules convs-defs)
     (for/fold ([convs-rules null] [convs-defs null])
-        ([conv-entry (in-list convs)])
+              ([conv-entry (in-list convs)])
       (let* ([c (car conv-entry)]
              [argu (cdr conv-entry)]
              [get-parser-id (conventions-get-procedures c)]


### PR DESCRIPTION
Fixes #1452 (syntax-parse discards the 'disappeared-uses property added by pattern-expanders)
