### PR TITLE
Fix bashism in Makefile for better portability

### DIFF
--- a/racket/src/Makefile.in
+++ b/racket/src/Makefile.in
@@ -109,11 +109,10 @@ plain-install:
 	$(MAKE) plain-install-@MAIN_VARIANT@
 
 install-common-first:
-	if [ "$(DESTDIR)" != "" ]; then \
-          if [[ "$(DESTDIR)" != /* ]]; then \
-            echo "expected an absolute path for DESTDIR; given: $(DESTDIR)"; exit 1; \
-          fi; \
-        fi
+	case "$(DESTDIR)" in \
+	  "" | /*) ;; \
+	  *) echo "expected an absolute path for DESTDIR; given: $(DESTDIR)"; exit 1;; \
+        esac
 	mkdir -p $(ALLDIRINFO)
 
 install-common-middle:


### PR DESCRIPTION
Syntax `[[ "foo" != /* ]]` is not defined by POSIX Shell Command
Language. It's supported only by ksh, Bash and ZSH. Other POSIX
shells, such as ash or dash, does not support it.

This patch replaces this problematic syntax with simple case statement
that is supported by all POSIX-sh compatible shells, including (but not
limited to) ash, bash, dash, ZSH.