### PR TITLE
Changes the "Report a Bug" url in the documentation

### DIFF
--- a/pkgs/racket-index/scribblings/main/config.rkt
+++ b/pkgs/racket-index/scribblings/main/config.rkt
@@ -4,7 +4,8 @@
 
 ;; Configuration of various parts of the main pages
 
-(define bug-url "http://bugs.racket-lang.org/")
+(define bug-url-fmt
+  "https://github.com/racket/racket/issues/new?body=Racket%20version:%20~a%0A%0A")
 
 ;; Link definitions: (id-sym title root-sym/#f-for-url subpath/url),
 ;; or a `---' for a spacer; the root-sym can be `plt' for standard
@@ -20,7 +21,7 @@
     (acks    "Acknowledgements" plt  "acks/index.html")
     (release "Release Notes"    user  "release/index.html")
     ---
-    (bugreport "Report a Bug"   #f ,(format "~a?v=~a" bug-url (version)))))
+    (bugreport "Report a Bug"   #f ,(format bug-url-fmt (version)))))
 
 ;; Section definitions for manuals that appear on the start page.
 (define manual-sections

--- a/racket/src/README
+++ b/racket/src/README
@@ -12,7 +12,7 @@ Per-platform instructions are below.
 
 Please report bugs via one of the following:
   - DrRacket's "submit bug report" menu            (preferred)
-  - http://bugs.racket-lang.org/
+  - https://github.com/racket/racket/issues
   - the mailing list (users@racket-lang.org)       (last resort)
 
 -PLT

--- a/racket/src/README
+++ b/racket/src/README
@@ -11,11 +11,10 @@ Windows, Mac OS, or any Unix/X platform (including Linux).
 Per-platform instructions are below.
 
 Please report bugs via one of the following:
-  - DrRacket's "submit bug report" menu            (preferred)
-  - https://github.com/racket/racket/issues
-  - the mailing list (users@racket-lang.org)       (last resort)
+  - https://github.com/racket/racket/issues/new
+  - the mailing list (users@racket-lang.org)
 
--PLT
+- The Racket team
  racket@racket-lang.org
 
 ========================================================================

--- a/racket/src/worksp/README
+++ b/racket/src/worksp/README
@@ -33,7 +33,7 @@ MSVC-based build to support Cygwin-built extensions.
 
 As always, please report bugs via one of the following:
   - DrRacket's "submit bug report" menu          (preferred)
-  - http://bugs.racket-lang.org/
+  - https://github.com/racket/racket/issues
   - the mailing list (users@racket-lang.org)     (last resort)
 
 -PLT


### PR DESCRIPTION
The sidebar for the main page on docs.racket-lang.org contains a "Report a Bug" link which points to http://bugs.racket-lang.org/, which seems to be the old page for reporting bugs (and GitHub is preferred nowadays).

A separate issue would be to update the URL used by DrRacket's "Send a bug report" window (https://github.com/racket/drracket/issues/114), but since I have basically no knowledge of the GitHub API beyond its existence, I won't do it myself.