### PR TITLE
typo: local-redirect 'page that is' => 'page is'

### DIFF
--- a/pkgs/racket-index/scribblings/main/local-redirect.scrbl
+++ b/pkgs/racket-index/scribblings/main/local-redirect.scrbl
@@ -9,7 +9,7 @@
 
 @title{Redirections}
 
-This page that is intended to redirect to the result of a search
+This page is intended to redirect to the result of a search
 request. Since you're reading this, it seems that the redirection
 did not work.
 


### PR DESCRIPTION
I _ think_ the redirect page is supposed to say:

> This page is intended to redirect to the result of a search request. Since you're reading this, it seems that the redirection did not work.

If so, we should merge this. If not, I can change it to the right wording.