### PR TITLE
Typos for counting numbers in German and French

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -594,7 +594,7 @@ key @racket[k] and value @racket[v], if a mapping from @racket[k] to some value
             (make-immutable-hash '([2 . two]))
             (make-immutable-hash '([3 . three])))
 (hash-union (make-immutable-hash '([1 . (one uno)] [2 . (two dos)]))
-            (make-immutable-hash '([1 . (ein une)] [2 . (zwei deux)]))
+            (make-immutable-hash '([1 . (eins un)] [2 . (zwei deux)]))
             #:combine/key (lambda (k v1 v2) (append v1 v2)))
 ]
 
@@ -623,7 +623,7 @@ h
 (hash-union! h (make-immutable-hash '([1 . (one uno)] [2 . (two dos)])))
 h
 (hash-union! h
-             (make-immutable-hash '([1 . (ein une)] [2 . (zwei deux)]))
+             (make-immutable-hash '([1 . (eins un)] [2 . (zwei deux)]))
              #:combine/key (lambda (k v1 v2) (append v1 v2)))
 h
 ]


### PR DESCRIPTION
In English, "one" can be used both when counting (1, 2, 3, 4, 5, ...) as well as an article in front of a noun (one tree, one bridge, ...).

In German the two use cases are distinct.
When counting it is "eins", but as an article it would be "ein" (for male or neutral nouns) or "eine" (for female nouns).
Thus in the text the correct term would be "eins" in German.

For the French counting, "une" is not quite correct.
It is much more common to count "un", "deux", "troix", "quatre", "cinq", ....
