### PR TITLE
Fix function name imap-get-messages

### DIFF
--- a/pkgs/net-doc/net/scribblings/imap.scrbl
+++ b/pkgs/net-doc/net/scribblings/imap.scrbl
@@ -314,7 +314,7 @@ Pending expunges must be handled before calling this function; see
 @racket[imap-get-expunges].
 
 @examples[
-(eval:alts (imap-get-message imap '(1 3 5) '(uid header))
+(eval:alts (imap-get-messages imap '(1 3 5) '(uid header))
            '((107 #"From: larry@stooges.com ...")
              (110 #"From: moe@stooges.com ...")
              (112 #"From: curly@stooges.com ...")))


### PR DESCRIPTION
The function is called `imap-get-messages` but the example refers to `imap-get-message`, which does not exist.