### PR TITLE
Have id-table-ref! call its failure thunks.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/id-table-test.rktl
+++ b/pkgs/racket-test-core/tests/racket/id-table-test.rktl
@@ -400,6 +400,8 @@
 
   (test 0 bound-id-table-ref! table x0 0)
   (test 1 bound-id-table-ref! table x1 1)
+  (test 0 bound-id-table-ref! table x0 (lambda () 0))
+  (test 1 bound-id-table-ref! table x1 (lambda () 1))
   (test 0 bound-id-table-ref table x0)
   (test 1 bound-id-table-ref (bound-id-table-update table2 y0 add1 0) y0)
   (test 1 bound-id-table-ref (bound-id-table-set* table2 y0 0 y1 1) y1)
@@ -417,6 +419,8 @@
 
   (test 0 free-id-table-ref! table x0 0)
   (test 1 free-id-table-ref! table x1 1)
+  (test 0 free-id-table-ref! table x0 (lambda () 0))
+  (test 1 free-id-table-ref! table x1 (lambda () 1))
   (test 0 free-id-table-ref table x0)
   (test 1 free-id-table-ref (free-id-table-update table2 y0 add1 0) y0)
   (test 1 free-id-table-ref (free-id-table-set* table2 y0 0 y1 1) y1)

--- a/racket/collects/syntax/private/id-table.rkt
+++ b/racket/collects/syntax/private/id-table.rkt
@@ -161,7 +161,7 @@ The {key,value}-{in-out} functions should all return a chaperone of their argume
   (define entry (id-table-ref who d id missing identifier->symbol identifier=?))
   (cond [(eq? entry missing)
          (id-table-set! who d id default identifier->symbol identifier=?)
-         default]
+         (if (procedure? default) (default) default)]
         [else entry]))
 
 (define (id-table-update/constructor who d id updater default constructor identifier->symbol identifier=?)


### PR DESCRIPTION
Closes 15346.

This is not bugwards compatible, and could conceivably break some programs.
But, the fixed behavior is consistent with the docs, as well as with all similar operations elsewhere in Racket.