### PR TITLE
optimizer: merge lookup_constant_proc and optimize_for_inline

### DIFF
--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -3298,11 +3298,6 @@ Scheme_Object *scheme_optimize_expr(Scheme_Object *, Optimize_Info *, int contex
 #define scheme_optimize_result_context(c) (c & (~(OPT_CONTEXT_TYPE_MASK | OPT_CONTEXT_NO_SINGLE | OPT_CONTEXT_SINGLED)))
 #define scheme_optimize_tail_context(c)   scheme_optimize_result_context(c) 
 
-Scheme_Object *scheme_optimize_apply_values(Scheme_Object *f, Scheme_Object *e, 
-                                            Optimize_Info *info,
-                                            int e_single_result,
-                                            int context);
-
 int scheme_ir_duplicate_ok(Scheme_Object *o, int cross_mod);
 int scheme_ir_propagate_ok(Scheme_Object *o, Optimize_Info *info);
 int scheme_is_statically_proc(Scheme_Object *value, Optimize_Info *info, int flags);


### PR DESCRIPTION
The objective of `lookup_constant_proc` and the first part of `optimize_for_inline` was to find out if the value of an expression was a procedure and get it to analyze its properties or try to inline it. Both were called together in a few places, because each one had some special cases that were missing in the other.

So, move the lookup and special cases from `optimize_for_inline` to `lookup_constant_proc`, and keep only the code relevant to inlinig in `optimize_for_inline`.

The changes are asier to undertand if you imagine that `optimize_for_inline` was splited and renamed as `lookup_constant_proc`, and then a few missing details of the old `lookup_constant_proc` were copied to the new `lookup_constant_proc`.

When there is an arity mismatch, it returns `scheme_true`. Another posibility would be to use `scheme_false` but I guess that when this code will be translated from C to racket, the `NULL` will be translated to `scheme_false` and casue a collision.

When not trying to inline, it will go inside `will_be_lambda`s. Please double check that this is correct.
[R2600](https://github.com/racket/racket/compare/master...gus-massa:16-11-Inline-NNN?expand=1#diff-5e09d7df9102fa81a4736e357a0c3e1aR2600)

I'm using directly `[var]->mode` and `[var]->optimize.known_val` instead of `optimize_info_lookup_lambda` to avoid the error when the mode is incorrect. See [2544](https://github.com/racket/racket/compare/master...gus-massa:16-11-Inline-NNN?expand=1#diff-5e09d7df9102fa81a4736e357a0c3e1aR2544) This is necesary in some code like:

    (call/cc 
     (let ([p (lambda (_) 0)
        p))

I don't want to move the optimization for call/cc after the argument is optimized because I exper it to be more useful in cases were the lambda is direct, like

    (let/cc exit
      (do-domething-ignoring-exit))
