### PR TITLE
doc: sequence/c elements vs. values

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -854,7 +854,7 @@ each element in the sequence.
          contract?]{
 
 Wraps a @tech{sequence},
-obligating it to produce as many values as there are @racket[elem/c] contracts,
+obligating it to produce elements with as many values as there are @racket[elem/c] contracts,
 and obligating each value to satisfy the corresponding @racket[elem/c].  The
 result is not guaranteed to be the same kind of sequence as the original value;
 for instance, a wrapped list is not guaranteed to satisfy @racket[list?].


### PR DESCRIPTION
Clarify that `sequence/c` works for sequences with arbitrarily many elements.

The current wording made me think `(list 1 2)` would not satisfy `(sequence/c integer?)`.