### PR TITLE
Fix for/stream, for*/stream to allow #:break in the body

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/for-body.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/for-body.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/manual
 @(require (for-label racket/base
-                     syntax/quote))
+                     syntax/quote
+                     syntax/for-body))
 
 @title{Parsing @racket[for] Bodies}
 

--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -62,4 +62,9 @@
 (test 1 'for/stream (stream-first (for*/stream ([x '(1 0)]) (/ x))))
 (test 625 'for/stream (stream-ref (for/stream ([x (in-naturals)]) (* x x)) 25))
 
+(test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)] #:break (> i 5)) i))
+(test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)]) #:break (> i 5) i))
+(test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)])
+                                    (define ii (sqr i)) #:break (> ii 30) i))
+
 (report-errs)

--- a/racket/collects/racket/stream.rkt
+++ b/racket/collects/racket/stream.rkt
@@ -317,10 +317,12 @@
              (raise-syntax-error (syntax-e #'derived-stx)
                                  "missing body expression after sequence bindings"
                                  stx #'body))
-           #`(sequence->stream
-              (in-generator
-               (#,derived-stx #,stx () clauses
-                (yield (let () . body))
-                (values)))))]))
+           (with-syntax ([((pre-body ...) body*) (split-for-body stx #'body)])
+             #`(sequence->stream
+                (in-generator
+                 (#,derived-stx #,stx () clauses
+                  pre-body ...
+                  (yield (let () . body*))
+                  (values))))))]))
     (values (make-for/stream #'for/fold/derived)
             (make-for/stream #'for*/fold/derived))))


### PR DESCRIPTION
Thanks @FalacerSelene for pointing out the bug. Also, I fixed the documentation for `split-for-body` to correctly link.

Fixes #1910.