### PR TITLE
Eliminate the need for syntax-local-match-introduce, syntax-local-require-introduce, syntax-local-provide-introduce, and syntax-local-syntax-parse-pattern-introduce

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -695,8 +695,9 @@ properties.
 }
 
 @defproc[(syntax-local-match-introduce [stx syntax?]) syntax?]{
-Like @racket[syntax-local-introduce], but for match expanders.
-}
+For backward compatibility only; equivalent to @racket[syntax-local-introduce].
+
+@history[#:changed "6.90.0.29" @elem{Made equivalent to @racket[syntax-local-introduce].}]}
 
 
 @defparam[match-equality-test comp-proc (any/c any/c . -> . any)]{

--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -578,8 +578,8 @@ a call of the @tech{syntax transformer} by the expander; see
 @secref["expand-steps"].
 
 Before the expander passes a @tech{syntax object} to a transformer,
-the @tech{syntax object} is extended with a fresh @tech{scope} (that
-applies to all sub-@tech{syntax objects}) to distinguish @tech{syntax objects}
+the @tech{syntax object} is extended with a fresh @deftech{macro-introduction scope}
+(that applies to all sub-@tech{syntax objects}) to distinguish @tech{syntax objects}
 at the macro's use site from @tech{syntax objects} that are introduced by the macro;
 in the result of the transformer the presence of the @tech{scope} is
 flipped, so that introduced @tech{syntax objects} retain the @tech{scope},

--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -2583,20 +2583,17 @@ procedure that accepts and returns a syntax object representing a
 
 This form expands to @racket[define-syntax] with a use of
 @racket[make-require-transformer] (see @secref["require-trans"] for
-more information), and the @tech{syntax object} passed to and from the
-macro transformer is adjusted via @racket[syntax-local-require-introduce].
+more information).
 
 The second form is a shorthand the same as for @racket[define-syntax]; it
 expands to a definition of the first form where the @racket[proc-expr] is a
 @racket[lambda] form.}
 
-@defproc[(syntax-local-require-introduce [stx syntax?])
-         syntax?]{
+@defproc[(syntax-local-require-introduce [stx syntax?]) syntax?]{
 
-Provided @racket[for-syntax] for use only during the application of a
-@racket[require] sub-form macro transformer: like
-@racket[syntax-local-introduce], but for @racket[require] sub-form
-expansion.}
+For backward compatibility only; equivalent to @racket[syntax-local-introduce].
+
+@history[#:changed "6.90.0.29" @elem{Made equivalent to @racket[syntax-local-introduce].}]}
 
 @; ----------------------------------------------------------------------
 
@@ -2614,20 +2611,17 @@ procedure that accepts and returns a syntax object representing a
 
 This form expands to @racket[define-syntax] with a use of
 @racket[make-provide-transformer] (see @secref["provide-trans"] for
-more information), and the @tech{syntax object} passed to and from the
-macro transformer is adjusted via @racket[syntax-local-provide-introduce].
+more information).
 
 The second form is a shorthand the same as for @racket[define-syntax]; it
 expands to a definition of the first form where the @racket[expr] is a
 @racket[lambda] form.}
 
