### PR TITLE
Add integer predicates to `racket/math`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -1299,7 +1299,7 @@ Returns @racket[#t] if @racket[x] is @racket[+inf.0], @racket[-inf.0], @racket[+
  @racket[#t] for non-negative @racket[inexact?] integers.}
 
 @defproc[(natural? [x any/c]) boolean?]{
- An alias for @racket[nonnegative-integer?].}
+ An alias for @racket[exact-nonnegative-integer?].}
 
 @; ----------------------------------------------------------------------
 @close-eval[math-eval]

--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -1280,7 +1280,23 @@ Returns @racket[#t] if @racket[x] is @racket[eqv?] to @racket[+nan.0] or @racket
 
 @defproc[(infinite? [x real?]) boolean?]{
 
-Returns @racket[#t] if @racket[z] is @racket[+inf.0], @racket[-inf.0], @racket[+inf.f], @racket[-inf.f]; otherwise @racket[#f].}
+Returns @racket[#t] if @racket[x] is @racket[+inf.0], @racket[-inf.0], @racket[+inf.f], @racket[-inf.f]; otherwise @racket[#f].}
+
+@defproc[(positive-integer? [x any/c]) boolean?]{
+ Like @racket[exact-positive-integer?], but also returns
+ @racket[#t] for positive @racket[inexact?] integers.}
+
+@defproc[(negative-integer? [x any/c]) boolean?]{
+ Like @racket[exact-negative-integer?], but also returns
+ @racket[#t] for negative @racket[inexact?] integers.}
+
+@defproc[(nonpositive-integer? [x any/c]) boolean?]{
+ Like @racket[exact-nonpositive-integer?], but also returns
+ @racket[#t] for non-positive @racket[inexact?] integers.}
+
+@defproc[(nonnegative-integer? [x any/c]) boolean?]{
+ Like @racket[exact-nonnegative-integer?], but also returns
+ @racket[#t] for non-negative @racket[inexact?] integers.}
 
 @; ----------------------------------------------------------------------
 @close-eval[math-eval]

--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -1298,6 +1298,9 @@ Returns @racket[#t] if @racket[x] is @racket[+inf.0], @racket[-inf.0], @racket[+
  Like @racket[exact-nonnegative-integer?], but also returns
  @racket[#t] for non-negative @racket[inexact?] integers.}
 
+@defproc[(natural? [x any/c]) boolean?]{
+ An alias for @racket[nonnegative-integer?].}
+
 @; ----------------------------------------------------------------------
 @close-eval[math-eval]
 @; ----------------------------------------------------------------------

--- a/pkgs/racket-test-core/tests/racket/math.rktl
+++ b/pkgs/racket-test-core/tests/racket/math.rktl
@@ -123,6 +123,58 @@
 (test #t infinite? +inf.0)
 
 ;; =========================================================================
+;; positive-integer?
+
+(test #t positive-integer? 1)
+(test #t positive-integer? 1.0)
+(test #t positive-integer? 3/3)
+(test #f positive-integer? 3/2)
+(test #f positive-integer? 0)
+(test #f positive-integer? 0.0)
+(test #f positive-integer? -1)
+(test #f positive-integer? 1.3)
+
+;; =========================================================================
+;; negative-integer?
+
+(test #t negative-integer? -1)
+(test #t negative-integer? -1.0)
+(test #t negative-integer? -3/3)
+(test #f negative-integer? -3/2)
+(test #f negative-integer? 0)
+(test #f negative-integer? -0)
+(test #f negative-integer? 1)
+(test #f negative-integer? -1.3)
+
+;; =========================================================================
+;; nonpositive-integer?
+
+(test #t nonpositive-integer? -1)
+(test #t nonpositive-integer? -1.0)
+(test #t nonpositive-integer? -3/3)
+(test #t nonpositive-integer? 0)
+(test #t nonpositive-integer? -0)
+(test #t nonpositive-integer? 0.0)
+(test #t nonpositive-integer? -0.0)
+(test #f nonpositive-integer? -3/2)
+(test #f nonpositive-integer? 1)
+(test #f nonpositive-integer? -1.3)
+
+;; =========================================================================
+;; nonnegative-integer? 
+
+(test #t nonnegative-integer? 1)
+(test #t nonnegative-integer? 1.0)
+(test #t nonnegative-integer? 3/3)
+(test #t nonnegative-integer? 0)
+(test #t nonnegative-integer? -0)
+(test #t nonnegative-integer? 0.0)
+(test #t nonnegative-integer? -0.0)
+(test #f nonnegative-integer? 3/2)
+(test #f nonnegative-integer? 0.5)
+(test #f nonnegative-integer? -5)
+
+;; =========================================================================
 ;; sqr
 
 (test 4 sqr -2)

--- a/pkgs/racket-test-core/tests/racket/math.rktl
+++ b/pkgs/racket-test-core/tests/racket/math.rktl
@@ -178,12 +178,12 @@
 ;; natural?
 
 (test #t natural? 1)
-(test #t natural? 1.0)
 (test #t natural? 3/3)
 (test #t natural? 0)
 (test #t natural? -0)
-(test #t natural? 0.0)
-(test #t natural? -0.0)
+(test #f natural? 1.0)
+(test #f natural? 0.0)
+(test #f natural? -0.0)
 (test #f natural? 3/2)
 (test #f natural? 0.5)
 (test #f natural? -5)

--- a/pkgs/racket-test-core/tests/racket/math.rktl
+++ b/pkgs/racket-test-core/tests/racket/math.rktl
@@ -175,6 +175,21 @@
 (test #f nonnegative-integer? -5)
 
 ;; =========================================================================
+;; natural?
+
+(test #t natural? 1)
+(test #t natural? 1.0)
+(test #t natural? 3/3)
+(test #t natural? 0)
+(test #t natural? -0)
+(test #t natural? 0.0)
+(test #t natural? -0.0)
+(test #f natural? 3/2)
+(test #f natural? 0.5)
+(test #f natural? -5)
+
+
+;; =========================================================================
 ;; sqr
 
 (test 4 sqr -2)

--- a/racket/collects/racket/math.rkt
+++ b/racket/collects/racket/math.rkt
@@ -9,6 +9,10 @@
 
 (provide pi pi.f
          nan? infinite?
+         positive-integer?
+         negative-integer?
+         nonpositive-integer?
+         nonnegative-integer?
          sqr
          sgn conjugate
          sinh cosh tanh
@@ -29,6 +33,18 @@
   (define (infinite? x)
     (unless (real? x) (raise-argument-error 'infinite? "real?" x))
     (or (= x +inf.0) (= x -inf.0)))
+
+  (define (positive-integer? x)
+    (and (integer? x) (positive? x)))
+
+  (define (negative-integer? x)
+    (and (integer? x) (negative? x)))
+
+  (define (nonpositive-integer? x)
+    (and (integer? x) (not (positive? x))))
+
+  (define (nonnegative-integer? x)
+    (and (integer? x) (not (negative? x))))
 
   ;; z^2
   (define (sqr z)

--- a/racket/collects/racket/math.rkt
+++ b/racket/collects/racket/math.rkt
@@ -13,6 +13,7 @@
          negative-integer?
          nonpositive-integer?
          nonnegative-integer?
+         natural?
          sqr
          sgn conjugate
          sinh cosh tanh
@@ -45,6 +46,8 @@
 
   (define (nonnegative-integer? x)
     (and (integer? x) (not (negative? x))))
+
+  (define natural? nonnegative-integer?)
 
   ;; z^2
   (define (sqr z)

--- a/racket/collects/racket/math.rkt
+++ b/racket/collects/racket/math.rkt
@@ -47,7 +47,7 @@
   (define (nonnegative-integer? x)
     (and (integer? x) (not (negative? x))))
 
-  (define natural? nonnegative-integer?)
+  (define natural? exact-nonnegative-integer?)
 
   ;; z^2
   (define (sqr z)


### PR DESCRIPTION
This PR adds the following 4 functions to `racket/math`:

- positive-integer?
- negative-integer?
- nonpositive-integer?
- nonnegative-integer?

 These are like the exact-* counterparts in racket/base, but also operate over inexact numbers too.

On the package server, both the `rsound` and `video` packages use these predicates. But only a one line change is required to fix that.

This PR is similar to PR #1623, but instead imports them to racket/math, rather than racket/contract.