### PR TITLE
Handle symbol changes between openssl-1.0 and 1.1

### DIFF
--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -338,10 +338,21 @@ TO DO:
 (define-crypto X509_NAME_get_entry (_fun _X509_NAME* _int -> _X509_NAME_ENTRY*/null))
 (define-crypto X509_NAME_ENTRY_get_data (_fun _X509_NAME_ENTRY* -> _ASN1_STRING*))
 (define-crypto X509_get_ext_d2i (_fun _X509* _int _pointer _pointer -> _STACK*/null))
-(define-crypto sk_num (_fun _STACK* -> _int))
-(define-crypto sk_GENERAL_NAME_value (_fun _STACK* _int -> _GENERAL_NAME-pointer)
-  #:c-id sk_value)
-(define-crypto sk_pop_free (_fun _STACK* _fpointer -> _void))
+(define sk_num
+  (or (get-ffi-obj 'sk_num libcrypto (_fun _STACK* -> _int)
+                   (lambda () #f))
+      (get-ffi-obj 'OPENSSL_sk_num libcrypto (_fun _STACK* -> _int)
+                   (make-not-available 'sk_num))))
+(define sk_GENERAL_NAME_value
+  (or (get-ffi-obj 'sk_value libcrypto (_fun _STACK* _int -> _GENERAL_NAME-pointer) 
+                   (lambda () #f))
+      (get-ffi-obj 'OPENSSL_sk_value libcrypto (_fun _STACK* _int -> _GENERAL_NAME-pointer) 
+                   (make-not-available "sk_GENERAL_NAME_value"))))
+(define sk_pop_free
+  (or (get-ffi-obj 'sk_pop_free libcrypto (_fun _STACK* _fpointer -> _void) 
+                   (lambda () #f))
+      (get-ffi-obj 'OPENSSL_sk_pop_free libcrypto (_fun _STACK* _fpointer -> _void)
+                   (make-not-available "sk_pop_free"))))
 
 ;; (define-crypto X509_get_default_cert_area (_fun -> _string))
 (define-crypto X509_get_default_cert_dir  (_fun -> _string))


### PR DESCRIPTION
In openssl-1.1 (specifically libcrypto) the functions sk_num, sk_value and sk_pop_free are prefixed by 'OPENSSL_'.
Now both symbol names looked for to support both version 1.0 and 1.1.

I've tested this with both versions on my machine (x86_64 linux) and it works fine. Previously when linking with openssl-1.1 using any of these functions would cause an error.