### PR TITLE
(Attempt to) fix license and acknowledgements links on docs.racket-lang.org.

### DIFF
--- a/pkgs/racket-index/scribblings/main/config.rkt
+++ b/pkgs/racket-index/scribblings/main/config.rkt
@@ -16,8 +16,8 @@
   `((start   "Racket Documentation" user "index.html")
     (search  "Search Manuals"   user "search/index.html")
     ---
-    (license "License"          plt  "license/index.html")
-    (acks    "Acknowledgements" plt  "acks/index.html")
+    (license "License"          user  "license/index.html")
+    (acks    "Acknowledgements" user  "acks/index.html")
     (release "Release Notes"    user  "release/index.html")
     ---
     (bugreport "Report a Bug"   #f ,(format "~a?v=~a" bug-url (version)))))


### PR DESCRIPTION
I'm not sure that's the right solution, though. Also can't really test locally.

May close #1619.