### PR TITLE
docs: Clarify order of arguments for stream-fold

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1088,7 +1088,8 @@ stream, but plain lists can be used as streams, and functions such as
          any/c]{
   Folds @racket[f] over each element of @racket[s] with @racket[i] as
   the initial accumulator.  If @racket[s] is infinite, this function
-  does not terminate.
+  does not terminate. The @racket[f] function takes the accumulator as
+  its first argument and the next stream element as its second.
 }
 
 @defproc[(stream-count [f procedure?] [s stream?])


### PR DESCRIPTION
`stream-fold` is implemented in terms of `sequence-fold`, which documents the order of arguments to the procedure `f`, but `stream-fold` doesn't. This tripped up one of our students (who was expecting it to be the same order as `foldl`). 