### PR TITLE
Track the origin of modules produced by module+ forms

### DIFF
--- a/pkgs/racket-test-core/tests/racket/submodule.rktl
+++ b/pkgs/racket-test-core/tests/racket/submodule.rktl
@@ -477,7 +477,7 @@
 (test 'b dynamic-require '(submod 'subm-example-12 b) 'b)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; The `section' form:
+;; The `module+' form:
 
 (module module+-example-1 racket/base
   (module+ alpha (define a root) (provide a))
@@ -518,6 +518,18 @@
     3 4))
 
 (test 3 dynamic-require '(submod 'module+-example-2 a b) 'x)
+
+;; Check that module+ propagates properties
+(let* ([stx-1 (syntax-property #'(module+ plus) 'foo 'bar)]
+       [stx-2 (syntax-property #'(module+ plus) 'baz 'qux)]
+       [expanded-stx (expand #`(module m racket/base
+                                 #,stx-1
+                                 #,stx-2))])
+  (syntax-case expanded-stx (module #%plain-module-begin)
+    [(module _ _ (#%plain-module-begin _ submodule))
+     (begin
+       (test 'bar syntax-property #'submodule 'foo)
+       (test 'qux syntax-property #'submodule 'baz))]))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check module-source for submodule:


### PR DESCRIPTION
Since `module+` creates modules via `syntax-local-lift-module-end-declaration`, the syntax that is eventually produced does not contain information about the forms that produced them. This means that Check Syntax does not draw arrows to `module+` identifiers, and it also won’t draw arrows to macro invocations that _expand_ to `module+` forms.

These changes ensure the `'origin` property is propagated by manually calling `syntax-track-origin` using each of the `module+` forms that contribute to the resulting module.
