### PR TITLE
Remove the documentation mentioning `chaperon-procedure*?`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/chaperones.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/chaperones.scrbl
@@ -169,10 +169,6 @@ reachable in addition to any value that @racket[v] impersonates
 
 @defproc[(procedure-impersonator*? [v any/c]) boolean?]{
 
-chaperone-procedure*?
-returns #t for any impersonator of a value produced by
-impersonate-procedure* or chaperone-procedure* (or something like that).
-
 Returns @racket[#t] for any procedure impersonator that either was produced by
 @racket[impersonate-procedure*] or @racket[chaperone-procedure*], or is
 an impersonator/chaperone of a value that was created with


### PR DESCRIPTION
The function `chaperon-procedure*?` mentioned in the documentation does not exist (or is out-dated).