### PR TITLE
passing get-timestamp rather than sys-type to write-central-directory (zip.rkt)

### DIFF
--- a/racket/collects/file/zip.rkt
+++ b/racket/collects/file/zip.rkt
@@ -289,7 +289,7 @@
                     files))])
         (when (zip-verbose)
           (eprintf "zip: writing headers...\n"))
-        (write-central-directory headers get-timestamp))
+        (write-central-directory headers sys-type))
       (when (zip-verbose)
         (eprintf "zip: done.\n"))))
 


### PR DESCRIPTION
It's worth noting that this hasn't caused me an issue, I came across it as I wanted to see what sys-type actually did. I couldn't say what the effect of this change would be and don't have a use case for it, it just looks wrong!