### PR TITLE
Some optimizations for schemify

### DIFF
--- a/racket/src/schemify/optimize.rkt
+++ b/racket/src/schemify/optimize.rkt
@@ -46,6 +46,10 @@
             '#t
             v)]
        [else v])]
+    [`(list)
+     ''()]
+    [`null
+     ''()]
     [`,_
      (define u (unwrap v))
      (cond

--- a/racket/src/schemify/optimize.rkt
+++ b/racket/src/schemify/optimize.rkt
@@ -19,6 +19,12 @@
      (if (literal? t)
          (if (unwrap t) e1 e2)
          v)]
+    [`(if (not ,t) ,e1 ,e2)
+     (optimize `(if ,t ,e2 ,e1) prim-knowns knowns imports mutated)]
+    [`(not ,t)
+     (if (literal? t)
+         `,(not (unwrap t))
+         v)]
     [`(procedure? ,e)
      (define u (unwrap e))
      (cond

--- a/racket/src/schemify/optimize.rkt
+++ b/racket/src/schemify/optimize.rkt
@@ -50,6 +50,10 @@
      ''()]
     [`null
      ''()]
+    [`(begin ,e)
+     e]
+    [`(let-values () ,e)
+     e]
     [`,_
      (define u (unwrap v))
      (cond


### PR DESCRIPTION
I was looking at [startup.inc](https://github.com/racket/racket/blob/master/racket/src/racket/src/startup.inc) and I notice a few patterns. I know this file is not related, but I guess the same patterns appear in the shemified version, so I added them.

Is it possible to run also these optimizations in the creation of startup.inc? IIUC it is not possible to run this in the expander in all the linklets because the linklets may be recombined later, but the code in startup.inc is in the final form, so it would be ok to apply some reductions.

About each commit: 

**add reduction of `(if (not t) e1 e2)`**

In startup.inc, there are approximately 700 instances of `(if (not t) e1 e2)` and 300 instances of `(not #f)` (and 200 of them are in the intersection).

**add reduction of `(list)` and `null` to `'()`**

I don't imagine how this could be useful now, but it's one of the small straightforward reductions that may compose nicely with other reductions in the future.

**add reduction of `(begin e)` and `(let-values () e)`**

In startup.inc, there are approximately 5000 instances of `(let-values () e)`, so removing them will reduce the size of startup.inc in a 5%. I hope this doesn't break the continuations marks or the splicing of `begin` in the modules.