### PR TITLE
fix: allow missing fields in `object/c-common-fields-stronger?`

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/stronger.rkt
+++ b/pkgs/racket-test/tests/racket/contract/stronger.rkt
@@ -454,6 +454,9 @@
          (object/c (field (f (<=/c 4))))
          (object/c (field (f (<=/c 4)))))
   (ctest #t contract-stronger?
+         (object/c (field (f (<=/c 4))))
+         (object/c))
+  (ctest #t contract-stronger?
          (object/c (m (-> any/c (<=/c 3)))
                    (n (-> any/c any/c)))
          (object/c (m (-> any/c (<=/c 4)))))

--- a/racket/collects/racket/private/class-c-old.rkt
+++ b/racket/collects/racket/private/class-c-old.rkt
@@ -1641,16 +1641,17 @@
                (names-sel this))
        (for/and ([this-name (in-list (names-sel this))]
                  [this-ctc (in-list (ctcs-sel this))])
-         (for/or ([that-name (in-list (names-sel that))]
-                  [that-ctc (in-list (ctcs-sel that))])
-           (and (equal? this-name that-name)
-                (contract-equivalent?
-                 (if (just-check-existence? this-ctc)
-                     any/c
-                     this-ctc)
-                 (if (just-check-existence? that-ctc)
-                     any/c
-                     that-ctc)))))))
+         (or (not (member this-name (names-sel that)))
+             (for/or ([that-name (in-list (names-sel that))]
+                      [that-ctc (in-list (ctcs-sel that))])
+               (and (equal? this-name that-name)
+                    (contract-equivalent?
+                     (if (just-check-existence? this-ctc)
+                         any/c
+                         this-ctc)
+                     (if (just-check-existence? that-ctc)
+                         any/c
+                         that-ctc))))))))
 
 (define-struct base-object/c (methods method-contracts fields field-contracts)
   #:property prop:custom-write custom-write-property-proc


### PR DESCRIPTION
Yesterday the Typed Racket unit tests failed with this message:

```
contract (object/c-opaque (h (->m (-> boolean? boolean? boolean?) integer?)) (field (x any/c))) is unexpectedly weaker than (object/c)
```

This PR fixes that failure by changing `object/c-common-fields-stronger?` to only compare the fields that are in both objects (instead of returning `#false` if the second object doesn't have a field from the first).

I think this is the right thing ... `object/c-stronger` is already checking `object/c-width-subtype` to guard against missing fields.

But, a different fix would be to implement this directly in Typed Racket.