### PR TITLE
match: check duplicate identifiers across list-no-order patters

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -155,7 +155,12 @@ In more detail, patterns match as follows:
        #:eval match-eval
        (match '(1 2 3)
          [(list-no-order 3 2 x) x])
-       ]}
+       ]
+
+       Unlike other patterns, @racketidfont{list-no-order} doesn't
+       allow duplicate identifiers between subpatterns. For example
+       the pattern @racket[(list-no-order x 1 x)] produces a syntax
+       error.}
 
  @item{@racket[(#,(racketidfont "list-no-order") _pat ... _lvp)] ---
        generalizes @racketidfont{list-no-order} to allow a pattern
@@ -166,7 +171,12 @@ In more detail, patterns match as follows:
        #:eval match-eval
        (match '(1 2 3 4 5 6)
          [(list-no-order 6 2 y ...) y])
-       ]}
+       ]
+
+       Unlike other patterns, @racketidfont{list-no-order} doesn't
+       allow duplicate identifiers between subpatterns. For example
+       the pattern @racket[(list-no-order x 1 x ...)] produces a
+       syntax error.}
 
  @item{@racket[(#,(racketidfont "vector") _lvp ...)] --- like a
        @racketidfont{list} pattern, but matching a vector.

--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -157,10 +157,11 @@ In more detail, patterns match as follows:
          [(list-no-order 3 2 x) x])
        ]
 
-       Unlike other patterns, @racketidfont{list-no-order} doesn't
-       allow duplicate identifiers between subpatterns. For example
-       the pattern @racket[(list-no-order x 1 x)] produces a syntax
-       error.}
+       @margin-note{
+         Unlike other patterns, @racketidfont{list-no-order} doesn't
+         allow duplicate identifiers between subpatterns. For example
+         the patterns @racket[(list-no-order x 1 x)] and
+         @racket[(list-no-order x 1 x ...)] both produce syntax errors.}}
 
  @item{@racket[(#,(racketidfont "list-no-order") _pat ... _lvp)] ---
        generalizes @racketidfont{list-no-order} to allow a pattern
@@ -171,12 +172,7 @@ In more detail, patterns match as follows:
        #:eval match-eval
        (match '(1 2 3 4 5 6)
          [(list-no-order 6 2 y ...) y])
-       ]
-
-       Unlike other patterns, @racketidfont{list-no-order} doesn't
-       allow duplicate identifiers between subpatterns. For example
-       the pattern @racket[(list-no-order x 1 x ...)] produces a
-       syntax error.}
+       ]}
 
  @item{@racket[(#,(racketidfont "vector") _lvp ...)] --- like a
        @racketidfont{list} pattern, but matching a vector.


### PR DESCRIPTION
The docs for `list-no-order` still need to be changed to say that duplicate identifiers aren't allowed across different sub-patterns.

This pull request fixes #1964 by changing the error message from this:
```
a10: unbound identifier;
 also, no #%top transformer is bound in: a10
```
To this: (where DrRacket highlights the the `a` in the second sub-pattern)
```
. list-no-order: unexpected duplicate identifier in: a
```

The way this pull request does the duplicate identifier check, programs like this get the "unexpected duplicate identifier" error:
```racket
(match (list 1 1)
  [(list-no-order x x)
   x])
```
But programs like this are fine:
```racket
(match (list (list 1 1))
  [(list-no-order (list x x))
   x])
```
```racket
(match (list (list 1 1) (list 2 2))
  [(list-no-order (list x x) (list y y))
   x])
```
Since they don't have duplicates that span *across multiple* sub-patterns.