### PR TITLE
Some small fixes to the documentation

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/for.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/for.scrbl
@@ -29,7 +29,7 @@ Iteratively evaluates @racket[body]s. The @racket[for-clause]s
 introduce bindings whose scope includes @racket[body] and that
 determine the number of times that @racket[body] is evaluated.
 A @racket[break-clause] either among the @racket[for-clause]s
-of @racket[body]s stops further iteration.
+or @racket[body]s stops further iteration.
 
 In the simple case, each @racket[for-clause] has one of its first two
 forms, where @racket[[id seq-expr]] is a shorthand for @racket[[(id)

--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -545,7 +545,7 @@ Supported for any @racket[st] that @impl{implements} @racket[set-remove!] and @s
 @defproc[(set-subtract [st0 generic-set?] [st generic-set?] ...) generic-set?]{
 
 Produces a set of the same type as @racket[st0] that includes the elements from
-@racket[st0] that not contained by any of the @racket[st]s.
+@racket[st0] that are not contained by any of the @racket[st]s.
 
 If @racket[st0] is a list, each @racket[st] must also be a list.  This
 operation runs on lists in time proportional to the total size of the

--- a/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
@@ -569,7 +569,7 @@ the binding creates a binding alias that effectively routes around the
 @history[#:added "6.3"]}
 
 
-@defproc[(syntax-local-value [id-stx syntax?]
+@defproc[(syntax-local-value [id-stx identifier?]
                              [failure-thunk (or/c (-> any) #f)
                                             #f]
                              [intdef-ctx (or/c internal-definition-context?
@@ -577,12 +577,12 @@ the binding creates a binding alias that effectively routes around the
                                          #f])
          any]{
 
-Returns the @tech{transformer} binding value of @racket[id-stx] in
-either the context associated with @racket[intdef-ctx] (if not
-@racket[#f]) or the context of the expression being expanded (if
-@racket[intdef-ctx] is @racket[#f]).  If @racket[intdef-ctx] is
-provided, it must be an extension of the context of the expression
-being expanded.
+Returns the @tech{transformer} binding value of the identifier
+@racket[id-stx] in either the context associated with
+@racket[intdef-ctx] (if not @racket[#f]) or the context of the
+expression being expanded (if @racket[intdef-ctx] is @racket[#f]). If
+@racket[intdef-ctx] is provided, it must be an extension of the
+context of the expression being expanded.
 
 If @racket[id-stx] is bound to a @tech{rename transformer} created
 with @racket[make-rename-transformer], @racket[syntax-local-value]
@@ -1107,7 +1107,7 @@ import sources.
 See also @racket[define-require-syntax], which supports macro-style
 @racket[require] transformers.
 
-@defproc[(expand-import [stx syntax?])
+@defproc[(expand-import [require-spec syntax?])
          (values (listof import?)
                  (listof import-source?))]{
 
@@ -1307,7 +1307,7 @@ See also @racket[define-provide-syntax], which supports macro-style
 @tech{provide transformers}.
 
 
-@defproc[(expand-export [stx syntax?] [modes (listof (or/c exact-integer? #f))])
+@defproc[(expand-export [provide-spec syntax?] [modes (listof (or/c exact-integer? #f))])
          (listof export?)]{
 
 Expands the given @racket[_provide-spec] to a list of exports. The
@@ -1318,7 +1318,7 @@ form, unless the @racket[modes] list specifies otherwise. Normally,
 @racket[modes] is either empty or contains a single element.}
 
 
-@defproc[(pre-expand-export [stx syntax?] [modes (listof (or/c exact-integer? #f))])
+@defproc[(pre-expand-export [provide-spec syntax?] [modes (listof (or/c exact-integer? #f))])
          syntax?]{
 
 Expands the given @racket[_provide-spec] at the level of @tech{provide

--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -1563,7 +1563,7 @@ used in the expression match those given in the earlier definition:
           (λ () 
             (raise-syntax-error 
              'sym-case
-             "expected an identifier bound via def-sym-case"
+             "expected an identifier bound via define-sym-case"
              stx
              #'id))))
        (define actual-ids (syntax->datum #'(sym ...)))

--- a/pkgs/racket-doc/syntax/scribblings/id-table.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/id-table.scrbl
@@ -146,7 +146,7 @@ Like @racket[hash-set].
 
 @defproc[(free-id-table-set*! [table mutable-free-id-table?]
                               [id identifier?]
-                              [v any/c] ...)
+                              [v any/c] ... ...)
          void?]{
 
 Like @racket[hash-set*!].
@@ -156,7 +156,7 @@ Like @racket[hash-set*!].
 
 @defproc[(free-id-table-set* [table immutable-free-id-table?]
                              [id identifier?]
-                             [v any/c] ...)
+                             [v any/c] ... ...)
          immutable-free-id-table?]{
 
 Like @racket[hash-set*].
@@ -322,11 +322,11 @@ etc) can be used on bound-identifier tables.
          immutable-bound-id-table?]
 @defproc[(bound-id-table-set*! [table mutable-bound-id-table?]
                                [id identifier?]
-                               [v any/c] ...)
+                               [v any/c] ... ...)
          void?]
 @defproc[(bound-id-table-set* [table immutable-bound-id-table?]
                               [id identifier?]
-                              [v any/c] ...)
+                              [v any/c] ... ...)
          immutable-bound-id-table?]
 @defproc[(bound-id-table-remove! [table mutable-bound-id-table?]
                                  [id identifier?])

--- a/pkgs/racket-test-core/tests/racket/stxparam.rktl
+++ b/pkgs/racket-test-core/tests/racket/stxparam.rktl
@@ -177,7 +177,7 @@
 
 ;; ----------------------------------------
 ;; Check rename-transformer stx-param when used as an expression,
-;; which involves calling the `prop:rename-transformer` is a
+;; which involves calling the `prop:rename-transformer` in a
 ;; `syntax-transforming?` mode
 
 (begin


### PR DESCRIPTION
* Wrong contract for syntax-local-value in the documentation.
* Clarified signature in documentation for expand-import, expand-export and pre-expand-export
* Corrected typo in documentation for "for".
* Fixed error message for function which seems to have been renamed in the docs
* Fixed typo in a comment in the tests
* Fixed a typo in the documentation for set-subtract.
* Use double ellipses for the free-id-table-set*, free-id-table-set*!, bound-id-table-set* and bound-id-table-set*! operations

This commit is a squashed rebase of several commits, if you prefer the individual commits, see https://github.com/jsmaniac/racket/tree/doc-changes-2 which contains exactly the same changes.

@stamourv I think this can safely be merged in the 6.7 `release` branch, since it only contains changes to the documentation, to a comment and to an error message which is inside an example in the docs.