### PR TITLE
add tau to racket/math

### DIFF
--- a/racket/collects/racket/math.rkt
+++ b/racket/collects/racket/math.rkt
@@ -9,6 +9,7 @@
          "private/math-predicates.rkt")
 
 (provide pi pi.f
+         tau tau.f
          nan? infinite?
          positive-integer?
          negative-integer?
@@ -24,6 +25,8 @@
 
 (define pi   (atan 0 -1))
 (define pi.f (atan 0.0f0 -1.0f0))
+(define tau (* 2.0 pi))
+(define tau.f (* 2.0f0 pi.f))
 
 (begin-encourage-inline
 


### PR DESCRIPTION
I want to add `tau` to racket/math.

For an in-depth look at why `tau` is better than `pi`, see [the tau manifesto](https://tauday.com/tau-manifesto).  The biggest obvious and practical benefit for Racket users is probably doing rotations and such.  A quarter turn of an image is `τ/4` rather than `π/2`, so you don't have to keep track of the extra factor of 2, or whether to multiply it or divide it.

The biggest potential problem is that people could already be using the name `tau` in modules using racket/math.  Perhaps it would be better to use the unicode symbol `τ`, but that could also be used.

This PR isn't really ready.  I haven't added documentation and I'm not really sure that this is the best way to calculate `tau`.  But I want to float the idea and see what people think, especially of the naming issue.
