### PR TITLE
fix id-set-symmetric-difference, same as 4716a6e fixed for sets

### DIFF
--- a/pkgs/racket-test-core/tests/racket/id-set-test.rktl
+++ b/pkgs/racket-test-core/tests/racket/id-set-test.rktl
@@ -322,6 +322,10 @@
                     (define ABCDE/MUTABLE (mk-mutable-id-set ABCDE-LIST))
                     (define ABCDE/IMMUTABLE (mk-immutable-id-set ABCDE-LIST))
                     
+                    (test 0 SET-COUNT
+                          (SET-SYMMETRIC-DIFFERENCE ABCDE/IMMUTABLE ABCDE/IMMUTABLE))
+                    (test 0 SET-COUNT
+                          (SET-SYMMETRIC-DIFFERENCE ABCDE/IMMUTABLE (mk-immutable-id-set ABCDE-LIST)))
                     (test 5 SET-COUNT (SET-SYMMETRIC-DIFFERENCE ABCDE/IMMUTABLE))
                     (test #t SET-EMPTY? (SET-SYMMETRIC-DIFFERENCE EMPTY/IMMUTABLE))
                     (test 4 SET-COUNT (SET-SYMMETRIC-DIFFERENCE EMPTY/IMMUTABLE ABCD))

--- a/racket/collects/syntax/private/id-set.rkt
+++ b/racket/collects/syntax/private/id-set.rkt
@@ -277,7 +277,7 @@
            (immutable-id-set
             (for/fold 
              ([table (id-set-get-table largest-immutable)])
-             ([s (in-list (cons set0 ss))] #:unless (eq? s largest-immutable))
+             ([s (in-list (remq largest-immutable (cons set0 ss)))])
               (for/fold ([table table]) 
                         ([id (in-dict-keys (id-set-get-table s))])
                 (if (id-table-ref table id #f)


### PR DESCRIPTION
bound/free-id-set-symmetric-difference doesn't always behave correctly when passed the same (`eq?`) input more than once. 

The implementation of free/bound-id-sets was almost directly based on code for normal sets, so this same kind of bug was fixed before, but stayed around here.