### PR TITLE
Fix wrap-expr/c and expr/c to reflect their intended use

### DIFF
--- a/racket/collects/syntax/contract.rkt
+++ b/racket/collects/syntax/contract.rkt
@@ -19,6 +19,27 @@
         #:context (or/c syntax? #f))
        syntax?)])
 
+(module macro-arg/c racket/base
+  (require racket/contract/base
+           racket/contract/combinator)
+
+  (provide macro-arg/c)
+
+  (define (macro-arg/c macro-name ctc)
+    (let ([ctc-project (get/build-late-neg-projection (coerce-contract 'wrap-expr/c ctc))])
+      ((cond [(flat-contract? ctc) make-flat-contract]
+             [(chaperone-contract? ctc) make-chaperone-contract]
+             [else make-contract])
+       #:name (contract-name ctc)
+       #:first-order (contract-first-order ctc)
+       #:late-neg-projection
+       (λ (blame)
+         (let ([blame* (if macro-name (blame-add-context blame #f #:important macro-name) blame)])
+           (ctc-project (blame-swap blame*))))
+       #:list-contract? (list-contract? ctc)))))
+
+(require (for-template 'macro-arg/c))
+
 (define (wrap-expr/c ctc-expr expr
                      #:positive [pos-source 'use-site]
                      #:negative [neg-source 'from-macro]
@@ -31,42 +52,47 @@
          [neg-source-expr
           (get-source-expr neg-source
                            (if (identifier? macro-name) macro-name ctx))]
+         [expr-name
+          (if (identifier? expr-name)
+              (syntax-e expr-name)
+              expr-name)]
          [macro-name
           (cond [(identifier? macro-name) (syntax-e macro-name)]
                 [(or (string? macro-name) (symbol? macro-name)) macro-name]
                 [(syntax? ctx)
                  (syntax-case ctx ()
                    [(x . _) (identifier? #'x) (syntax-e #'x)]
-                   [x (identifier? #'#'x)]
+                   [x (identifier? #'x) (syntax-e #'x)]
                    [_ #f])]
                 [else #f])])
-    (base-wrap-expr/c expr ctc-expr
-                      #:positive #'(quote-module-name)
+    (base-wrap-expr/c expr #`(macro-arg/c '#,macro-name #,ctc-expr)
+                      #:positive pos-source-expr
                       #:negative neg-source-expr
-                      #:expr-name (cond [(and expr-name macro-name)
-                                          (format "~a of ~a" expr-name macro-name)]
-                                         [expr-name expr-name]
-                                         [else #f])
+                      #:expr-name (cond [(and macro-name expr-name)
+                                         (format "~a of ~a" expr-name macro-name)]
+                                        [(or macro-name expr-name)
+                                         => (λ (name) (format "~a" name))]
+                                        [else #f])
                       #:source #`(quote-syntax #,expr))))
 
 (define (base-wrap-expr/c expr ctc-expr
                           #:positive positive
                           #:negative negative
-                          #:expr-name [expr-name #f]
-                          #:source [source #f])
+                          #:expr-name expr-name
+                          #:source source)
   (let ([expr-name (or expr-name #'#f)]
         [source (or source #'#f)])
     (quasisyntax/loc expr
       (contract #,ctc-expr
                 #,expr
-                #,positive
                 #,negative
+                #,positive
                 #,expr-name
                 #,source))))
 
 (define (get-source-expr source ctx)
   (cond [(eq? source 'use-site)
-         #'(quote-module-name)]
+         #'(quote-module-path)]
         [(eq? source 'unknown)
          #'(quote "unknown")]
         [(eq? source 'from-macro)


### PR DESCRIPTION
The `expr/c` syntax class, as well as its underlying implementation function, `wrap-expr/c`, currently produces misleading error messages. The main purpose of these two utilities is to ensure a user-provided expression conforms to a macro-provided contract. However, contract errors produced by these forms are consistent with situations where both value and contract were provided by the same party.

These changes fix the discrepancy by changing how these forms assign blame to emulate contract errors that arise from improper function arguments, since most expressions provided to macros are semantically similar to function arguments. All examples within the existing documentation itself reflect this use case.

For a comparison between error messages, take a look at [the documentation for `wrap-expr/c`](http://docs.racket-lang.org/syntax/wrapc.html#%28def._%28%28lib._syntax%2Fcontract..rkt%29._wrap-expr%2Fc%29%29) for examples. Before these changes, the first two contract errors are as follows:

```
the parameter argument of myparameterize1: broke its own
contract
  promised: parameter?
  produced: 'whoops
  in: parameter?
  contract from: top-level
  blaming: top-level
   (assuming the contract is correct)
  at: eval:4.0

the function argument of app: contract violation
  expected: number?
  given: 'apple
  in: the 1st argument of
      (-> number? number?)
  contract from: top-level
  blaming: (quote mod)
   (assuming the contract is correct)
  at: eval:8.0
```

After the changes, the messages change to these:

```
myparameterize1: contract violation
  expected: parameter?
  given: 'whoops
  in: parameter?
  contract from: top-level
  contract on: the parameter argument of myparameterize1
  blaming: top-level
   (assuming the contract is correct)
  at: eval:4.0

app: broke its own contract
  promised: number?
  produced: 'apple
  in: the 1st argument of
      (-> number? number?)
  contract from: top-level
  contract on: the function argument of app
  blaming: top-level
   (assuming the contract is correct)
  at: eval:8.0
```

Note two important differences:

  1. For the first error—the one involving `myparameterize`—the old error message incorrectly indicates that the contract error was user-supplied (by using the wording “broke its own contract”). The new error message correctly treats the contract as distinct from the client code.

  2. For the second other error, the old error message technically blamed the correct party, but the beginning of the contract error implicated precisely the *wrong* party, implying that the user-provided function did not conform to its contract. The new contract error is much clearer, indicating that the error is the fault of the macro itself, not its client.

Since these changes alter the contents of error messages raised by `expr/c` and `wrap-expr/c`, they could theoretically break some test suites. However, it’s extremely unlikely that any non-test code would depend on the precise wording of contract error messages, and the interface is otherwise completely backwards-compatible.

This is related to a discussion I had on slack with @rfindler, but this particular piece of code is probably owned by @rmculpepper.

fixes #1412