### PR TITLE
Point make-meta-reader to the document of read and read-syntax

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/read.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/read.scrbl
@@ -12,7 +12,8 @@ default reader is used, as parameterized by the
 @racket[current-readtable] parameter, as well as many other
 parameters.
 
-See @secref["reader"] for information on the default reader.}
+See @secref["reader"] for information on the default reader and
+@secref["parse-reader"] for the protocol of @racket[read].}
 
 @defproc[(read-syntax [source-name any/c (object-name in)]
                       [in input-port? (current-input-port)])
@@ -24,7 +25,8 @@ source field of the syntax object; it can be an arbitrary value, but
 it should generally be a path for the source file.
 
 See @secref["reader"] for information on the default reader in
-@racket[read-syntax] mode.}
+@racket[read-syntax] mode and @secref["parse-reader"] for
+the protocol of @racket[read-syntax].}
 
 @defproc[(read/recursive [in input-port? (current-input-port)]
                          [start (or/c char? #f) #f]

--- a/pkgs/racket-doc/syntax/scribblings/module-reader.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/module-reader.scrbl
@@ -417,6 +417,8 @@ succeeds, then the loaded module's @racketidfont{read},
 @racketidfont{read-syntax}, or @racketidfont{get-info} export is
 passed to @racket[convert-read], @racket[convert-read-syntax], or
 @racket[convert-get-info], respectively.
+See @secref["parse-reader" #:doc ref-doc] for information on
+the protocol of @racketidfont{read} and @racketidfont{read-syntax}.
 
 @margin-note{The @racketmodname[at-exp] language supplies
   @racket[convert-read] and @racket[convert-read-syntax] to add


### PR DESCRIPTION
- Point read, read-syntax and make-meta-reader to
  the documentation explaining the arguments of
  read and read-syntax (the ones discussing x and x+4
  arguments).