### PR TITLE
Quoting URLs in sendurl

### DIFF
--- a/pkgs/net-lib/net/sendurl.rkt
+++ b/pkgs/net-lib/net/sendurl.rkt
@@ -247,7 +247,7 @@
     [(not browser)
      (error 'send-url "Couldn't find a browser to open URL: ~e" url)]
     [(custom-browser? browser)
-     (browser-run #:shell #t (string-append (car browser) "\"" url "\"" (cdr browser)))]
+     (browser-run #:shell #t (format "~a~s~a" (car browser) url (cdr browser)))]
     ;; if it's a known browser, then it must be an existing one at this point
     [(not exe) (error 'send-url "internal error")]
     ;; if it's gone throw an error (refiltering will break assumptions of

--- a/pkgs/net-lib/net/sendurl.rkt
+++ b/pkgs/net-lib/net/sendurl.rkt
@@ -247,7 +247,7 @@
     [(not browser)
      (error 'send-url "Couldn't find a browser to open URL: ~e" url)]
     [(custom-browser? browser)
-     (browser-run #:shell #t (string-append (car browser) url (cdr browser)))]
+     (browser-run #:shell #t (string-append (car browser) "\"" url "\"" (cdr browser)))]
     ;; if it's a known browser, then it must be an existing one at this point
     [(not exe) (error 'send-url "internal error")]
     ;; if it's gone throw an error (refiltering will break assumptions of


### PR DESCRIPTION
This fixes #1890. Note that because `"` is not a valid character in URL, it won't appear in `url`.