### PR TITLE
PR fix for Issue #1702

### DIFF
--- a/racket/collects/db/private/sqlite3/connection.rkt
+++ b/racket/collects/db/private/sqlite3/connection.rkt
@@ -212,10 +212,16 @@
                       ;; entry of stmt in table.
                       (A (let-values ([(prep-status stmt tail?)
                                        (sqlite3_prepare_v2 db sql)])
-                           (when tail?
-                             (when stmt (sqlite3_finalize stmt))
-                             (error* fsym "multiple statements given"
-                                     '("given" value) sql))
+                           (cond
+                             [(not (= 0 prep-status))
+                              (when stmt (sqlite3_finalize stmt))
+                              (error* fsym (get-error-message)
+                                      '("given" value) sql)]
+                             [else
+                              (when tail?
+                                (when stmt (sqlite3_finalize stmt))
+                                (error* fsym "multiple statements given"
+                                        '("given" value) sql))])
                            (when stmt (hash-set! stmt-table stmt #t))
                            (values prep-status stmt))))])
         (when DEBUG?

--- a/racket/collects/db/private/sqlite3/ffi.rkt
+++ b/racket/collects/db/private/sqlite3/ffi.rkt
@@ -2,6 +2,7 @@
 (require (for-syntax racket/base
                      setup/cross-system)
          racket/runtime-path
+         racket/string
          ffi/unsafe
          ffi/unsafe/define
          setup/cross-system)
@@ -60,7 +61,7 @@
 ;; -- Stmt --
 
 (define (copy-buffer buffer)
-  (let* ([buffer (string->bytes/utf-8 buffer)]
+  (let* ([buffer (string->bytes/utf-8 (string-trim buffer))]
          [n (bytes-length buffer)]
          [rawcopy (malloc (add1 n) 'atomic-interior)]
          [copy (make-sized-byte-string rawcopy n)])

--- a/racket/collects/db/private/sqlite3/ffi.rkt
+++ b/racket/collects/db/private/sqlite3/ffi.rkt
@@ -60,8 +60,8 @@
 
 ;; -- Stmt --
 
-(define (copy-buffer buffer)
-  (let* ([buffer (string->bytes/utf-8 (string-trim buffer))]
+(define (trim-and-copy-buffer buffer)
+  (let* ([buffer (string->bytes/utf-8 (string-trim #:left? #f buffer))]
          [n (bytes-length buffer)]
          [rawcopy (malloc (add1 n) 'atomic-interior)]
          [copy (make-sized-byte-string rawcopy n)])
@@ -76,7 +76,7 @@
 (define-sqlite sqlite3_prepare
   (_fun (db sql) ::
         (db : _sqlite3_database)
-        (sql-buffer : _bytes = (copy-buffer sql))
+        (sql-buffer : _bytes = (trim-and-copy-buffer sql))
         ((bytes-length sql-buffer) : _int)
         (statement : (_ptr o _sqlite3_statement/null))
         (tail : (_ptr o _gcpointer)) ;; points into sql-buffer (atomic-interior)
@@ -87,7 +87,7 @@
 (define-sqlite sqlite3_prepare_v2
   (_fun (db sql) ::
         (db : _sqlite3_database)
-        (sql-buffer : _bytes = (copy-buffer sql))
+        (sql-buffer : _bytes = (trim-and-copy-buffer sql))
         ((bytes-length sql-buffer) : _int)
         ;; bad prepare statements set statement to NULL, with no error reported
         (statement : (_ptr o _sqlite3_statement/null))


### PR DESCRIPTION
Please see Issue #1702 for an explanation of the reasons behind this pull request.

The tests are being committed to the `db` repository, I will submit a separate pull request there.

Some notes for your consideration.

In the commit dealing with connection.rkt, my changes are within the atomic execution region in the prepare1* method. As far as I can tell, the changes, including the call to `get-error-message` are safe with respect to atomic execution but I'm not 100% sure.

For the specific commit relating to the ffi.rkt file, which aims to fix the issue of semi-colon terminated statement with extra space throwing an exception. I think it's user friendly for the `db` collection to proactively trim all strings from callers so they don't have to do it themselves before calling query-exec and its friends.

I use `string-trim` from racket/string in the copy-buffer procedure because it's a convenient central location which captures all SQL strings given to the connection object. Are there any performance concerns with bringing another dependency into ffi.rkt? I checked and it seems racket/string is a small library.