### PR TITLE
Fix the contract for with-intercepted-logging

### DIFF
--- a/racket/collects/racket/logging.rkt
+++ b/racket/collects/racket/logging.rkt
@@ -10,12 +10,13 @@
 
 (provide/contract [with-intercepted-logging
                    (->* ((-> log-event? any)
-                         (-> any))
+                         (-> any)
+                         log-level/c)
                         (#:logger logger?)
                         #:rest log-spec?
                         any)]
                   [with-logging-to-port
-                   (->* (output-port? (-> any))
+                   (->* (output-port? (-> any) log-level/c)
                         (#:logger logger?)
                         #:rest log-spec?
                         any)])


### PR DESCRIPTION
The contract was missing the required log-level/c. This commit
adds it.