### PR TITLE
Adds built-in syntax classes which match regular expressions

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/lib.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/lib.scrbl
@@ -37,7 +37,9 @@ actually a valid expression.
 @defstxclass[integer]
 @defstxclass[exact-integer]
 @defstxclass[exact-nonnegative-integer]
-@defstxclass[exact-positive-integer])]{
+@defstxclass[exact-positive-integer]
+@defstxclass[regexp]
+@defstxclass[byte-regexp])]{
 
 Match syntax satisfying the corresponding predicates.
 }
@@ -59,6 +61,7 @@ and bytes, respectively.
 @defstxclass[id]{ Alias for @racket[identifier]. }
 @defstxclass[nat]{ Alias for @racket[exact-nonnegative-integer]. }
 @defstxclass[str]{ Alias for @racket[string]. }
+@defstxclass[character]{ Alias for @racket[char]. }
 
 @defstxclass[(static [predicate (-> any/c any/c)]
                      [description (or/c string? #f)])]{

--- a/racket/collects/syntax/parse/private/lib.rkt
+++ b/racket/collects/syntax/parse/private/lib.rkt
@@ -14,7 +14,7 @@
          exact-integer
          exact-nonnegative-integer
          exact-positive-integer
-
+         
          id
          nat
          char
@@ -37,6 +37,8 @@
 (define exact-integer-stx? (stxof exact-integer?))
 (define exact-nonnegative-integer-stx? (stxof exact-nonnegative-integer?))
 (define exact-positive-integer-stx? (stxof exact-positive-integer?))
+(define regexp-stx? (stxof regexp?))
+(define byte-regexp-stx? (stxof byte-regexp?))
 
 
 ;; == Integrable syntax classes ==
@@ -58,10 +60,16 @@
 
 (define-integrable-syntax-class -string (quote "string") string-stx?)
 (define-integrable-syntax-class -bytes (quote "bytes") bytes-stx?)
+(define-integrable-syntax-class -regexp (quote "regexp") regexp-stx?)
+(define-integrable-syntax-class -byte-regexp (quote "byte-regexp") byte-regexp-stx?)
+
+;; Overloading the meaning of existing identifiers
 (begin-for-syntax
   (set-box! alt-stxclass-mapping
             (list (cons #'string (syntax-local-value #'-string))
-                  (cons #'bytes  (syntax-local-value #'-bytes)))))
+                  (cons #'bytes  (syntax-local-value #'-bytes))
+                  (cons #'regexp (syntax-local-value #'-regexp))
+                  (cons #'byte-regexp (syntax-local-value #'-byte-regexp)))))
 
 ;; Aliases
 (define-syntax id (make-rename-transformer #'identifier))


### PR DESCRIPTION
I'm not very satisfied with the names, suggestions are welcome:

```
rx
px
rx-not-px
byte-rx
byte-px
byte-rx-not-px
```

I included `rx-not-px` and `byte-rx-not-px` Should these be discarded? They can be made rather easily with `{~and :rx {~not :px}}` and will probably be very rarely used.

Also, should I add a `rx-or-byte-rx` syntax class, which matches all regular expressions (byte or other)?