### PR TITLE
Move rackunit-lib to build-deps instead of deps

### DIFF
--- a/racket/collects/pkg/private/new.rkt
+++ b/racket/collects/pkg/private/new.rkt
@@ -165,9 +165,8 @@ EOS
         (lambda () (expand/display #<<EOS
 #lang info
 (define collection "<<name>>")
-(define deps '("base"
-               "rackunit-lib"))
-(define build-deps '("scribble-lib" "racket-doc"))
+(define deps '("base"))
+(define build-deps '("scribble-lib" "racket-doc" "rackunit-lib"))
 (define scribblings '(("scribblings/<<name>>.scrbl" ())))
 (define pkg-desc "Description Here")
 (define version "0.0")


### PR DESCRIPTION
This should only be needed for development purposes and not at runtime for the typical package.
Fixes #1791 