### PR TITLE
Added #:cut pattern directive to syntax/parse

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/stxclasses.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/stxclasses.scrbl
@@ -350,6 +350,14 @@ example.
 Equivalent to @racket[#:and (~undo defn-or-expr ...)].
 }
 
+@specsubform[(code:line #:cut)]{
+
+Eliminates backtracking choice points and commits parsing to the
+current branch at the current point.
+
+Equivalent to @racket[#:and ~!].
+}
+
 
 @;{----------}
 

--- a/pkgs/racket-test/tests/stxparse/test.rkt
+++ b/pkgs/racket-test/tests/stxparse/test.rkt
@@ -535,6 +535,17 @@
       (check-equal? (reverse (lits)) '(a c))))
   )
 
+;; #:cut
+
+(test-case "#:cut after pattern"
+  (check-exn #rx"correct exn"
+             (lambda ()
+               (syntax-parse #'#t
+                 [b #:cut
+                    #:fail-when (syntax-e #'b) "correct exn"
+                    (values)]
+                 [_ (error "wrong exn")]))))
+
 ;; state unwinding
 
 (let ()

--- a/racket/collects/syntax/parse/private/rep.rkt
+++ b/racket/collects/syntax/parse/private/rep.rkt
@@ -1267,6 +1267,9 @@
     [(cons (list '#:undo undo-stx stmts) rest)
      (cons (action:undo stmts)
            (parse-pattern-sides rest decls))]
+    [(cons (list '#:cut cut-stx) rest)
+     (cons (action:cut)
+           (parse-pattern-sides rest decls))]
     ['()
      '()]))
 
@@ -1632,7 +1635,8 @@
         (list '#:and check-expression)
         (list '#:post check-expression)
         (list '#:do check-stmt-list)
-        (list '#:undo check-stmt-list)))
+        (list '#:undo check-stmt-list)
+        (list '#:cut)))
 
 ;; fail-directive-table
 (define fail-directive-table


### PR DESCRIPTION
The pattern directive `#:cut` is equivalent to `#:and ~!` but more explicit.

Th rationale is that often I want to cut backtracking to improve error messages, but it's not clear if I should use `#:with ~! #'dummy` or `#:and ~!` or put `~!` into the clause pattern. The latter is more insidious because it can lead to subtle problems. [Example from lecture with Stephen Chang](https://ghostbin.com/paste/sx8fo)