### PR TITLE
setup-scribblings: check that info procedure is defined for 'scribblings

### DIFF
--- a/pkgs/racket-index/setup/scribble.rkt
+++ b/pkgs/racket-index/setup/scribble.rkt
@@ -180,7 +180,7 @@
                            infos)])
            (and (not (memq #f infos)) infos))))
   (define ((get-docs main-dirs) i rec)
-    (let* ([pre-s (and i (i 'scribblings))]
+    (let* ([pre-s (and i (i 'scribblings (λ () #f)))]
            [s (validate-scribblings-infos pre-s)]
            [dir (directory-record-path rec)])
       (if s


### PR DESCRIPTION
After working on https://github.com/racket/typed-racket/pull/591 (add scribblings for the `syntax/source-syntax` module), I checked out Typed Racket's `master` branch & eventually ran `raco setup`.
The setup failed with a very short error message:

```
$ raco setup
..... (omitted) ....
raco setup: --- building documentation ---
raco setup: docs failure: info.rkt: no info for scribblings
raco setup: --- installing collections ---
raco setup: --- post-installing collections ---
```

This PR adds a `with-handlers` around the code that raised the exception.
The new error message is:

```
$ raco setup
.... (omitted) ....
raco setup: --- building documentation ---
info.rkt: no info for scribblings
  context...:
   /Users/ben/code/racket/fork/racket/collects/racket/contract/private/../../private/kw.rkt:763:9
   /Users/ben/code/racket/fork/pkgs/racket-index/setup/scribble.rkt:187:2
   /Users/ben/code/racket/fork/racket/collects/racket/private/map.rkt:38:19: loop
   [repeats 59 more times]
   /Users/ben/code/racket/fork/racket/collects/racket/list.rkt:583:2: append-map
   /Users/ben/code/racket/fork/pkgs/racket-index/setup/scribble.rkt:138:0: setup-scribblings
   /Users/ben/code/racket/fork/racket/collects/setup/setup-core.rkt:71:0: setup-core
   /Users/ben/code/racket/fork/racket/collects/setup/main.rkt: [running body]
   /Users/ben/code/racket/fork/racket/collects/raco/main.rkt: [running body]
raco setup: WARNING: bad 'scribblings info: #<procedure:...etup/getinfo.rkt:102:17> from: #<path:/Users/ben/code/racket/fork/extra-pkgs/typed-racket/source-syntax>
raco setup: --- installing collections ---
raco setup: --- post-installing collections ---
raco setup: --- summary of errors ---
raco setup: error: during building docs for <pkgs>/source-syntax
raco setup:   info.rkt: no info for scribblings
```

- - -

I think this PR should be rejected & the problem caught earlier.
But this is the best I came up with.