### PR TITLE
Add option to create relative paths for 'serialize'

### DIFF
--- a/pkgs/racket-test-core/tests/racket/serialize.rktl
+++ b/pkgs/racket-test-core/tests/racket/serialize.rktl
@@ -605,4 +605,23 @@
 
 ;; ----------------------------------------
 
+(let ([fn (make-temporary-file)])
+  (with-output-to-file fn
+    #:exists 'truncate
+    (lambda () (display
+                (string-append "#lang racket/base\n"
+                               "(require racket/serialize)\n"
+                               "(module+ main\n"
+                               "   (provide s)\n"
+                               "   (serializable-struct foo (bar))\n"
+                               "   (define s (serialize (foo 49)\n"
+                               "               #:relative-directory (find-system-path\n"
+                               "                                      'temp-dir)))\n"))))
+  (define s (dynamic-require `(submod ,fn main) 's))
+  (parameterize ([current-load-relative-directory (find-system-path 'temp-dir)])
+    (test #t (deserialize s)))
+  (delete-file fn))
+
+;; ----------------------------------------
+
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/serialize.rktl
+++ b/pkgs/racket-test-core/tests/racket/serialize.rktl
@@ -612,15 +612,26 @@
                 (string-append "#lang racket/base\n"
                                "(require racket/serialize)\n"
                                "(module+ main\n"
-                               "   (provide s)\n"
+                               "   (provide s foo?)\n"
                                "   (serializable-struct foo (bar))\n"
                                "   (define s (serialize (foo 49)\n"
                                "               #:relative-directory (find-system-path\n"
-                               "                                      'temp-dir)))\n"))))
+                               "                                      'temp-dir))))\n"))))
   (define s (dynamic-require `(submod ,fn main) 's))
+  (define foo? (dynamic-require `(submod ,fn main) 'foo?))
   (parameterize ([current-load-relative-directory (find-system-path 'temp-dir)])
-    (test #t (deserialize s)))
+    (test #t 'relative-dir (foo? (deserialize s))))
+  (test 'correct-error 'unrelative-dir
+        (with-handlers ([exn:fail:contract?
+                          (λ (e) 'correct-error)])
+          (deserialize s)))
   (delete-file fn))
+
+(test (build-path "/" "home" "hotdogs")
+      'path-data
+      (deserialize
+       (serialize (build-path "/" "home" "hotdogs")
+                  #:relative-directory (build-path "/" "home"))))
 
 ;; ----------------------------------------
 

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -13,11 +13,12 @@
     [else (apply build-path rel-elems)]))
 
 (define (path->relative-path-elements v
+                                      #:write-relative-directory [write-relative-directory #f]
                                       #:exploded-base-dir [exploded-base-dir (box 'not-ready)]
                                       #:exploded-wrt-rel-dir [exploded-wrt-rel-dir (box 'not-ready)])
   (when (and (eq? (unbox exploded-base-dir) 'not-ready)
              (path? v))
-    (define wr-dir (current-write-relative-directory))
+    (define wr-dir (or write-relative-directory (current-write-relative-directory)))
     (define wrt-dir (and wr-dir (if (pair? wr-dir) (car wr-dir) wr-dir)))
     (define base-dir (and wr-dir (if (pair? wr-dir) (cdr wr-dir) wr-dir)))
     (set-box! exploded-base-dir (and base-dir (explode-path base-dir)))

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -1,0 +1,44 @@
+#lang racket/base
+
+(provide relative-path-elements->path
+         path->relative-path-elements)
+
+(define (relative-path-elements->path elems)
+  (define wrt-dir (current-load-relative-directory))
+  (define rel-elems (for/list ([p (in-list elems)])
+                      (if (bytes? p) (bytes->path-element p) p)))
+  (cond
+    [wrt-dir (apply build-path wrt-dir rel-elems)]
+    [(null? rel-elems) (build-path 'same)]
+    [else (apply build-path rel-elems)]))
+
+(define (path->relative-path-elements v
+                                      #:exploded-base-dir [exploded-base-dir (box 'not-ready)]
+                                      #:exploded-wrt-rel-dir [exploded-wrt-rel-dir (box 'not-ready)])
+  (when (and (eq? (unbox exploded-base-dir) 'not-ready)
+             (path? v))
+    (define wr-dir (current-write-relative-directory))
+    (define wrt-dir (and wr-dir (if (pair? wr-dir) (car wr-dir) wr-dir)))
+    (define base-dir (and wr-dir (if (pair? wr-dir) (cdr wr-dir) wr-dir)))
+    (set-box! exploded-base-dir (and base-dir (explode-path base-dir)))
+    (set-box! exploded-wrt-rel-dir
+              (if (eq? base-dir wrt-dir)
+                  '()
+                  (list-tail (explode-path wrt-dir)
+                             (length (unbox exploded-base-dir))))))
+  (and (unbox exploded-base-dir)
+       (path? v)
+       (let ([exploded (explode-path v)])
+         (and (for/and ([base-p (in-list (unbox exploded-base-dir))]
+                        [p (in-list exploded)])
+                (equal? base-p p))
+              (let loop ([exploded-wrt-rel-dir (unbox exploded-wrt-rel-dir)]
+                         [rel (list-tail exploded (length (unbox exploded-base-dir)))])
+                (cond
+                  [(null? exploded-wrt-rel-dir) rel]
+                  [(and (pair? rel)
+                        (equal? (car rel) (car exploded-wrt-rel-dir)))
+                   (loop (cdr exploded-wrt-rel-dir) (cdr rel))]
+                  [else (append (for/list ([p (in-list exploded-wrt-rel-dir)])
+                                  'up)
+                                rel)]))))))

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -67,7 +67,7 @@
   (define (protect-path p rel-to)
     (cond
      [(path? p) (if rel-to
-                    `(relative ,(path->relative-path-elements p #:write-relative-directory rel-to))
+                    `(relative . ,(path->relative-path-elements p #:write-relative-directory rel-to))
                     (path->bytes p))]
      [(and (pair? p) (eq? (car p) 'submod) (path? (cadr p)))
       `(submod ,(protect-path (cadr p) rel-to) . ,(cddr p))]
@@ -75,7 +75,8 @@
   (define (unprotect-path p)
     (cond
      [(bytes? p) (bytes->path p)]
-     [(and (pair? p) (eq? (car p) 'submod) (bytes? (cadr p)))
+     [(and (pair? p) (eq? (car p) 'submod) (or (bytes? (cadr p))
+                                               (list? (cadr p))))
       `(submod ,(unprotect-path (cadr p)) . ,(cddr p))]
      [(and (pair? p) (eq? (car p) 'relative))
       (relative-path-elements->path (cdr p))]

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -4,6 +4,7 @@
            racket/list
            racket/flonum
            racket/fixnum
+           "relative-path.rkt"
            "serialize-structs.rkt")
 
   ;; This module implements the core serializer. The syntactic

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -435,7 +435,7 @@
       (cons 'pf (cons (prefab-struct-key v)
                       (sub1 (vector-length (struct->vector v)))))]))
 
-  (define (serialize v #:relative-to [rel-to #f])
+  (define (serialize v #:relative-directory [rel-to #f])
     (let ([mod-map (make-hasheq)]
 	  [mod-map-cache (make-hash)]
 	  [share (make-hasheq)]

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -351,11 +351,7 @@
 	    (bytes? v))
 	(cons 'u v)]
        [(path-for-some-system? v)
-        (list* 'p+
-               (if rel-to
-                   (path->relative-path-elements v #:write-relative-directory rel-to)
-                   (path->bytes v))
-               (path-convention-type v))]
+        (list* 'p+ (path->bytes v) (path-convention-type v))]
        [(vector? v)
         (define elems (map (serial #t) (vector->list v)))
         (if (and (immutable? v)
@@ -545,14 +541,8 @@
 		 (cond
 		  [(string? x) (string-copy x)]
 		  [(bytes? x) (bytes-copy x)]))]
-	  [(p) (let ([x (cdr v)])
-                 (cond
-                   [(bytes? x) (bytes->path x)]
-                   [(list? x) (relative-path-elements->path x)]))]
-	  [(p+) (let ([x (cadr v)])
-                  (cond
-                    [(bytes? x) (bytes->path x (cddr v))]
-                    [(list? x) (relative-path-elements->path x)]))]
+	  [(p) (bytes->path (cdr v))]
+	  [(p+) (bytes->path (cdr v))]
 	  [(c) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(c!) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(m) (mcons (loop (cadr v)) (loop (cddr v)))]

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -63,18 +63,40 @@
   ;; If a module is dynamic-required through a path,
   ;;  then it can cause simplified module paths to be paths;
   ;;  keep the literal path, but marshal it to bytes.
-  (define (protect-path p)
+  (define (protect-path p rel-to)
     (cond
-     [(path? p) (path->bytes p)]
+     [(path? p) (path->relative-bytes p rel-to)]
      [(and (pair? p) (eq? (car p) 'submod) (path? (cadr p)))
-      `(submod ,(protect-path (cadr p)) . ,(cddr p))]
+      `(submod ,(protect-path (cadr p) rel-to) . ,(cddr p))]
      [else p]))
   (define (unprotect-path p)
     (cond
-     [(bytes? p) (bytes->path p)]
+     [(bytes? p) (relative-bytes->path p)]
      [(and (pair? p) (eq? (car p) 'submod) (bytes? (cadr p)))
       `(submod ,(unprotect-path (cadr p)) . ,(cddr p))]
      [else p]))
+
+  ;; If a relative path is given, convert paths to those
+  ;; relative paths.
+  (define (path->relative-bytes v rel-dir)
+    (define new-path (path->relative-path-elements v rel-dir))
+    (path->bytes (or (and new-path (apply build-path new-path))
+                     v)))
+  (define (relative-bytes->path v [type (system-path-convention-type)])
+    (define rel-path (bytes->path v type))
+    (cond
+      [(complete-path? rel-path) rel-path]
+      [else
+       (path->complete-path rel-path (current-load-relative-directory))]))
+  (define (path->relative-path-elements v rel-dir)
+    (define exploded-rel-dir (and rel-dir (explode-path rel-dir)))
+    (and exploded-rel-dir
+         (path? v)
+         (let ([exploded (explode-path v)])
+           (and (for/and ([wrt-p (in-list exploded-rel-dir)]
+                          [p (in-list exploded)])
+                  (equal? wrt-p p))
+                (list-tail exploded (length exploded-rel-dir))))))
 
   ;; A deserialization function is provided from a `deserialize-info`
   ;; module:
@@ -107,7 +129,7 @@
                 v2))
           v)))
   
-  (define (mod-to-id info mod-map cache)
+  (define (mod-to-id info mod-map cache rel-to)
     (let ([deserialize-id (serialize-info-deserialize-id info)])
       (hash-ref 
        cache deserialize-id
@@ -125,7 +147,8 @@
 				      (collapse/resolve-module-path-index 
 				       (caddr b)
 				       (build-path (serialize-info-dir info)
-						   "here.ss")))))
+						   "here.ss"))
+                                      rel-to)))
 			    (syntax-e deserialize-id)))]
 			[(symbol? deserialize-id)
 			 (cons #f deserialize-id)]
@@ -137,7 +160,8 @@
 			       (collapse/resolve-module-path-index 
 				(cdr deserialize-id)
 				(build-path (serialize-info-dir info)
-					    "here.ss"))))
+					    "here.ss"))
+                               rel-to))
 			  (car deserialize-id))])])
 		  (hash-ref 
 		   mod-map path+name
@@ -302,7 +326,7 @@
             (byte-regexp? v)
             (bytes? v))))
 
