### PR TITLE
Corrected Racket Reference for get/build-late-neg-projection …

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -2115,7 +2115,7 @@ contracts.  The error messages assume that the function named by
 }
 
 @defproc[(get/build-val-first-projection [c contract?])
-         (-> contract? blame? (-> any/c (-> any/c any/c)))]{
+         (-> blame? (-> any/c (-> any/c any/c)))]{
   Returns the @racket[_val-first] projection for @racket[c].
               
   See @racket[make-contract] for more details.
@@ -2124,7 +2124,7 @@ contracts.  The error messages assume that the function named by
 }
 
 @defproc[(get/build-late-neg-projection [c contract?])
-         (-> contract? blame? (-> any/c any/c any/c))]{
+         (-> blame? (-> any/c any/c any/c))]{
  Returns the @racket[_late-neg] projection for @racket[c].
               
  If @racket[c] does not have a @racket[_late-neg] contract,


### PR DESCRIPTION
and `get/build-val-first-projection`.

Both had incorrectly shown that the returned function took a `contract?` as an extra first argument.