### PR TITLE
Added +inf.0 and -inf.0 support to json

### DIFF
--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -46,7 +46,7 @@
           )))
 
 (define (print-tests)
-  (for ([x (list 0 1 -1 12345 0.0 1.0 #t #f (λ(n) n) "" "abc" "abc\n\\"
+  (for ([x (list 0 1 -1 12345 0.0 1.0 +inf.0 -inf.0 #t #f (λ(n) n) "" "abc" "abc\n\\"
                  '() '(1 2 3) (λ(n) `(1 "2" (3) #t #f ,n)) '((((()))))
                  '#hasheq()
                  '#hasheq([x . 1])

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -105,6 +105,10 @@
           [(eq? x #f)     (write-bytes #"false" o)]
           [(eq? x #t)     (write-bytes #"true" o)]
           [(eq? x jsnull) (write-bytes #"null" o)]
+          ;; render "inf" as "1e+9999" and "-inf" as "-1e+9999" to to overflow the parser's
+          ;; float type and result in proper inf and -inf at the end of decoding
+          [(equal? x +inf.0) (write-bytes #"1e9999" o)]
+          [(equal? x -inf.0) (write-bytes #"-1e999" o)]
           [(string? x) (write-json-string x)]
           [(list? x)
            (write-bytes #"[" o)


### PR DESCRIPTION
I don't know that inf is part of the json standard, but this allows us to pass +inf.0 and -inf.0 values and seems to work in practice.
(string->jsexpr (jsexpr->string +inf.0))