### PR TITLE
define-simple-macro now works with an ~or macro.

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
@@ -20,7 +20,7 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 @racketblock[
 (define-syntax (macro-id stx)
   (syntax-parse stx
-    [(macro-id . pattern) pattern-directive ... (syntax template)]))
+    [((~var macro-id id) . pattern) pattern-directive ... (syntax template)]))
 ]
 
 @(the-eval '(require syntax/parse/define))
@@ -37,6 +37,8 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 ((fn2 a b (+ a b)) 3 4)
 (fn2 a #:b 'c)
 ]
+
+@history[#:changed "6.12.0.3" "Change generated pattern head to (~var macro-name id) from macro-name"]
 
 }
 

--- a/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
@@ -38,8 +38,10 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 (fn2 a #:b 'c)
 ]
 
-@history[#:changed "6.12.0.3" "Change generated pattern head to (~var macro-name id) from macro-name"]
-
+@history[#:changed "6.12.0.3" @elem{Changed pattern head to @racket[(~var macro-id id)] from
+                                    @racket[macro-id], allowing tilde-prefixed identifiers or
+                                    identifiers containing colons to be used as @racket[macro-id]
+                                    without producing a syntax error.}]
 }
 
 @defform[(define-syntax-parser macro-id parse-option ... clause ...+)]{

--- a/pkgs/racket-test/tests/stxparse/test.rkt
+++ b/pkgs/racket-test/tests/stxparse/test.rkt
@@ -810,7 +810,7 @@
     (define-simple-macro (~or . _)
       #:with stx (syntax/loc this-syntax (void))
       stx)
-    (check-eq? (~or) void)
+    (check-eq? (~or) (void))
     ))
 
 ;; from Jay McCarthy (4/2016)

--- a/pkgs/racket-test/tests/stxparse/test.rkt
+++ b/pkgs/racket-test/tests/stxparse/test.rkt
@@ -807,6 +807,10 @@
       #:with stx (syntax/loc this-syntax (void))
       stx)
     (check-eq? (x) (void))
+    (define-simple-macro (~or . _)
+      #:with stx (syntax/loc this-syntax (void))
+      stx)
+    (check-eq? (~or) void)
     ))
 
 ;; from Jay McCarthy (4/2016)

--- a/racket/collects/syntax/parse/define.rkt
+++ b/racket/collects/syntax/parse/define.rkt
@@ -8,11 +8,11 @@
 
 (define-syntax (define-simple-macro stx)
   (syntax-parse stx
-    [(define-simple-macro (~and (macro:id . _) pattern) . body)
+    [(define-simple-macro (macro:id . pattern) . body)
      #`(define-syntax macro
          (syntax-parser/template
           #,((make-syntax-introducer) stx)
-          [pattern . body]))]))
+          [(_ . pattern) . body]))]))
 
 (define-simple-macro (define-syntax-parser macro:id option-or-clause ...)
   (define-syntax macro

--- a/racket/collects/syntax/parse/define.rkt
+++ b/racket/collects/syntax/parse/define.rkt
@@ -12,7 +12,7 @@
      #`(define-syntax macro
          (syntax-parser/template
           #,((make-syntax-introducer) stx)
-          [(_ . pattern) . body]))]))
+          [((~var macro id) . pattern) . body]))]))
 
 (define-simple-macro (define-syntax-parser macro:id option-or-clause ...)
   (define-syntax macro


### PR DESCRIPTION
The previous definition of define-simple-macro would fail (with
a very poor error message) if the user made a simple macro like:

(define-simple-macro (~or a b)
  (let ([tmp a])
    (if tmp tmp b)))

While the define-simple-macro form does allow syntax-parse patterns,
this should not be enabled for the initial head pattern, as described
in the define-simple-macro documentation.