### PR TITLE
doc: small typos + missing for-label links

### DIFF
--- a/pkgs/racket-doc/file/scribblings/gif.scrbl
+++ b/pkgs/racket-doc/file/scribblings/gif.scrbl
@@ -1,5 +1,5 @@
 #lang scribble/doc
-@(require scribble/manual
+@(require "common.rkt"
           scribble/extract
           (for-label file/gif))
 

--- a/pkgs/racket-doc/file/scribblings/unzip.scrbl
+++ b/pkgs/racket-doc/file/scribblings/unzip.scrbl
@@ -165,7 +165,7 @@ If @racket[entry] is not in @racket[zipdir], an
          #:changed "6.0.1.12" @elem{Added the @racket[#:utc-timestamps?] argument.}]}
 
 
-@defproc[(call-with-unzip-entry [in path-string? input-port]
+@defproc[(call-with-unzip-entry [in (or/c path-string? input-port?)]
                                 [entry path-string?]
                                 [proc (-> path-string? any)])
          any]{

--- a/pkgs/racket-doc/syntax/scribblings/srcloc.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/srcloc.scrbl
@@ -1,7 +1,8 @@
 #lang scribble/manual
 @(require scribble/eval
           scribble/decode
-          (for-label racket/base 
+          (for-label racket/base
+                     racket/contract
                      syntax/srcloc
                      syntax/location
                      setup/path-to-relative))
@@ -138,7 +139,7 @@ than simply @racket[#f].
 @deftogether[(
 @defproc[(source-location-source [loc source-location?]) any/c]
 @defproc[(source-location-line [loc source-location?])
-         (or/c orexact-positive-integer? #f)]
+         (or/c exact-positive-integer? #f)]
 @defproc[(source-location-column [loc source-location?])
          (or/c exact-nonnegative-integer? #f)]
 @defproc[(source-location-position [loc source-location?])


### PR DESCRIPTION
Affects `file/unzip` `file/gif` `syntax/srcloc`