### PR TITLE
[doc] link max <--> argmax

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -5,7 +5,8 @@
                      racket/fixnum
                      racket/unsafe/ops
                      racket/require
-                     racket/random))
+                     racket/random
+                     racket/list))
 
 @(define math-eval (make-base-eval))
 @examples[#:hidden #:eval math-eval (require racket/math)]
@@ -352,7 +353,7 @@ If @racket[m] is exact @racket[0], the
 
 Returns the largest of the @racket[x]s, or @racket[+nan.0] if any
  @racket[x] is @racket[+nan.0].  If any @racket[x] is inexact, the
- result is coerced to inexact.
+ result is coerced to inexact.  See also @racket[argmax].
 
 @mz-examples[(max 1 3 2) (max 1 3 2.0)]}
 
@@ -361,7 +362,7 @@ Returns the largest of the @racket[x]s, or @racket[+nan.0] if any
 
 Returns the smallest of the @racket[x]s, or @racket[+nan.0] if any
  @racket[x] is @racket[+nan.0].  If any @racket[x] is inexact, the
- result is coerced to inexact.
+ result is coerced to inexact.  See also @racket[argmin].
 
 @mz-examples[(min 1 3 2) (min 1 3 2.0)]}
 

--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/doc
 @(require "mz.rkt" scribble/scheme racket/generator racket/list
-          (for-syntax racket/base))
+          (for-syntax racket/base)
+          (for-label racket/list))
 
 @(define (generate-c_r-example proc)
   (define (make-it start n)
@@ -1358,6 +1359,7 @@ it builds the permutations one-by-one on each iteration}
 
 Returns the first element in the list @racket[lst] that minimizes the
 result of @racket[proc].  Signals an error on an empty list.
+See also @racket[min].
 
 @mz-examples[#:eval list-eval
   (argmin car '((3 pears) (1 banana) (2 apples)))
@@ -1369,11 +1371,11 @@ result of @racket[proc].  Signals an error on an empty list.
 
 Returns the first element in the list @racket[lst] that maximizes the
 result of @racket[proc].  Signals an error on an empty list.
+See also @racket[max].
 
 @mz-examples[#:eval list-eval
   (argmax car '((3 pears) (1 banana) (2 apples)))
   (argmax car '((3 pears) (3 oranges)))]}
-
 
 @defproc[(group-by [key (-> any/c any/c)]
                    [lst list?]


### PR DESCRIPTION
This is the right look, but is it possible to use a `seclink` instead of the `for-label` import?