### PR TITLE
fix a broken pattern-expander example

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -1151,9 +1151,10 @@ Returns a @tech{pattern expander} that uses @racket[proc] to transform the patte
 @examples[#:eval the-eval
 (define-syntax ~maybe
   (pattern-expander
-   (syntax-rules ()
-    [(~maybe pat ...)
-     (~optional (~seq pat ...))])))
+   (lambda (stx)
+     (syntax-case stx ()
+       [(~maybe pat ...)
+        #'(~optional (~seq pat ...))]))))
 ]}
 
 @defthing[prop:pattern-expander (struct-type-property/c (-> pattern-expander? (-> syntax? syntax?)))]{


### PR DESCRIPTION
The original example using syntax-rules would produce
```
~optional: cannot use identifier tainted by macro transformation in: ~optional
```