### PR TITLE
Add scheme_atexit c function.

### DIFF
--- a/racket/src/racket/include/mzscheme.exp
+++ b/racket/src/racket/include/mzscheme.exp
@@ -63,6 +63,7 @@ scheme_close_managed
 scheme_schedule_custodian_close
 scheme_add_custodian_extractor
 scheme_add_atexit_closer
+scheme_add_atexit
 scheme_add_evt
 scheme_add_evt_through_sema
 scheme_is_evt

--- a/racket/src/racket/include/mzscheme3m.exp
+++ b/racket/src/racket/include/mzscheme3m.exp
@@ -63,6 +63,7 @@ scheme_close_managed
 scheme_schedule_custodian_close
 scheme_add_custodian_extractor
 scheme_add_atexit_closer
+scheme_atexit
 scheme_add_evt
 scheme_add_evt_through_sema
 scheme_is_evt

--- a/racket/src/racket/include/mzwin.def
+++ b/racket/src/racket/include/mzwin.def
@@ -80,6 +80,7 @@ EXPORTS
  scheme_add_flush
  scheme_remove_flush
  scheme_add_atexit_closer
+ scheme_atexit
  scheme_add_evt
  scheme_add_evt_through_sema
  scheme_is_evt

--- a/racket/src/racket/include/racket.exp
+++ b/racket/src/racket/include/racket.exp
@@ -77,6 +77,7 @@ scheme_flush_managed
 scheme_add_flush
 scheme_remove_flush
 scheme_add_atexit_closer
+scheme_atexit
 scheme_add_evt
 scheme_add_evt_through_sema
 scheme_is_evt

--- a/racket/src/racket/include/racket3m.exp
+++ b/racket/src/racket/include/racket3m.exp
@@ -77,6 +77,7 @@ scheme_flush_managed
 scheme_add_flush
 scheme_remove_flush
 scheme_add_atexit_closer
+scheme_atexit
 scheme_add_evt
 scheme_add_evt_through_sema
 scheme_is_evt

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -172,6 +172,7 @@ MZ_EXTERN Scheme_Object *scheme_add_flush(Scheme_Plumber *p, Scheme_Object *proc
 MZ_EXTERN void scheme_remove_flush(Scheme_Object *h);
 
 MZ_EXTERN void scheme_add_atexit_closer(Scheme_Exit_Closer_Func f);
+MZ_EXTERN int scheme_atexit(void (*func)(void));
 
 MZ_EXTERN void scheme_add_evt(Scheme_Type type,
 				   Scheme_Ready_Fun ready,

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -123,6 +123,7 @@ int (*scheme_flush_managed)(Scheme_Plumber *p, int catch_errors);
 Scheme_Object *(*scheme_add_flush)(Scheme_Plumber *p, Scheme_Object *proc_or_port, int weak_flush);
 void (*scheme_remove_flush)(Scheme_Object *h);
 void (*scheme_add_atexit_closer)(Scheme_Exit_Closer_Func f);
+int (*scheme_atexit)(void (*func)());
 void (*scheme_add_evt)(Scheme_Type type,
 				   Scheme_Ready_Fun ready,
 				   Scheme_Needs_Wakeup_Fun wakeup,

--- a/racket/src/racket/src/schemex.inc
+++ b/racket/src/racket/src/schemex.inc
@@ -86,6 +86,7 @@
   scheme_extension_table->scheme_add_flush = scheme_add_flush;
   scheme_extension_table->scheme_remove_flush = scheme_remove_flush;
   scheme_extension_table->scheme_add_atexit_closer = scheme_add_atexit_closer;
+  scheme_extension_table->scheme_atexit = scheme_atexit
   scheme_extension_table->scheme_add_evt = scheme_add_evt;
   scheme_extension_table->scheme_add_evt_through_sema = scheme_add_evt_through_sema;
   scheme_extension_table->scheme_is_evt = scheme_is_evt;

--- a/racket/src/racket/src/schemexm.h
+++ b/racket/src/racket/src/schemexm.h
@@ -86,6 +86,7 @@
 #define scheme_add_flush (scheme_extension_table->scheme_add_flush)
 #define scheme_remove_flush (scheme_extension_table->scheme_remove_flush)
 #define scheme_add_atexit_closer (scheme_extension_table->scheme_add_atexit_closer)
+#define scheme_atexit (scheme_extension_table->scheme_atexit)
 #define scheme_add_evt (scheme_extension_table->scheme_add_evt)
 #define scheme_add_evt_through_sema (scheme_extension_table->scheme_add_evt_through_sema)
 #define scheme_is_evt (scheme_extension_table->scheme_is_evt)

--- a/racket/src/racket/src/thread.c
+++ b/racket/src/racket/src/thread.c
@@ -1984,6 +1984,11 @@ void scheme_add_atexit_closer(Scheme_Exit_Closer_Func f)
   cust_closers = scheme_make_raw_pair((Scheme_Object *)f, cust_closers);
 }
 
+int scheme_atexit(void (*func)(void))
+{
+  return atexit(func);
+}
+
 void scheme_schedule_custodian_close(Scheme_Custodian *c)
 {
   /* This procedure might be called by a garbage collector to register

--- a/racket/src/racket/src/thread.c
+++ b/racket/src/racket/src/thread.c
@@ -1966,15 +1966,7 @@ void scheme_add_atexit_closer(Scheme_Exit_Closer_Func f)
 
   if (!cust_closers) {
     if (RUNNING_IN_ORIGINAL_PLACE) {
-      if (replacement_at_exit) {
-        replacement_at_exit(do_run_atexit_closers_on_all);
-      } else {
-#ifdef USE_ON_EXIT_FOR_ATEXIT
-        on_exit(do_run_atexit_closers_on_all, NULL);
-#else
-        atexit(do_run_atexit_closers_on_all);
-#endif
-      }
+      scheme_atexit(do_run_atexit_closers_on_all);
     }
 
     REGISTER_SO(cust_closers);
@@ -1986,7 +1978,15 @@ void scheme_add_atexit_closer(Scheme_Exit_Closer_Func f)
 
 int scheme_atexit(void (*func)(void))
 {
-  return atexit(func);
+      if (replacement_at_exit) {
+        return replacement_at_exit(func);
+      } else {
+#ifdef USE_ON_EXIT_FOR_ATEXIT
+        return on_exit(func, NULL);
+#else
+        return atexit(func);
+#endif
+      }
 }
 
 void scheme_schedule_custodian_close(Scheme_Custodian *c)


### PR DESCRIPTION
This way programs can actually call atexit. (Otherwise atexit
is frequently not provided in libc as a symbol.)