### PR TITLE
Fix spelling errors

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/bytes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/bytes.scrbl
@@ -78,7 +78,7 @@ positions are initialized with the given @racket[b]s.
 
 @defproc[(bytes-ref [bstr bytes?] [k exact-nonnegative-integer?])
  byte?]{  Returns the character at position @racket[k] in @racket[bstr].
- The first position in the bytes cooresponds to @racket[0], so the
+ The first position in the bytes corresponds to @racket[0], so the
  position @racket[k] must be less than the length of the bytes,
  otherwise the @exnraise[exn:fail:contract].
 
@@ -88,7 +88,7 @@ positions are initialized with the given @racket[b]s.
 @defproc[(bytes-set! [bstr (and/c bytes? (not/c immutable?))] [k
  exact-nonnegative-integer?] [b byte?]) void?]{  Changes the
  character position @racket[k] in @racket[bstr] to @racket[b].  The first
- position in the byte string cooresponds to @racket[0], so the position
+ position in the byte string corresponds to @racket[0], so the position
  @racket[k] must be less than the length of the bytes, otherwise the
  @exnraise[exn:fail:contract].
 


### PR DESCRIPTION
“cooresponds” → “corresponds” x2