### PR TITLE
struct-out: get correct list of super-struct mutators

### DIFF
--- a/pkgs/racket-test-extra/tests/racket/struct-out-supertype.rkt
+++ b/pkgs/racket-test-extra/tests/racket/struct-out-supertype.rkt
@@ -1,0 +1,25 @@
+#lang racket/base
+
+;; Regression test for GitHub issue #2123
+;; <https://github.com/racket/racket/issues/2123>
+;;
+;; - define a struct (with a mutable field)
+;; - inherit the struct in two other modules
+;; - import the sub-structs in a new module and use struct-out on one
+
+(module private racket/base
+  (struct container (a [b #:mutable]))
+  (provide (struct-out container)))
+
+(module sub1 racket/base
+  (require (submod ".." private))
+  (struct sub-container-1 container (c))
+  (provide (struct-out sub-container-1)))
+
+(module sub2 racket/base
+  (require (submod ".." private))
+  (struct sub-container-2 container (d))
+  (provide (struct-out sub-container-2)))
+
+(require 'sub1 'sub2)
+(provide (struct-out sub-container-1))

--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -1071,7 +1071,7 @@
                                           (list-ref super-v 3)))
                            (list-ize (list-ref v 4)
                                      (and super-v
-                                          (list-ref super-v 3)))))))
+                                          (list-ref super-v 4)))))))
                   (raise-syntax-error
                    #f
                    "identifier is not bound to struct type information"


### PR DESCRIPTION
struct-out was putting the super-struct's accessors into two parts of a
struct-info: the accessor list and the mutator list

this commit puts the accessors only in the accessor list and the
mutators in the mutator list