### PR TITLE
Update broken link in com-auto.scrbl

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/com-auto.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/com-auto.scrbl
@@ -439,7 +439,7 @@ application itself need not be installed on the client machine.
 
 There are a number of configuration issues relating to DCOM. See
 
-@centerline{@link["http://www.distribucon.com/dcom95.aspx"]{http://www.distribucon.com/dcom95.html}}
+@centerline{@link["https://web.archive.org/web/20061013184653/www.distribucon.com/dcom95.html"]{http://www.distribucon.com/dcom95.html}}
 
 for more information on how to setup client and server machines for DCOM.
 


### PR DESCRIPTION
http://www.distribucon.com/dcom95.aspx is dead.  I was not able to find an updated copy of the content with a new path, so I changed the link to point at the last available version on web.archive.org.