### PR TITLE
doc: index 'RED' and 'REL'

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/windows-paths.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/windows-paths.scrbl
@@ -148,7 +148,7 @@ include @litchar{\}.
         three or more @litchar{\}s. This Racket-specific path form
         supports relative paths with elements that are not normally
         expressible in Windows paths (e.g., a final element that ends
-        in a space). The @litchar{REL} part must be exactly the three
+        in a space). The @as-index{@litchar{REL}} part must be exactly the three
         uppercase letters, and @litchar{/}s cannot be used in place
         of @litchar{\}s. If the path starts
         @litchar{\\?\REL\..}  then for as long as the
@@ -173,7 +173,7 @@ include @litchar{\}.
         no sequence of three or more @litchar{\}s. This
         Racket-specific path form supports drive-relative paths (i.e.,
         absolute given a drive) with elements that are not normally
-        expressible in Windows paths. The @litchar{RED} part must be
+        expressible in Windows paths. The @as-index{@litchar{RED}} part must be
         exactly the three uppercase letters, and @litchar{/}s cannot
         be used in place of @litchar{\}s. Unlike
         @litchar{\\?\REL} paths, a @litchar{..} element is always


### PR DESCRIPTION
Adds `REL` and `RED` to the index for searching.

I'm happy with this, but if anyone has suggestions for making the link jump to the top of the paragraph (instead of the middle), I can change the PR.

- - -

Preview of the search page:
![screen shot 2017-10-24 at 00 44 58](https://user-images.githubusercontent.com/1731829/31925058-069fd05c-b854-11e7-92ea-2f1413512c77.png)

Docs, immediately after clicking "RED" (jumps to middle of paragraph):
![screen shot 2017-10-24 at 00 45 04](https://user-images.githubusercontent.com/1731829/31925072-132d4f20-b854-11e7-85d4-dafb821892a4.png)