### PR TITLE
Clearly distinguish ~datum/~literal in examples

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -397,12 +397,17 @@ symbolically, in contrast to the @racket[~literal] form, which
 recognizes them by binding.
 
 @examples[#:eval the-eval
-(syntax-parse (let ([define 'something-else]) #'(define x y))
-  [((~datum define) var:id e:expr) 'yes]
-  [_ 'no])
-(syntax-parse (let ([define 'something-else]) #'(define x y))
-  [((~literal define) var:id e:expr) 'yes]
-  [_ 'no])
+(define-syntax (is-define? stx)
+  (syntax-parse stx
+    [(_is-define? id)
+     (syntax-parse #'id
+       [(~literal define) #''yes]
+       [(~datum   define) #''not-really]
+       [_                 #''not-even-close])]))
+(is-define? define)
+(let ([define 42])
+  (is-define? define))
+(is-define? something-else)
 ]
 }
 


### PR DESCRIPTION
As discussed on the racket users list (subj: [~literal vs ~datum](https://groups.google.com/d/msg/racket-users/KWANfGc7qcI/G_MClWJpBAAJ))
New example based on code from Jens Axel Soegaard.
Caveat: I've run this in DrRacket with (require (for-syntax syntax/parse)) to verify the three distinct outputs, but am editing & submitting this PR in-browser, so I haven't run the doc build on it myself.