### PR TITLE
Fix typo

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
@@ -96,7 +96,7 @@ popular among Racketeers as well.
        documentation in the minibuffer.
 
        While this mode was designed for @seclink["r5rs"]{@|r5rs|}, it
-       can still be useful for Racket development. That the tool is
+       can still be useful for Racket development. The tool is
        unaware of large portions of the Racket standard library, and
        there may be some discrepancies in the live documentation in
        cases where Scheme and Racket have diverged.}


### PR DESCRIPTION
Removed an unnecessary word at the beginning of a sentence and capitalized the new first word.

`That the tool is unaware of large portions of the Racket standard library, and there may be some discrepancies in the live documentation in cases where Scheme and Racket have diverged.`

becomes

`The tool is unaware of large portions of the Racket standard library, and there may be some discrepancies in the live documentation in cases where Scheme and Racket have diverged.`