### PR TITLE
Fix “git-checkout”

### DIFF
--- a/racket/collects/net/git-checkout.rkt
+++ b/racket/collects/net/git-checkout.rkt
@@ -745,7 +745,8 @@
                    #:ssl? (if (eq? transport 'https)
                               (ssl-context verify?)
                               #f)
-                   #:port port)
+                   #:port port
+                   #:auto-reconnect? #t)
   
   (define packfiles
     (get-packfile-list conn repo))


### PR DESCRIPTION
Closes https://github.com/racket/racket/issues/1616

I added `http-conn-sendrecv!/reuse` to `net/http-client`. Using it, the following snippet works:

```racket
#lang racket
(require net/http-client)

(define conn (http-conn))
(http-conn-open! conn "git.leafac.com" #:ssl? 'secure #:port 443)
(http-conn-sendrecv!/reuse conn "git.leafac.com" "/" #:ssl? 'secure #:port 443)
(http-conn-live? conn) ; => #f
(http-conn-sendrecv!/reuse conn "git.leafac.com" "/" #:ssl? 'secure #:port 443)
```

I’m asking for your (@mflatt, @jeapostrophe, and anyone else that is interested) feedback on this approach before I proceed with the following tasks:

**EDIT**: The following tasks became stale, as we decided to go with a different approach. See conversation below.

- [x] Adapt `net/git-checkout` to use `http-conn-sendrecv!/reuse` in `read-dumb-objects`.
- [x] Write automated tests for `http-conn-sendrecv!/reuse`.
- [x] Document `http-conn-sendrecv!/reuse`.

------

@jeapostrophe: I decided to go with `http-conn-sendrecv!/reuse` instead of `http-conn-open/reuse` because it is a smaller change to `http-client`. In particular, to implement `http-conn-open/reuse` I would have to change the `http-conn` struct itself, to keep around the `host` (which is lost on `http-conn-close!`) and `ssl?` (which is never stored in `http-conn` in the first place).

The benefit of this approach is that users **have control** over how the reconnection might happen. For example, they might want change the policy of SSL validation upon reconnection. The problem with this approach is that users **have to control** how the reconnection might happen. In `net/git-checkout`, for example, this means keeping `host`, `ssl?` and `port` around, even after `http-conn-open!`.

------

Thank you for your feedback.