### PR TITLE
Fix typo (pre-heating -> preheating)

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/simple-syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/simple-syntax.scrbl
@@ -107,7 +107,7 @@ evaluated only for some side-effect, such as printing.
 @defexamples[
 #:eval ex-eval
 (define (bake flavor)
-  (printf "pre-heating oven...\n")
+  (printf "preheating oven...\n")
   (string-append flavor " pie"))
 (bake "apple")
 ]


### PR DESCRIPTION
As far as I know, `pre-heating` is not considered a correct spelling of this word. Maybe it was intentionally written this way for a reason. If unintentional, I propose using it without the dash.

`pre-defines` and `pre-defined` appear in the same document. Is this a stylistic choice?