### PR TITLE
One line revert to patch: 41fd4f3a5e0c6d4ca0ef822b168bf33a5c9068a6

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
@@ -232,7 +232,7 @@ identifier, the @racket[exn:fail:contract] exception is raised.
 
 @defproc[(local-expand [stx any/c]
                        [context-v (or/c 'expression 'top-level 'module 'module-begin list?)]
-                       [stop-ids (or/c (listof identifier?) (cons/c 'only (listof identifier?)) #f)]
+                       [stop-ids (or/c (listof identifier?) empty #f)]
                        [intdef-ctx (or/c internal-definition-context?
                                          (listof internal-definition-context?)
                                          #f)


### PR DESCRIPTION
The docs had an erroneous 'only, probably from development, that should
be removed.