### PR TITLE
Fix fasl bug in Racket 7.0 beta!

### DIFF
--- a/pkgs/racket-test-core/tests/racket/fasl.rktl
+++ b/pkgs/racket-test-core/tests/racket/fasl.rktl
@@ -145,17 +145,18 @@
 (test (srcloc ".../a/.." 1 2 3 4) fasl->s-exp (s-exp->fasl (srcloc (build-path "a" 'up) 1 2 3 4)))
 (test (srcloc ".../a/." 1 2 3 4) fasl->s-exp (s-exp->fasl (srcloc (build-path "a" 'same) 1 2 3 4)))
 
-(test
- (build-path "/")
- 'longer-relative
- (parameterize ([current-write-relative-directory (build-path "/" "a")])
-   (fasl->s-exp (s-exp->fasl (build-path "/")))))
+(let ([root (car (filesystem-root-list))])
+  (test
+   root
+   'longer-relative
+   (parameterize ([current-write-relative-directory (build-path root "a")])
+     (fasl->s-exp (s-exp->fasl root))))
 
-(test
- (build-path 'same)
- 'this-dir-path
- (parameterize ([current-write-relative-directory (build-path "/")]
-                [current-load-relative-directory #f])
-   (fasl->s-exp (s-exp->fasl (build-path "/" 'same)))))
+  (test
+   (build-path 'same)
+   'this-dir-path
+   (parameterize ([current-write-relative-directory root]
+                  [current-load-relative-directory #f])
+     (fasl->s-exp (s-exp->fasl (build-path root 'same))))))
 
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/fasl.rktl
+++ b/pkgs/racket-test-core/tests/racket/fasl.rktl
@@ -145,4 +145,10 @@
 (test (srcloc ".../a/.." 1 2 3 4) fasl->s-exp (s-exp->fasl (srcloc (build-path "a" 'up) 1 2 3 4)))
 (test (srcloc ".../a/." 1 2 3 4) fasl->s-exp (s-exp->fasl (srcloc (build-path "a" 'same) 1 2 3 4)))
 
+(test
+ (build-path "/")
+ 'longer-relative
+ (parameterize ([current-write-relative-directory (build-path "/" "a")])
+   (fasl->s-exp (s-exp->fasl (build-path "/")))))
+
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/fasl.rktl
+++ b/pkgs/racket-test-core/tests/racket/fasl.rktl
@@ -151,4 +151,11 @@
  (parameterize ([current-write-relative-directory (build-path "/" "a")])
    (fasl->s-exp (s-exp->fasl (build-path "/")))))
 
+(test
+ (build-path 'same)
+ 'this-dir-path
+ (parameterize ([current-write-relative-directory (build-path "/")]
+                [current-load-relative-directory #f])
+   (fasl->s-exp (s-exp->fasl (build-path "/" 'same)))))
+
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/serialize.rktl
+++ b/pkgs/racket-test-core/tests/racket/serialize.rktl
@@ -724,4 +724,22 @@
 
 ;; ----------------------------------------
 
+(test
+ 'right-error
+ 'non-base-dir
+ (with-handlers ([exn:fail:contract? (λ (e) (log-error "~s" e) 'right-error)])
+   (serialize (string->path "/x")
+              #:relative-directory (cons "/x"
+                                         "/x/y"))))
+
+(test
+ 'right-error
+ 'different-base-dir
+ (with-handlers ([exn:fail:contract? (λ (e) (log-error "~s" e) 'right-error)])
+   (serialize (string->path "/x")
+              #:relative-directory (cons "/x/z"
+                                         "/x/y"))))
+
+;; ----------------------------------------
+
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/serialize.rktl
+++ b/pkgs/racket-test-core/tests/racket/serialize.rktl
@@ -724,21 +724,25 @@
 
 ;; ----------------------------------------
 
-(test
- 'right-error
- 'non-base-dir
- (with-handlers ([exn:fail:contract? (λ (e) (log-error "~s" e) 'right-error)])
-   (serialize (string->path "/x")
-              #:relative-directory (cons "/x"
-                                         "/x/y"))))
+(let ()
+  (define (test-relative data rel)
+    (test
+     'right-error
+     'non-base-dir
+     (with-handlers ([exn:fail:contract?
+                      (λ (e)
+                        (if (string-prefix?
+                             (exn-message e)
+                             (string-append "serialize: relative-directory pair's first"
+                                            " path does not extend second path"))
+                            'right-error
+                            'wrong-error))])
+       (serialize data
+                  #:relative-directory rel))))
 
-(test
- 'right-error
- 'different-base-dir
- (with-handlers ([exn:fail:contract? (λ (e) (log-error "~s" e) 'right-error)])
-   (serialize (string->path "/x")
-              #:relative-directory (cons "/x/z"
-                                         "/x/y"))))
+   (test-relative (string->path "/x") (cons "/x" "/x/y"))
+
+   (test-relative (string->path "/x") (cons "/x/z" "/x/y")))
 
 ;; ----------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/serialize.rktl
+++ b/pkgs/racket-test-core/tests/racket/serialize.rktl
@@ -710,4 +710,18 @@
 
 ;; ----------------------------------------
 
+(let ([root (car (filesystem-root-list))])
+  (test
+   root
+   'longer-relative
+   (deserialize (serialize root #:relative-directory (build-path root "a"))))
+
+  (test
+   (build-path 'same)
+   'this-dir-path
+   (parameterize ([current-load-relative-directory #f])
+     (deserialize (serialize (build-path root 'same) #:relative-directory root)))))
+
+;; ----------------------------------------
+
 (report-errs)

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -3,12 +3,6 @@
 (provide relative-path-elements->path
          make-path->relative-path-elements)
 
-(define (truncating-list-tail lst pos)
-  (if ((length lst) . >= . pos)
-      (list-tail lst pos)
-      '()))
-
-
 (define (relative-path-elements->path elems)
   (define wrt-dir (current-load-relative-directory))
   (define rel-elems (for/list ([p (in-list elems)])
@@ -47,8 +41,8 @@
          (set! exploded-wrt-rel-dir
                (if (eq? base-dir wrt-dir)
                    '()
-                   (truncating-list-tail (explode-path wrt-dir)
-                                         (length exploded-base-dir)))))
+                   (list-tail (explode-path wrt-dir)
+                              (length exploded-base-dir)))))
        (and exploded-base-dir
             (path? v)
             (let ([exploded (explode-path v)])
@@ -59,7 +53,8 @@
                    (let loop ([exploded-wrt-rel-dir exploded-wrt-rel-dir]
                               [rel (list-tail exploded (length exploded-base-dir))])
                      (cond
-                       [(null? exploded-wrt-rel-dir) (map path-element->bytes rel)]
+                       [(null? exploded-wrt-rel-dir) (for/list ([p (in-list rel)])
+                                                       (if (path? p) (path-element->bytes p) p))]
                        [(and (pair? rel)
                              (equal? (car rel) (car exploded-wrt-rel-dir)))
                         (loop (cdr exploded-wrt-rel-dir) (cdr rel))]

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -36,13 +36,22 @@
        (when (and (eq? exploded-base-dir 'not-ready)
                   (path? v))
          (define wrt-dir (and wr-dir (if (pair? wr-dir) (car wr-dir) wr-dir)))
+         (define exploded-wrt-dir (explode-path wrt-dir))
          (define base-dir (and wr-dir (if (pair? wr-dir) (cdr wr-dir) wr-dir)))
          (set! exploded-base-dir (and base-dir (explode-path base-dir)))
-         (set! exploded-wrt-rel-dir
-               (if (eq? base-dir wrt-dir)
-                   '()
-                   (list-tail (explode-path wrt-dir)
-                              (length exploded-base-dir)))))
+         (cond
+           [(eq? base-dir wrt-dir) (set! exploded-wrt-rel-dir '())]
+           [(and ((length exploded-wrt-dir) . >= . (length exploded-base-dir))
+                 (for/and ([a (in-list exploded-wrt-dir)]
+                           [b (in-list exploded-base-dir)])
+                   (equal? a b)))
+            (set! exploded-wrt-rel-dir
+                      (list-tail exploded-wrt-dir
+                                 (length exploded-base-dir)))]
+           [else (raise-arguments-error (or who "make-path->relative-path-elements")
+                                        "first path does not extend second path"
+                                        "first path" wrt-dir
+                                        "second path" base-dir)]))
        (and exploded-base-dir
             (path? v)
             (let ([exploded (explode-path v)])

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -3,6 +3,12 @@
 (provide relative-path-elements->path
          make-path->relative-path-elements)
 
+(define (truncating-list-tail lst pos)
+  (if ((length lst) . >= . pos)
+      (list-tail lst pos)
+      '()))
+
+
 (define (relative-path-elements->path elems)
   (define wrt-dir (current-load-relative-directory))
   (define rel-elems (for/list ([p (in-list elems)])
@@ -41,14 +47,15 @@
          (set! exploded-wrt-rel-dir
                (if (eq? base-dir wrt-dir)
                    '()
-                   (list-tail (explode-path wrt-dir)
-                              (length exploded-base-dir)))))
+                   (truncating-list-tail (explode-path wrt-dir)
+                                         (length exploded-base-dir)))))
        (and exploded-base-dir
             (path? v)
             (let ([exploded (explode-path v)])
               (and (for/and ([base-p (in-list exploded-base-dir)]
                              [p (in-list exploded)])
                      (equal? base-p p))
+                   ((length exploded) . >= . (length exploded-base-dir))
                    (let loop ([exploded-wrt-rel-dir exploded-wrt-rel-dir]
                               [rel (list-tail exploded (length exploded-base-dir))])
                      (cond

--- a/racket/collects/racket/private/relative-path.rkt
+++ b/racket/collects/racket/private/relative-path.rkt
@@ -39,19 +39,23 @@
          (define exploded-wrt-dir (explode-path wrt-dir))
          (define base-dir (and wr-dir (if (pair? wr-dir) (cdr wr-dir) wr-dir)))
          (set! exploded-base-dir (and base-dir (explode-path base-dir)))
-         (cond
-           [(eq? base-dir wrt-dir) (set! exploded-wrt-rel-dir '())]
-           [(and ((length exploded-wrt-dir) . >= . (length exploded-base-dir))
-                 (for/and ([a (in-list exploded-wrt-dir)]
-                           [b (in-list exploded-base-dir)])
-                   (equal? a b)))
-            (set! exploded-wrt-rel-dir
-                      (list-tail exploded-wrt-dir
-                                 (length exploded-base-dir)))]
-           [else (raise-arguments-error (or who "make-path->relative-path-elements")
-                                        "first path does not extend second path"
-                                        "first path" wrt-dir
-                                        "second path" base-dir)]))
+         (set! exploded-wrt-rel-dir
+               (cond
+                 [(eq? base-dir wrt-dir) '()]
+                 [else
+                  (define exploded-wrt-dir (explode-path wrt-dir))
+                  (define base-len (length exploded-base-dir))
+                  (when who
+                    (unless (and 
+                             ((length exploded-wrt-dir) . >= . base-len)
+                             (for/and ([a (in-list exploded-wrt-dir)]
+                                       [b (in-list exploded-base-dir)])
+                               (equal? a b)))
+                      (raise-arguments-error who
+                                             "relative-directory pair's first path does not extend second path"
+                                             "first path" wrt-dir
+                                             "second path" base-dir)))
+                  (list-tail exploded-wrt-dir base-len)])))
        (and exploded-base-dir
             (path? v)
             (let ([exploded (explode-path v)])


### PR DESCRIPTION
The following program causes racket to error in Racket 7.

(parameterize ([current-write-relative-directory (build-path "/" "a")])
  (s-exp->fasl (build-path "/")))

This bug appears to have been introduced in Racket 7, and not in
Racket 6.x.

(You might want to consider bringing this fix into the beta for Racket 7 @stamourv !)