### PR TITLE
Moved release of lock to fix use after free

### DIFF
--- a/racket/src/rktio/rktio_process.c
+++ b/racket/src/rktio/rktio_process.c
@@ -99,6 +99,7 @@ static void add_group_signal_fd(rktio_signal_handle_t *signal_fd);
 static void remove_group_signal_fd(rktio_signal_handle_t *signal_fd);
 static void do_group_signal_fds();
 static int centralized_get_child_status(int pid, int in_group, int can_check_group, int *status);
+static int raw_get_child_status(int pid, int *status, int done_only, int do_remove, int do_free);
 
 static void add_child_status(int pid, int status)
 {
@@ -129,12 +130,13 @@ static void add_child_status(int pid, int status)
   if (st->signal_fd && st->in_group)
     remove_group_signal_fd(st->signal_fd);
 
-  pthread_mutex_unlock(&child_status_lock);
   
   if (st->signal_fd)
     rktio_signal_received_at(st->signal_fd);
   if (st->unneeded)
-    (void)centralized_get_child_status(st->pid, 0, 0, NULL);
+    (void)raw_get_child_status(st->pid, NULL, 1, 1, 1);
+
+  pthread_mutex_unlock(&child_status_lock);
 }
 
 static int raw_get_child_status(int pid, int *status, int done_only, int do_remove, int do_free)


### PR DESCRIPTION
Credit to @scottybauer for figuring this bug out.  I tested it by building racket, but since this was a non-deterministic bug I can't be sure this is a real fix.