### PR TITLE
Fix curry input contract

### DIFF
--- a/pkgs/racket-test/tests/racket/curry.rkt
+++ b/pkgs/racket-test/tests/racket/curry.rkt
@@ -1,0 +1,32 @@
+#lang racket/base
+(require racket/function rackunit)
+
+#| TODO: provide more comprehensive tests for
+         other racket/function functions. |#
+
+(check-pred procedure? (curry +))
+(check-pred procedure? (curry + 1))
+(check-equal? ((curry + 2) 3) 5)
+(check-equal? ((curry + 2 3) 1) 6)
+
+(define (three a b c)
+  (+ a (* b c)))
+
+(check-pred procedure? (curry three))
+(check-pred procedure? (curry three 1))
+(check-pred procedure? (curry three 1 2))
+(check-pred procedure? ((curry three 1) 2))
+(check-equal? ((curry three 1) 2 3) 7)
+(check-equal? ((curry three 4 5) 6) 34)
+(check-equal? (((curry three 3) 2) 1) 5)
+
+(check-pred procedure? ((curry list) 1 2))
+(check-pred procedure? ((curry cons) 1))
+
+(check-equal? ((curry cons) 1 2) '(1 . 2))
+(check-equal? (((curry list) 1 2) 3) '(1 2 3))
+(check-equal? (((curry list) 1) 3) '(1 3))
+(check-equal? ((((curry foldl) +) 0) '(1 2 3)) 6)
+
+(check-exn exn:fail:contract? (λ () (curry 1 2)))
+; (check-exn exn:fail:contract? (λ () (curry 1)))

--- a/pkgs/racket-test/tests/racket/curry.rkt
+++ b/pkgs/racket-test/tests/racket/curry.rkt
@@ -29,4 +29,4 @@
 (check-equal? ((((curry foldl) +) 0) '(1 2 3)) 6)
 
 (check-exn exn:fail:contract? (λ () (curry 1 2)))
-; (check-exn exn:fail:contract? (λ () (curry 1)))
+(check-exn exn:fail:contract? (λ () (curry 1)))

--- a/racket/collects/racket/function.rkt
+++ b/racket/collects/racket/function.rkt
@@ -75,9 +75,15 @@
           curried))))
   ;; curry is itself curried -- if we get args then they're the first step
   (define curry
-    (case-lambda [(f) (define (curried . args) (curry* f args '() '()))
-                      curried]
-                 [(f . args) (curry* f args '() '())]))
+    (case-lambda
+      [(f)
+       (unless (procedure? f)
+         (raise-argument-error (if right? 'curryr 'curry) "procedure?" f))
+       (define (curried . args) (curry* f args '() '()))
+       curried]
+      [(f . args)
+       (curry* f args '() '())]))
+
   (make-keyword-procedure (lambda (kws kvs f . args) (curry* f args kws kvs))
                           curry))
 


### PR DESCRIPTION
`curry` now immediately raises a contract exception when immediatly given a non-procedure argument.