### PR TITLE
DO NOT MERGE: Have release-tagged versions use the proper catalog for their release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ DEFAULT_SRC_CATALOG = https://pkgs.racket-lang.org
 
 # Belongs in the "Configuration options" section, but here
 # to accomodate nmake:
-SRC_CATALOG = $(DEFAULT_SRC_CATALOG)
+SRC_CATALOG = "https://download.racket-lang.org/releases/6.12/catalog/"
 
 CPUS = 
 


### PR DESCRIPTION
At least twice now, users have reported trying to build a release from source by checking out the release's tag (or downloading one of github's "release" bundles). The result is a build that has, say, a 6.12 main repo, and tries to get the latest version of packages from pkgs.r-l.org, which (usually) won't work.

A likely better solution would have to have release-tagged branches default to using the release catalog from the appropriate release. This is what the change in this commit would do.

So the idea would be to add a similar commit (with the appropriate version number) to release branches (which get turned into version tags) as the release is finalized. Such commits would never find their way to master (as they shouldn't).

If that solution has legs (and won't break anything else), I'll add it to our release scripts.

[cc: @samth, @endobson ]