### PR TITLE
JSON serialize structs with prop:json-serialize

### DIFF
--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -35,7 +35,7 @@ the @rfc for more information about JSON.
     @item{@racket[string?]}
     @item{@racket[(or/c exact-integer? inexact-real?)]}
     @item{@racket[(listof jsexpr?)]}
-    @item{@racket[(and/c hash-eq? (hash/c symbol? jsexpr?))]}]
+    @item{@racket[(and/c hash-eq? (hash/c (or/c symbol? string?) jsexpr?))]}]
 
 @examples[#:eval ev
   (jsexpr? 'null)

--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -35,7 +35,8 @@ the @rfc for more information about JSON.
     @item{@racket[string?]}
     @item{@racket[(or/c exact-integer? inexact-real?)]}
     @item{@racket[(listof jsexpr?)]}
-    @item{@racket[(and/c hash-eq? (hash/c (or/c symbol? string?) jsexpr?))]}]
+    @item{@racket[(and/c hash-eq? (hash/c (or/c symbol? string?) jsexpr?))]}
+    @item{@racket[(json-serializable-struct?)]}]
 
 @examples[#:eval ev
   (jsexpr? 'null)
@@ -143,6 +144,54 @@ the @rfc for more information about JSON.
   (bytes->jsexpr #"{\"pancake\" : 5, \"waffle\" : 7}")
 ]
 }
+
+@subsection{JSON Serialization of structs}
+
+@defthing[prop:json-serializable property?]{
+
+This property identifies structures and structure types that are
+JSON serializable. The property value should be constructed with
+@racket[make-json-serialize-info].}
+
+@defproc[(make-json-serialize-info [to-json (any/c . -> . jsexpr?)])
+         any]{
+
+Produces a value to be associated with a structure type through the
+@racket[prop:json-serializable] property. This value is used by
+the @racket[json] module.
+
+The @racket[to-json] procedure should accept a structure instance
+and produce a @racket[jsexpr?] for the instance's content.}
+
+@examples[
+ #:eval ev
+ (struct pie (type)
+   #:transparent
+   #:property prop:json-serializable
+   (make-json-serialize-info
+    (λ (this)
+      (hash 'type (pie-type this)))))
+
+ (define original-pie
+   (pie "apple"))
+ original-pie
+ (define json-pie
+   (jsexpr->string original-pie))
+ json-pie
+ ]
+
+
+@defproc[(json-serializable-struct? [x any/c])
+         any]{
+
+Returns @racket[true] if @racket[x] is a struct that has a
+@racket[prop:json-serializable] property.}
+
+@examples[
+ #:eval ev
+ (json-serializable-struct? original-pie)
+ ]
+
 
 @section{A Word About Design}
 

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -32,8 +32,8 @@
         (jsexpr? '#hasheq([x . 1] [y . 2]))
         (jsexpr? '#hash([x . 1] [y . 2])) ; fine as a jsexpr too
         (jsexpr? '#hasheq([|x\y| . 1] [y . 2]))
+        (jsexpr? '#hasheq(["x" . 1]))
         (not (jsexpr? '#hasheq([1 . 1])))
-        (not (jsexpr? '#hasheq(["x" . 1])))
         (not (jsexpr? '#hasheq(['() . 1])))
         (not (jsexpr? (/ 1.0 0.0)))
         (not (jsexpr? (/ -1.0 0.0)))

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -82,7 +82,22 @@
         (jsexpr->string (string->jsexpr "{\"\U0010FFFF\":\"\U0010FFFF\"}")
                         #:encode 'all)
           => "{\"\\udbff\\udfff\":\"\\udbff\\udfff\"}"
-        ))
+          ))
+
+(define (struct-json-serialize-tests)
+  (define-struct foo (x y)
+    #:property prop:json-serializable
+    (make-json-serialize-info
+     (lambda (x)
+       (hash 'x (foo-x x)
+             'y (foo-y x)))))
+
+  (define-struct bar (w))
+
+  (test (jsexpr? (foo 1 2))
+        (not (jsexpr? (bar 1))))
+
+  (test (jsexpr->string (foo 1 2))))
 
 (define (parse-tests)
   (test (string->jsexpr @T{  1   }) =>  1
@@ -101,7 +116,7 @@
         (string->jsexpr @T{ {} }) => '#hasheq()
         (string->jsexpr @T{ {"x":1} }) => '#hasheq([x . 1])
         (string->jsexpr @T{ {"x":1,"y":2} }) => '#hasheq([x . 1] [y . 2])
-        (string->jsexpr @T{ [{"x": 1}, {"y": 2}] }) => 
+        (string->jsexpr @T{ [{"x": 1}, {"y": 2}] }) =>
                         '(#hasheq([x . 1]) #hasheq([y . 2]))
 
         ;; string escapes
@@ -148,4 +163,5 @@
 
 (test do (pred-tests)
       do (print-tests)
-      do (parse-tests))
+      do (parse-tests)
+      do (struct-json-serialize-tests))

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -54,7 +54,7 @@
         (eq? x jsnull)
         (and (list? x) (andmap loop x))
         (and (hash? x) (for/and ([(k v) (in-hash x)])
-                         (and (symbol? k) (loop v)))))))
+                         (and (or (symbol? k) (string? k)) (loop v)))))))
 
 (define (real-real? x) ; not nan or inf
   (and (inexact-real? x) (not (member x '(+nan.0 +inf.0 -inf.0)))))
@@ -116,12 +116,11 @@
            (write-bytes #"{" o)
            (define first? #t)
            (for ([(k v) (in-hash x)])
-             (unless (symbol? k)
-               (raise-type-error who "legal JSON key value" k))
              (if first? (set! first? #f) (write-bytes #"," o))
-             ;; use a string encoding so we get the same deal with
-             ;; `rx-to-encode'
-             (write-json-string (symbol->string k))
+             (cond
+              [(symbol? k) (write-json-string (symbol->string k))]
+              [(string? k) (write-json-string k)]
+              [else (raise-type-error who "legal JSON key value" k)])
              (write-bytes #":" o)
              (loop v))
            (write-bytes #"}" o)]

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -9,10 +9,10 @@
 ;; SERVICES
 
 (provide
- ;; Parameter 
- json-null ;; Parameter 
- 
- ;; Any -> Boolean 
+ ;; Parameter
+ json-null ;; Parameter
+
+ ;; Any -> Boolean
  jsexpr?
 
  #;
@@ -20,12 +20,12 @@
  ;; #:null (json-null)
  ;; #:encode 'control
  write-json
- 
+
  #;
  (->* (Input-Port) ([#:null Any]))
  ;; #null: (json-null)
  read-json
- 
+
  jsexpr->string
  jsexpr->bytes
  string->jsexpr


### PR DESCRIPTION
Yesterday on #irc, someone asked about JSON serializing arbitrary structs easily. I had suggested that I didn't know of a way (confirmed by others) but thought it'd be a great addition.

I went to @samth with an idea to do the `to-json` part via a struct property, and quickly made a working prototype. This is that prototype, cleaned up a little bit, presented with the intention of starting a discussion around it's inclusion. Is it an alright idea given there's no parsing story? Are there problems with this basic implementation?

Possible enhancements:
- `make-json-serializable-info` would be nicer, probably, with a contract.

This builds on top of #1877, a bug fix to allow string keys in hashes to be considered `jsexpr?`, but does not actually depend on the fix, itself.