### PR TITLE
doc: fix zo struct typos

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -547,9 +547,9 @@ result will not call @racket[proc] with @racket['unlock].)
             compilations of the same Racket source files in multiple places.
 }
 
-@defproc[(install-module-hashes! [bstr btyes?]
-                                 [start exact-nonnegatve-integer? 0]
-                                 [end exact-nonnegatve-integer? (bytes-length bstr)])
+@defproc[(install-module-hashes! [bstr bytes?]
+                                 [start exact-nonnegative-integer? 0]
+                                 [end exact-nonnegative-integer? (bytes-length bstr)])
          void?]{
 
 Adjusts the bytecode representation in @racket[bstr] (from bytes

--- a/pkgs/racket-doc/scribblings/raco/zo-parse.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/zo-parse.scrbl
@@ -22,8 +22,8 @@ The @racketmodname[compiler/zo-parse] module re-exports
   represent the bytecode are subject to frequent changes across Racket
   versons.
 
-  The parsed bytecode is returned in a @racket[link-directory] or
-  @racket[link-bundle] structure---the latter only for the compilation
+  The parsed bytecode is returned in a @racket[linkl-directory] or
+  @racket[linkl-bundle] structure---the latter only for the compilation
   of a module that contains no submodules.
 
   Within a linklet, the bytecode representation of an expression is closer to an
@@ -67,11 +67,3 @@ The @racketmodname[compiler/zo-parse] module re-exports
   variables, but individual boxes are referenced from the stack and
   closures.}
 
-
-@defproc[(decode-module-binding [binding module-binding?]
-                                [name symbol?])
-         decoded-module-binding?]{
-
-Given a compact-form representation of a module binding and the name
-from which the binding is mapped, returns a normalized form of the
-binding.}

--- a/pkgs/racket-doc/scribblings/raco/zo-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/zo-struct.scrbl
@@ -154,9 +154,6 @@ returns.}
 Represents the shape of an expected import as a structure-type
 binding, constructor, etc.}
 
-@defstruct+[(stx zo) ([content stx-obj?])]{
-  Wraps a syntax object as it appears in a @racket[prefix].}
-
 
 @; --------------------------------------------------
 @section{Forms and Inline Variants}


### PR DESCRIPTION
- remove `decode-module-binding`, because this function doesn't seem to
  be provided
- remove the `stx` struct
- fix small typos / broken links