### PR TITLE
Make curry properly support functions with keyword arguments

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/procedures.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/procedures.scrbl
@@ -698,25 +698,35 @@ of arguments have been accumulated, at which point the original
 (((curry list) 1 2) 3)
 (((curry list) 1) 3)
 ((((curry foldl) +) 0) '(1 2 3))
+(define foo (curry (lambda (x y z) (list x y z))))
+(foo 1 2 3)
+(((((foo) 1) 2)) 3)
 ]
 
 A function call @racket[(curry proc v ...)] is equivalent to
 @racket[((curry proc) v ...)]. In other words, @racket[curry] itself
 is curried.
 
-The @racket[curry] function provides limited support for keyworded
-functions: only the @racket[curry] call itself can receive keyworded
-arguments to be propagated eventually to @racket[proc].
-
 @mz-examples[#:eval fun-eval
   (map ((curry +) 10) '(1 2 3))
   (map (curry + 10) '(1 2 3))
   (map (compose (curry * 2) (curry + 10)) '(1 2 3))
-  (define foo (curry (lambda (x y z) (list x y z))))
-  (foo 1 2 3)
-  (((((foo) 1) 2)) 3)
-]}
+]
 
+The @racket[curry] function also supports functions with keyword arguments:
+keyword arguments will be accumulated in the same way as positional arguments
+until all required keyword arguments have been supplied.
+
+@mz-examples[#:eval fun-eval
+  (eval:no-prompt
+   (define (f #:a a #:b b #:c c)
+     (list a b c)))
+  (eval:check ((((curry f) #:a 1) #:b 2) #:c 3) (list 1 2 3))
+  (eval:check ((((curry f) #:b 1) #:c 2) #:a 3) (list 3 1 2))
+  (eval:check ((curry f #:a 1 #:c 2) #:b 3) (list 1 3 2))
+]
+
+@history[#:changed "7.0.0.7" @elem{Added support for keyword arguments.}]}
 
 @defproc*[([(curryr [proc procedure?]) procedure?]
            [(curryr [proc procedure?] [v any/c] ...+) any/c])]{

--- a/pkgs/racket-test/tests/racket/curry.rkt
+++ b/pkgs/racket-test/tests/racket/curry.rkt
@@ -30,3 +30,41 @@
 
 (check-exn exn:fail:contract? (λ () (curry 1 2)))
 (check-exn exn:fail:contract? (λ () (curry 1)))
+
+(define (kw #:a a #:b b #:c c)
+  (list a b c))
+
+(check-equal? (((curry kw #:a 1) #:b 2) #:c 3) (list 1 2 3))
+(check-equal? (((curry kw #:b 1) #:c 2) #:a 3) (list 3 1 2))
+(check-equal? (((curry kw #:c 1) #:a 2) #:b 3) (list 2 3 1))
+(check-equal? (((curry kw) #:a 1 #:b 2) #:c 3) (list 1 2 3))
+(check-equal? (((curry kw) #:b 1 #:c 2) #:a 3) (list 3 1 2))
+(check-equal? (((curry kw) #:c 1 #:a 2) #:b 3) (list 2 3 1))
+
+(check-exn exn:fail:contract? (λ () (curry kw #:d 1)))
+(check-exn exn:fail:contract? (λ () ((curry kw) #:d 1)))
+(check-exn exn:fail:contract? (λ () (curry kw 1)))
+(check-exn exn:fail:contract? (λ () ((curry kw) 1)))
+(check-exn exn:fail:contract? (λ () (((curry kw) #:a 1) #:a 2)))
+(check-exn exn:fail:contract? (λ () ((curry kw #:a 1) #:a 2)))
+
+(define (kw+pos a b #:x x #:y y)
+  (list a b x y))
+
+(check-equal? ((((curry kw+pos 1) 2) #:x 3) #:y 4) (list 1 2 3 4))
+(check-equal? ((((curry kw+pos 1) 2) #:y 3) #:x 4) (list 1 2 4 3))
+(check-equal? ((curry kw+pos 1 #:x 3) 2 #:y 4) (list 1 2 3 4))
+(check-equal? ((curry kw+pos 1 #:y 3) 2 #:x 4) (list 1 2 4 3))
+(check-equal? ((curry kw+pos 1 #:x 3 #:y 4) 2) (list 1 2 3 4))
+(check-equal? ((curry kw+pos 1 #:y 3 #:x 4) 2) (list 1 2 4 3))
+
+(check-exn exn:fail:contract? (λ () ((curry kw+pos) 1 2 3)))
+(check-exn exn:fail:contract? (λ () ((curry kw+pos) #:d 1)))
+
+(define (opt-kw+pos #:a [a #f] b)
+  (list a b))
+
+(check-pred procedure? (curry opt-kw+pos #t))
+(check-pred procedure? ((curry opt-kw+pos) #t))
+(check-equal? (curry opt-kw+pos #:a #t #t) (list #t #t))
+(check-equal? ((curry opt-kw+pos) #:a #t #t) (list #t #t))


### PR DESCRIPTION
This PR rewrites the implementation of `curry` and `curryr` from `racket/function` to properly handle functions with keyword arguments. This has come up a number of times on IRC, Slack, and the mailing list; for an example of the latter, see @dstorrs’s [recent mailing list post on the subject](https://groups.google.com/d/msg/racket-users/F8gtAia6KUY/Mdxl9TV8CwAJ).

For a while now, the documentation for `curry` has made the following claim:

> The `curry` function provides limited support for keyworded functions: only the `curry` call itself can receive keyworded arguments to be propagated eventually to *`proc`*.

As far as I can tell, this claim is simply not true. Keyword arguments do not work correctly in any capacity in the existing implementation of `curry`, even when they are provided to the initial call to `curry` itself:

```racket
Welcome to Racket v6.12.
> (define (f #:a a b) (list a b))
> ((curry f #:a 1) 2)
#<procedure:curried>
```

This PR not only fixes that immediate issue, but also adds support for keyword arguments supplied to the functions produced by `curry`. At the same time, it also makes `curry` play nice with `procedure-arity` and `procedure-keywords`, and it gives curried procedures more useful dynamic names (in the sense of `object-name`). The implementation is significantly expanded to handle these additional features, but it provides a fast path for functions without keywords to avoid any significant overhead in the most common cases.