### PR TITLE
Make stx.rkt cross-phase persistent.

### DIFF
--- a/racket/collects/racket/private/cond.rkt
+++ b/racket/collects/racket/private/cond.rkt
@@ -3,7 +3,7 @@
 ;; cond
 
 (module cond '#%kernel
-  (#%require (for-syntax "stx.rkt" "qq-and-or.rkt" '#%kernel))
+  (#%require (for-syntax "stx.rkt" "qq-and-or.rkt" '#%kernel "gen-temp.rkt"))
 
   (define-syntaxes (=>)
     (lambda (stx)

--- a/racket/collects/racket/private/gen-temp.rkt
+++ b/racket/collects/racket/private/gen-temp.rkt
@@ -1,0 +1,18 @@
+;;----------------------------------------------------------------------
+;; stateful syntax support
+
+(module gen-temp '#%kernel
+  (define-values (intro) #f)
+  (define-values (counter) 0)
+  (define-values (gen-temp-id)
+    ;; Even though we gensym, using an introducer helps the
+    ;;  syntax system simplify renamings that can't apply
+    ;;  to other identifiers (when the generated identifier
+    ;;  is used as a binding id)
+    (lambda (pfx)
+      (if intro
+          (void)
+          (set! intro (make-syntax-introducer)))
+      (set! counter (add1 counter))
+      (intro (datum->syntax #f (string->uninterned-symbol (format "~a~a" pfx counter))))))
+  (#%provide gen-temp-id))

--- a/racket/collects/racket/private/stx.rkt
+++ b/racket/collects/racket/private/stx.rkt
@@ -2,7 +2,7 @@
 ;; basic syntax utilities
 
 (module stx '#%kernel
-
+  (#%declare #:cross-phase-persistent)
   ;; These utilities facilitate operations on syntax objects.
   ;; A syntax object that represents a parenthesized sequence
   ;; can contain a mixture of cons cells and syntax objects,
@@ -197,20 +197,6 @@
                       (loop s))])
 	(values pre post (= m n)))))
 
-  (define-values (intro) #f)
-  (define-values (counter) 0)
-  (define-values (gen-temp-id)
-    ;; Even though we gensym, using an introducer helps the
-    ;;  syntax system simplify renamings that can't apply
-    ;;  to other identifiers (when the generated identifier
-    ;;  is used as a binding id)
-    (lambda (pfx)
-      (if intro
-          (void)
-          (set! intro (make-syntax-introducer)))
-      (set! counter (add1 counter))
-      (intro (datum->syntax #f (string->uninterned-symbol (format "~a~a" pfx counter))))))
-
   (#%provide identifier? stx-null? stx-null/#f stx-pair? stx-list?
              stx-car stx-cdr stx->list
              stx-vector? stx-vector-ref
@@ -218,5 +204,4 @@
              stx-prefab?
              stx-check/esc cons/#f append/#f
              stx-rotate stx-rotate*
-             split-stx-list
-             gen-temp-id))
+             split-stx-list))

--- a/racket/collects/racket/private/stxcase.rkt
+++ b/racket/collects/racket/private/stxcase.rkt
@@ -5,7 +5,7 @@
   (#%require "stx.rkt" "small-scheme.rkt" '#%paramz '#%unsafe
              "ellipses.rkt"
              (for-syntax "stx.rkt" "small-scheme.rkt"
-                         "member.rkt" "sc.rkt" '#%kernel))
+                          "gen-temp.rkt" "member.rkt" "sc.rkt" '#%kernel))
 
   (-define interp-match
      (lambda (pat e literals immediate=?)

--- a/racket/collects/racket/private/with-stx.rkt
+++ b/racket/collects/racket/private/with-stx.rkt
@@ -4,7 +4,7 @@
 (module with-stx '#%kernel
   (#%require "stx.rkt" "small-scheme.rkt" "stxcase.rkt"
              (for-syntax '#%kernel "stx.rkt" "stxcase.rkt" "stxloc.rkt" 
-                         "sc.rkt" "qq-and-or.rkt" "cond.rkt"))
+                         "gen-temp.rkt" "sc.rkt" "qq-and-or.rkt" "cond.rkt"))
 
   (-define (with-syntax-fail stx)
     (raise-syntax-error

--- a/racket/collects/racket/repl.rkt
+++ b/racket/collects/racket/repl.rkt
@@ -1,5 +1,5 @@
 (module repl '#%kernel
-
+  (#%declare #:cross-phase-persistent)
   (#%provide read-eval-print-loop)
 
   (define-values (read-eval-print-loop)


### PR DESCRIPTION
This eliminates more than 70 linklet instance creations.

I'm not sure if this is a good idea. Linklet instance creation
is measured in pycket, which is the equivalent of `-c`.