### PR TITLE
syntax/parse: Arrange for built-in macro’s names to be preserved

### DIFF
--- a/pkgs/racket-test/tests/stxparse/test-errors.rkt
+++ b/pkgs/racket-test/tests/stxparse/test-errors.rkt
@@ -1,5 +1,6 @@
 #lang scheme
 (require syntax/parse
+         (only-in syntax/parse [syntax-parse renamed-syntax-parse])
          syntax/parse/debug
          rackunit
          "setup.rkt")
@@ -205,4 +206,8 @@
        #rx"^define-syntax-class: "
        #rx"expected attribute name")
 ;; two more
+
+(tcerr "renamed syntax-parse bad syntax"
+       (renamed-syntax-parse)
+       #rx"^renamed-syntax-parse: ")
 

--- a/racket/collects/syntax/parse/private/sc.rkt
+++ b/racket/collects/syntax/parse/private/sc.rkt
@@ -6,10 +6,7 @@
 ;; keep and keep as abs. path -- lazy-loaded macros produce references to this
 ;; must be required via *absolute module path* from any disappearing module
 ;; (so for consistency etc, require absolutely from all modules)
-(require syntax/parse/private/residual
-         racket/syntax
-         racket/stxparam
-         syntax/stx)
+(require syntax/parse/private/residual)
 
 (begin-for-syntax
  (lazy-require
@@ -60,9 +57,7 @@
                   define-eh-alternative-set)
   (let ([tx (lambda (get-id)
               (lambda (stx)
-                (syntax-case stx ()
-                  [(_ . args)
-                   (datum->syntax stx (cons (get-id) #'args) stx)])))])
+                ((syntax-local-value (get-id)) stx)))])
     (values 
      (tx id:define-syntax-class)
      (tx id:define-splicing-syntax-class)


### PR DESCRIPTION
The dance that syntax/parse performs to lazily load its implementation rewrites uses of syntax/parse macros in such a way that their original names were discarded, which shows up in error messages. This arranges for users’ names to be preserved.

fixes #1909