### PR TITLE
require racket/contract/base in generic.scrbl to fix label links

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/generic.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/generic.scrbl
@@ -1,5 +1,5 @@
 #lang scribble/manual
-@(require (for-label racket/base racket/generic))
+@(require (for-label racket/base racket/generic racket/contract/base))
 
 @title[#:tag "struct-generics"]{Generic Interfaces}
 


### PR DESCRIPTION
The contracts in this page weren't linked, because the contract library was not `require`d.