### PR TITLE
Typo

### DIFF
--- a/pkgs/racket-doc/scribblings/style/scribble.scrbl
+++ b/pkgs/racket-doc/scribblings/style/scribble.scrbl
@@ -178,7 +178,7 @@ normally lowercase. For example, use ``The @racket[_thing] argument
 is...'' instead of ``@racket[_thing] is...''
 
 Use @racket[etc] for ``@|etc|'' when it does not end a sentence, and
-include a comma after ``@|etc|'' unless it ends a sentence of is
+include a comma after ``@|etc|'' unless it ends a sentence that is
 followed by other punctuation (such as a parenthesis).
 
 @section{Section Titles}

--- a/pkgs/racket-doc/scribblings/style/style.scrbl
+++ b/pkgs/racket-doc/scribblings/style/style.scrbl
@@ -32,7 +32,7 @@ Many pieces of the code base don't live up to the guidelines yet.  Here is how
  workings. If doing so takes quite a while due to inconsistencies with the
  guidelines, please take the time to fix (portions of) the file. After all, if
  the inconsistencies throw you off for that much time, others are likely to
- have the same problems. If you help fixing it, you reduce future
+ have the same problems. If you help fix it, you reduce future
  maintenance time. Whoever touches the file next will be grateful to you.
  @emph{Do} run the test suites, and do @emph{not} change the behavior of
  the file.


### PR DESCRIPTION
Fix typos for "How to Program Racket: a Style Guide".
Please review. Thanks.