### PR TITLE
rename ??,?@ to ~?,~@

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-patterns.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-patterns.scrbl
@@ -270,7 +270,7 @@ the individual @racket[stx-expr].
 (math 3 1 4 1 5 9)
 ]}
 
-@defform[#:literals (?? ?@) (syntax template)
+@defform[#:literals (~? ~@) (syntax template)
          #:grammar
          ([template id
                     (head-template ...)
@@ -278,16 +278,16 @@ the individual @racket[stx-expr].
                     (code:line #,(tt "#")(head-template ...))
                     (code:line #,(tt "#&")template)
                     (code:line #,(tt "#s")(key-datum head-template ...))
-                    (?? template template)
+                    (~? template template)
                     (ellipsis stat-template)
                     const]
           [head-template template
                          (code:line head-template ellipsis ...+)
-                         (?@ . template)
-                         (?? head-template head-template)
-                         (?? head-template)]
+                         (~@ . template)
+                         (~? head-template head-template)
+                         (~? head-template)]
           [stat-template @#,elem{like @svar{template}, but without @|lit-ellipsis|,
-                                 @racket[??], and @racket[?@]}]
+                                 @racket[~?], and @racket[~@]}]
           [ellipsis #,lit-ellipsis])]{
 
 Constructs a syntax object based on a @racket[template], which can
@@ -297,7 +297,7 @@ include @tech{pattern variables} bound by @racket[syntax-case] or
 A @svar[template] produces a single syntax object. A
 @svar[head-template] produces a sequence of zero or more syntax
 objects. A @svar[stat-template] is like a @svar[template], except that
-@|lit-ellipsis|, @racket[??], and @racket[?@] are interpreted as
+@|lit-ellipsis|, @racket[~?], and @racket[~@] are interpreted as
 constants instead of template forms.
 
 A @svar[template] produces a syntax object as follows:
@@ -350,7 +350,7 @@ A @svar[template] produces a syntax object as follows:
    The @racket[key-datum] must correspond to a valid first argument of
    @racket[make-prefab-struct].}
 
- @specsubform[#:literals (??) (?? template1 template2)]{
+ @specsubform[#:literals (~?) (~? template1 template2)]{
 
    Produces the result of @racket[template1] if @racket[template1] has no
    pattern variables with ``missing values''; otherwise, produces the result of
@@ -363,16 +363,16 @@ A @svar[template] produces a syntax object as follows:
    @examples[#:eval (let ([ev (syntax-eval)]) (ev '(require syntax/parse/pre)) ev)
    (syntax-parse #'(m 1 2 3)
      [(_ (~optional (~seq #:op op:expr)) arg:expr ...)
-      #'((?? op +) arg ...)])
+      #'((~? op +) arg ...)])
    (syntax-parse #'(m #:op max 1 2 3)
      [(_ (~optional (~seq #:op op:expr)) arg:expr ...)
-      #'((?? op +) arg ...)])
+      #'((~? op +) arg ...)])
    ]}
 
  @specsubform[(ellipsis stat-template)]{
 
   Produces the same result as @racket[stat-template], which is like a
-  @racket[template], but @racket[...], @racket[??], and @racket[?@]
+  @racket[template], but @racket[...], @racket[~?], and @racket[~@]
   are treated like an @racket[id] (with no pattern binding).}
 
  @specsubform[const]{
@@ -414,7 +414,7 @@ A @racket[head-template] produces a sequence of syntax objects; that sequence is
   not occur at a depth less than its @tech{depth marker}; otherwise, an error is
   raised.}
 
- @specsubform[#:literals (?@) (?@ . template)]{
+ @specsubform[#:literals (~@) (~@ . template)]{
 
    Produces the sequence of elements in the syntax list produced by
    @racket[template]. If @racket[template] does not produce a proper syntax list,
@@ -423,23 +423,23 @@ A @racket[head-template] produces a sequence of syntax objects; that sequence is
    @examples[#:eval (syntax-eval)
    (with-syntax ([(key ...) #'('a 'b 'c)]
                  [(val ...) #'(1 2 3)])
-     #'(hash (?@ key val) ...))
+     #'(hash (~@ key val) ...))
    (with-syntax ([xs #'(2 3 4)])
-     #'(list 1 (?@ . xs) 5))
+     #'(list 1 (~@ . xs) 5))
    ]}
 
- @specsubform[#:literals (??) (?? head-template1 head-template2)]{
+ @specsubform[#:literals (~?) (~? head-template1 head-template2)]{
 
    Produces the result of @racket[head-template1] if none of its pattern
    variables have ``missing values''; otherwise produces the result of
    @racket[head-template2]. }
 
- @specsubform[#:literals (??) (?? head-template)]{
+ @specsubform[#:literals (~?) (~? head-template)]{
 
    Produces the result of @racket[head-template] if none of its pattern
    variables have ``missing values''; otherwise produces nothing.
 
-   Equivalent to @racket[(?? head-template (?@))]. }
+   Equivalent to @racket[(~? head-template (~@))]. }
 
 A @racket[(#,(racketkeywordfont "syntax") template)] form is normally
 abbreviated as @racket[#'template]; see also
@@ -447,7 +447,7 @@ abbreviated as @racket[#'template]; see also
 variables, then @racket[#'template] is equivalent to
 @racket[(quote-syntax template)].
 
-@history[#:changed "6.90.0.24" @elem{Added @racket[?@] and @racket[??].}]
+@history[#:changed "6.90.0.24" @elem{Added @racket[~@] and @racket[~?].}]
 }
 
 
@@ -569,11 +569,11 @@ where it indicates a pattern that matches any syntax object. See
 @racket[syntax-case].}
 
 @deftogether[[
-@defidform[??]
-@defidform[?@]
+@defidform[~?]
+@defidform[~@]
 ]]{
 
-The @racket[??] and @racket[?@] transformer bindings prohibit these forms from
+The @racket[~?] and @racket[~@] transformer bindings prohibit these forms from
 being used as an expression. The bindings are useful only in syntax templates.
 See @racket[syntax].
 

--- a/pkgs/racket-doc/syntax/scribblings/parse/ex-kw-args.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/ex-kw-args.scrbl
@@ -64,9 +64,9 @@ There's a simpler way of writing the @racket[~or*] pattern above:
 ]
 
 
-@section{Optional Arguments with @racket[??]}
+@section{Optional Arguments with @racket[~?]}
 
-The @racket[??] template form provides a compact alternative to
+The @racket[~?] template form provides a compact alternative to
 explicitly testing attribute values. Here's one way to do it:
 
 @interaction[#:eval the-eval
@@ -74,11 +74,11 @@ explicitly testing attribute values. Here's one way to do it:
   (syntax-parse stx
     [(mycond (~optional (~seq #:error-on-fallthrough who:expr))
              clause ...)
-     #'(mycond* (?? (?@ #t who) (?@ #f #f)) clause ...)]))
+     #'(mycond* (~? (~@ #t who) (~@ #f #f)) clause ...)]))
 ]
 
-If @racket[who] matched, then the @racket[??] subtemplate splices in
-the two terms @racket[#t who] into the enclosing template (@racket[?@]
+If @racket[who] matched, then the @racket[~?] subtemplate splices in
+the two terms @racket[#t who] into the enclosing template (@racket[~@]
 is the template splicing form). Otherwise, it splices in @racket[#f #f].
 
 Here's an alternative definition that re-uses Racket's @racket[cond] macro:
@@ -88,15 +88,15 @@ Here's an alternative definition that re-uses Racket's @racket[cond] macro:
   (syntax-parse stx
     [(mycond (~optional (~seq #:error-on-fallthrough who:expr))
              clause ...)
-     #'(cond clause ... (?? [else (error 'who "no clause matched")] (?@)))]))
+     #'(cond clause ... (~? [else (error 'who "no clause matched")] (~@)))]))
 ]
 
 In this version, we optionally insert an @racket[else] clause at the
 end to signal the error; otherwise we use @racket[cond]'s fall-through
 behavior (that is, returning @racket[(void)]).
 
-If the second subtemplate of a @racket[??] template is
-@racket[(?@)]---that is, it produces no terms at all---the second
+If the second subtemplate of a @racket[~?] template is
+@racket[(~@)]---that is, it produces no terms at all---the second
 subtemplate can be omitted.
 
 

--- a/pkgs/racket-doc/syntax/scribblings/parse/experimental.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/experimental.scrbl
@@ -293,6 +293,14 @@ Equivalent to @racket[syntax], @racket[syntax/loc],
 Equivalent to @racket[datum].
 }
 
+@deftogether[[
+@defidform[??]
+@defidform[?@]
+]]{
+
+Equivalent to @racket[~?] and @racket[~@], respectively.
+}
+
 @defform*[[(define-template-metafunction metafunction-id expr)
            (define-template-metafunction (metafunction-id . formals) body ...+)]]{
 

--- a/pkgs/racket-test-core/tests/racket/stx.rktl
+++ b/pkgs/racket-test-core/tests/racket/stx.rktl
@@ -2623,28 +2623,28 @@
            (equal? (syntax-line #'cons) (syntax-line #'one))])))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Minimal tests for syntax and ?@, ??
+;; Minimal tests for syntax and ~@, ~?
 ;; More tests in pkgs/racket-test/tests/stxparse/test-syntax.rkt
 
 (test '(a 1 b 2 c 3)
       'syntax
       (with-syntax ([(x ...) #'(a b c)] [(y ...) #'(1 2 3)])
-        (syntax->datum #'((?@ x y) ...))))
+        (syntax->datum #'((~@ x y) ...))))
 
 (test '(1 2 3 4)
       'syntax
       (with-syntax ([xs #'(2 3)])
-        (syntax->datum #'(1 (?@ . xs) 4))))
+        (syntax->datum #'(1 (~@ . xs) 4))))
 
 (test '(1 2 3)
       'syntax
       (with-syntax ([x #'(1 2 3)])
-        (syntax->datum #'(?? x "missing"))))
+        (syntax->datum #'(~? x "missing"))))
 
 (test '(4 5 6)
       'syntax
       (with-syntax ([(x ...) #'(4 5 6)])
-        (syntax->datum #'((?? x) ...))))
+        (syntax->datum #'((~? x) ...))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/racket/collects/racket/private/ellipses.rkt
+++ b/racket/collects/racket/private/ellipses.rkt
@@ -1,15 +1,15 @@
 (module ellipses '#%kernel
   (#%require (for-syntax '#%kernel))
 
-  (#%provide ... _ ?? ?@)
+  (#%provide ... _ ~? ~@)
 
   (define-syntaxes (...)
     (lambda (stx)
       (raise-syntax-error #f "ellipses not allowed as an expression" stx)))
 
-  (define-syntaxes (??)
+  (define-syntaxes (~?)
     (lambda (stx) (raise-syntax-error #f "not allowed as an expression" stx)))
-  (define-syntaxes (?@)
+  (define-syntaxes (~@)
     (lambda (stx) (raise-syntax-error #f "not allowed as an expression" stx)))
 
   (define-syntaxes (_)

--- a/racket/collects/racket/private/qqstx.rkt
+++ b/racket/collects/racket/private/qqstx.rkt
@@ -105,7 +105,7 @@
                                                     [ctx (datum->syntax #'x 'ctx #'x)])
                                         (convert-k (datum->syntax
                                                     stx
-                                                    (cons #'(?@! . temp) rest-v)
+                                                    (cons #'(~@! . temp) rest-v)
                                                     stx
                                                     stx)
                                                    (with-syntax ([check check-splicing-list-id])

--- a/racket/collects/racket/private/stxloc.rkt
+++ b/racket/collects/racket/private/stxloc.rkt
@@ -56,4 +56,4 @@
               #'id))])))
 
   (#%provide syntax/loc quote-syntax/prune syntax-case* syntax-case datum-case
-             ... _ ?? ?@))
+             ... _ ~? ~@))

--- a/racket/collects/syntax/parse/experimental/template.rkt
+++ b/racket/collects/syntax/parse/experimental/template.rkt
@@ -5,8 +5,9 @@
 (provide (rename-out [syntax template]
                      [syntax/loc template/loc]
                      [quasisyntax quasitemplate]
-                     [quasisyntax/loc quasitemplate/loc])
-         ?? ?@
+                     [quasisyntax/loc quasitemplate/loc]
+                     [~? ??]
+                     [~@ ?@])
          define-template-metafunction)
 
 ;; ============================================================


### PR DESCRIPTION
One of the old names (`??`) conflicts with Rosette (see PR #2031).
