### PR TITLE
Relative paths should still be readable.

### DIFF
--- a/racket/collects/racket/fasl.rkt
+++ b/racket/collects/racket/fasl.rkt
@@ -211,8 +211,7 @@
            (cond
              [rel-elems
               (write-byte fasl-relative-path-type o)
-              (loop (for/list ([p (in-list rel-elems)])
-                      (if (path? p) (path-element->bytes p) p)))]
+              (loop rel-elems)]
              [else
               (write-byte fasl-path-type o)
               (write-fasl-bytes (path->bytes v) o)

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -58,4 +58,5 @@
                         (loop (cdr exploded-wrt-rel-dir) (cdr rel))]
                        [else (append (for/list ([p (in-list exploded-wrt-rel-dir)])
                                        'up)
-                                     (map path-element->bytes rel))]))))))]))
+                                     (for/list ([p (in-list rel)])
+                                       (if (path? p) (path-element->bytes p) p)))]))))))]))

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -52,10 +52,10 @@
                    (let loop ([exploded-wrt-rel-dir exploded-wrt-rel-dir]
                               [rel (list-tail exploded (length exploded-base-dir))])
                      (cond
-                       [(null? exploded-wrt-rel-dir) rel]
+                       [(null? exploded-wrt-rel-dir) (map path-element->bytes rel)]
                        [(and (pair? rel)
                              (equal? (car rel) (car exploded-wrt-rel-dir)))
                         (loop (cdr exploded-wrt-rel-dir) (cdr rel))]
                        [else (append (for/list ([p (in-list exploded-wrt-rel-dir)])
                                        'up)
-                                     rel)]))))))]))
+                                     (map path-element->bytes rel))]))))))]))

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -68,7 +68,7 @@
     (cond
      [(path? p) (let ([rel (deser-path->relative-path p)])
                   (if rel
-                      `(relative . ,rel)
+                      `(relative . ,(map path->bytes rel))
                       (path->bytes p)))]
      [(and (pair? p) (eq? (car p) 'submod) (path? (cadr p)))
       `(submod ,(protect-path (cadr p) deser-path->relative-path) . ,(cddr p))]
@@ -80,7 +80,7 @@
                                                (list? (cadr p))))
       `(submod ,(unprotect-path (cadr p)) . ,(cddr p))]
      [(and (pair? p) (eq? (car p) 'relative))
-      (relative-path-elements->path (cdr p))]
+      (relative-path-elements->path (map bytes->path (cdr p)))]
      [else p]))
 
   ;; A deserialization function is provided from a `deserialize-info`
@@ -358,7 +358,7 @@
        [(path-for-some-system? v)
         (let ([v-rel (and (path? v) (path->relative-path v))])
           (if v-rel
-              (cons 'p* v-rel)
+              (cons 'p* (map path->bytes v-rel))
               (list* 'p+ (path->bytes v) (path-convention-type v))))]
        [(vector? v)
         (define elems (map (serial #t) (vector->list v)))
@@ -555,7 +555,7 @@
 		  [(bytes? x) (bytes-copy x)]))]
 	  [(p) (bytes->path (cdr v))]
 	  [(p+) (bytes->path (cadr v) (cddr v))]
-	  [(p*) (relative-path-elements->path (cdr v))]
+	  [(p*) (relative-path-elements->path (map bytes->path (cdr v)))]
 	  [(c) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(c!) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(m) (mcons (loop (cadr v)) (loop (cddr v)))]

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -68,7 +68,7 @@
     (cond
      [(path? p) (let ([rel (deser-path->relative-path p)])
                   (if rel
-                      `(relative . ,(map path->bytes rel))
+                      `(relative . ,rel)
                       (path->bytes p)))]
      [(and (pair? p) (eq? (car p) 'submod) (path? (cadr p)))
       `(submod ,(protect-path (cadr p) deser-path->relative-path) . ,(cddr p))]
@@ -80,7 +80,7 @@
                                                (list? (cadr p))))
       `(submod ,(unprotect-path (cadr p)) . ,(cddr p))]
      [(and (pair? p) (eq? (car p) 'relative))
-      (relative-path-elements->path (map bytes->path (cdr p)))]
+      (relative-path-elements->path (cdr p))]
      [else p]))
 
   ;; A deserialization function is provided from a `deserialize-info`
@@ -358,7 +358,7 @@
        [(path-for-some-system? v)
         (let ([v-rel (and (path? v) (path->relative-path v))])
           (if v-rel
-              (cons 'p* (map path->bytes v-rel))
+              (cons 'p* v-rel)
               (list* 'p+ (path->bytes v) (path-convention-type v))))]
        [(vector? v)
         (define elems (map (serial #t) (vector->list v)))
@@ -555,7 +555,7 @@
 		  [(bytes? x) (bytes-copy x)]))]
 	  [(p) (bytes->path (cdr v))]
 	  [(p+) (bytes->path (cadr v) (cddr v))]
-	  [(p*) (relative-path-elements->path (map bytes->path (cdr v)))]
+	  [(p*) (relative-path-elements->path (cdr v))]
 	  [(c) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(c!) (cons (loop (cadr v)) (loop (cddr v)))]
 	  [(m) (mcons (loop (cadr v)) (loop (cddr v)))]


### PR DESCRIPTION
The resent PR to enable relative serialization resulted in serialzed
objects that weren't actually readable (containing literal path
elements). This PR converts them to bytes.