### PR TITLE
Remove argument of finish_optimize_application

### DIFF
--- a/racket/src/racket/src/resolve.c
+++ b/racket/src/racket/src/resolve.c
@@ -3117,7 +3117,7 @@ static Scheme_Object *unresolve_lambda(Scheme_Lambda *rlam, Unresolve_Info *ui)
 
 static void check_nonleaf_rator(Scheme_Object *rator, Unresolve_Info *ui)
 {
-  if (!scheme_check_leaf_rator(rator, NULL))
+  if (!scheme_check_leaf_rator(rator))
     ui->has_non_leaf = 1;
 }
 

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -3310,7 +3310,7 @@ Scheme_Object *scheme_unresolve(Scheme_Object *, int argv, int *_has_cases,
                                 Scheme_Object *from_modidx, Scheme_Object *to_modidx);
 Scheme_Object *scheme_unresolve_top(Scheme_Object *, Comp_Prefix **, int comp_flags);
 
-int scheme_check_leaf_rator(Scheme_Object *le, int *_flags);
+int scheme_check_leaf_rator(Scheme_Object *le);
 
 int scheme_is_ir_lambda(Scheme_Object *o, int can_be_closed, int can_be_liftable);
 


### PR DESCRIPTION
The value of `rator_flags` was calculated in `optimize_application` and used in `finish_optimize_application`, but it is possible to calculate it directly in `finish_optimize_application`, and then remove some internal coupling.

This also simplifies other locations where the `rator ` of an application was changed and then it was necessary to recalculate the value of `rator_flags` to complete the optimization steps.