### PR TITLE
Export contract-random-generate-env? in racket/contract

### DIFF
--- a/racket/collects/racket/contract.rkt
+++ b/racket/collects/racket/contract.rkt
@@ -19,6 +19,7 @@
          contract-random-generate/choose
          contract-random-generate-fail
          contract-random-generate-fail?
+         contract-random-generate-env?
          contract-exercise
          get/build-val-first-projection
          contract-custom-write-property-proc)


### PR DESCRIPTION
This pull request exports [`contract-random-generate-env?`](https://docs.racket-lang.org/reference/Random_generation.html#%28def._%28%28lib._racket%2Fcontract%2Fprivate%2Fbase..rkt%29._contract-random-generate-env~3f%29%29) in `racket/contract` because (1) it is documented as a public API and (2) [some](https://docs.racket-lang.org/reference/Random_generation.html#%28def._%28%28lib._racket%2Fcontract..rkt%29._contract-random-generate-stash%29%29) [functions](https://docs.racket-lang.org/reference/Random_generation.html#%28def._%28%28lib._racket%2Fcontract..rkt%29._contract-random-generate-get-current-environment%29%29) refer to it in their contracts.
