### PR TITLE
Fix build-[chaperone-]contract-property document

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -2764,7 +2764,7 @@ returns @racket[#f] but @racket[value-blame] returns @racket[#f].
            (λ (c) (λ (x) #t))]
           [#:late-neg-projection
            late-neg-proj
-           (or/c #f (-> contract? blame? (-> any/c any/c any/c)))
+           (or/c #f (-> contract? (-> blame? (-> any/c any/c any/c))))
            #f]
           [#:val-first-projection 
            val-first-proj
@@ -2820,7 +2820,7 @@ returns @racket[#f] but @racket[value-blame] returns @racket[#f].
            (λ (c) (λ (x) #t))]
           [#:late-neg-projection
            late-neg-proj
-           (or/c #f (-> contract? blame? (-> any/c any/c any/c)))
+           (or/c #f (-> contract? (-> blame? (-> any/c any/c any/c))))
            #f]
           [#:val-first-projection 
            val-first-proj


### PR DESCRIPTION
The keyword argument `#:late-neg-projection [get-late-neg-projection #f]` takes a curried function. The documentation is missing an arrow.