### PR TITLE
Fix default exercise and generate procedure for contracts

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -2745,11 +2745,11 @@ returns @racket[#f] but @racket[value-blame] returns @racket[#f].
           [#:generate
            generate
            (->i ([c contract?])
-                ([generator
-                  (c)
-                  (-> (and/c positive? real?)
-                      (or/c (-> (or/c contract-random-generate-fail? c))
-                            #f))]))
+                [generator
+                 (c)
+                 (-> (and/c positive? real?)
+                     (or/c (-> (or/c contract-random-generate-fail? c))
+                           #f))])
            (λ (c) (λ (fuel) #f))]
           [#:list-contract? is-list-contract? (-> contract? boolean?) (λ (c) #f)])
          flat-contract-property?]
@@ -2791,21 +2791,21 @@ returns @racket[#f] but @racket[value-blame] returns @racket[#f].
           [#:generate
            generate
            (->i ([c contract?])
-                ([generator
-                  (c)
-                  (-> (and/c positive? real?)
-                      (or/c (-> (or/c contract-random-generate-fail? c))
-                            #f))]))
+                [generator
+                 (c)
+                 (-> (and/c positive? real?)
+                     (or/c (-> (or/c contract-random-generate-fail? c))
+                           #f))])
            (λ (c) (λ (fuel) #f))]
           [#:exercise
            exercise
            (->i ([c contract?])
-                ([result
-                  (c)
-                  (-> (and/c positive? real?)
-                      (values
-                       (-> c void?)
-                       (listof contract?)))]))
+                [result
+                 (c)
+                 (-> (and/c positive? real?)
+                     (values
+                      (-> c void?)
+                      (listof contract?)))])
            (λ (c) (λ (fuel) (values void '())))]
           [#:list-contract? is-list-contract? (-> contract? boolean?) (λ (c) #f)])
          chaperone-contract-property?]
@@ -2847,21 +2847,21 @@ returns @racket[#f] but @racket[value-blame] returns @racket[#f].
           [#:generate
            generate
            (->i ([c contract?])
-                ([generator
-                  (c)
-                  (-> (and/c positive? real?)
-                      (or/c (-> (or/c contract-random-generate-fail? c))
-                            #f))]))
+                [generator
+                 (c)
+                 (-> (and/c positive? real?)
+                     (or/c (-> (or/c contract-random-generate-fail? c))
+                           #f))])
            (λ (c) (λ (fuel) #f))]
           [#:exercise
            exercise
            (->i ([c contract?])
-                ([result
-                  (c)
-                  (-> (and/c positive? real?)
-                      (values
-                       (-> c void?)
-                       (listof contract?)))]))
+                [result
+                 (c)
+                 (-> (and/c positive? real?)
+                     (values
+                      (-> c void?)
+                      (listof contract?)))])
            (λ (c) (λ (fuel) (values void '())))]
           [#:list-contract? is-list-contract? (-> contract? boolean?) (λ (c) #f)])
          contract-property?])]{

--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -435,12 +435,20 @@
      #:late-neg-projection
      (λ (ctc) (λ (b) (λ (v np) v)))))
   (define impersonate-any/c (impersonate-any/c-struct))
+  (struct chaperone-proc?/c-struct ()
+    #:property prop:chaperone-contract
+    (build-chaperone-contract-property
+     #:late-neg-projection
+     (λ (ctc) (λ (b) (λ (v np) v)))))
+  (define chaperone-proc?/c (chaperone-proc?/c-struct))
   (check-exn cannot-generate-exn? (λ () (test-contract-generation impersonate-any/c)))
   (check-exn cannot-generate-exn?
              (λ ()
                (test-contract-generation
                 (->i ([n integer?])
-                     [_ (n) (λ (r) (eq? r (even? n)))])))))
+                     [_ (n) (λ (r) (eq? r (even? n)))]))))
+  ;; Testing the default return value for contract-struct-generate
+  (check-exn cannot-generate-exn? (λ () (test-contract-generation chaperone-proc?/c))))
 
 (check-exercise
  10

--- a/racket/collects/racket/contract/private/prop.rkt
+++ b/racket/collects/racket/contract/private/prop.rkt
@@ -199,7 +199,7 @@
   (define generate (contract-property-generate prop))
   (if (procedure? generate)
       (generate c)
-      #f))
+      (λ (fuel) #f)))
 
 (define (contract-struct-exercise c)
   (define prop (contract-struct-property c))

--- a/racket/collects/racket/contract/private/prop.rkt
+++ b/racket/collects/racket/contract/private/prop.rkt
@@ -298,7 +298,7 @@
          #:late-neg-projection [get-late-neg-projection #f]
          #:stronger [stronger #f]
          #:equivalent [equivalent #f]
-         #:generate [generate (λ (ctc) (λ () #f))]
+         #:generate [generate (λ (ctc) (λ (fuel) #f))]
          #:exercise [exercise (λ (ctc) (λ (fuel) (values void '())))]
          #:list-contract? [list-contract? (λ (c) #f)])
   (unless (or get-first-order
@@ -476,8 +476,8 @@
          #:late-neg-projection [late-neg-projection #f]
          #:stronger [stronger #f]
          #:equivalent [equivalent #f]
-         #:generate [generate (λ (ctc) (λ () #f))]
-         #:exercise [exercise (λ (ctc) (λ (fuel) (values void '())))]
+         #:generate [generate (λ (fuel) #f)]
+         #:exercise [exercise (λ (fuel) (values void '()))]
          #:list-contract? [list-contract? #f])
 
   (unless (or first-order


### PR DESCRIPTION
This pull request fixes the default values in commit ffc5720 and the default generate procedure in the internal `contract-struct-generate` function.

- In `make[-*]contract`, the default procedures for generation and exercise should not take the `ctc` argument. They should be:
    * For `#:generate`, `(λ (fuel) #f)` instead of `(λ (ctc) (λ () #f))`.
    * For `#:exercise`, `(λ (fuel) (values void '()))` instead of `(λ (ctc) (λ (fuel) (values void '())))`.
- In `build[-*]-contract-property`, the default generation procedure should be `(λ (ctc) (λ (fuel) #f))`. For `build-chaperone-contract-property`, this is further fixed by changing the default return value in `contract-struct-generate`.

The old test case
```
(check-false
 (contract-random-generate
  (make-chaperone-contract
   #:late-neg-projection
   (λ (b) (λ (f v np) v)))))
```
is fixed since `contract-random-generate` should have failed to generate a value instead of returning `#f`.