### PR TITLE
Fix indentation

### DIFF
--- a/racket/collects/setup/main.rkt
+++ b/racket/collects/setup/main.rkt
@@ -201,7 +201,7 @@
 
   (if (or (on? "--clean")
           (on? "-c")
-	  (on? "--no-zo")
+          (on? "--no-zo")
           (on? "-n"))
       ;; Don't use .zos, in case they're out of date, and don't load
       ;;  cm:


### PR DESCRIPTION
Remove tab and add spaces, which is how the rest of the file deals with this.
Avoid a misaligned preview in github editor.