### PR TITLE
syntax/transformer: add id-transformer

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/transformer.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/transformer.scrbl
@@ -37,4 +37,34 @@ op
 @history[#:added "6.3"]{}
 }
 
+@defproc[(id-transformer [id-trans (-> identifier? syntax?)])
+         (-> syntax? syntax?)]{
+
+Creates a transformer for an identifier macro that calls
+@racket[id-trans] on the identifier, whether the macro is
+used as a bare identifier or within parentheses.
+
+@examples[#:eval the-eval
+(code:comment
+ "simple example, could be done with make-variable-like-transformer")
+(define-syntax my-add1
+  (id-transformer
+   (lambda (stx) #'add1)))
+my-add1
+(my-add1 5)
+(code:comment
+ "more complex example, taking advantage of being a transformer")
+(define-syntax whereami
+  (id-transformer
+   (lambda (stx)
+     (unless (even? (syntax-line stx))
+       (raise-syntax-error #f "must be used on an even-numbered line" stx))
+     (syntax-property #'add1 'line (syntax-line stx)))))
+(eval:error whereami)     ; line 11
+whereami                  ; line 12
+(eval:error (whereami 6)) ; line 13
+(whereami 6)              ; line 14
+]
+}
+
 @close-eval[the-eval]


### PR DESCRIPTION
When writing identifier macros, people tend to "want to" write something like
```racket
(define-syntax my-id-macro
  (lambda (stx)
    (syntax-parse stx
      [_:id (... some arbitrary expression producing syntax ...)])))
```

But when this identifier macro is used in a function application position, they get the error `my-id-macro: expected identifier`, even if `my-id-macro` could produce a function expression.

To fix this, people can do this for all their identifier macros:
```racket
(define-syntax my-id-macro
  (lambda (stx)
    (syntax-parse stx
      [_:id (... some expression ...)]
      [(my-id-macro:id . rst) #`(#,(... some expression ...) . rst)])))
```

The `id-transformer` function gets rid of this pattern and allows them to write this instead:
```racket
(define-syntax my-id-macro
  (id-transformer
    (lambda (stx) (... some expression ...))))
```