### PR TITLE
fix misuse of `trace-printf`

### DIFF
--- a/racket/collects/compiler/cm.rkt
+++ b/racket/collects/compiler/cm.rkt
@@ -573,7 +573,7 @@
                             (when ok-to-compile?
                               (log-compile-event path 'start-compile)
                               (when zo-exists? (try-delete-file zo-name #f))
-                              (trace-printf (format "compiling ~a" actual-path))
+                              (trace-printf "compiling ~a" actual-path)
                               (parameterize ([depth (+ (depth) 1)])
                                 (with-handlers
                                     ([exn:get-module-code?


### PR DESCRIPTION
Fix for issue #1536. This use of `trace-printf` is inconsistent with others nearby, causing the incorrect behavior described there.