### PR TITLE
document raco/all-tools, fix typos in raco documentation

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/api.scrbl
@@ -106,7 +106,7 @@ collection.  The following fields are used:
 
  @item{@indexed-racket[compile-omit-paths] : A list of immediate file
        and directory paths that should not be compiled. Alternatively,
-       this field's value @racket['all], which is equivalent to
+       this field's value is @racket['all], which is equivalent to
        specifying all files and directories in the collection (to
        effectively ignore the collection for
        compilation). Automatically omitted files and directories are
@@ -123,8 +123,9 @@ collection.  The following fields are used:
        contents of @racket[compile-omit-paths].  Do not use this
        field; it is for backward compatibility.}
 
- @item{@indexed-racket[scribblings] : A list of pairs, each of which
-       starts with a path for documentation source. The sources (and
+ @item{@indexed-racket[scribblings] : A list of lists, each of which
+       starts with a path for documentation source.  See @secref["setup-info"]
+       for more information.  The sources (and
        the files that they require) are compiled in the same way as
        other module files, unless @racket[skip-docs?] is a true value.}
 
@@ -133,7 +134,7 @@ collection.  The following fields are used:
        are compiled based on the file's extension, being in @racket[scribblings],
        or being @racket[require]d by other compiled files.}
 
- @item{@racket[module-suffixes] and @racket[doc-module-suffixes] ---
+ @item{@racket[module-suffixes] and @racket[doc-module-suffixes] :
        Used indirectly via @racket[get-module-suffixes].}
 
 ]
@@ -142,7 +143,7 @@ collection.  The following fields are used:
 
 
 @defproc[(compile-directory-zos [path path-string?]
-                                [info ()]
+                                [info procedure?]
                                 [#:verbose verbose? any/c #f]
                                 [#:skip-path skip-path (or/c path-string? #f) #f]
                                 [#:skip-paths skip-paths (listof path-string?) null]
@@ -167,7 +168,7 @@ recognizing file suffixes that correspond to Racket modules for the
 purposes of compiling files in a directory, running tests for files in
 a directory, and so on. The set of suffixes always includes
 @filepath{.rkt}, @filepath{.ss}, and @filepath{.scm}, but it can be
-extended globally by @filepath{info.rkt} configuration in collections.}
+extended globally by @filepath{info.rkt} configurations in collections.}
 
 @history[#:added "6.3"]
 

--- a/pkgs/racket-doc/scribblings/raco/bundle-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/bundle-api.scrbl
@@ -23,7 +23,7 @@ archive.}
          void?]{
 
 Packages @racket[dir] into @racket[dist-file]. If @racket[dist-file]
-has no extension, a file extension is added automatcially (using the
+has no extension, a file extension is added automatically (using the
 first result of @racket[bundle-put-file-extension+style+filters]).
 
 The created archive contains a directory with the same name as

--- a/pkgs/racket-doc/scribblings/raco/c-mods.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/c-mods.scrbl
@@ -18,7 +18,7 @@ program can embed Racket with a set of modules so that it does not
 need a @filepath{collects} directory to load modules at run time.
 
 If the embedded modules refer to runtime files, the files can be
-gathers by supplying the @DFlag{runtime} argument to @exec{raco ctool
+gathered by supplying the @DFlag{runtime} argument to @exec{raco ctool
 --cmods}, specifying a directory @nonterm{dir} to hold the files.
 Normally, @nonterm{dir} is a relative path, and files are found at run
 time in @nonterm{dir} relative to the executable, but a separate path

--- a/pkgs/racket-doc/scribblings/raco/command.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/command.scrbl
@@ -1,6 +1,6 @@
 #lang scribble/doc
 @(require scribble/manual "common.rkt"
-          (for-label racket/base raco/command-name racket/cmdline))
+          (for-label racket/base raco/all-tools raco/command-name racket/contract/base racket/cmdline))
 
 @title[#:tag "command"]{Adding a @exec{raco} Command}
 
@@ -11,8 +11,8 @@ command is added by defining @indexed-racket[raco-commands] in the
 and then @exec{raco setup} (as called directly or as part of a package
 or @|PLaneT| installation) must index the @filepath{info.rkt} file.
 
-The value bound to @racket[raco-commands] must be a list of command
-specifications, where each specification is a list of four values:
+The value bound to @racket[raco-commands] must be a list of @deftech{command
+specifications}, where each specification is a list of four values:
 
 @racketblock[
    (list _command-string
@@ -40,7 +40,7 @@ The @racket[_description-string] is a short string used to describe the
 command in response to @exec{raco help}. The description should not be
 capitalized or end with a period.
 
-The @racket[_prominence] value should be a read number or
+The @racket[_prominence] value should be a real number or
 @racket[#f]. A @racket[#f] value means that the command should not be
 included in the short list of ``frequently used commands.'' A number
 indicates the relative prominence of the command; the @exec{help}
@@ -113,3 +113,23 @@ so that @exec{raco decompile --help} prints
 
 Like @racket[short-program+command-name], but the path (if any) is not
 stripped from the current executable's name.}
+
+@section{Accessing @exec{raco} Commands}
+
+@defmodule[raco/all-tools]{The @racketmodname[raco/all-tools]
+library collects the @indexed-racket[raco-commands] specifications for
+installed packages, @|PLaneT| packages, and other collections.}
+
+@defproc[(all-tools) (hash/c string? (list/c string? module-path? string? (or/c real? #f)))]{
+Returns a hashtable with collection names as keys and @tech{command specifications} as values.
+For example, the following program invokes @exec{raco make file.rkt}:
+@racketblock[
+  (require raco/all-tools)
+
+  (define raco-make-spec (hash-ref (all-tools) "make"))
+
+  (parameterize ([current-command-line-arguments (vector "file.rkt")])
+    (dynamic-require (second raco-make-spec) #f))
+]
+}
+

--- a/pkgs/racket-doc/scribblings/raco/config.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/config.scrbl
@@ -166,7 +166,7 @@ directory}:
        is @racket[""], otherwise it is @racket["CGC"].}
 
  @item{@indexed-racket['3m-suffix] --- analogous to @racket['cgc-suffix], but
-       for 3m. A @racket[#f] value means that if the @filepath{racket}
+       for 3m. A @racket[#f] value means that if the @exec{racket}
        binary identifies itself as CGC, then the suffix is
        @racket["3m"], otherwise it is @racket[""].}
 

--- a/pkgs/racket-doc/scribblings/raco/demod.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/demod.scrbl
@@ -3,10 +3,10 @@
 
 @title[#:tag "demod"]{@exec{raco demod}: Demodularizing Programs}
 
-The @exec{raco demod} command takes a racket module and flattens 
+The @exec{raco demod} command takes a Racket module and flattens
 all of its dependencies into a single compiled module. 
 A file @filepath{@nonterm{name}.rkt} is demodularized into 
 @filepath{@nonterm{name}_rkt_merged.zo}.
 
 The demodularized zo file can be run by passing it as an argument to
-the racket command-line program.
+the @exec{racket} command-line program.

--- a/pkgs/racket-doc/scribblings/raco/exe-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe-api.scrbl
@@ -161,7 +161,7 @@ embeds the module @racket[m] from the file @filepath{m.rkt}, without
 prefixing the name of the module; the @racket[literal-sexpr] argument
 to go with the above might be @racket['(require m)]. When submodules
 are available and included, the submodule is given a name by
-symbol-appending the @racket[write] form of submodule path to the
+symbol-appending the @racket[write] form of the submodule path to the
 enclosing module's name.
 
 Modules are normally compiled before they are embedded into the target
@@ -233,7 +233,7 @@ currently supported keys are as follows:
   @item{@racket['framework-root] (Mac OS) : A string to prefix the
         executable's path to the Racket and GRacket frameworks
         (including a separating slash); note that when the prefix
-        starts @filepath{@"@"executable_path/} works for a
+        start @filepath{@"@"executable_path/} works for a
         Racket-based application, the corresponding prefix start for
         a GRacket-based application is
         @filepath{@"@"executable_path/../../../}; if @racket[#f] is
@@ -297,7 +297,7 @@ created executable maintains its built-in (relative) path to the main
 @racket[(find-system-path 'collects-dir)] when the executable is
 run---plus a potential list of other directories for finding library
 collections---which are used to initialize the
-@racket[current-library-collection-paths] list in combination with
+@racket[current-library-collection-paths] list in combination with the
 @envvar{PLTCOLLECTS} environment variable.  Otherwise, the argument
 specifies a replacement; it must be either a path, string, or
 list of paths and strings. In the last case, the first path
@@ -313,7 +313,7 @@ is initialized to an empty list, and
 use of @tech[#:doc reference-doc]{collection links files}.
 
 If the @racket[#:launcher?] argument is @racket[#t], then
-@racket[lid-list] should be null, @racket[literal-files] should be
+@racket[mod-list] should be null, @racket[literal-files] should be
 null, @racket[literal-sexp] should be @racket[#f], and the platform
 should be Windows or Mac OS. The embedding executable is created in
 such a way that @racket[(find-system-path 'exec-file)] produces the
@@ -439,7 +439,7 @@ Returns three values suitable for use as the @racket[extension],
 respectively.
 
 If Racket/GRacket launchers for the current platform were directories
-form the user's perspective, the @racket[style] result is suitable for
+from the user's perspective, the @racket[style] result is suitable for
 use with @racket[get-directory], and the @racket[extension] result may
 be a string indicating a required extension for the directory name. }
 

--- a/pkgs/racket-doc/scribblings/raco/exe.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe.scrbl
@@ -107,7 +107,7 @@ The @exec{raco exe} command accepts the following command-line flags:
    to the executable. The default is to have no path, which means that
    the @racket[current-library-collection-paths] and
    @racket[current-library-collection-links] parameters are
-   initialized at empty when the executable starts. Beware that
+   initialized as @racket[null] when the executable starts. Beware that
    various other directories are located relative to the @tech{main
    collection directory} by default (see @secref["config-file"]), so
    that installing @nonterm{path} may allow other directories to be

--- a/pkgs/racket-doc/scribblings/raco/launcher.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/launcher.scrbl
@@ -50,7 +50,7 @@ the following additional associations apply to launchers:
 @itemize[
 
  @item{@racket['independent?] (Windows) --- a boolean; @racket[#t]
-       creates an old-style launcher that work with any
+       creates an old-style launcher that works with any
        Racket or GRacket binary, like @exec{raco.exe}. No other
        @racket[aux] associations are used for an old-style launcher.}
 
@@ -335,7 +335,7 @@ platforms.}
 
 @defproc[(racket-launcher-is-actually-directory?) boolean?]{
 
-Like @racket[gracket-launcher-is-actuall-directory?], but for Racket
+Like @racket[gracket-launcher-is-actually-directory?], but for Racket
 launchers. The result is @racket[#f] for all platforms.}
 
 
@@ -358,7 +358,7 @@ Returns three values suitable for use as the @racket[extension],
 @racket[style], and @racket[filters] arguments to @racket[put-file],
 respectively.
 
-If GRacket launchers for the current platform were directories form the
+If GRacket launchers for the current platform were directories from the
 user's perspective, the @racket[style] result is suitable for use with
 @racket[get-directory], and the @racket[extension] result may be a
 string indicating a required extension for the directory name. }
@@ -508,7 +508,7 @@ are as follows:
  @item{@filepath{.extreg} @'rarr @racket['extension-register] as
        @racket[read] content (a single S-expression), but with
        relative (to the @filepath{.extreg} file) paths converted
-       absolute; for use on Windows}
+       to absolute paths; for use on Windows}
 
 ]}
 

--- a/pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -12,6 +12,7 @@
                      compiler/compilation-path
                      compiler/compile-file
                      syntax/modread
+                     (only-in racket/unit define-signature)
                      (only-in compiler/compiler compile-zos)))
 
 
@@ -268,7 +269,7 @@ consistent with the caching of the default module name resolver (see
 
 If @racket[use-compiled-file-paths] contains an empty list when
 @racket[make-compilation-manager-load/use-compiled-handler] is called,
-then @racket[exn:fail:contract] exception is raised.
+then an @racket[exn:fail:contract] exception is raised.
 
 If the @racket[delete-zos-when-rkt-file-does-not-exist?] argument is a true
 value, then the returned handler will delete @filepath{.zo} files
@@ -282,7 +283,7 @@ the security guard in the @racket[current-security-guard] when
 the files are created is used (not the security guard at the point 
 @racket[make-compilation-manager-load/use-compiled-handler] is called).
 
-The continuation the compilation of a module is marked with a
+The continuation of the compilation of a module is marked with a
 @racket[managed-compiled-context-key] and the module's source path.
 
 @emph{Do not} install the result of
@@ -300,7 +301,6 @@ structure:
 @racketblock[
   (struct compile-event (timestamp path type) #:prefab)
 ]
-
 The @racket[timestamp] field is the time at which the event occured in
 milliseconds since the epoch.  The @racket[path] field is the path of a file
 being compiled for which the event is about. The @racket[type] field is a symbol
@@ -311,7 +311,7 @@ are @racket['locking], @racket['start-compile], @racket['finish-compile], and
 @history[#:changed "6.1.1.8" @elem{Added identification of the compilation
                                     context via @racket[managed-compiled-context-key].}
          #:changed "6.6.0.3" @elem{added check on a source's SHA1 hash to complement the
-                                   timestamp check, where the altter can be disabled
+                                   timestamp check, where the latter can be disabled
                                    via @racket[use-compile-file-check].}]}
 
 
@@ -363,7 +363,7 @@ to the module's source.
           [orig-handlers (string? any/c . -> . void?)])
          (string? any/c . -> . void?)]{
 
-Produces a handler suitable for use as a
+Produces a handler suitable for use as an
 @racket[error-display-handler] value, given an existing such value.
 The generated handler shows information about the compilation context
 when the handler's second argument is an exception whose continuation
@@ -402,7 +402,7 @@ A parameter for a procedure of one argument that is called to report
  the procedure is a string.
  
  The default value of the parameter logs the argument, along with 
- @racket[current-inexact-milliseconds] to, a logger named @racket['compiler/cm]
+ @racket[current-inexact-milliseconds], to a logger named @racket['compiler/cm]
  at the @racket['debug] level.
  }
 
@@ -529,7 +529,7 @@ result will not call @racket[proc] with @racket['unlock].)
          (-> (or/c 'lock 'unlock) bytes? boolean?)]{
 
   Returns a function that follows the @racket[parallel-lock-client]
-  by communicating over @racket[pc]. The argument must have 
+  by communicating over @racket[pc]. The argument must
   be the result of @racket[make-compile-lock].
   
   This communication protocol implementation is not kill safe. To make it kill safe,
@@ -544,7 +544,7 @@ result will not call @racket[proc] with @racket['unlock].)
 @defproc[(make-compile-lock) place-channel?]{
   Creates a @racket[place-channel?] that can be used with
             @racket[compile-lock->parallel-lock-client] to avoid concurrent
-            compilations of the same racket source files in multiple places.
+            compilations of the same Racket source files in multiple places.
 }
 
 @defproc[(install-module-hashes! [bstr btyes?]
@@ -576,9 +576,8 @@ messages are instances of a @racket[parallel-compile-event] prefab structure:
 @racketblock[
   (struct parallel-compile-event (worker event) #:prefab)
 ]
-
 The worker field is the index of the worker that the created the event. The event
-field is a @racket[compile-event] as document in
+field is a @racket[compile-event] as documented in
 @racket[make-compilation-manager-load/use-compiled-handler].
 
 
@@ -629,7 +628,7 @@ The return value is @racket[(void)] if it was successful, or @racket[#f] if ther
                       [_prefix string?] 
                       [_exn (or/c exn? (cons/c string? string?) #f)]
                       [_out string?]
-                      [_err srtring?]
+                      [_err string?]
                       [_message string?])
                      void?)]
   [collects-tree (listof any/c)])  (void)]{
@@ -639,10 +638,10 @@ compile collections in parallel. The @racket[worker-count] argument
 specifies the number of compilation workers to spawn during parallel
 compilation. The @racket[setup-fprintf] and @racket[append-error]
 functions communicate intermediate compilation results and errors. The
-@racket[collects-tree] argument is a compound datastructure containing
+@racket[collects-tree] argument is a compound data structure containing
 an in-memory tree representation of the collects directory.
 
-When the @racket[_exn] argument to @racket[append-error] is a part of
+When the @racket[_exn] argument to @racket[append-error] is a pair of
 strings, the first string is a long form of the error message, and the
 second string is a short form (omitting evaluation context
 information, for example).
@@ -748,7 +747,7 @@ See also @racket[managed-compile-zo].}
          (values path? path?)]{
 
 Determines the directory that holds the bytecode form of @racket[path]
-plus base name of @racket[path].
+plus the base name of @racket[path].
 
 The directory is determined by checking @racket[roots] in order, and
 for each element of @racket[roots] checking @racket[modes] in order.
@@ -781,7 +780,7 @@ path.}
 The @DFlag{no-deps} mode for @exec{raco make} is an improverished
 form of the compilation, because it does not track import
 dependencies. It does, however, support compilation of non-module
-source in an namespace that initially imports @racketmodname[scheme].
+source in a namespace that initially imports @racketmodname[scheme].
 
 Outside of a module, top-level @racket[define-syntaxes],
 @racket[module], @racket[#%require],

--- a/pkgs/racket-doc/scribblings/raco/setup.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/setup.scrbl
@@ -221,7 +221,7 @@ flags:
   (as opposed to installation-specific) setup actions.}
 
  @item{@DFlag{no-planet} --- refrain from any setup actions for
-  @|PLaneT| actions; this flags is implied by @DFlag{no-user}.}
+  @|PLaneT| actions; this flag is implied by @DFlag{no-user}.}
 
  @item{@DFlag{avoid-main} --- refrain from any setup actions that
   affect the installation, as opposed to user-specific actions.}
@@ -316,7 +316,7 @@ installed as a package using @exec{raco pkg} (see @other-manual['(lib
 facilities for uninstalling the package and managing dependencies.
 
 An older approach is to supply a @filepath{.plt} file to @exec{raco
-setup} with the @Flag{A} flag, the files contained in the
+setup} with the @Flag{A} flag; the files contained in the
 @filepath{.plt} archive are unpacked (according to specifications
 embedded in the @filepath{.plt} file) and only collections specified
 by the @filepath{.plt} file are compiled and setup. Archives processed
@@ -361,7 +361,7 @@ Optional @filepath{info.rkt} fields trigger additional actions by
 
    More precisely a @racketidfont{scribblings} entry must be a value
    that can be generated from an expression matching the following
-   @racket[entry] grammar:
+   @racket[_entry] grammar:
 
    @racketgrammar*[
      #:literals (list)
@@ -417,16 +417,16 @@ Optional @filepath{info.rkt} fields trigger additional actions by
            is not itself located in the main installation.}
 
      @item{@racket['depends-all] : Indicates that the document should
-           be re-built if any other document is rebuilt---except for
+           be rebuilt if any other document is rebuilt---except for
            documents that have the @racket['no-depend-on] flag.}
 
      @item{@racket['depends-all-main] : Indicates that the document
-           should be re-built if any other document is rebuilt that is
+           should be rebuilt if any other document is rebuilt that is
            installed into the main installation---except for documents
            that have the @racket['no-depend-on] flag.}
 
      @item{@racket['depends-all-user] : Indicates that the document
-           should be re-built if any other document is rebuilt that is
+           should be rebuilt if any other document is rebuilt that is
            installed into the user's space---except for documents
            that have the @racket['no-depend-on] flag.}
 
@@ -561,7 +561,7 @@ Optional @filepath{info.rkt} fields trigger additional actions by
 
    A @racketidfont{release-note-files} entry must be a value
    that can be generated from an expression matching the following
-   @racket[entry] grammar:
+   @racket[_entry] grammar:
 
    @racketgrammar*[
      #:literals (list)
@@ -814,7 +814,7 @@ Optional @filepath{info.rkt} fields trigger additional actions by
 When @exec{raco setup} is run with no arguments,@margin-note*{Unless
 @DFlag{check-pkg-deps} is specified, dependency checking is disabled
 if any collection is specified for @exec{raco setup}.} after building
-all collections and documentation, @exec{raco setup} check package
+all collections and documentation, @exec{raco setup} checks package
 dependencies. Specifically, it inspects compiled files and
 documentation to check that references across package boundaries are
 reflected by dependency declarations in each package-level
@@ -874,7 +874,7 @@ cooperate with @racket[raco make] are visible for dependency checking.
 
 Dependency checking is sensitive to whether a dependency is needed
 only as a build-time dependency. If @exec{raco setup} detects that a
-missing dependency could be added as a built-time dependency, it will
+missing dependency could be added as a build-time dependency, it will
 suggest the addition, but @exec{raco setup} will not suggest
 converting a normal dependency to a build-time dependency (since every
 normal dependency counts as a build-time dependency, too).
@@ -931,7 +931,7 @@ Runs @exec{raco setup} with various options:
        assuming that documentation is built}
 
  @item{@racket[force-user-docs?] --- if true, then when building
-       documentation, create a user-specific documentation entry point
+       documentation, creates a user-specific documentation entry point
        even if it has the same content as the installation}
 
  @item{@racket[clean?] --- if true, enables cleaning mode instead of setup mode}
@@ -1030,7 +1030,7 @@ form.}
   }
   
 @defboolparam[verbose on?]{
-  If on, prints message from @exec{make} to @envvar{stderr}.
+  If on, prints messages from @exec{make} to @envvar{stderr}.
   @defaults[@racket[#f]]}
 
 @defboolparam[make-verbose on?]{
@@ -1141,7 +1141,7 @@ form.}
 @defboolparam[archive-implies-reindex on?]{
   If on, when @racket[archives] has a non-empty list of packages, if any
   documentation is built, then suitable documentation start pages, search pages,
-  and master index pages are re-built. @defaults[@racket[#t]]}
+  and master index pages are rebuilt. @defaults[@racket[#t]]}
 
 @defparam[current-target-directory-getter thunk (-> path-string?)]{
   A thunk that returns the target directory for unpacking a relative
@@ -1280,7 +1280,7 @@ function for installing a single @filepath{.plt} file.
 
 @defproc[(get-links-search-files) path?]{
   Returns a list of paths to installation @tech[#:doc
-  reference-doc]{collection links files} that are search in
+  reference-doc]{collection links files} to search in
   order. (Normally, the result includes the result of
   @racket[(find-links-file)], which is where new installation-wide
   links are installed by @exec{raco link} or @racket[links].) The
@@ -1512,7 +1512,7 @@ function for installing a single @filepath{.plt} file.
                #f)]{
 
    Accepts a path to a directory. If it finds either a well-formed
-   an @filepath{info.rkt} file or an @filepath{info.ss} file (with
+   @filepath{info.rkt} file or an @filepath{info.ss} file (with
    preference for the @filepath{info.rkt} file), 
    it returns an info procedure that accepts either one
    or two arguments. The first argument to the info procedure is
@@ -1532,8 +1532,8 @@ function for installing a single @filepath{.plt} file.
    is raised. If the @filepath{info.rkt} file loaded, @racket[get-info/full]
    returns the @racket[get-info] file. If the @filepath{info.rkt} file does not exist, 
    then @racket[get-info/full] does
-   the same checks for the @filepath{info.rkt} file, either raising an exception
-   or returning the @racket[get-info] function from the @filepath{info.rkt} file.
+   the same checks for the @filepath{info.ss} file, either raising an exception
+   or returning the @racket[get-info] function from the @filepath{info.ss} file.
 
    The @filepath{info.rkt} (or @filepath{info.ss}) module is loaded
    into @racket[namespace] if it is not @racket[#f], or a private,
@@ -1580,7 +1580,7 @@ function for installing a single @filepath{.plt} file.
    If @racket[mode] is specified, it must be either
    @racket['preferred] (the default), @racket['all-available],
    @racket['no-planet], or @racket['no-user]. If @racket[mode] is
-   @racket['all-available], @racket[find-relevant-collections] returns
+   @racket['all-available], @racket[find-relevant-directories] returns
    all installed directories whose info files contain the specified
    symbols---for instance, all versions of all installed PLaneT
    packages will be searched if @racket['all-available] is
@@ -1590,7 +1590,7 @@ function for installing a single @filepath{.plt} file.
    will be returned. If @racket[mode] is @racket['no-planet], then
    PLaneT packages are not included in the search. If @racket[mode] is
    @racket['no-user], then only installation-wide directories are
-   search, which means omitting @|PLaneT| package directories.
+   searched, which means omitting @|PLaneT| package directories.
 
    Collection links from the installation-wide @tech[#:doc
    reference-doc]{collection links file} or packages with installation
@@ -1604,7 +1604,7 @@ function for installing a single @filepath{.plt} file.
 
 @defproc[(find-relevant-directory-records
           [syms (listof symbol?)]
-          [key (or/c 'preferred 'all-available)])
+          [key (or/c 'preferred 'all-available 'no-planet 'no-user)])
          (listof directory-record?)]{
   Like @racket[find-relevant-directories], but returns @racket[directory-record] structs
   instead of @racket[path?]s.
@@ -1618,7 +1618,7 @@ function for installing a single @filepath{.plt} file.
   A struct that records information about a collection or a @PLaneT package that has been installed.
   Collections will have the major version being @racket[1] and the minor version being @racket[0].
   The @racket[spec] field is a quoted module spec; the @racket[path] field is where the @tt{info.rkt}
-  file for this collection or @PLaneT package exists on the filesystem the @racket[syms] field holds the 
+  file for this collection or @PLaneT package exists on the filesystem; the @racket[syms] field holds the
   identifiers defined in that file.
 }
 

--- a/pkgs/racket-doc/scribblings/raco/unpack.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/unpack.scrbl
@@ -25,7 +25,7 @@ Command-line flags:
        before unpacking or listing the archive content.}
 
  @item{@Flag{f} or @DFlag{force} --- replace files that exist already;
-       fails that the archive says should be replaced will be replaced
+       files that the archive says should be replaced will be replaced
        without this flag.}
 
 ]
@@ -103,7 +103,7 @@ while the second will refer to the main installation.}
 Traverses the content of @racket[archive], which must be a
 @filepath{.plt} archive that is created with the default unpacking
 unit and configuration expression. The configuration expression is not
-evaluated, the unpacking unit is not invoked, and not files are
+evaluated, the unpacking unit is not invoked, and files are not
 unpacked to the filesystem. Instead, the information in the archive is
 reported back through @racket[on-config], @racket[on-setup-unit],
 @racket[on-directory], and @racket[on-file], each of which can build on
@@ -113,7 +113,7 @@ final value is returned.
 The @racket[on-config-fn] function is called once with an S-expression
 that represents a function to implement configuration information.
 The second argument to @racket[on-config] is @racket[initial-value],
-and the function's result is passes on as the last argument to @racket[on-setup-unit].
+and the function's result is passed on as the last argument to @racket[on-setup-unit].
 
 The @racket[on-setup-unit] function is called with the S-expression
 representation of the installation unit, an input port that points to

--- a/pkgs/racket-doc/scribblings/raco/zo-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/zo-struct.scrbl
@@ -90,7 +90,7 @@ structures that are produced by @racket[zo-parse] and consumed by
   
   When an element of @racket[stxs] is @racket[#f], it coresponds to a
   syntax object that was optimized away at the last minute. The slot
-  must not be referenced vt a @racket[topsyntax] form.
+  must not be referenced by a @racket[topsyntax] form.
 
   The @racket[src-inspector-desc] field provides an inspector name that
   is used within syntax-object bindings. At run time, the prefix gets
@@ -278,7 +278,7 @@ binding, constructor, etc.}
   created by @racket[body] forms (not counting the @racket[prefix]
   array).
   
-  The @racket[dummy] variable is used to access to the top-level
+  The @racket[dummy] variable is used to access the top-level
   namespace.
 
   The @racket[lang-info] value specifies an optional module path that
@@ -643,7 +643,7 @@ binding, constructor, etc.}
   run-time path. The @racket[simple-scopes] field records scopes that
   are attached to the syntax object at all phases, and @racket[multi-scopes]
   records phase-specific scopes (which are always attached as a group)
-  along with a phase shift for every scope within the group).}
+  along with a phase shift for every scope within the group.}
 
 @defstruct+[(module-shift zo) ([from (or/c #f module-path-index?)]
                                [to (or/c #f module-path-index?)]


### PR DESCRIPTION
The point of this PR was to put `raco/all-tools` in the docs, but it turns out most of the edits are typo fixes.