### PR TITLE
Add a #%namespaced form to racket/base for use with language extensions

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -17,6 +17,8 @@
                      (only-in compiler/cm-accomplice
                               register-external-module)
                      racket/performance-hint
+                     (only-in syntax/module-reader
+                              make-meta-reader)
                      syntax/parse))
 
 @(define require-eval (make-base-eval))
@@ -1753,6 +1755,36 @@ expander introduces @racketidfont{#%app} identifiers.
 
 Like @racket[#%app], but without support for keyword arguments.
 As a special case, @racket[(#%plain-app)] produces @racket['()].}
+
+@;------------------------------------------------------------------------
+@section[#:tag "namespaced-transformer"]{Explicitly Namespaced Identifiers: @racket[#%namespaced]}
+
+The @racket[#%namespaced] form adds a form of explicit identifier namespacing, designed to be used in
+contexts where syntax objects must be created without lexical scope, such as when implementing
+@racket[read-syntax] for a language. This is especially useful for “language extensions”, also known
+as “meta languages”, such as languages created using @racket[make-meta-reader]. Since language
+extensions do not have control over the lexical environment that the produced syntax objects will be
+evaluated in, it is difficult to create hygienic extensions that adjust semantics. If the “host”
+language provides @racket[#%namespaced], then language extensions can use it to safely hook into
+the result by defining ordinary syntax transformers.
+
+For other use cases, @racket[#%namespaced] is usually the wrong choice. See @racket[local-require] for
+a more flexible, alternative way to scope imported identifiers without the need for explicit
+namespacing.
+
+@defform[(#%namespaced module-path form)
+         #:grammar ([form id (id . args)])]{
+Equivalent to @racket[form], except that @racket[id]’s lexical context is adjusted to refer to an
+identifier imported from @racket[module-path]. All source locations and syntax properties in
+@racket[form] are preserved, and if @racket[form] is a pair, then @racket[args] are passed through
+entirely unmodified.
+
+@mz-examples[
+(#%namespaced racket/math pi)
+(#%namespaced racket/list (take '(1 2 3) 2))
+(#%namespaced racket/match (match '(1 2 3)
+                             [(list _ x _) x]))
+]}
 
 @;------------------------------------------------------------------------
 @section[#:tag "lambda"]{Procedure Expressions: @racket[lambda] and @racket[case-lambda]}

--- a/pkgs/racket-test/tests/racket/namespaced-transformer.rkt
+++ b/pkgs/racket-test/tests/racket/namespaced-transformer.rkt
@@ -1,0 +1,14 @@
+#lang racket/base
+
+(require rackunit
+         syntax/macro-testing)
+
+(check-= (#%namespaced racket/math pi) 3.14159 0.00001)
+(check-equal? (#%namespaced racket/list (take '(a b c) 2)) '(a b))
+(check-equal? (#%namespaced racket/match (match '(a b c)
+                                           [(list _ x _) x]))
+              'b)
+
+(check-exn #rx"^quote: unbound identifier"
+           (λ () (convert-syntax-error
+                  (#%namespaced racket/list '(1 2 3)))))

--- a/racket/collects/racket/private/base.rkt
+++ b/racket/collects/racket/private/base.rkt
@@ -12,6 +12,7 @@
              "cert.rkt"
              "submodule.rkt"
              "generic-interfaces.rkt"
+             "namespaced-transformer.rkt"
              (for-syntax "stxcase-scheme.rkt"))
 
   (#%provide (all-from-except "pre-base.rkt"
@@ -38,6 +39,7 @@
              (all-from "cert.rkt")
              (all-from "submodule.rkt")
              (all-from "generic-interfaces.rkt")
+             (all-from "namespaced-transformer.rkt")
              (for-syntax syntax-rules syntax-id-rules ... _)
              (rename -open-input-file open-input-file)
              (rename -open-output-file open-output-file)

--- a/racket/collects/racket/private/namespaced-transformer.rkt
+++ b/racket/collects/racket/private/namespaced-transformer.rkt
@@ -1,0 +1,53 @@
+(module namespaced-transformer "pre-base.rkt"
+
+  (require (for-syntax "pre-base.rkt"
+                       "stx.rkt"
+                       "stxcase-scheme.rkt"))
+
+  (provide #%namespaced)
+
+  (define-for-syntax (strip-context e)
+    (cond
+      [(syntax? e)
+       (datum->syntax #f (strip-context (syntax-e e)) e e)]
+      [(pair? e) (cons (strip-context (car e))
+                       (strip-context (cdr e)))]
+      [(vector? e) (list->vector
+                    (map (lambda (e) (strip-context e))
+                         (vector->list e)))]
+      [(box? e) (box (strip-context (unbox e)))]
+      [(prefab-struct-key e)
+       => (lambda (k)
+            (apply make-prefab-struct k
+                   (strip-context (vector->list (cdr (struct->vector e))))))]
+      [else e]))
+
+  (define-syntax (#%namespaced stx)
+    (syntax-case stx ()
+      [(_ module-path form)
+       (unless (module-path? (syntax->datum #'module-path))
+         (raise-syntax-error #f "bad module path" stx #'module-path))
+       (cond
+         [(identifier? #'form)
+          (syntax-local-introduce
+           (syntax-local-lift-require
+            (syntax-local-introduce (strip-context #'module-path))
+            (syntax-local-introduce (strip-context #'form))))]
+         [(stx-pair? #'form)
+          (unless (identifier? (stx-car #'form))
+            (raise-syntax-error #f "namespaced form must start with identifier" stx (stx-car #'form)))
+          (datum->syntax #'form
+                    (cons (syntax-local-introduce
+                           (syntax-local-lift-require
+                            (syntax-local-introduce (strip-context #'module-path))
+                            (syntax-local-introduce (strip-context (stx-car #'form)))))
+                          (stx-cdr #'form))
+                    #'form #'form)]
+         [else
+          (raise-syntax-error #f "namespaced form must be pair or identifier" stx #'form)])]
+      [(_ _)
+       (raise-syntax-error #f "missing namespaced form" stx)]
+      [(_)
+       (raise-syntax-error #f "missing module path and namespaced form" stx)]
+      [(_ _ _ . _)
+       (raise-syntax-error #f "too many sub-forms" stx)])))


### PR DESCRIPTION
This is a set of changes designed to make implementation of language extensions, aka “meta-languages”, easier. It is related to an email conversation I had with @mflatt and @AlexKnauth a couple months ago.

Currently, simple language extensions like `s-exp` and `at-exp` work well with the Racket `#lang` model, but more complex ones like Alex’s `afl`, `debug`, and `hygienic-quote`, my own `curly-fn`, and DrRacket’s graphical syntax rely on a set of hacks to work properly. Here’s a summary of the problem:

  1. Historically, `read` and `read-syntax` are supposed to have identical behavior, the only difference is that `read-syntax` includes source location information. Importantly, syntax objects produced by `read-syntax` are *not* supposed to include lexical context.

  2. Implementation of new syntactic features is easy in most `#lang`s: the reader simply produces some kind of tagged s-expression, and the module language provides a macro bound to that tag. This allows most logic to remain in macro-expansion, instead of the reader, which is nice. It also permits adding arbitrary syntactic features without adding the dimension of lexical scopes to reader functions.

  3. Language extensions/meta-languages that want to introduce new syntactic features have a problem: they do not have any control of the lexical environment being provided by the module language. I will use `curly-fn` as an example, since it is my package and I am most familiar with it, but the below comments also apply to many of Alex’s packages and “graphical syntax”, and I’m sure it has other applications as well.

Currently, `curly-fn` and similar packages use a hacky workaround that involves using `make-syntax-introducer` to apply a scope to the entire module, then selectively removing it for identifiers that should be hygienically introduced by the language extension. This is to avoid ambiguous binding errors caused by inappropriately returning syntax objects with lexical context from `read-syntax`. This solution sort of works, but it is not without significant problems:

  1. Doing this completely breaks `read`. Given that a proper interpretation of a module now *requires* additional lexical context, this introduces an extra dimension to module reading that currently didn’t exist.

  2. Languages implemented this way are difficult to compose or reuse. Even though `curly-fn` is implemented via readtable, it’s impossible to use the `curly-fn` readtable in another `#lang`, because the scope introduced by `make-syntax-introducer` won’t exist in the other language.

  3. For similar reasons to the above two points, these kinds of extensions don’t really work in the REPL, at least not without a lot of extra work to create a separate set of hacks for handling top-level interactions.

  4. It isn’t well-supported by the compiler, so it leads to [things like this][1] to get namespacing to work properly. This is pretty brittle, so it’s definitely a bad pattern to see.

There are two obvious ways to fix this problem. The first would be to enhance the compiler and macro expander to properly support syntax objects with lexical produced by `read-syntax` and do away with `read` entirely. This would involve a lot of work, and it’s not entirely clear what it would take. I don’t actually personally think that obsoleting `read` for reading languages would be much of a loss, but it would definitely be a break from things.

The alternative approach is to provide a hook in base languages that language extensions can use to safely introduce hygienic syntactic extensions. This pull request implements such a hook, in the form of a new `#%namespaced` syntax transformer that is provided by `#lang racket/base`. This is a form of simple, explicit identifier namespacing implemented as an entirely derived concept within the existing Racket macro system—the only reason it needs to go in `base` is so that `racket/base` can provide it.

There’s no doubt that `#%namespaced` is an easy way out of a larger problem: it effectively reintroduces a limited solution that other languages use as a “hygiene substitute”. However, here it is only used as a hook for language extensions to offload as much work as possible to the hygienic macro expander, so it’s not nearly as insidious as it might first appear. It also solves a practical problem that various people seem to have run into, myself included, while the more general approach would involve an unknown effort that nobody really has the time to research and implement.

To see the compromise solution in action, I have updated my `curly-fn` package to demonstrate what a use of `#%namespaced` looks like in the implementation of a language extension. You can see the [relevant lines here][2], though the existing implementation is a little bit cluttered because it supports `#lang`s that don’t support `#%namespaced` using the older approach. However, for languages that *do* support `#%namespaced`, `curly-fn` can both be easily mixed in using its readtable extension *and* works in the REPL without any additional effort. I would imagine this sort of solution would also work with other packages as well as DrRacket’s graphical syntax.

My apologies for the long pull request description—I want to make the motivations as clear for this change as possible. Please let me know if you have any questions, suggestions, or concerns.

[1]: https://github.com/lexi-lambda/racket-curly-fn/blob/cef01874a9a5282d0a72e3acc2630c7605359c93/curly-fn-lib/curly-fn/lang/reader.rkt#L3-L9
[2]: https://github.com/lexi-lambda/racket-curly-fn/blob/cef01874a9a5282d0a72e3acc2630c7605359c93/curly-fn-lib/curly-fn/lang/reader.rkt#L59-L63