### PR TITLE
filesystem-change-evt? typo

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -575,7 +575,7 @@ change events}.
 
 @defproc[(filesystem-change-evt? [v any/c]) boolean?]{
 
-Returns @racket[#f] if @racket[v] is a @tech{filesystem change
+Returns @racket[#t] if @racket[v] is a @tech{filesystem change
 event}, @racket[#f] otherwise.}
 
 


### PR DESCRIPTION
changed
Returns #f if v is a filesystem change event, #f otherwise.
to 
Returns #t if v is a filesystem change event, #f otherwise.