### PR TITLE
[WIP] Guide on how to upgrade from one version of Racket to another

### DIFF
--- a/pkgs/racket-doc/scribblings/getting-started/upgrading.scrbl
+++ b/pkgs/racket-doc/scribblings/getting-started/upgrading.scrbl
@@ -4,33 +4,14 @@
 
 @section{Linux}
 
-@subsection{Upgrading from a release version to a newer release versions, or from a nightly to a newer nightly}
-
 @itemlist[
   @item{Download the newer release from @url{https://download.racket-lang.org/}.}
   @item{@code{chmod +x racket-X.Y-PLATFORM.sh}}
   @item{@code{./racket-X.Y-PLATFORM.sh} and answer the questions to choose where the new version should be installed.}
+  @item{@code{raco pkg migrate}
   @item{@code{raco setup}}]
 
-@subsection{Upgrading from a release version to a nightly}
-
-@itemlist[
-  @item{Download the newer release from @url{https://download.racket-lang.org/}.}
-  @item{@code{chmod +x racket-X.Y-PLATFORM.sh}}
-  @item{@code{./racket-X.Y-PLATFORM.sh} and answer the questions to choose where the new version should be installed.}
-  @item{@code{mv ~/.racket/snapshot ~/.racket/snapshot.bak} remove and make a backup of the old "snapshot" folder if one existed}
-  @item{@code{mv ~/.racket/OLD_VERSION ~/.racket/snapshot}}
-  @item{@code{raco setup}}]
-
-@subsection{Upgrading from a nightly to a release version}
-
-@itemlist[
-  @item{Download the newer release from @url{https://download.racket-lang.org/}.}
-  @item{@code{chmod +x racket-X.Y-PLATFORM.sh}}
-  @item{@code{./racket-X.Y-PLATFORM.sh} and answer the questions to choose where the new version should be installed.}
-  @item{@code{mv ~/.racket/SOME_VERSION} remove and make a backup of the old "snapshot" folder if one existed}
-  @item{@code{mv ~/.racket/snapshot ~/.racket/SOME_VERSION}}
-  @item{@code{raco setup}}]
+Note that in order to preserve the DrRacket preferences, it is currently necessary to manually copy the old Racket configuration folder to the new one (these folders can be @code{~/.racket/RACKET_VERSION} or @code{~/.racket/snapshot} for a nightly build).
 
 @section{Upgrading from earlier versions}
 


### PR DESCRIPTION
Hi all!

This is a very early draft of a guide helping users upgrade from one version of Racket to another (e.g. 6.11 to 6.12)

Before I fill in the prose, translate the commands to Windows & macOS, and integrate this somewhere in the docs, I would like feedback on whether these lists of commands are the correct ones.

Comments on where this should be placed in the docs, and on how upgrade from 5.x to 6.x needs to be done are also very welcome.

Since there are a few changes from 6.x to 7.x (e.g. `(require syntax/parse)` is not needed anymore), would this be a good place to gather a short guide on how to update code to get rid of legacy stuff?