### PR TITLE
informal RFC: return expression for for/fold?

### DIFF
--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -1541,6 +1541,8 @@
 
   (define-syntax for/fold/derived
     (syntax-rules ()
+      [(_ orig-stx ([fold-var finid-init] ...) #:return ret-expr . rest)
+       (for/foldX/derived/final [orig-stx #f] ([fold-var finid-init] ...) ret-expr . rest)]
       [(_ orig-stx ([fold-var finid-init] ...) . rest)
        (for/foldX/derived/final [orig-stx #f] ([fold-var finid-init] ...) (values* fold-var ...) . rest)]))
 


### PR DESCRIPTION
TL;DR it would be great if a `for/fold` user could provide an expression that determined what value(s) is(are) returned from a for-loop upon completion.

Longer description:

On numerous occasions I have wished that I could have a little more control over what value(s) are returned by my `for/fold`s.

In particular, sometimes I need to perform a final computation before I'm truly done (maybe reverse a list I've been accumulating) and other times I'm only actually interested in a subset of the fold variables values persisting after the loop completes.

This PR was me just tinkering around seeing how easy it would be to add such a feature.

Here is my first ghetto version in use:

```racket
(define sorted-nums
  '(1 1 2 3 4 4 4 5 6 7 7 8 9 10 10))

;; returns a de-duped version of sorted-nums
;; that preserves the order from sorted-nums
(define deduped-sorted-nums
  (for/fold ([acc '()]
             [seen (hash)])
            #:return (reverse acc)
    ([x (in-list sorted-nums)])
    (cond
      [(hash-ref seen x #f) (values acc seen)]
      [else (values (cons x acc) (hash-set seen x #t))])))

deduped-sorted-nums
;; ==> '(1 2 3 4 5 6 7 8 9 10)
```

In that example, I have a hash I want to use during the for loop but am not interested in afterwards, and I want my accumulator list to be reversed once the for loop is done before being returned.

With the `#:return` expression I can specify the final result should only return one value, namely `(reverse acc)`.

I would find a feature like this really useful... thoughts?