### PR TITLE
changed make-variable-like-transformer to create #%app form

### DIFF
--- a/racket/collects/syntax/transformer.rkt
+++ b/racket/collects/syntax/transformer.rkt
@@ -24,5 +24,5 @@
               [else
                (raise-syntax-error #f "cannot mutate identifier" stx #'id)])]
        [(id . args)
-        (let ([stx* (cons #'(#%expression id) (cdr (syntax-e stx)))])
-          (datum->syntax stx stx* stx))]))))
+        (with-syntax ([app (datum->syntax stx '#%app)])
+          (syntax/loc stx (app id . args)))]))))


### PR DESCRIPTION
The docs claim that "Uses of the macro in operator position are
interpreted as an application", yet the current implementation
confusingly wraps #%expression around the operator instead of just
creating #%app.

Worse, the #%expression isn't in the phase level of the application,
meaning that languages can't easily use make-variable-like-transformer
if they intend to reimplement #%app. Maybe I'm mistaken and there is
rationale behind doing it this way / code that depends on the current
behavior. I find my self needing this macro but just rewriting it this
way since the bad phase-level #%expression just gets in the way and I
wanted #%app instead.