### PR TITLE
xform: add __isinff128

### DIFF
--- a/racket/collects/compiler/private/xform.rkt
+++ b/racket/collects/compiler/private/xform.rkt
@@ -905,7 +905,7 @@
                strlen cos cosl sin sinl exp expl pow powl log logl sqrt sqrtl atan2 atan2l frexp
                isnan isinf fpclass signbit _signbit _fpclass __fpclassify __fpclassifyf __fpclassifyl
 	       _isnan __isfinited __isnanl __isnan __signbit __signbitf __signbitd __signbitl
-               __isinff __isinfl isnanf isinff __isinfd __isnanf __isnand __isinf
+               __isinff __isinfl isnanf isinff __isinfd __isnanf __isnand __isinf __isinff128
                __inline_isnanl __inline_isnan __inline_signbit __inline_signbitf __inline_signbitd __inline_signbitl
                __builtin_popcount __builtin_clz __builtin_isnan __builtin_isinf __builtin_signbit
                __builtin_signbitf __builtin_signbitd __builtin_signbitl __builtin_isinf_sign


### PR DESCRIPTION
The __isinff128 helper function is used by recent glibc to work around a bug in gcc <7, it is [defined in math_private.h here](https://github.com/bminor/glibc/blob/ea99fcd03875caf59ceda354ec8ed813bb5a5f79/sysdeps/generic/math_private.h#L229-L241).  Otherwise building racket fails with:
```
libtool: compile:  gcc -g -O2 -Wall -I./.. -I../../../racket/gc2/../include -I../../../racket/gc2/../../rktio -I../../rktio -pthread -DUSE_SENORA_GC -DMZ_USES_SHARED_LIB -c xsrc/numarith.c  -fPIC -DPIC -o .libs/numarith.o
env XFORM_USE_PRECOMP=xsrc/precomp.h ../racketcgc  -cqu ../../../racket/gc2/xform.rkt --setup . --depends --cpp "gcc -E -I./.. -I../../../racket/gc2/../include -I../../../racket/gc2/../../rktio -I../../rktio -pthread   -DUSE_SENORA_GC   -DMZ_USES_SHARED_LIB "  --keep-lines -o xsrc/number.c ../../../racket/gc2/../src/number.c
Error [GCING] 1958 in ../../../racket/gc2/../src/number.c: Function double_is_integer declared __xform_nongcing__, but includes a function call at __isinff128.
Error [GCING] 4050 in ../../../racket/gc2/../src/number.c: Function double_fits_fixnum declared __xform_nongcing__, but includes a function call at __isinff128.
xform: Errors converting
  context...:
   /tmp/nix-build-racket-6.11.drv-0/racket-6.11/src/build/racket/gc2/xform-collects/compiler/private...:8:2: xform
   /tmp/nix-build-racket-6.11.drv-0/racket-6.11/src/build/racket/gc2/xform-collects/xform/xform-mod.rkt: [running body]
   /tmp/nix-build-racket-6.11.drv-0/racket-6.11/src/racket/gc2/xform.rkt: [running body]
```

See nixos/nixpkgs#31017.