### PR TITLE
relax contract for (random min max)

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -842,8 +842,8 @@ both in binary and as integers.
                     [rand-gen pseudo-random-generator?
                                (current-pseudo-random-generator)])
             exact-nonnegative-integer?]
-           [(random [min (integer-in 1 4294967087)]
-                    [max (integer-in 1 4294967087)]
+           [(random [min exact-integer?]
+                    [max (integer-in (+ 1 min) (+ 4294967087 min))]
                     [rand-gen pseudo-random-generator?
                               (current-pseudo-random-generator)])
             exact-nonnegative-integer?]

--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -2462,9 +2462,15 @@
 (test (begin (random-seed 23) (list (random 10) (random 20) (random 30)))
       'random-seed-same
       (begin (random-seed 23) (list (random 10) (random 20) (random 30))))
-(test (begin (random-seed 23) (list (random 10 20) (random 20 30) (random 30 40)))
+(test (begin (random-seed 23) (list (random 10 20) (random 20 30) (random 30 40)
+                                    (random 0 5) (random -10 10) (random -9 -3)
+                                    (random big-num (+ 10 big-num))
+                                    (random (- -3 big-num) (- big-num))))
       'random-seed-same2
-      (begin (random-seed 23) (list (random 10 20) (random 20 30) (random 30 40))))
+      (begin (random-seed 23) (list (random 10 20) (random 20 30) (random 30 40)
+                                    (random 0 5) (random -10 10) (random -9 -3)
+                                    (random big-num (+ 10 big-num))
+                                    (random (- -3 big-num) (- big-num)))))
 (test (begin (random-seed 23) (list (random-ref '(1 2 3)) (random-ref '(4 5 6)) (random-ref '(7 8 9))))
       'random-seed-same3
       (begin (random-seed 23) (list (random-ref '#(1 2 3)) (random-ref '#(4 5 6)) (random-ref '#(7 8 9)))))
@@ -2484,7 +2490,11 @@
 (err/rt-test (random 4294967088))
 (err/rt-test (random (expt 2 32)))
 (err/rt-test (random big-num))
+(err/rt-test (random big-num))
 (err/rt-test (random 10 5))
+(err/rt-test (random -2 -3))
+(err/rt-test (random 0 big-num))
+(err/rt-test (random -big-num 0))
 
 (random-seed 101)
 (define x (list (random 10) (random 20) (random 30)))


### PR DESCRIPTION
Relax contract for `(random min max)` to accept any pair of integers such that:
- `(< min max)`
- `(- max min)` is between 1 and 4294967087