### PR TITLE
doc: change input/output contracts for 'current-command-line-arguments'

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/runtime.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/runtime.scrbl
@@ -162,8 +162,8 @@ ends with a newline.}
 
 
 @defparam*[current-command-line-arguments argv
-                                          (vectorof (and/c string? immutable?))
-                                          (vectorof string?)]{
+                                          (vectorof string?)
+                                          (vectorof (and/c string? immutable?))]{
 
 A @tech{parameter} that is initialized with command-line arguments when
 Racket starts (not including any command-line arguments that were


### PR DESCRIPTION
The parameter accepts a vector of string & converts the input to a
vector of immutable strings.

Example:

```
#lang racket/base
(require rackunit)

(define str (make-string 3 #\B)) ;; mutable string
(check-false (immutable? str)) ;; yes of course

(define arg
  (parameterize ([current-command-line-arguments (vector str)]) ;; this is OK
    (vector-ref (current-command-line-arguments) 0)))
(check-true (immutable? arg)) ;; interesting

(check-equal? str arg)
```