### PR TITLE
Make PLTDISABLEGC work again

### DIFF
--- a/racket/src/racket/gc2/newgc.c
+++ b/racket/src/racket/gc2/newgc.c
@@ -726,7 +726,7 @@ static void NewGC_initialize(NewGC *newgc, NewGC *inheritgc, NewGC *parentgc) {
       memcpy(newgc->mark_table, inheritgc->mark_table, newgc->number_of_tags * sizeof(Mark2_Proc));
       memcpy(newgc->fixup_table, inheritgc->fixup_table, newgc->number_of_tags * sizeof(Fixup2_Proc));
     }
-    newgc->avoid_collection = 0;
+    newgc->avoid_collection = inheritgc->avoid_collection;
 #ifdef MZ_USE_PLACES
     newgc->parent_gc = parentgc;
 #endif


### PR DESCRIPTION
It looks like `PLTDISABLEGC` hasn't been working for a while.

A git bisect points at e59f888 as the commit where this setting broke. In that change, new GCs no longer inherit the `avoid_collection` value, which is what PLTDISABLEGC increments. So as soon as the new GC is created for the master place ([GC_switch_out_master_gc](racket/src/racket/gc2/places_gc.c#372)), that setting is lost.

I'm not 100% sure this is the right fix because the invariants here are tricky; in particular, the old code in b24c387 incremented `avoid_collection` just before creating the new GC, and then decremented it when inheriting. But it didn't break my places-using code, and does indeed disable the GC now :-)