### PR TITLE
Small changes to the documentation

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/serialization.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/serialization.scrbl
@@ -408,7 +408,7 @@ information bound to
 
 The @racket[-v0] suffix on the deserialization enables future
 versioning on the structure type through
-@racket[serializable-struct/version].
+@racket[serializable-struct/versions].
 
 When a supertype is supplied as @racket[maybe-super],
 compile-time information bound to the supertype identifier must

--- a/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
@@ -1183,9 +1183,6 @@ A structure representing a single imported identifier:
  @item{@racket[src-mod-path] --- a @tech{module path} (relative to the
        importing module) for the source of the imported binding.}
 
- @item{@racket[orig-stx] --- a @tech{syntax object} for the source of
-       the import, used for error reporting.}
-
  @item{@racket[mode] --- the @tech{phase level} of the binding in the
        importing module.}
 
@@ -1194,6 +1191,9 @@ A structure representing a single imported identifier:
 
  @item{@racket[orig-mode] --- the @tech{phase level} of the
        binding as exported by the exporting module.}
+
+ @item{@racket[orig-stx] --- a @tech{syntax object} for the source of
+       the import, used for error reporting.}
 
 ]}
 
@@ -1420,14 +1420,14 @@ A structure representing a single imported identifier:
 
  @item{@racket[out-sym] --- the external name of the binding.}
 
- @item{@racket[orig-stx] --- a @tech{syntax object} for the source of
-       the export, used for error reporting.}
+ @item{@racket[mode] --- the @tech{phase level} of the binding in the
+       exporting module.}
 
  @item{@racket[protect?] --- indicates whether the identifier should
        be protected (see @secref["modprotect"]).}
 
- @item{@racket[mode] --- the @tech{phase level} of the binding in the
-       exporting module.}
+ @item{@racket[orig-stx] --- a @tech{syntax object} for the source of
+       the export, used for error reporting.}
 
 ]}
 

--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -1080,8 +1080,8 @@ definition in a @racket[~do] block.
 
 @specsubform[(@#,def[~post a] A-pattern)]{
 
-Like the @Spattern version, @ref[~post s], but matches a head
-pattern instead.
+Like the @Spattern version, @ref[~post s], but contains only
+@tech{@Apatterns}.
 }
 
 


### PR DESCRIPTION
* Fixed typo in the docs for serialization (serializable-struct/version → serializable-struct/versions)
* Fixed typo in scribble documentation (head pattern → a-pattern)
* Made the order of the argument descriptions match the order of the arguments in the documentation for import and export