### PR TITLE
gzip: use path-add-extension as default

### DIFF
--- a/pkgs/racket-doc/file/scribblings/gzip.scrbl
+++ b/pkgs/racket-doc/file/scribblings/gzip.scrbl
@@ -8,13 +8,17 @@ utilities to create archive files in @exec{gzip} format, or simply to
 compress data using the @exec{pkzip} ``deflate'' method.}
 
 @defproc[(gzip [in-file path-string?]
-               [out-file path-string? (string-append in-file ".gz")])
+               [out-file path-string? (path-add-extension in-file ".gz" #".")])
          void?]{
 
 Compresses data to the same format as the @exec{gzip} utility, writing
 the compressed data directly to a file. The @racket[in-file] argument
 is the name of the file to compress. If the file named by
-@racket[out-file] exists, it will be overwritten.}
+@racket[out-file] exists, it will be overwritten.
+
+@history[#:changed "6.8.0.2"
+         @elem{Changed default expression of @racket[out-file] to use
+               @racket[path-add-extension] instead of @racket[string-append].}]}
 
 
 @defproc[(gzip-through-ports [in input-port?]

--- a/pkgs/racket-doc/scribblings/reference/paths.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/paths.scrbl
@@ -561,22 +561,25 @@ extension separator.
 
 
 @defproc[(path-add-extension [path (or/c path-string? path-for-some-system?)]
-                             [ext (or/c string? bytes?)])
+                             [ext (or/c string? bytes?)]
+                             [sep (or/c string? bytes?) #"_"])
          path-for-some-system?]{
 
 Similar to @racket[path-replace-extension], but any existing extension on
 @racket[path] is preserved by replacing the @litchar{.} before the extension
-with @litchar{_}, and then the @racket[ext] is added
+with @racket[sep], and then the @racket[ext] is added
 to the end.
 
 @examples[
 (path-add-extension "x/y.ss" #".rkt")
 (path-add-extension "x/y" #".rkt")
 (path-add-extension "x/y.tar.gz" #".rkt")
+(path-add-extension "x/y.tar.gz" #".rkt" #".")
 (path-add-extension "x/.racketrc" #".rkt")
 ]
 
-@history[#:added "6.5.0.3"]}
+@history[#:changed "6.8.0.2" @elem{Added the @racket[sep] optional argument.}
+         #:added "6.5.0.3"]}
 
 
 @defproc[(path-replace-suffix [path (or/c path-string? path-for-some-system?)]

--- a/pkgs/racket-test-core/tests/racket/path.rktl
+++ b/pkgs/racket-test-core/tests/racket/path.rktl
@@ -44,6 +44,11 @@
 (test (string->path ".zo.y") path-add-extension ".zo" #".y")
 (test (string->path ".tar_gz.y") path-add-extension ".tar.gz" ".y")
 (test (string->path ".tar_gz.y") path-add-extension ".tar.gz" #".y")
+(test (string->some-system-path "p/x.tar.gz" 'unix)
+      path-add-extension (string->some-system-path "p/x.tar" 'unix) ".gz" #".")
+(test (string->some-system-path "p/x.tar.gz" 'windows)
+      path-add-extension (string->some-system-path "p/x.tar" 'windows) ".gz" ".")
+(err/rt-test (path-add-extension "x" ".zip" #f))
 
 (test (string->path ".y") path-replace-suffix ".zo" ".y")
 (test (string->path ".y") path-replace-suffix ".zo" #".y")

--- a/racket/collects/file/gzip.rkt
+++ b/racket/collects/file/gzip.rkt
@@ -2208,7 +2208,7 @@
 
 (define gzip
   (case-lambda
-   [(infile) (gzip infile (string-append infile ".gz"))]
+   [(infile) (gzip infile (path-add-extension infile ".gz" #"."))]
    [(infile outfile) ((car (code)) infile outfile)]))
 
 (define (gzip-through-ports in out origname time_stamp)


### PR DESCRIPTION
Instead of `string-append`-ing the extension, because that doesn't work for all path strings