### PR TITLE
 schemify: fix boolean-or-fixnum?

### DIFF
--- a/racket/src/schemify/equal.rkt
+++ b/racket/src/schemify/equal.rkt
@@ -15,18 +15,19 @@
      (let ([val (unwrap val)])
        (or (symbol? val)
            (keyword? val)
+           (null? val)
            (boolean-or-fixnum? val)))]
     [`,val
      (let ([val (unwrap val)])
-       ;; Booleans and numbers don't have to be quuted
+       ;; Booleans and numbers don't have to be quoted
        (boolean-or-fixnum? val))]))
 
 (define (boolean-or-fixnum? val)
-  (boolean? val)
-  (and (integer? val)
-       (exact? val)
-       ;; Always fixnum? Conversatively...
-       (<= (- (expt 2 16)) val (expt 2 16))))
+  (or (boolean? val)
+      (and (integer? val)
+           (exact? val)
+           ;; Always fixnum? conservatively...
+           (<= (- (expt 2 24)) val (- (expt 2 24) 1)))))
 
 (define (equal-implies-eqv? e)
   (match e


### PR DESCRIPTION
The first commit is the interesting one, and it fix the ignored `boolean?` test.

The seccond commit is silly, but I've wrote too much assembly when I was young and that `fixnum?` range makes me uneasy. Fell free to ignore it. Anyway, `(expt 2 16)` is too conservative. What about `24` bits? But you have more knowdledge about the landscape of the scheme implementations.

The third one is guaranted by the scheme standard (IIRC). I'm not sure if in that point the `null`s must be quoted or not. So look at it carefuly.

The three commits are very related, so it would be good to squash them before merging.

