### PR TITLE
doc: swap takef / dropf codomain contracts

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -1055,8 +1055,8 @@ except that it can be faster.
 
 
 @deftogether[(
-  @defproc[(takef-right [lst any/c] [pred procedure?]) list?]
-  @defproc[(dropf-right [lst any/c] [pred procedure?]) any/c]
+  @defproc[(takef-right [lst any/c] [pred procedure?]) any/c]
+  @defproc[(dropf-right [lst any/c] [pred procedure?]) list?]
   @defproc[(splitf-at-right [lst any/c] [pred procedure?]) (values list? any/c)]
 )]{
 


### PR DESCRIPTION
The codomain for `takef-right` didn't match `take-right`.
Same for `dropf-right`.

Evidence:

```
> (takef-right 'x values)
'x
> (dropf-right 'x values)
'()
```