### PR TITLE
adding file extension ".scrbl" to fix redirection

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -2356,7 +2356,7 @@ contracts.  The error messages assume that the function named by
 @defform*[[(with-contract-continuation-mark blame body ...)
           (with-contract-continuation-mark blame+neg-party body ...)]]{
 Inserts a continuation mark that informs the contract profiler (see
-@other-doc['(lib "contract-profile/scribblings/contract-profile")
+@other-doc['(lib "contract-profile/scribblings/contract-profile.scrbl")
            #:indirect "contract profiling"])
 that contract checking is happening.
 For the costs from checking your new combinator to be included, you should wrap


### PR DESCRIPTION
adding file extension ".scrbl" to fix url redirect error. Otherwises, it triggers a redirection error.

This link is just before [section 8.7.1 in reference of contract](https://docs.racket-lang.org/reference/Building_New_Contract_Combinators.html)

This fix works and I guess it's correct.

I didn't compile the document project but I searched other `@other-doc` tags in project, the link in lib are all ending with `.scrbl`

The current generated url is:
https://download.racket-lang.org/docs/6.9/html/local-redirect/index.html?tag=%28part._%28.%27%28lib._contract-profile%2Fscribblings%2Fcontract-profile..rkt%29.%27._.%27top.%27%29%29&version=6.9

If changing `rkt` to `scrbl` in the url:
https://download.racket-lang.org/docs/6.9/html/local-redirect/index.html?tag=%28part._%28.%27%28lib._contract-profile%2Fscribblings%2Fcontract-profile..scrbl%29.%27._.%27top.%27%29%29&version=6.9

The redirected result is correct.