-@defproc[(syntax-local-provide-introduce [stx syntax?])
-         syntax?]{
+@defproc[(syntax-local-provide-introduce [stx syntax?]) syntax?]{
 
-Provided @racket[for-syntax] for use only during the application of a
-@racket[provide] sub-form macro transformer: like
-@racket[syntax-local-introduce], but for @racket[provide] sub-form
-expansion.}
+For backward compatibility only; equivalent to @racket[syntax-local-introduce].
+
+@history[#:changed "6.90.0.29" @elem{Made equivalent to @racket[syntax-local-introduce].}]}
 
 @;------------------------------------------------------------------------
 @section[#:tag "begin"]{Sequencing: @racket[begin], @racket[begin0], and @racket[begin-for-syntax]}

--- a/pkgs/racket-doc/syntax/scribblings/apply-transformer.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/apply-transformer.scrbl
@@ -1,0 +1,27 @@
+#lang scribble/doc
+@(require "common.rkt" (for-label syntax/apply-transformer))
+
+@title[#:tag "syntax/apply-transformer"]{Applying Macro Transformers}
+
+@defmodule[syntax/apply-transformer]
+
+@defproc[(local-apply-transformer [transformer (or/c (-> syntax? syntax?) set!-transformer?)]
+                                  [stx syntax?]
+                                  [context (or/c 'expression 'top-level 'module 'module-begin list?)]
+                                  [intdef-ctxs (listof internal-definition-context?) '()])
+         syntax?]{
+
+Applies @racket[transformer] as a @tech[#:doc refman]{syntax transformer} to @racket[stx] in the
+current expansion context. The result is similar to expanding @racket[(m stx)] with
+@racket[local-expand], where @racket[m] is bound to @racket[transformer], except that expansion is
+guaranteed to stop after applying a single macro transformation (assuming @racket[transformer] does
+not explicitly force further recursive expansion).
+
+Unlike simply applying @racket[transformer] to @racket[stx] directly, using
+@racket[local-apply-transformer] introduces the appropriate @tech[#:doc refman]{use-site scope} and
+@tech[#:doc refman]{macro-introduction scope} that would be added by the expander.
+
+The @racket[context] and @racket[intdef-ctxs] arguments are treated the same way as the corresponding
+arguments to @racket[local-expand].
+
+@history[#:added "6.90.0.29"]}

--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -1181,7 +1181,8 @@ Returns @racket[#t] if @racket[v] is a @tech{pattern expander},
 
 @defproc[(syntax-local-syntax-parse-pattern-introduce [stx syntax?]) syntax?]{
 
-Like @racket[syntax-local-introduce], but for @tech{pattern expanders}.
-}
+For backward compatibility only; equivalent to @racket[syntax-local-introduce].
+
+@history[#:changed "6.90.0.29" @elem{Made equivalent to @racket[syntax-local-introduce].}]}
 
 @(close-eval the-eval)

--- a/pkgs/racket-doc/syntax/scribblings/transformer-helpers.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/transformer-helpers.scrbl
@@ -11,3 +11,4 @@
 @include-section["path-spec.scrbl"]
 @include-section["template.scrbl"]
 @include-section["transformer.scrbl"]
+@include-section["apply-transformer.scrbl"]

--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -841,5 +841,18 @@
               (set! foo 2)
               (check-equal? x 2))
 
+   (test-case
+    "match-expander with arity 2"
+    (define-syntax forty-two-pat
+      (let ()
+        (define-struct datum-pat (datum)
+          #:property prop:match-expander
+          (lambda (pat stx)
+            (datum->syntax #'here (datum-pat-datum pat) stx)))
+        (make-datum-pat 42)))
+    (check-equal? (match 42
+                    [(forty-two-pat) #t])
+                  #t))
+
 
 ))

--- a/racket/collects/racket/match/syntax-local-match-introduce.rkt
+++ b/racket/collects/racket/match/syntax-local-match-introduce.rkt
@@ -1,15 +1,8 @@
 #lang racket/base
 
-(provide syntax-local-match-introduce
-         current-match-introducer)
-
-(define current-match-introducer
-  (make-parameter
-   (lambda (x)
-     (error 'syntax-local-match-introduce "not expanding match expander form"))))
+(provide syntax-local-match-introduce)
 
 (define (syntax-local-match-introduce x)
   (unless (syntax? x)
     (raise-argument-error 'syntax-local-match-introduce "syntax?" x))
-  ((current-match-introducer) x))
-
+  (syntax-local-introduce x))

--- a/racket/collects/racket/provide-syntax.rkt
+++ b/racket/collects/racket/provide-syntax.rkt
@@ -4,27 +4,18 @@
          (for-syntax syntax-local-provide-introduce))
 
 (require (for-syntax racket/base
+                     syntax/apply-transformer
                      "provide-transform.rkt"))
-
-(define-for-syntax orig-insp (variable-reference->module-declaration-inspector
-                              (#%variable-reference)))
-
-(define-for-syntax current-provide-introducer
-  (make-parameter (lambda (x) (error "not expanding provide form"))))
 
 (define-for-syntax (syntax-local-provide-introduce x)
   (unless (syntax? x)
     (raise-argument-error 'syntax-local-introduce-provide "syntax?" x))
-  ((current-provide-introducer) x))
+  (syntax-local-introduce x))
 
 (define-for-syntax (make-provide-macro proc)
   (make-provide-transformer
    (lambda (stx modes)
-     (let* ([i (make-syntax-introducer)]
-            [d-stx (syntax-disarm stx orig-insp)]
-            [new-stx (parameterize ([current-provide-introducer i])
-                       (i (proc (i d-stx))))])
-       (expand-export (syntax-rearm new-stx stx) modes)))))
+     (expand-export (local-apply-transformer proc stx 'expression) modes))))
 
 (define-syntax (define-provide-syntax stx)
   (syntax-case stx ()

--- a/racket/collects/racket/require-syntax.rkt
+++ b/racket/collects/racket/require-syntax.rkt
@@ -3,27 +3,19 @@
 (provide define-require-syntax
          (for-syntax syntax-local-require-introduce))
 
-(require (for-syntax racket/base "require-transform.rkt"))
-
-(define-for-syntax orig-insp (variable-reference->module-declaration-inspector
-                              (#%variable-reference)))
-
-(define-for-syntax current-require-introducer
-  (make-parameter (lambda (x) (error "not expanding require form"))))
+(require (for-syntax racket/base
+                     syntax/apply-transformer
+                     "require-transform.rkt"))
 
 (define-for-syntax (syntax-local-require-introduce x)
   (unless (syntax? x)
     (raise-argument-error 'syntax-local-introduce-require "syntax?" x))
-  ((current-require-introducer) x))
+  (syntax-local-introduce x))
 
 (define-for-syntax (make-require-macro proc)
   (make-require-transformer
    (lambda (stx)
-     (let* ([i (make-syntax-introducer)]
-            [d-stx (syntax-disarm stx orig-insp)]
-            [new-stx (parameterize ([current-require-introducer i])
-                       (i (proc (i d-stx))))])
-       (expand-import (syntax-rearm new-stx stx))))))
+     (expand-import (local-apply-transformer proc stx 'expression)))))
 
 (define-syntax (define-require-syntax stx)
   (syntax-case stx ()

--- a/racket/collects/syntax/apply-transformer.rkt
+++ b/racket/collects/syntax/apply-transformer.rkt
@@ -1,0 +1,55 @@
+#lang racket/base
+
+(require (for-template racket/base)
+         racket/syntax)
+
+(provide local-apply-transformer)
+
+(define ((make-quoting-transformer transformer-proc) stx)
+  (syntax-case stx ()
+    [(_ form)
+     (let ([result (transformer-proc #'form)])
+       (unless (syntax? result)
+         (raise-arguments-error 'local-apply-transformer
+                                "received value from syntax expander was not syntax"
+                                "received" result))
+       #`(quote #,result))]))
+
+(define (local-apply-transformer transformer stx context [intdef-ctxs '()])
+  (unless (or (set!-transformer? transformer)
+              (and (procedure? transformer)
+                   (procedure-arity-includes? transformer 1)))
+    (raise-argument-error 'local-apply-transformer
+                          "(or/c (-> syntax? syntax?) set!-transformer?)"
+                          transformer))
+  (unless (syntax? stx)
+    (raise-argument-error 'local-apply-transformer "syntax?" stx))
+  (unless (or (eq? context 'expression)
+              (eq? context 'top-level)
+              (eq? context 'module)
+              (eq? context 'module-begin)
+              (list? context))
+    (raise-argument-error 'local-apply-transformer
+                          "(or/c 'expression 'top-level 'module 'module-begin list?)"
+                          context))
+  (unless (and (list? intdef-ctxs)
+               (andmap internal-definition-context? intdef-ctxs))
+    (raise-argument-error 'local-apply-transformer
+                          "(listof internal-definition-context?)"
+                          intdef-ctxs))
+  (unless (syntax-transforming?)
+    (raise-arguments-error 'local-apply-transformer "not currently expanding"))
+  (let* ([intdef-ctx (syntax-local-make-definition-context #f #f)]
+         [transformer-proc (if (set!-transformer? transformer)
+                               (set!-transformer-procedure transformer)
+                               transformer)]
+         [transformer-id (internal-definition-context-introduce
+                          intdef-ctx
+                          (generate-temporary 'local-apply-transformer))]
+         [intdef-ctxs* (cons intdef-ctx intdef-ctxs)])
+    (syntax-local-bind-syntaxes
+     (list transformer-id)
+     #`(quote #,(make-quoting-transformer transformer-proc))
+     intdef-ctx)
+    (syntax-case (local-expand #`(#,transformer-id #,stx) context '() intdef-ctxs*) (quote)
+      [(quote form) #'form])))

--- a/racket/collects/syntax/parse/private/rep.rkt
+++ b/racket/collects/syntax/parse/private/rep.rkt
@@ -7,6 +7,7 @@
          racket/contract/base
          "make.rkt"
          "minimatch.rkt"
+         syntax/apply-transformer
          syntax/private/id-table
          syntax/stx
          syntax/keyword
@@ -616,13 +617,8 @@
 
 ;; expand-pattern : pattern-expander Syntax -> Syntax
 (define (expand-pattern pe stx)
-  (let* ([proc (pattern-expander-proc pe)]
-         [introducer (make-syntax-introducer)]
-         [mstx (introducer (syntax-local-introduce stx))]
-         [mresult (parameterize ([current-syntax-parse-pattern-introducer introducer])
-                    (proc mstx))]
-         [result (syntax-local-introduce (introducer mresult))])
-    result))
+  (let ([proc (pattern-expander-proc pe)])
+    (local-apply-transformer proc stx 'expression)))
 
 ;; parse-ellipsis-head-pattern : stx DeclEnv -> (listof EllipsisHeadPattern)
 (define (parse-ellipsis-head-pattern stx decls)

--- a/racket/collects/syntax/parse/private/residual-ct.rkt
+++ b/racket/collects/syntax/parse/private/residual-ct.rkt
@@ -19,7 +19,6 @@
          prop:pattern-expander
          pattern-expander?
          pattern-expander-proc
-         current-syntax-parse-pattern-introducer
          syntax-local-syntax-parse-pattern-introduce)
 
 (define-logger syntax-parse)
@@ -94,10 +93,5 @@ An EH-alternative is
   (define get-proc (get-proc-getter pat-expander))
   (get-proc pat-expander))
 
-(define current-syntax-parse-pattern-introducer
-  (make-parameter
-   (lambda (stx)
-     (error 'syntax-local-syntax-parse-pattern-introduce "not expanding syntax-parse pattern"))))
-
 (define (syntax-local-syntax-parse-pattern-introduce stx)
-  ((current-syntax-parse-pattern-introducer) stx))
+  (syntax-local-introduce stx))


### PR DESCRIPTION
This PR changes `match` expanders, `require` expanders, `provide` expanders, and `syntax/parse` pattern expanders to reuse more macro expansion machinery, making them capable of reusing `syntax-local-introduce` instead of the current proliferation of custom functions. The bindings are still provided for backwards-compatibility, but they are made equivalent to `syntax-local-introduce`.

It does this by adding a new `syntax/apply-transformer` module, which implements a `local-apply-transformer` function that uses `local-expand` internally to apply a transformer exactly once.

I’m not sure who is best suited to review this PR, but I imagine @mflatt, @rmculpepper, and @samth might be interested parties.