### PR TITLE
optimzer: more reductions in ignored expressions

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -1349,6 +1349,17 @@
 (test-comp '(lambda (v) (unsafe-unbox* (box v)))
            '(lambda (v) v))
 
+(test-comp '(lambda () (car (cons (random 2) (random 3))))
+           '(lambda () (begin0 (random 2) (random 3))))
+(test-comp '(lambda () (car (cons (random 2) (begin (random 3) (lambda (x) x)))))
+           '(lambda () (begin0 (random 2) (random 3))))
+(test-comp '(lambda () (cdr (cons (random 2) (random 3))))
+           '(lambda () (begin (random 2) (random 3))))
+(test-comp '(lambda () (cdr (cons (begin (random 2) (lambda (x) x)) (random 3))))
+           '(lambda () (begin (random 2) (random 3))))
+(test-comp '(lambda () (cdr (cons (begin (random 1) (random 2) (lambda (x) x)) (random 3))))
+           '(lambda () (begin (random 1) (random 2) (random 3))))
+
 (test-comp '(lambda (w z) (pair? (list)))
            '(lambda (w z) #f))
 (test-comp '(lambda (w z) (null? (list)))


### PR DESCRIPTION
Extend `optimize_ignore` to go inside expressions with `begin`, `begin0 `and `let`.

For example this reduces

    (list? (let ([r (random)]) (list r r)))

to

    (begin (let ([r (random)]) #f) #t)

instead of

    (begin (let ([r (random)]) (list r r)) #t)

so the final code avoids the creation of the `list`.

The code tries to simplify the `begin `and `begin0 `if they are small and the result expression is omittable. But it doesn’t try to simplify the `let` in case the last expression is omittable.

--

The second part tries to reuse the `begin`'s in `make_discarding_sequence`

When the first expression is a `begin` with a omittable last expression, it replaces the last expression with the second expression instead of allocating a new `begin` to wrap them.

For example, instead of

    (begin (begin X Y #f) Z)

the final expression is

    (begin X Y Z)

I’m not sure about this part. I think that applying this for `begin`’s is enough.  It can be generalized to include `let`’s, but the length of the code will be much bigger. It also can be extended to use `extract_tail_inside` but it may get a quadratic time. I think that this version is a good compromise.
 

