### PR TITLE
add -p option to the raco expand command

### DIFF
--- a/pkgs/compiler-lib/compiler/commands/expand.rkt
+++ b/pkgs/compiler-lib/compiler/commands/expand.rkt
@@ -6,7 +6,9 @@
            racket/pretty)
   
   (provide show-program)
-  
+
+  (define print-only (make-parameter #f))
+
   (define (show-program expand)
     (define source-files
       (command-line
@@ -18,11 +20,13 @@
             (raise-user-error (string->symbol (short-program+command-name))
                               "not a valid column count: ~a" n))
           (pretty-print-columns num))]
+       ["-p" "Print the document back out without performing expansion." (print-only #t)]
        #:args source-file
        source-file))
 
     (for ([src-file source-files])
-      (let ([src-file (path->complete-path src-file)])
+      (let ([src-file (path->complete-path src-file)]
+            [f (if (print-only) (lambda (i) i) expand)])
         (let-values ([(base name dir?) (split-path src-file)])
           (parameterize ([current-load-relative-directory base]
                          [current-namespace (make-base-namespace)]
@@ -34,7 +38,7 @@
                (let loop ()
                  (let ([e (read-syntax src-file in)])
                    (unless (eof-object? e)
-                     (pretty-write (syntax->datum (expand e)))
+                     (pretty-write (syntax->datum (f e)))
                      (loop))))))))))))
 
 (require (submod "." expand))


### PR DESCRIPTION
This change adds a `-p` boolean flag to the raco expand command. It allows you to just print the file context back, without performing any macro expansion.

The main use of this is to transform #lang code into equivalent racket code. Here is a comparison:

```
$ cat ./racket/share/pkgs/datalog/tests/examples/path.rkt
#lang datalog
% path test from Chen & Warren
edge(a, b). edge(b, c). edge(c, d). edge(d, a).
path(X, Y) :- edge(X, Y).
path(X, Y) :- edge(X, Z), path(Z, Y).
path(X, Y)?
$ ./racket/bin/raco expand ./racket/share/pkgs/datalog/tests/examples/path.rkt
(module path datalog/sexp/lang
  (#%module-begin
   (module configure-runtime '#%kernel
     (#%module-begin (#%require racket/runtime-config) (#%app configure '#f)))
   (define-values
    (lifted/1)
    (#%app
     module-name-fixup
...
     do-partial-app
     idZ3
     theory
     'theory
     pos-module-source
     (#%app kernel:srcloc '"<pkgs>/datalog/lang/reader.rkt" '#f '#f '#f '#f)
     '#f))))
$ ./racket/bin/raco expand -p ./racket/share/pkgs/datalog/tests/examples/path.rkt
(module path datalog/sexp/lang
  (#%module-begin
   (! (edge a b))
   (! (edge b c))
   (! (edge c d))
   (! (edge d a))
   (! (:- (path X Y) (edge X Y)))
   (! (:- (path X Y) (edge X Z) (path Z Y)))
   (? (path X Y))))
```