### PR TITLE
delete unnecessary linebreak

### DIFF
--- a/pkgs/racket-index/scribblings/main/start.scrbl
+++ b/pkgs/racket-index/scribblings/main/start.scrbl
@@ -17,7 +17,6 @@
     (or @exec{Racket Documentation} on Windows or Mac OS)
     may open a different page with local and user-specific
     documentation, including documentation for installed packages.
-
     @elem[#:style path-info-style]{Searching or following a
      ``top'' link will use go to a different starting point that
      includes user-specific information.


### PR DESCRIPTION
To obviate this problem on the `docs` server where there ends up being an empty paragraph in the margin note, which creates extra space at the bottom of the box:

![screen shot 2017-01-10 at jan 10 11 41 54 am](https://cloud.githubusercontent.com/assets/1425051/21821841/dc1f4634-d729-11e6-8ccb-7cad01d3f015.gif)

Without the linebreak, it will look like so:

![screen shot 2017-01-10 at jan 10 11 45 44 am](https://cloud.githubusercontent.com/assets/1425051/21821993/62ebff0e-d72a-11e6-8f3c-b13967a1cbba.gif)

The linebreak, and the `p` tag it impliedly imposes, is unnecessary because the lower half of this margin note is inside a `span` that has a `display:block` CSS style explicitly imposed in the tag, so it’s still spaced properly when it’s revealed.

![screen shot 2017-01-10 at jan 10 11 43 36 am](https://cloud.githubusercontent.com/assets/1425051/21821943/39f5f12c-d72a-11e6-9688-5316a9d07317.gif)
 