### PR TITLE
Fix typo

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/distributed.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/distributed.scrbl
@@ -51,7 +51,7 @@ symbol.
 The code for the tuple-server place exists in the file
 @filepath{tuple.rkt}.  The @filepath{tuple.rkt} file contains the use of
 @racket[define-named-remote-server] form, which defines a RPC server
-suitiable for invocation by @racket[supervise-named-dynamic-place-at].
+suitable for invocation by @racket[supervise-named-dynamic-place-at].
 
 
 


### PR DESCRIPTION
'suitiable' should read 'suitable'