### PR TITLE
Need parentheses

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -633,7 +633,7 @@ in the first position of pattern sequence.
      (λ (stx) #''()))
    (define (len l)
      (match l
-       [nil 0]
+       [(nil) 0]
        [(cons hd tl) (+ 1 (len tl))])))
   (len nil)
   (len (cons 1 nil))


### PR DESCRIPTION
This needs parentheses. Otherwise, it's going to be just `id` which will "match anything, bind identifier", and give

```
0
0
0
```

while the expected output is

```
0
1
2
```

@rfindler (who originally wrote this part): does this seem correct?