### PR TITLE
Fix typo

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/quote.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/quote.scrbl
@@ -55,7 +55,7 @@ and this shorthand is almost always used instead of
 @racket[quote]. The shorthand applies even within the @racket[_datum],
 so it can produce a list containing @racket[quote].
 
-@refdetails["parse-quote"]{the @racketvalfont{'} shorthand}
+@refdetails["parse-quote"]{the @racketvalfont{@literal{'}} shorthand}
 
 @examples[
 'apple

--- a/pkgs/racket-doc/scribblings/guide/truth.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/truth.scrbl
@@ -165,7 +165,7 @@ a number or string:
 ]
 
 @;------------------------------------------------------------------------
-@section{Abbreviating @racket[quote] with @racketvalfont{'}}
+@section{Abbreviating @racket[quote] with @racketvalfont{@literal{'}}}
 
 As you may have guessed, you can abbreviate a use of
 @racket[quote] by just putting @litchar{'} in front of a form to


### PR DESCRIPTION
In http://docs.racket-lang.org/guide/Pairs__Lists__and_Racket_Syntax.html#%28part._.Abbreviating_quote_with__%29, it should use the single vertical quotation mark—`'` instead of `’`. `@racketvalfont{'}}` generates `’` while, `@racketvalfont{@literal{'}}` generates `'`.