### PR TITLE
Copy source location to generate runtime paths.

### DIFF
--- a/racket/collects/racket/runtime-path.rkt
+++ b/racket/collects/racket/runtime-path.rkt
@@ -186,7 +186,8 @@
                                         (path-of
                                          #,(datum->syntax
                                             #'orig-stx
-                                            `(,#'this-expression-source-file))))
+                                            `(,#'this-expression-source-file)
+                                            #'orig-stx)))
                                     #'void)])
                  (apply to-values (resolve-paths (#%variable-reference)
                                                  get-dir


### PR DESCRIPTION
Fix found by @lexi-lambda. Bug reported by dbenoit@fedoraproject.org.