-  (define (serialize-one v share check-share? mod-map mod-map-cache)
+  (define (serialize-one v share check-share? mod-map mod-map-cache rel-to)
     (define ((serial check-share?) v)
       (cond
        [(or (boolean? v)
@@ -329,7 +353,7 @@
         v]
        [(serializable-struct? v)
 	(let ([info (serializable-info v)])
-	  (cons (mod-to-id info mod-map mod-map-cache) 
+	  (cons (mod-to-id info mod-map mod-map-cache rel-to) 
 		(map (serial #t)
 		     (vector->list
 		      ((serialize-info-vectorizer info) v)))))]
@@ -344,7 +368,7 @@
 	    (bytes? v))
 	(cons 'u v)]
        [(path-for-some-system? v)
-	(list* 'p+ (path->bytes v) (path-convention-type v))]
+        (list* 'p+ (path->relative-bytes v rel-to) (path-convention-type v))]
        [(vector? v)
         (define elems (map (serial #t) (vector->list v)))
         (if (and (immutable? v)
@@ -403,11 +427,11 @@
        [else (error 'serialize "shouldn't get here")]))
     ((serial check-share?) v))
   
-  (define (serial-shell v mod-map mod-map-cache)
+  (define (serial-shell v mod-map mod-map-cache rel-to)
     (cond
      [(serializable-struct? v)
       (let ([info (serializable-info v)])
-	(mod-to-id info mod-map mod-map-cache))]
+	(mod-to-id info mod-map mod-map-cache rel-to))]
      [(vector? v)
       (cons 'v (vector-length v))]
      [(mpair? v)
@@ -424,7 +448,7 @@
       (cons 'pf (cons (prefab-struct-key v)
                       (sub1 (vector-length (struct->vector v)))))]))
 
-  (define (serialize v)
+  (define (serialize v #:relative-to [rel-to #f])
     (let ([mod-map (make-hasheq)]
 	  [mod-map-cache (make-hash)]
 	  [share (make-hasheq)]
@@ -442,16 +466,16 @@
 				  (if (hash-ref cycle v #f)
 				      ;; Box indicates cycle record allocation
 				      ;;  followed by normal serialization
-				      (box (serial-shell v mod-map mod-map-cache))
+				      (box (serial-shell v mod-map mod-map-cache rel-to))
 				      ;; Otherwise, normal serialization
-				      (serialize-one v share #f mod-map mod-map-cache)))
+				      (serialize-one v share #f mod-map mod-map-cache rel-to)))
 				ordered)]
 	      [fixups (hash-map 
 		       cycle
 		       (lambda (v n)
 			 (cons n
-			       (serialize-one v share #f mod-map mod-map-cache))))]
-	      [main-serialized (serialize-one v share #t mod-map mod-map-cache)]
+			       (serialize-one v share #f mod-map mod-map-cache rel-to))))]
+	      [main-serialized (serialize-one v share #t mod-map mod-map-cache rel-to)]
 	      [mod-map-l (map car (sort (hash-map mod-map cons)
                                         (lambda (a b) (< (cdr a) (cdr b)))))])
 	  (list '(3) ;; serialization-format version
@@ -534,8 +558,8 @@
 		 (cond
 		  [(string? x) (string-copy x)]
 		  [(bytes? x) (bytes-copy x)]))]
-	  [(p) (bytes->path (cdr v))]
-	  [(p+) (bytes->path (cadr v) (cddr v))]
+	  [(p) (relative-bytes->path (cdr v))]
+	  [(p+) (relative-bytes->path (cadr v) (cddr v))]
 	  [(c) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(c!) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(m) (mcons (loop (cadr v)) (loop (cddr v)))]

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -542,7 +542,7 @@
 		  [(string? x) (string-copy x)]
 		  [(bytes? x) (bytes-copy x)]))]
 	  [(p) (bytes->path (cdr v))]
-	  [(p+) (bytes->path (cdr v))]
+	  [(p+) (bytes->path (cadr v) (cddr v))]
 	  [(c) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(c!) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(m) (mcons (loop (cadr v)) (loop (cddr v)))]


### PR DESCRIPTION
Serialize would previously always create complete byte-string paths.
This adds an optional parameter to serialize (#:relative-to) to enable
relative path creation.

Now when deserialize finds a relative path, it resolves it with
respect to `current-load-relative-directory`.