### PR TITLE
Improve `namespace-attach-module` example

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/namespaces.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/namespaces.scrbl
@@ -300,15 +300,20 @@ undefined.}
 @examples[
  (module food racket/base
    (provide apple)
-   (define apple "pie"))
+   (define apple (list "pie")))
  (namespace-require ''food)
+ (define ns (current-namespace))
  (eval:error
   (parameterize ([current-namespace (make-base-namespace)])
     (namespace-require ''food)))
- (define ns (current-namespace))
  (parameterize ([current-namespace (make-base-namespace)])
    (namespace-attach-module ns ''food)
-   apple)]}
+   (namespace-require ''food)
+   (eq? (eval 'apple) apple))
+ (parameterize ([current-namespace (make-base-namespace)])
+   (namespace-attach-module-declaration ns ''food)
+   (namespace-require ''food)
+   (eq? (eval 'apple) apple))]}
 
 @defproc[(namespace-attach-module-declaration [src-namespace namespace?]
                                               [modname module-path?]


### PR DESCRIPTION
The current example fails to illustrate the complete use, as the final evaluation of `apple` would succeed even without the `namespace-attach-module` call. This updated example demonstrates that `namespace-require` is still needed after the module is attached, and also shows how the behavior differs from `namespace-attach-module-declaration`.