### PR TITLE
add stream-take + docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1049,6 +1049,11 @@ stream, but plain lists can be used as streams, and functions such as
   the resulting stream.
 }
 
+@defproc[(stream-take [s stream?] [i exact-nonnegative-integer?])
+         stream?]{
+  Returns a list of the first @racket[i] elements of @racket[s].
+}
+
 @defproc[(stream-append [s stream?] ...)
          stream?]{
   Returns a stream that contains all elements of each stream in the

--- a/racket/collects/racket/stream.rkt
+++ b/racket/collects/racket/stream.rkt
@@ -33,6 +33,7 @@
          stream-length
          stream-ref
          stream-tail
+         stream-take
          stream-append
          stream-map
          stream-andmap
@@ -114,6 +115,14 @@
                              "stream" st)]
      [else
       (loop (sub1 n) (stream-rest s))])))
+
+(define (stream-take st i)
+  (unless (stream? st) (raise-argument-error 'stream-take "stream?" st))
+  (unless (exact-nonnegative-integer? i)
+    (raise-argument-error 'stream-take "exact-nonnegative-integer?" i))
+  (for/list ([e (in-stream st)]
+             [_i (in-range i)])
+    e))
 
 (define (stream-append . l)
   (for ([s (in-list l)])


### PR DESCRIPTION
I believe having a `take` function for streams is very useful, and is pretty basic functionality to be included in `base`.

(this is my first non-documentation PR, so please excuse me for my ignorance and help me overcoming it :)

note: I haven't re-built and tested racket after these changes, mostly because it will take 8h+ on my computer, as per https://blog.racket-lang.org/2017/09/tutorial-contributing-to-racket.html and the fact that my computer is old.