### PR TITLE
replace references to "[Mac] OS X" with "macOS"

### DIFF
--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -53,7 +53,7 @@ If you stick with this repository, then you have several options:
 Quick Instructions: In-place Build
 ==================================
 
-On Unix (including Linux) and Mac OS X, `make' (or `make in-place')
+On Unix (including Linux) and macOS, `make' (or `make in-place')
 creates a build in the "racket" directory.
 
 On Windows with Microsoft Visual Studio (any version between 2008/9.0
@@ -81,7 +81,7 @@ installs into "<dir>" (which must be an absolute path) with binaries
 in "<dir>/bin", packages in "<dir>/share/racket/pkgs", documentation
 in "<dir>/share/racket/doc", etc.
 
-On Mac OS X, `make unix-style PREFIX=<dir>' builds and installs into
+On macOS, `make unix-style PREFIX=<dir>' builds and installs into
 "<dir>" (which must be an absolute path) with binaries in "<dir>/bin",
 packages in "<dir>/share/pkgs", documentation in "<dir>/doc", etc.
 
@@ -321,7 +321,7 @@ normalizing the Windows results to "i386-win32" and "x86_63-win32",
 -<dist-suffix> is omitted unless a `#:dist-suffix' string is specified
 for the client in the site configuration, and <ext> is
 platform-specific: ".sh" for Unix (including Linux), ".dmg" or ".pkg"
-for Mac OS X, and ".exe" for Windows.
+for macOS, and ".exe" for Windows.
 
 Generating Installer Web Sites
 ------------------------------
@@ -517,7 +517,7 @@ In more detail:
      To create a ".tgz" archive instead of an installer (or any
      platform), set `TGZ_MODE' to "--tgz".
 
-     For a Mac OS X installer, set `SIGN_IDENTITY' as the name to
+     For a macOS installer, set `SIGN_IDENTITY' as the name to
      which the signing certificate is associated. Set `MAC_PKG_MODE'
      to "--mac-pkg" to create a ".pkg" installer instead of a ".dmg"
      image.

--- a/pkgs/net-doc/net/scribblings/dns.scrbl
+++ b/pkgs/net-doc/net/scribblings/dns.scrbl
@@ -104,7 +104,7 @@ for @racket["ollie.cs.rice.edu"] might be @racket["cs.rice.edu"].}
 @defproc[(dns-find-nameserver) (or/c string? false/c)]{
 
 Attempts to find the address of a nameserver on the present system.
-On Unix and Mac OS X, this procedure parses @filepath{/etc/resolv.conf} to
+On Unix and macOS, this procedure parses @filepath{/etc/resolv.conf} to
 extract the first nameserver address. On Windows, it runs
 @exec{nslookup.exe}.}
 

--- a/pkgs/net-doc/net/scribblings/osx-ssl.scrbl
+++ b/pkgs/net-doc/net/scribblings/osx-ssl.scrbl
@@ -3,11 +3,11 @@
           (for-label net/osx-ssl
                      openssl))
 
-@title[#:tag "osx-ssl"]{OS X Native SSL: Secure Communication}
+@title[#:tag "osx-ssl"]{macOS Native SSL: Secure Communication}
 
 @defmodule[net/osx-ssl]{The @racketmodname[net/osx-ssl] module
 offers a fraction of the functionality of @racketmodname[openssl] and
-works only on OS X, but it has the advantage that it works before
+works only on macOS, but it has the advantage that it works before
 OpenSSL libraries are installed.}
 
 @history[#:added "6.3.0.12"]

--- a/pkgs/net-doc/net/scribblings/osx-ssl.scrbl
+++ b/pkgs/net-doc/net/scribblings/osx-ssl.scrbl
@@ -3,7 +3,7 @@
           (for-label net/osx-ssl
                      openssl))
 
-@title[#:tag "osx-ssl"]{macOS Native SSL: Secure Communication}
+@title[#:tag "osx-ssl"]{OS X Native SSL: Secure Communication}
 
 @defmodule[net/osx-ssl]{The @racketmodname[net/osx-ssl] module
 offers a fraction of the functionality of @racketmodname[openssl] and

--- a/pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -24,7 +24,7 @@ On Windows, @racket[send-url] normally uses @racket[shell-execute]
 to launch a browser. (If the URL appears to contain a fragment, it may
 use an intermediate redirecting file due to a bug in IE7.)
 
-On Mac OS X, @racket[send-url] runs @exec{osascript} to start the
+On macOS, @racket[send-url] runs @exec{osascript} to start the
 user's chosen browser.
 
 On Unix, @racket[send-url] uses a user-preference, or when none is
@@ -80,7 +80,7 @@ above.}
 @defproc[(send-url/mac [url string?]
                        [#:browser browser (or/c string? #f) #f])
          void?]{
- Like @racket[send-url], but only for use on a Mac OS X machine.
+ Like @racket[send-url], but only for use on a macOS machine.
 
  The optional @racket[browser] argument, if present, should be the name
  of a browser installed on the system. For example,

--- a/pkgs/racket-doc/file/scribblings/tar.scrbl
+++ b/pkgs/racket-doc/file/scribblings/tar.scrbl
@@ -11,7 +11,7 @@ directories, files, and symbolic links, and owner
 information is not preserved; the owner that is stored in the archive
 is always ``root.''
 
-Symbolic links (on Unix and Mac OS X) are not followed by default, and the path
+Symbolic links (on Unix and macOS) are not followed by default, and the path
 in a link must be less than 100 bytes.}
 
 

--- a/pkgs/racket-doc/file/scribblings/zip.scrbl
+++ b/pkgs/racket-doc/file/scribblings/zip.scrbl
@@ -5,7 +5,7 @@
 
 @defmodule[file/zip]{The @racketmodname[file/zip] library provides
 utilities to create @exec{zip} archive files, which are compatible
-with both Windows and Unix (including Mac OS X) unpacking. The actual
+with both Windows and Unix (including macOS) unpacking. The actual
 compression is implemented by @racket[deflate].}
 
 @defproc[(zip [zip-file path-string?] [path path-string?] ...
@@ -33,7 +33,7 @@ resulting @exec{zip} file, up to the current directory (using
 
 Files are packaged as usual for
 @exec{zip} files, including permission bits for both Windows and Unix
-(including Mac OS X).  The permission bits are determined by
+(including macOS).  The permission bits are determined by
 @racket[file-or-directory-permissions], which does not preserve the
 distinction between owner/group/other permissions. Also, symbolic
 links are always followed.

--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -28,10 +28,10 @@ or with the Racket distribution. In particular:
 @filepath{libeay32.dll} and @filepath{ssleay32.dll}, which are
 included in the Racket distribution for Windows.}
 
-@item{For Mac OS X, @racketmodname[openssl] depends on
+@item{For macOS, @racketmodname[openssl] depends on
 @filepath{libssl.dylib} and @filepath{libcrypto.dylib}. Although those
-libraries are provided by Mac OS X 10.2 and later, their use is
-deprecated, so the Racket distribution for Mac OS X includes newer
+libraries are provided by macOS 10.2 and later, their use is
+deprecated, so the Racket distribution for macOS includes newer
 versions.}
 
 @item{For Unix, @racketmodname[openssl] depends on
@@ -462,7 +462,7 @@ immediately. Only supported on Windows.}
 
 @item{If @racket[src] is @racket[(list 'macosx-keychain _path)], then
 the certificates from the keychain stored at @racket[_path] are loaded
-immediately. Only supported on Mac OS X.}
+immediately. Only supported on macOS.}
 
 ]
 
@@ -493,7 +493,7 @@ on the platform:
 @tt{SSL_CERT_FILE} and @tt{SSL_CERT_DIR} environment variables, if the
 variables are set, or the system-wide default locations otherwise.}
 
-@item{On Mac OS X, the default sources consist of the system keychain
+@item{On macOS, the default sources consist of the system keychain
 for root certificates: @racket['(macosx-keychain
 "/System/Library/Keychains/SystemRootCertificates.keychain")].}
 

--- a/pkgs/racket-doc/pkg/scribblings/strip.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/strip.scrbl
@@ -199,7 +199,7 @@ or @racket[move-man-pages] definitions in an @filepath{info.rkt} file,
 retrieving them if they are not present at referenced location but are
 present in a user-specific target directory (i.e., the directory
 reported by @racket[find-user-lib-dir], @racket[find-user-share-dir],
-or @racket[find-user-man-dir], respectively). On Mac OS X, when an
+or @racket[find-user-man-dir], respectively). On macOS, when an
 unmoved file for @racket[move-foreign-libs] is a Mach-O file that
 includes a reference to another library in one of the directories reported by
 @racket[(get-lib-search-dirs)], then the reference is changed to a

--- a/pkgs/racket-doc/scribblings/foreign/intro.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/intro.scrbl
@@ -60,7 +60,7 @@ To use the FFI, you must have in mind
 The library corresponds to a file with a suffix such as
 @filepath{.dll}, @filepath{.so}, or @filepath{.dylib} (depending on
 the platform), or it might be a library within a @filepath{.framework}
-directory on Mac OS X.
+directory on macOS.
 
 Knowing the library's name and/or path is often the trickiest part of
 using the FFI.  Sometimes, when using a library name without a path

--- a/pkgs/racket-doc/scribblings/foreign/ns.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/ns.scrbl
@@ -8,7 +8,7 @@
 
 The @racketmodname[ffi/unsafe/nsalloc] and
 @racketmodname[ffi/unsafe/nsstring] libraries provide basic
-facilities for working with Cocoa and/or Mac OS X Foundation
+facilities for working with Cocoa and/or macOS Foundation
 libraries (usually along with @racket[ffi/objc]).
 
 @; ----------------------------------------

--- a/pkgs/racket-doc/scribblings/foreign/objc.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/objc.scrbl
@@ -111,7 +111,7 @@ Defines each @racket[class-id] to the class (a value with FFI type
 
 A class accessed by @racket[import-class] is normally declared as a
 side effect of loading a foreign library. For example, if you want to
-import the class @tt{NSString} on Mac OS X, the @filepath{Foundation}
+import the class @tt{NSString} on macOS, the @filepath{Foundation}
 framework must be loaded, first. Beware that if you use
 @racket[import-class] in DrRacket or a module that @racket[require]s
 @racketmodname[racket/gui/base], then @filepath{Foundation} will have

--- a/pkgs/racket-doc/scribblings/getting-started/getting-started.scrbl
+++ b/pkgs/racket-doc/scribblings/getting-started/getting-started.scrbl
@@ -15,7 +15,7 @@ Start menu. In Windows Vista or newer, you can just type @exec{DrRacket}.  You c
 also run it from its folder, which you can find in @onscreen{Program Files} →
 @onscreen{Racket} → @onscreen{DrRacket}.
 
-On Mac OS X, double click on the @onscreen{DrRacket} icon. It is probably in a
+On macOS, double click on the @onscreen{DrRacket} icon. It is probably in a
 @onscreen{Racket} folder that you dragged into your
 @onscreen{Applications} folder. If you want to use command-line tools, instead,
 Racket executables are in the @filepath{bin} directory of the @onscreen{Racket}

--- a/pkgs/racket-doc/scribblings/guide/module-basics.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/module-basics.scrbl
@@ -247,7 +247,7 @@ installation or one of the directories reported by
 the list of searched directories by setting the @envvar{PLTCOLLECTS}
 environment variable.@margin-note*{If you set @envvar{PLTCOLLECTS},
 include an empty path in by starting the value with a colon (Unix and
-Mac OS X) or semicolon (Windows) so that the original search paths are
+macOS) or semicolon (Windows) so that the original search paths are
 preserved.} The best option, however, is to add a @tech{package}.
 
 Creating a package @emph{does not} mean that you have to register with

--- a/pkgs/racket-doc/scribblings/guide/scripts.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/scripts.scrbl
@@ -4,12 +4,12 @@
 @title[#:tag "scripts"]{Scripts}
 
 Racket files can be turned into executable scripts on Unix and Mac
-OS X.  On Windows, a compatibility layer like Cygwin support the
+macOS.  On Windows, a compatibility layer like Cygwin support the
 same kind of scripts, or scripts can be implemented as batch files.
 
 @section{Unix Scripts}
 
-In a Unix environment (including Linux and Mac OS X), a Racket file can
+In a Unix environment (including Linux and macOS), a Racket file can
 be turned into an executable script using the shell's @as-index{@tt{#!}}
 convention. The first two characters of the file must be @litchar{#!};
 the next character must be either a space or @litchar{/}, and the

--- a/pkgs/racket-doc/scribblings/guide/scripts.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/scripts.scrbl
@@ -3,8 +3,8 @@
 
 @title[#:tag "scripts"]{Scripts}
 
-Racket files can be turned into executable scripts on Unix and Mac
-macOS.  On Windows, a compatibility layer like Cygwin support the
+Racket files can be turned into executable scripts on Unix and macOS.  
+On Windows, a compatibility layer like Cygwin support the
 same kind of scripts, or scripts can be implemented as batch files.
 
 @section{Unix Scripts}

--- a/pkgs/racket-doc/scribblings/guide/welcome.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/welcome.scrbl
@@ -181,7 +181,7 @@ To package the program as an executable, you have a few options:
        the program. See @secref[#:doc '(lib
        "scribblings/raco/raco.scrbl") "exe"] for more information.}
 
- @item{With Unix or Mac OS X, you can turn the program file into an
+ @item{With Unix or macOS, you can turn the program file into an
        executable script by inserting the line
 
        @margin-note{See @secref["scripts"] for more information on

--- a/pkgs/racket-doc/scribblings/inside/embedding.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/embedding.scrbl
@@ -51,7 +51,7 @@ To embed Racket CGC in a program, follow these steps:
   use. (@filepath{Racket.exe} and @filepath{GRacket.exe} use the latter
   strategy.)
 
-  On Mac OS X, dynamic libraries are provided by the
+  On macOS, dynamic libraries are provided by the
   @filepath{Racket} framework, which is typically installed in
   @filepath{lib} sub-directory of the installation. Supply
   @exec{-framework Racket} to @exec{gcc} when linking, along
@@ -160,7 +160,7 @@ to Racket objects can be kept in registers, stack variables, or
 structures allocated with @cppi{scheme_malloc}. In an embedding
 application on some platforms, static variables are also automatically
 registered as roots for garbage collection (but see notes below
-specific to Mac OS X and Windows).
+specific to macOS and Windows).
 
 For example, the following is a simple embedding program which
 evaluates all expressions provided on the command line and displays
@@ -232,7 +232,7 @@ executable, but the embedding application must call
 @cppi{scheme_set_exec_cmd} to set the executable path (typically
 @cpp{argv[0]}) before declaring modules.
 
-On Mac OS X, or on Windows when Racket is compiled to a DLL
+On macOS, or on Windows when Racket is compiled to a DLL
 using Cygwin, the garbage collector cannot find static variables
 automatically. In that case, @cppi{scheme_main_setup} must be called with a
 non-zero first argument.
@@ -286,7 +286,7 @@ In addition, some library details are different:
   separate library for 3m analogous to CGC's
   @filepath{libmzgc@italic{x}.lib}.}
 
-  @item{On Mac OS X, 3m dynamic libraries are provided by the
+  @item{On macOS, 3m dynamic libraries are provided by the
   @filepath{Racket} framework, just as for CGC, but as a version
   suffixed with @filepath{_3m}.}
 

--- a/pkgs/racket-doc/scribblings/inside/extensions.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/extensions.scrbl
@@ -80,17 +80,17 @@ steps:
  but it locates a C compiler on the system and launches it with the
  appropriate compilation flags.  If the platform is a relatively
  standard Unix system, a Windows system with either Microsoft's C
- compiler or @exec{gcc} in the path, or a Mac OS X system with Apple's
+ compiler or @exec{gcc} in the path, or a macOS system with Apple's
  developer tools installed, then using @|mzc| is typically easier than
  working with the C compiler directly. Use the @as-index{@DFlag{cgc}}
  flag to indicate that the build is for use with Racket CGC.}
 
 
  @item{Link the extension C/C++ files with
- @as-index{@filepath{mzdyn.o}} (Unix, Mac OS X) or
+ @as-index{@filepath{mzdyn.o}} (Unix, macOS) or
  @as-index{@filepath{mzdyn.obj}} (Windows) to create a shared object. The
  resulting shared object should use the extension @filepath{.so} (Unix),
- @filepath{.dll} (Windows), or @filepath{.dylib} (Mac OS X).
+ @filepath{.dll} (Windows), or @filepath{.dylib} (macOS).
 
  The @filepath{mzdyn} object file is distributed in the installation's
  @filepath{lib} directory. For Windows, the object file is in a
@@ -184,7 +184,7 @@ must be extended as follows:
  @as-index{@DFlag{3m}} flags, @cpp{MZ_PRECISE_GC} is automatically
  defined.}
 
- @item{Link with @as-index{@filepath{mzdyn3m.o}} (Unix, Mac OS X) or
+ @item{Link with @as-index{@filepath{mzdyn3m.o}} (Unix, macOS) or
  @as-index{@filepath{mzdyn3m.obj}} (Windows) to create a shared
  object.  When using @|mzc|, use the @DFlag{ld} and @DFlag{3m} flags
  to link to these libraries.}

--- a/pkgs/racket-doc/scribblings/inside/memory.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/memory.scrbl
@@ -882,7 +882,7 @@ requires a few frames.
 
 If @var{stack_end} is @cpp{NULL}, then the stack end is computed
 automatically: the stack size assumed to be the limit reported by
-@cpp{getrlimit} on Unix and Mac OS X, or it is assumed to be the
+@cpp{getrlimit} on Unix and macOS, or it is assumed to be the
 stack reservation of the executable (or 1 MB if parsing the
 executable fails) on Windows; if this size is greater than 8 MB, then 8 MB is
 assumed, instead; the size is decremented by 50000 bytes

--- a/pkgs/racket-doc/scribblings/inside/overview.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/overview.scrbl
@@ -130,7 +130,7 @@ for the original place.
 Racket implements threads for Racket programs without aid from the
 operating system, so that Racket threads are cooperative from the
 perspective of C code. On Unix, stand-alone Racket uses a single
-OS-implemented thread. On Windows and Mac OS X, stand-alone
+OS-implemented thread. On Windows and macOS, stand-alone
 Racket uses a few private OS-implemented threads for background
 tasks, but these OS-implemented threads are never exposed by the
 Racket API.

--- a/pkgs/racket-doc/scribblings/inside/ports.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/ports.scrbl
@@ -994,7 +994,7 @@ from position @var{d} in @var{bytes}. If @var{d} is non-zero, then
            [FSSpec* spec]
            [int isdir])]{
 
-Mac OS X only: Converts an @cppi{FSSpec} record (defined by Mac OS X)
+macOS only: Converts an @cppi{FSSpec} record (defined by macOS)
 into a pathname string. If @var{spec} contains only directory
 information (via the @cpp{vRefNum} and @cpp{parID} fields),
 @var{isdir} should be @cpp{1}, otherwise it should be @cpp{0}.}
@@ -1004,11 +1004,11 @@ information (via the @cpp{vRefNum} and @cpp{parID} fields),
            [FSSpec* spec]
            [intptr_t* type])]{
 
-Mac OS X only: Converts a pathname into an @cppi{FSSpec} record
-(defined by Mac OS X), returning @cpp{1} if successful and @cpp{0}
+macOS only: Converts a pathname into an @cppi{FSSpec} record
+(defined by macOS), returning @cpp{1} if successful and @cpp{0}
 otherwise. If @var{type} is not @cpp{NULL} and @var{filename} is a
 file that exists, @var{type} is filled with the file's four-character
-Mac OS X type. If @var{type} is not @cpp{NULL} and @var{filename} is
+macOS type. If @var{type} is not @cpp{NULL} and @var{filename} is
 not a file that exists, @var{type} is filled with @cpp{0}.}
 
 @function[(char* scheme_os_getcwd

--- a/pkgs/racket-doc/scribblings/inside/subprocesses.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/subprocesses.scrbl
@@ -4,7 +4,7 @@
 
 @title{Subprocesses}
 
-On Unix and Mac OS X, subprocess handling involves
+On Unix and macOS, subprocess handling involves
 @as-index[@cpp{fork}], @as-index[@cpp{waitpid}], and
 @as-index[@cpp{SIGCHLD}], which creates a variety of issues within an
 embedding application. On Windows, subprocess handling is more

--- a/pkgs/racket-doc/scribblings/inside/threads.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/threads.scrbl
@@ -604,7 +604,7 @@ The @cpp{scheme_add_fd_handle} function is useful for implementing
  the second procedure passed to @cpp{scheme_wait_until}, or for
  implementing a custom input port.
 
-On Unix and Mac OS X, this function has no effect.}
+On Unix and macOS, this function has no effect.}
 
 
 @function[(void scheme_add_fd_eventmask
@@ -621,7 +621,7 @@ The event mask is only used when some handle is installed with
  @cpp{scheme_add_fd_handle}. This awkward restriction may force you
  to create a dummy semaphore that is never posted.
 
-On Unix, and Mac OS X, this function has no effect.}
+On Unix, and macOS, this function has no effect.}
 
 @function[(void scheme_add_evt
            [Scheme_Type type]

--- a/pkgs/racket-doc/scribblings/raco/bundle-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/bundle-api.scrbl
@@ -12,7 +12,7 @@
 The @racketmodname[compiler/bundle-dist] library provides a function
 to pack a directory (usually assembled by
 @racket[assemble-distribution]) into a distribution file.  On
-Windows, the result is a @filepath{.zip} archive; on Mac OS X, it's
+Windows, the result is a @filepath{.zip} archive; on macOS, it's
 a @filepath{.dmg} disk image; on Unix, it's a @filepath{.tgz}
 archive.}
 
@@ -27,7 +27,7 @@ has no extension, a file extension is added automatcially (using the
 first result of @racket[bundle-put-file-extension+style+filters]).
 
 The created archive contains a directory with the same name as
-@racket[dir]---except on Mac OS X when @racket[for-exe?] is true
+@racket[dir]---except on macOS when @racket[for-exe?] is true
 and @racket[dir] contains a single a single file or directory, in
 which case the created disk image contains just the file or
 directory. The default for @racket[for-exe?] is @racket[#f].

--- a/pkgs/racket-doc/scribblings/raco/dist.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/dist.scrbl
@@ -33,7 +33,7 @@ platform-specific:
       distribution directory, and DLLs and other run-time files go
       into a @filepath{lib} sub-directory.}
 
-@item{On Mac OS X, GUI executables go into the distribution
+@item{On macOS, GUI executables go into the distribution
       directory, other executables go into a @filepath{bin}
       subdirectory, and frameworks (i.e., shared libraries) go into a
       @filepath{lib} sub-directory along with other run-time files. As

--- a/pkgs/racket-doc/scribblings/raco/exe-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe-api.scrbl
@@ -184,7 +184,7 @@ currently supported keys are as follows:
 
 @itemize[
 
-  @item{@racket['icns] (Mac OS X) : An icon file path (suffix
+  @item{@racket['icns] (macOS) : An icon file path (suffix
         @filepath{.icns}) to use for the executable's desktop icon.}
 
   @item{@racket['ico] (Windows) : An icon file path (suffix
@@ -194,10 +194,10 @@ currently supported keys are as follows:
         executable are replaced with icons from the file,
         instead of setting only certain sizes and depths.}]}
 
-  @item{@racket['creator] (Mac OS X) : Provides a 4-character string
+  @item{@racket['creator] (macOS) : Provides a 4-character string
         to use as the application signature.}
 
-  @item{@racket['file-types] (Mac OS X) : Provides a list of
+  @item{@racket['file-types] (macOS) : Provides a list of
         association lists, one for each type of file handled by the
         application; each association is a two-element list, where the
         first (key) element is a string recognized by Finder, and the
@@ -205,7 +205,7 @@ currently supported keys are as follows:
         @racketmodname[xml/plist]). See @filepath{drracket.filetypes}
         in the @filepath{drracket} collection for an example.}
 
-  @item{@racket['uti-exports] (Mac OS X) : Provides a list of
+  @item{@racket['uti-exports] (macOS) : Provides a list of
         association lists, one for each @as-index{Uniform Type
         Identifier} (UTI) exported by the executable; each association
         is a two-element list, where the first (key) element is a
@@ -214,7 +214,7 @@ currently supported keys are as follows:
         @filepath{drracket.utiexports} in the @filepath{drracket}
         collection for an example.}
 
-  @item{@racket['resource-files] (Mac OS X) : extra files to copy into
+  @item{@racket['resource-files] (macOS) : extra files to copy into
         the @filepath{Resources} directory of the generated
         executable.}
 
@@ -230,7 +230,7 @@ currently supported keys are as follows:
         where the configuration directory is consulted for information
         about collection link files).}
 
-  @item{@racket['framework-root] (Mac OS X) : A string to prefix the
+  @item{@racket['framework-root] (macOS) : A string to prefix the
         executable's path to the Racket and GRacket frameworks
         (including a separating slash); note that when the prefix
         starts @filepath{@"@"executable_path/} works for a
@@ -264,7 +264,7 @@ currently supported keys are as follows:
         brings the other instance to the front; @racket[#f] means that
         multiple instances are expected.}
 
-  @item{@racket['forget-exe?] (Windows, Mac OS X) : A boolean;
+  @item{@racket['forget-exe?] (Windows, macOS) : A boolean;
         @racket[#t] for a launcher (see @racket[launcher?] below) does
         not preserve the original executable name for
         @racket[(find-system-path 'exec-file)]; the main consequence
@@ -276,7 +276,7 @@ currently supported keys are as follows:
         executable, instead of a wrapper binary that execs the
         original; the default is @racket[#f].}
 
-  @item{@racket['relative?] (Unix, Windows, Mac OS X) : A boolean;
+  @item{@racket['relative?] (Unix, Windows, macOS) : A boolean;
         @racket[#t] means that, to the degree that the generated
         executable must refer to another, it can use a relative path
         (so the executables can be moved together, but not
@@ -315,7 +315,7 @@ use of @tech[#:doc reference-doc]{collection links files}.
 If the @racket[#:launcher?] argument is @racket[#t], then
 @racket[lid-list] should be null, @racket[literal-files] should be
 null, @racket[literal-sexp] should be @racket[#f], and the platform
-should be Windows or Mac OS X. The embedding executable is created in
+should be Windows or macOS. The embedding executable is created in
 such a way that @racket[(find-system-path 'exec-file)] produces the
 source Racket or GRacket path instead of the embedding executable (but
 the result of @racket[(find-system-path 'run-file)] is still the
@@ -426,7 +426,7 @@ currently @racket[#f] for all platforms.}
 
 Indicates whether Racket/GRacket executables for the current platform
 actually correspond to directories. The result is @racket[#t] on
-Mac OS X when @racket[mred?] is @racket[#t], @racket[#f] otherwise.}
+macOS when @racket[mred?] is @racket[#t], @racket[#f] otherwise.}
 
 
 @defproc[(embedding-executable-put-file-extension+style+filters [mred? any/c])

--- a/pkgs/racket-doc/scribblings/raco/exe-dylib-path.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe-dylib-path.scrbl
@@ -4,11 +4,11 @@
                      racket/contract
                      compiler/exe-dylib-path))
 
-@title[#:tag "exe-dylib-path"]{Mac OS X Dynamic Library Paths}
+@title[#:tag "exe-dylib-path"]{macOS Dynamic Library Paths}
 
 @defmodule[compiler/exe-dylib-path]{The
 @racketmodname[compiler/exe-dylib-path] library provides functions for
-reading and adjusting dynamic-library references in a Mac OS X
+reading and adjusting dynamic-library references in a macOS
 executable.}
 
 @history[#:added "6.3"]

--- a/pkgs/racket-doc/scribblings/raco/exe.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe.scrbl
@@ -39,7 +39,7 @@ For example, the command
 @commandline{raco exe --gui hello.rkt}
 
 produces either @filepath{hello.exe} (Windows), @filepath{hello.app}
-(Mac OS X), or @filepath{hello} (Unix), which runs the same as running
+(macOS), or @filepath{hello} (Unix), which runs the same as running
 the @filepath{hello.rkt} module in @exec{gracket}.
 
 Library modules or other files that are referenced
@@ -80,7 +80,7 @@ The @exec{raco exe} command accepts the following command-line flags:
 
  @item{@Flag{o} @nonterm{file} --- create the executable as
    @nonterm{file}, adding a suffix to @nonterm{file} as appropriate
-   for the platform and executable type. On Mac OS X in @DFlag{gui}
+   for the platform and executable type. On macOS in @DFlag{gui}
    mode, @nonterm{file} is actually a bundle directory, but it appears
    as a file within Finder.}
 
@@ -127,7 +127,7 @@ The @exec{raco exe} command accepts the following command-line flags:
    use of the @racket['ico] auxiliary association for more information
    about expected icon sizes and transformations.}
 
- @item{@DFlag{icns} @nonterm{.icns-path} --- on Mac OS X, set the icons
+ @item{@DFlag{icns} @nonterm{.icns-path} --- on macOS, set the icons
    for the generated executable to be the content of
    @nonterm{.icns-path}.}
 

--- a/pkgs/racket-doc/scribblings/raco/launcher.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/launcher.scrbl
@@ -169,8 +169,8 @@ tethering.
                                [aux (listof (cons/c symbol? any/c)) null])
          void?]{
 
-Like @racket[make-gracket-launcher], but for starting Racket. On Mac
-macOS, the @racket['exe-name] @racket[aux] association is ignored.}
+Like @racket[make-gracket-launcher], but for starting Racket. On macOS, 
+the @racket['exe-name] @racket[aux] association is ignored.}
 
 
 @defproc[(make-gracket-program-launcher [file string?]
@@ -470,8 +470,7 @@ are as follows:
 
 @itemize[
 
- @item{@filepath{.icns} @'rarr @racket['icns] file for use on Mac
-       macOS}
+ @item{@filepath{.icns} @'rarr @racket['icns] file for use on macOS}
 
  @item{@filepath{.ico} @'rarr @racket['ico] file for use on
        Windows or Unix}

--- a/pkgs/racket-doc/scribblings/raco/launcher.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/launcher.scrbl
@@ -44,7 +44,7 @@ platform-specific options (i.e., it is a list of pairs where the first
 element of the pair is a key symbol and the second element is the
 value for that key). See also @racket[build-aux-from-path]. See
 @racket[create-embedding-executable] for a list that applies to both
-stand-alone executables and launchers on Windows and Mac OS X GRacket;
+stand-alone executables and launchers on Windows and macOS GRacket;
 the following additional associations apply to launchers:
 
 @itemize[
@@ -54,7 +54,7 @@ the following additional associations apply to launchers:
        Racket or GRacket binary, like @exec{raco.exe}. No other
        @racket[aux] associations are used for an old-style launcher.}
 
- @item{@racket['exe-name] (Mac OS X, @racket['script-3m] or
+ @item{@racket['exe-name] (macOS, @racket['script-3m] or
        @racket['script-cgc] variant) --- provides the base name for a
        @racket['3m]-/@racket['cgc]-variant launcher, which the script
        will call ignoring @racket[args]. If this name is not provided,
@@ -170,7 +170,7 @@ tethering.
          void?]{
 
 Like @racket[make-gracket-launcher], but for starting Racket. On Mac
-OS X, the @racket['exe-name] @racket[aux] association is ignored.}
+macOS, the @racket['exe-name] @racket[aux] association is ignored.}
 
 
 @defproc[(make-gracket-program-launcher [file string?]
@@ -296,7 +296,7 @@ For Windows, the @filepath{.exe}
 suffix is automatically appended to @racket[name]. For Unix,
 @racket[name] is changed to lowercase, whitespace is changed to
 @litchar{-}, and the path includes the @filepath{bin} subdirectory of
-the Racket installation. For Mac OS X, the @filepath{.app} suffix
+the Racket installation. For macOS, the @filepath{.app} suffix
 is appended to @racket[name].
 
 @history[#:changed "6.5.0.2" @elem{Added the @racket[#:tethered?] argument.}]}
@@ -329,7 +329,7 @@ launchers.}
 
 Returns @racket[#t] if GRacket launchers for the current platform are
 implemented as directories from the filesystem's perspective. The
-result is @racket[#t] for Mac OS X, @racket[#f] for all other
+result is @racket[#t] for macOS, @racket[#f] for all other
 platforms.}
 
 
@@ -471,7 +471,7 @@ are as follows:
 @itemize[
 
  @item{@filepath{.icns} @'rarr @racket['icns] file for use on Mac
-       OS X}
+       macOS}
 
  @item{@filepath{.ico} @'rarr @racket['ico] file for use on
        Windows or Unix}
@@ -483,17 +483,17 @@ are as follows:
        (the file content is ignored) for use on Windows}
 
  @item{@filepath{.creator} @'rarr @racket['creator] as the initial
-       four characters in the file for use on Mac OS X}
+       four characters in the file for use on macOS}
 
  @item{@filepath{.filetypes} @'rarr @racket['file-types] as
        @racket[read] content (a single S-expression), and
        @racket['resource-files] as a list constructed by finding
        @racket["CFBundleTypeIconFile"] entries in @racket['file-types]
-       (and filtering duplicates); for use on Mac OS X}
+       (and filtering duplicates); for use on macOS}
 
  @item{@filepath{.utiexports} @'rarr @racket['uti-exports] as
        @racket[read] content (a single S-expression); for use on
-       Mac OS X}
+       macOS}
 
  @item{@filepath{.wmclass} @'rarr @racket['wm-class] as the literal
        content, removing a trailing newline if any; for use on Unix}
@@ -517,7 +517,7 @@ are as follows:
 A parameter that indicates a variant of Racket or GRacket to use for
 launcher creation and for generating launcher names. The default is
 the result of @racket[(system-type 'gc)]. On Unix and Windows, the
-possibilities are @racket['cgc] and @racket['3m]. On Mac OS X, the
+possibilities are @racket['cgc] and @racket['3m]. On macOS, the
 @racket['script-3m] and @racket['script-cgc] variants are also
 available for GRacket launchers.}
 
@@ -527,7 +527,7 @@ Returns a list of symbols corresponding to available variants of GRacket
 in the current Racket installation. The list normally includes at
 least one of @racket['3m] or @racket['cgc]--- whichever is the result
 of @racket[(system-type 'gc)]---and may include the other, as well as
-@racket['script-3m] and/or @racket['script-cgc] on Mac OS X.}
+@racket['script-3m] and/or @racket['script-cgc] on macOS.}
 
 @defproc[(available-racket-variants) (listof symbol?)]{
 

--- a/pkgs/racket-doc/scribblings/raco/setup.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/setup.scrbl
@@ -649,7 +649,7 @@ Optional @filepath{info.rkt} fields trigger additional actions by
    If @racket[install-platform] is defined, then the files are copied
    only if the current platform matches the definition.
 
-   On Mac OS X, when a Mach-O file is copied, if the copied file
+   On macOS, when a Mach-O file is copied, if the copied file
    includes a library reference that starts @litchar{@"@"loader_path/},
    and if the referenced library exists in a different location among
    the paths listed by @racket[(get-lib-search-dirs)], then the

--- a/pkgs/racket-doc/scribblings/reference/bytes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/bytes.scrbl
@@ -477,7 +477,7 @@ the custodian is shut down. A converter is not registered with a
 custodian (and does not need to be closed) if it is one of the
 guaranteed combinations not involving @racket[""] on Unix, or if it
 is any of the guaranteed combinations (including @racket[""]) on
-Windows and Mac OS X.
+Windows and macOS.
 
 @margin-note{In the Racket software distributions for Windows, a suitable
 @filepath{iconv.dll} is included with @filepath{libmzsch@italic{VERS}.dll}.}

--- a/pkgs/racket-doc/scribblings/reference/encodings.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/encodings.scrbl
@@ -57,17 +57,17 @@ the locale's encoding; and, finally, Racket provides functions such as
 encoding.
 
 A Unix user selects a locale by setting environment variables, such as
-@envvar{LC_ALL}. On Windows and Mac OS X, the operating system
+@envvar{LC_ALL}. On Windows and macOS, the operating system
 provides other mechanisms for setting the locale. Within Racket, the
 current locale can be changed by setting the @racket[current-locale]
 parameter. The locale name within Racket is a string, and the
 available locale names depend on the platform and its configuration,
 but the @racket[""] locale means the current user's default locale;
-on Windows and Mac OS X, the encoding for @racket[""] is always
+on Windows and macOS, the encoding for @racket[""] is always
 UTF-8, and locale-sensitive operations use the operating system's
 native interface. (In particular, setting the @envvar{LC_ALL} and
 @envvar{LC_CTYPE} environment variables does not affect the locale
-@racket[""] on Mac OS X. Use @racket[getenv] and
+@racket[""] on macOS. Use @racket[getenv] and
 @racket[current-locale] to explicitly install the
 environment-specified locale, if desired.) Setting the current locale
 to @racket[#f] makes locale-sensitive operations locale-insensitive,

--- a/pkgs/racket-doc/scribblings/reference/eval.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/eval.scrbl
@@ -212,7 +212,7 @@ An @tech{extension-load handler} takes the same arguments as a
 @tech{load handler}, but the file should be a platform-specific
 @deftech{dynamic extension}, typically with the file suffix
 @filepath{.so} (Unix), @filepath{.dll} (Windows), or @filepath{.dylib}
-(Mac OS X).  The file is loaded using internal, OS-specific
+(macOS).  The file is loaded using internal, OS-specific
 primitives. See @other-manual['(lib
 "scribblings/inside/inside.scrbl")] for more information on
 @tech{dynamic extensions}.}

--- a/pkgs/racket-doc/scribblings/reference/file-ports.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/file-ports.scrbl
@@ -339,10 +339,10 @@ affect only the ability of processes to acquire locks) or they may
 correspond to mandatory locks that prevent reads and writes to the
 locked file. Specifically, locks are mandatory on Windows and advisory
 on other platforms. Multiple tries for a @racket['shared] lock on a
-single port can succeed; on Unix and Mac OS X, a single
+single port can succeed; on Unix and macOS, a single
 @racket[port-file-unlock] release the lock, while on other Windows, a
 @racket[port-file-unlock] is needed for each successful
-@racket[port-try-file-lock?]. On Unix and Mac OS X, multiple tries for
+@racket[port-try-file-lock?]. On Unix and macOS, multiple tries for
 a @racket['exclusive] lock can succeed and a single
 @racket[port-file-unlock] releases the lock, while on Windows, a try
 for an @racket['exclusive] lock fails for a given port if the port
@@ -355,9 +355,9 @@ output port, and vice versa. If the output port from
 corresponding input port can still acquire a @racket['shared] lock,
 even multiple times; on Windows, a @racket[port-file-unlock] is needed
 for each successful lock try, while a single @racket[port-file-unlock]
-balances the lock tries on Unix and Mac OS X. A @racket['shared] lock on
+balances the lock tries on Unix and macOS. A @racket['shared] lock on
 an input port can be upgraded to an @racket['exclusive] lock through the
-corresponding output port on Unix and Mac OS X, in which case a single
+corresponding output port on Unix and macOS, in which case a single
 @racket[port-file-unlock] (on either port) releases the lock, while
 such upgrades are not allowed on Windows.
 

--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -31,7 +31,7 @@ by @racket[kind], which must be one of the following:
  variable is defined as a @tech{complete} path, then the path is used
  as the user's home directory.
 
- On Unix and Mac OS X, when @envvar{PLTUSERHOME} does not apply,
+ On Unix and macOS, when @envvar{PLTUSERHOME} does not apply,
  the user's home directory is determined by
  expanding the path @filepath{~}, which is expanded by first checking
  for a @indexed-envvar{HOME} environment variable. If none is defined,
@@ -58,7 +58,7 @@ by @racket[kind], which must be one of the following:
  determined by @envvar{PLTUSERHOME}, otherwise in the user's
  application-data folder as specified by the Windows registry; the
  application-data folder is usually @filepath{Application Data} in the
- user's profile directory. On Mac OS X, the preferences directory
+ user's profile directory. On macOS, the preferences directory
  is @filepath{Library/Preferences} in the
  @tech{user's home directory}. The preferences directory might not exist.}
 
@@ -115,7 +115,7 @@ by @racket[kind], which must be one of the following:
  environment variable or flag is specified, or if the value is not a
  legal path name, then this directory defaults to
  @filepath{Library/Racket} in the @tech{user's home directory} on Mac
- OS X and @racket['pref-dir] otherwise.  The directory might not
+ macOS and @racket['pref-dir] otherwise.  The directory might not
  exist.}
 
  @item{@indexed-racket['doc-dir] --- the standard directory for
@@ -124,7 +124,7 @@ by @racket[kind], which must be one of the following:
  home directory} if determined by @envvar{PLTUSERHOME}, otherwise it
  is the user's documents folder as specified by the Windows registry;
  the documents folder is usually @filepath{My Documents} in the user's
- home directory.  On Mac OS X, it's the @filepath{Documents} directory
+ home directory.  On macOS, it's the @filepath{Documents} directory
  in the @tech{user's home directory}.}
 
  @item{@indexed-racket['desk-dir] --- the directory for the current user's
@@ -132,7 +132,7 @@ by @racket[kind], which must be one of the following:
  Windows, it is the @tech{user's home directory} if determined by
  @envvar{PLTUSERHOME}, otherwise it is the user's desktop folder as
  specified by the Windows registry; the desktop folder is usually
- @filepath{Desktop} in the user's home directory. On Mac OS X, it is
+ @filepath{Desktop} in the user's home directory. On macOS, it is
  @filepath{Desktop} in the @tech{user's home directory}}
 
  @item{@indexed-racket['sys-dir] --- the directory containing the
@@ -301,12 +301,12 @@ This procedure can be used to move a file/directory to a different
 directory (on the same filesystem) as well as rename a file/directory within
 a directory. Unless @racket[exists-ok?]  is provided as a true value,
 @racket[new] cannot refer to an existing file or directory, but the
-check is not atomic with the rename operation on Unix and Mac OS X. Even if
+check is not atomic with the rename operation on Unix and macOS. Even if
 @racket[exists-ok?] is true, @racket[new] cannot refer to an existing
 file when @racket[old] is a directory, and vice versa.
 
 If @racket[new] exists and is replaced, the replacement is atomic
-on Unix and Mac OS X, but it is not guaranteed to be atomic on
+on Unix and macOS, but it is not guaranteed to be atomic on
 Windows. Furthermore, if @racket[new] exists and is opened by any
 process for reading or writing, then attempting to replace it will
 typically fail on Windows. See also @racket[call-with-atomic-output-file].
@@ -405,7 +405,7 @@ identity of the referenced file or directory (if any).}
 @defproc[(file-size [path path-string?]) exact-nonnegative-integer?]{
 
 Returns the (logical) size of the specified file in bytes. On Mac
-OS X, this size excludes the resource-fork size. On error (e.g., if no
+macOS, this size excludes the resource-fork size. On error (e.g., if no
 such file exists), the @exnraise[exn:fail:filesystem].}
 
 
@@ -471,7 +471,7 @@ simplified, complete, directory path.
 
 The path is not checked for existence when the parameter is set.
 
-On Unix and Mac OS X, the initial value of the parameter for a Racket
+On Unix and macOS, the initial value of the parameter for a Racket
 process is taken from the @indexed-envvar{PWD} environment
 variable---if the value of the environment variable identifies the
 same directory as the operating system's report of the current
@@ -1199,7 +1199,7 @@ Opens a temporary file for writing in the same directory as
 @racket[file], calls @racket[proc] to write to the temporary file, and
 then atomically moves the temporary file in place of @racket[file].
 The atomic move simply uses @racket[rename-file-or-directory] on Unix
-and Mac OS X, but it uses an extra rename step (see below) on Windows
+and macOS, but it uses an extra rename step (see below) on Windows
 to avoid problems due to concurrent readers of @racket[file].
 
 The @racket[proc] function is called with an output port for the
@@ -1288,7 +1288,7 @@ paths are checked for compatibility with old versions of Racket:
 
  @item{Windows: @racket[(build-path (find-system-path 'pref-dir) 'up "PLT Scheme" "plt-prefs.ss")]}
 
- @item{Mac OS X: @racket[(build-path (find-system-path 'pref-dir) "org.plt-scheme.prefs.ss")]}
+ @item{macOS: @racket[(build-path (find-system-path 'pref-dir) "org.plt-scheme.prefs.ss")]}
 
  @item{Unix: @racket[(expand-user-path "~/.plt-scheme/plt-prefs.ss")]}
 

--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -114,9 +114,8 @@ by @racket[kind], which must be one of the following:
  overridden by the @DFlag{addon} or @Flag{A} command-line flag.  If no
  environment variable or flag is specified, or if the value is not a
  legal path name, then this directory defaults to
- @filepath{Library/Racket} in the @tech{user's home directory} on Mac
- macOS and @racket['pref-dir] otherwise.  The directory might not
- exist.}
+ @filepath{Library/Racket} in the @tech{user's home directory} on macOS 
+ and @racket['pref-dir] otherwise.  The directory might not exist.}
 
  @item{@indexed-racket['doc-dir] --- the standard directory for
  storing the current user's documents. On Unix, it's
@@ -404,8 +403,7 @@ identity of the referenced file or directory (if any).}
 
 @defproc[(file-size [path path-string?]) exact-nonnegative-integer?]{
 
-Returns the (logical) size of the specified file in bytes. On Mac
-macOS, this size excludes the resource-fork size. On error (e.g., if no
+Returns the (logical) size of the specified file in bytes. On macOS, this size excludes the resource-fork size. On error (e.g., if no
 such file exists), the @exnraise[exn:fail:filesystem].}
 
 

--- a/pkgs/racket-doc/scribblings/reference/futures.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/futures.scrbl
@@ -13,7 +13,7 @@
 @note-lib[racket/future]
 
 @margin-note{Currently, parallel support for @racket[future] is enabled
-  by default for Windows, Linux x86/x86_64, and Mac OS X x86/x86_64. To
+  by default for Windows, Linux x86/x86_64, and macmacOS86/x86_64. To
   enable support for other platforms, use @DFlag{enable-futures} with
   @exec{configure} when building Racket.}
 

--- a/pkgs/racket-doc/scribblings/reference/futures.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/futures.scrbl
@@ -13,7 +13,7 @@
 @note-lib[racket/future]
 
 @margin-note{Currently, parallel support for @racket[future] is enabled
-  by default for Windows, Linux x86/x86_64, and macmacOS86/x86_64. To
+  by default for Windows, Linux x86/x86_64, and macOS x86/x86_64. To
   enable support for other platforms, use @DFlag{enable-futures} with
   @exec{configure} when building Racket.}
 

--- a/pkgs/racket-doc/scribblings/reference/logging.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/logging.scrbl
@@ -62,7 +62,7 @@ through environment variables:
        same as for @envvar{PLTSTDERR}.
 
        The default is @racket["none"] for Unix or @racket["error"] for
-       Windows and Mac OS X.}
+       Windows and macOS.}
 
 ]
 

--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -26,7 +26,7 @@ hardware threads.
 
 @margin-note{Currently, parallel support for places is enabled
   only for Racket 3m (which is the main variant of Racket), and only
-  by default for Windows, Linux x86/x86_64, and Mac OS X x86/x86_64. To
+  by default for Windows, Linux x86/x86_64, and macmacOS86/x86_64. To
   enable support for other platforms, use @DFlag{enable-places} with
   @exec{configure} when building Racket. The @racket[place-enabled?]
   function reports whether places run in parallel.}

--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -26,7 +26,7 @@ hardware threads.
 
 @margin-note{Currently, parallel support for places is enabled
   only for Racket 3m (which is the main variant of Racket), and only
-  by default for Windows, Linux x86/x86_64, and macmacOS86/x86_64. To
+  by default for Windows, Linux x86/x86_64, and macOS x86/x86_64. To
   enable support for other platforms, use @DFlag{enable-places} with
   @exec{configure} when building Racket. The @racket[place-enabled?]
   function reports whether places run in parallel.}

--- a/pkgs/racket-doc/scribblings/reference/runtime.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/runtime.scrbl
@@ -40,7 +40,7 @@ In @indexed-racket['link] mode, the possible symbol results are:
 @item{@indexed-racket['static] (Unix)}
 @item{@indexed-racket['shared] (Unix)}
 @item{@indexed-racket['dll] (Windows)}
-@item{@indexed-racket['framework] (Mac OS X)}
+@item{@indexed-racket['framework] (macOS)}
 ]
 
 Future ports of Racket may expand the list of @racket['os],
@@ -74,7 +74,7 @@ are:
 @item{@indexed-racket['scalable] --- resources consumed by a
  @tech{filesystem change event} are effectively limited only by
  available memory, as opposed to file-descriptor limits; this property
- is @racket[#f] on Mac OS X and BSD variants of Unix}
+ is @racket[#f] on macOS and BSD variants of Unix}
 @item{@indexed-racket['low-latency] --- creation and checking of a
  @tech{filesystem change event} is practically instantaneous; this
  property is @racket[#f] on Linux}
@@ -90,7 +90,7 @@ are:
 Returns a string to identify the current user's language and
 country.
 
-On Unix and Mac OS X, the string is five characters: two lowercase
+On Unix and macOS, the string is five characters: two lowercase
 ASCII letters for the language, an underscore, and two uppercase ASCII
 letters for the country. On Windows, the string can be arbitrarily
 long, but the language and country are in English (all ASCII letters
@@ -102,7 +102,7 @@ On Unix, the result is determined by checking the
 result is used if the environment variable's value starts with two
 lowercase ASCII letters, an underscore, and two uppercase ASCII
 letters, followed by either nothing or a period). On Windows and
-Mac OS X, the result is determined by system calls.}
+macOS, the result is determined by system calls.}
 
 
 @defproc[(system-library-subpath [mode (or/c 'cgc '3m #f)

--- a/pkgs/racket-doc/scribblings/reference/startup.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/startup.scrbl
@@ -19,7 +19,7 @@ The core Racket run-time system is available in two main variants:
 
  @item{Racket, which provides the primitives libraries on which
        @racketmodname[racket/base] is implemented. On Unix and Mac
-       OS X, the executable is called
+       macOS, the executable is called
        @as-index{@exec{racket}}. On Windows, the executable is
        called @as-index{@exec{Racket.exe}}.}
 
@@ -30,7 +30,7 @@ The core Racket run-time system is available in two main variants:
        the @racket[racket/gui/base] library. On Windows, the
        executable is called @as-index{@exec{GRacket.exe}}, and it is a
        GUI application (as opposed to a console application) that
-       implements single-instance support. On Mac OS X, the
+       implements single-instance support. On macOS, the
        @exec{gracket} script launches @as-index{@exec{GRacket.app}}.}
 
 ]
@@ -181,7 +181,7 @@ flags:
 
   @item{@FlagFirst{k} @nonterm{n} @nonterm{m} @nonterm{p} : Loads code
         embedded in the executable from file position @nonterm{n} to
-        @nonterm{m} and from @nonterm{m} to @nonterm{p}. (On Mac OS X,
+        @nonterm{m} and from @nonterm{m} to @nonterm{p}. (On macOS,
         @nonterm{n}, @nonterm{m}, and @nonterm{p} are relative to a
         @tt{__PLTSCHEME} segment in the executable. On Windows,
         they are relative to a resource of type 257 and ID 1.) The first range
@@ -228,7 +228,7 @@ flags:
   @item{@FlagFirst{v} or @DFlagFirst{version} : Shows
         @racket[(banner)].}
 
-  @item{@FlagFirst{K} or @DFlagFirst{back} : GRacket, Mac OS X only;
+  @item{@FlagFirst{K} or @DFlagFirst{back} : GRacket, macOS only;
         leave application in the background.}
 
   @item{@FlagFirst{V} @DFlagFirst{no-yield} : Skips final
@@ -401,7 +401,7 @@ the insertion of @Flag{u}/@DFlag{require-script}):
 
 ]
 
-Similarly, on Mac OS X, a leading switch starting with
+Similarly, on macOS, a leading switch starting with
 @FlagFirst{psn_} is treated as a special configuration option. It
 indicates that Finder started the application, so the current input,
 output, and error output are redirected to a GUI window.

--- a/pkgs/racket-doc/scribblings/reference/startup.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/startup.scrbl
@@ -18,10 +18,9 @@ The core Racket run-time system is available in two main variants:
 @itemize[
 
  @item{Racket, which provides the primitives libraries on which
-       @racketmodname[racket/base] is implemented. On Unix and Mac
-       macOS, the executable is called
-       @as-index{@exec{racket}}. On Windows, the executable is
-       called @as-index{@exec{Racket.exe}}.}
+       @racketmodname[racket/base] is implemented. On Unix and macOS, 
+       the executable is called @as-index{@exec{racket}}. On Windows, 
+       the executable is called @as-index{@exec{Racket.exe}}.}
 
  @item{GRacket, which is a GUI variant of @exec{racket} to the degree
        that the system distinguishes them. On Unix, the executable

--- a/pkgs/racket-doc/scribblings/reference/subprocess.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/subprocess.scrbl
@@ -29,7 +29,7 @@ environment variables @racket[current-environment-variables]. See also
 @racket[system] and @racket[process] from
 @racketmodname[racket/system].
 
-@margin-note{On Unix and Mac OS X, subprocess creation is separate
+@margin-note{On Unix and macOS, subprocess creation is separate
 from starting the program indicated by @racket[command]. In
 particular, if @racket[command] refers to a non-existent or
 non-executable file, an error will be reported (via standard error and
@@ -40,7 +40,7 @@ The @racket[command] argument is a path to a program executable, and
 the @racket[arg]s are command-line arguments for the program. See
 @racket[find-executable-path] for locating an executable based on
 the @envvar{PATH} environment variable. On
-Unix and Mac OS X, command-line arguments are passed as byte strings,
+Unix and macOS, command-line arguments are passed as byte strings,
 and string @racket[arg]s are converted using the current locale's
 encoding (see @secref["encodings"]). On Windows, command-line
 arguments are passed as strings, and bytes strings are converted using
@@ -155,14 +155,14 @@ current platform:
  @item{@racket[force?] is true, not a group, all platforms: Terminates
        the process if the process still running.}
 
- @item{@racket[force?] is false, not a group, on Unix or Mac OS X:
+ @item{@racket[force?] is false, not a group, on Unix or macOS:
        Sends the process an interrupt signal instead of a kill
        signal.}
 
  @item{@racket[force?] is false, not a group, on Windows: No action
        is taken.}
 
- @item{@racket[force?] is true, a group, on Unix or Mac OS X:
+ @item{@racket[force?] is true, a group, on Unix or macOS:
        Terminates all processes in the group, but only if
        @racket[subprocess-status] has never produced a
        non-@racket['running] result for the subprocess and only if
@@ -175,7 +175,7 @@ current platform:
  @item{@racket[force?] is true, a group, on Windows: Terminates
        the process if the process still running.}
 
- @item{@racket[force?] is false, a group, on Unix or Mac OS X: The
+ @item{@racket[force?] is false, a group, on Unix or macOS: The
        same as when @racket[force?] is @racket[#t], but when the group
        is sent a signal, it is an interrupt signal instead of a kill
        signal.}
@@ -344,7 +344,7 @@ real process ID).}
                  [#:set-pwd? set-pwd? any/c (member (system-type) '(unix macosx))])
          boolean?]{
 
-Executes a Unix, Mac OS X, or Windows shell command synchronously
+Executes a Unix, macOS, or Windows shell command synchronously
 (i.e., the call to @racket[system] does not return until the
 subprocess has ended). The @racket[command] argument is a string or
 byte string containing no nul characters. If the command succeeds, the
@@ -424,7 +424,7 @@ Like @racket[system*], but returns the exit code like
                ((or/c 'status 'wait 'interrupt 'kill) . -> . any))]{
 
 Executes a shell command asynchronously (using @exec{sh} on Unix
-and Mac OS X, @exec{cmd} on Windows). The result is a list of five
+and macOS, @exec{cmd} on Windows). The result is a list of five
 values:
 
 @margin-note{See also @racket[subprocess] for notes about error
@@ -460,7 +460,7 @@ handling and the limited buffer capacity of subprocess pipes.}
     on @|AllUnix|, and takes no action on Windows. The result is
     @|void-const|.
 
-     @margin-note{On Unix and Mac OS X, if @racket[command] runs a
+     @margin-note{On Unix and macOS, if @racket[command] runs a
      single program, then @exec{sh} typically runs the program in
      such a way that it replaces @exec{sh} in the same process. For
      reliable and precise control over process creation, however, use

--- a/pkgs/racket-doc/scribblings/reference/unix-paths.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/unix-paths.scrbl
@@ -34,7 +34,7 @@ _path)]. Since that is not the case for other platforms, however,
 @racket[path-element->bytes] and @racket[path-element->string] should
 be used when converting individual path elements.
 
-On Mac OS X, Finder aliases are zero-length files.
+On macOS, Finder aliases are zero-length files.
 
 
 @section[#:tag "unixpathrep"]{Unix Path Representation}

--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -432,7 +432,7 @@ elements have an attributes list (even if it's empty).}
 The @racketmodname[xml/plist] library provides the ability to read and
 write XML documents that conform to the @defterm{plist} DTD, which is
 used to store dictionaries of string--value associations.  This format
-is used by Mac OS X (both the operating system and its applications)
+is used by macOS (both the operating system and its applications)
 to store all kinds of data.
 
 A @deftech{plist value} is a value that could be created by an

--- a/pkgs/racket-index/scribblings/main/start.scrbl
+++ b/pkgs/racket-index/scribblings/main/start.scrbl
@@ -14,7 +14,7 @@
   @margin-note{
     @not-on-the-web{This is an installation-specific listing.}
     Running @exec{raco docs}
-    (or @exec{Racket Documentation} on Windows or Mac OS X)
+    (or @exec{Racket Documentation} on Windows or macOS)
     may open a different page with local and user-specific
     documentation, including documentation for installed packages.
 


### PR DESCRIPTION
Because what’s old is new again.