### PR TITLE
Add #:src argument to syntax:read-xml

### DIFF
--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -227,12 +227,16 @@ Reads a single XML element from the port.  The next non-whitespace
 character read must start an XML element, but the input port can
 contain other data after the element.}
 
-@defproc[(syntax:read-xml [in input-port? (current-input-port)]) syntax?]{
+@defproc[(syntax:read-xml [in input-port? (current-input-port)]
+                          [#:src source-name any/c (object-name in)])
+         syntax?]{
 
 Reads in an XML document and produces a syntax object version (like
 @racket[read-syntax]) of an @tech{X-expression}.}
 
-@defproc[(syntax:read-xml/element [in input-port? (current-input-port)]) syntax?]{
+@defproc[(syntax:read-xml/element [in input-port? (current-input-port)]
+                                  [#:src source-name any/c (object-name in)])
+         syntax?]{
 
 Like @racket[syntax:real-xml], but it reads an XML element like
 @racket[read-xml/element].}

--- a/pkgs/racket-test/tests/xml/test.rkt
+++ b/pkgs/racket-test/tests/xml/test.rkt
@@ -427,6 +427,20 @@ END
      (test-syntax:read-xml
       "<!-- comment --><br />"
       '(br ()))
+
+     (check-equal?
+       (syntax-source
+        (syntax:read-xml
+         #:src "file.xml"
+         (open-input-string "<span>From a file</span>")))
+       "file.xml")
+
+     (check-equal?
+      (syntax-source
+       (last (syntax->list
+              (syntax:read-xml #:src "file-with-span.xml"
+                               (open-input-string "<span>From a file</span>")))))
+      "file-with-span.xml")
      
      ; XXX need more syntax:read-xml tests
      
@@ -480,6 +494,21 @@ END
      (test-syntax:read-xml/element/exn
       "<!-- comment --><br />"
       "read-xml: parse-error: expected root element - received (comment ")
+
+     (check-equal?
+      (syntax-source
+       (syntax:read-xml/element
+        #:src "file-with-element.xml"
+        (open-input-string "<span>From a file</span>")))
+      "file-with-element.xml")
+
+     (check-equal?
+      (syntax-source
+       (last (syntax->list
+              (syntax:read-xml/element
+               #:src "file-with-span-element.xml"
+               (open-input-string "<span>From a file</span>")))))
+      "file-with-span-element.xml")
      
      ; XXX need more syntax:read-xml/element tests
      

--- a/racket/collects/xml/private/syntax.rkt
+++ b/racket/collects/xml/private/syntax.rkt
@@ -7,48 +7,57 @@
 
 (provide/contract
  ; XXX these should both actually return syntax? that is also xexpr/c
- [syntax:read-xml (() (input-port?) . ->* . syntax?)]
- [syntax:read-xml/element (() (input-port?) . ->* . syntax?)])
+ [syntax:read-xml (() (input-port? #:src any/c) . ->* . syntax?)]
+ [syntax:read-xml/element (() (input-port? #:src any/c) . ->* . syntax?)])
 
-(define (syntax:read-xml [in (current-input-port)])
+;; the `src` argument is like the 1st argument to `read-syntax`:
+;; it goes in the `syntax-source` field of the result
+(define (syntax:read-xml [in (current-input-port)]
+                         #:src [src (object-name in)])
   (define the-xml (read-xml in))
   (define the-xml-element (document-element the-xml))
-  (element->xexpr-syntax the-xml-element))
+  (element->xexpr-syntax src the-xml-element))
 
-(define (syntax:read-xml/element [in (current-input-port)])
+;; the `src` argument is like the 1st argument to `read-syntax`:
+;; it goes in the `syntax-source` field of the result
+(define (syntax:read-xml/element [in (current-input-port)]
+                                 #:src [src (object-name in)])
   (define the-xml-element (read-xml/element in))
-  (element->xexpr-syntax the-xml-element))
+  (element->xexpr-syntax src the-xml-element))
 
-(define (position from to)
+(define (position src from to)
   (let ([start-offset (location-offset from)])
-    (list #f (location-line from) (location-char from) start-offset
+    (list src
+          (location-line from) (location-char from) start-offset
           (- (location-offset to) start-offset))))
 
-(define (wrap s e)
-  (datum->syntax #f e (position (source-start s) (source-stop s))))  
+(define (wrap src s e)
+  (datum->syntax #f e (position src (source-start s) (source-stop s))))  
 
-(define (attribute->syntax a)
-  (wrap a (list (attribute-name a) (attribute-value a))))
+(define ((attribute->syntax src) a)
+  (wrap src a (list (attribute-name a) (attribute-value a))))
 
-(define (non-dropping-combine atts body)
-  (list* (map attribute->syntax atts) body))
+(define (non-dropping-combine src atts body)
+  (list* (map (attribute->syntax src) atts) body))
 
-(define (combine atts body)
+(define (combine src atts body)
   (if (xexpr-drop-empty-attributes)
       (if (empty? atts)
           body
-          (non-dropping-combine atts body))
-      (non-dropping-combine atts body)))
+          (non-dropping-combine src atts body))
+      (non-dropping-combine src atts body)))
 
-(define (element->xexpr-syntax e)
-  (wrap e
+(define (element->xexpr-syntax src e)
+  (wrap src
+        e
         (list* (element-name e)
-               (combine (element-attributes e)
-                        (map content->xexpr-syntax (element-content e))))))
+               (combine src
+                        (element-attributes e)
+                        (map (content->xexpr-syntax src) (element-content e))))))
 
-(define (content->xexpr-syntax x)
+(define ((content->xexpr-syntax src) x)
   (cond
-    [(element? x) (element->xexpr-syntax x)]
-    [(pcdata? x) (wrap x (pcdata-string x))]
-    [(entity? x) (wrap x (entity-text x))]
-    [else (wrap x x)]))
+    [(element? x) (element->xexpr-syntax src x)]
+    [(pcdata? x) (wrap src x (pcdata-string x))]
+    [(entity? x) (wrap src x (entity-text x))]
+    [else (wrap src x x)]))


### PR DESCRIPTION
This PR adds an optional `#:src` argument to `syntax:read-xml` and `syntax:read-xml/element`, and puts this value into the `syntax-source` field of the result, just like `read-syntax` does with its first argument.

```racket
> (syntax:read-xml #:src "file.xml" (open-input-file "file.xml"))
#<syntax:file.xml:1:0 (tag...>
```