### PR TITLE
add test for ormap

### DIFF
--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -731,7 +731,7 @@
             (collect-garbage)
             (when (weak-box-value b)
               (set! retained (add1 retained)))))
-      (test #t `(in-... ,retained) (< retained (/ N 2)))))
+      (test #t `(for/... in-... proc extra ... ,N ,retained) (< retained (/ N 2)))))
   (check for/list in-list #f)
   (check for/list values #f)
   (check for/stream in-stream #f)
@@ -747,6 +747,7 @@
   (check for/list values map)
   (check for/list values map extra) ; 1 and 2 arguments are special-cased
   (check for/list values for-each)
+  (check for/list values ormap)
   (check for/list values andmap))
 
 ;; ----------------------------------------


### PR DESCRIPTION
An aditional test fo [adjust `map` and `for ... in-list` to not retain their lists](https://github.com/racket/racket/commit/d7b18e7a9c7c421a9799c4cd9653b094edafccbc)  ( https://github.com/racket/racket/commit/d7b18e7a9c7c421a9799c4cd9653b094edafccbc )

Also, add more details to the error messages in the test. 