### PR TITLE
improve `hash-ref` error message for non-thunk failure procedure

### DIFF
--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -2191,7 +2191,7 @@
       (test #t eq? (equal-hash-code l) (equal-hash-code (list 1 2 3)))
       (hash-set! h1 l 'ok)
       (test 'ok hash-ref h1 l)
-      (err/rt-test (hash-ref h1 'nonesuch (lambda (x) 'bad-proc)) exn:fail:contract:arity?)
+      (err/rt-test (hash-ref h1 'nonesuch (lambda (x) 'bad-proc)) exn:fail:contract? "hash-ref")
       (test #t hash-has-key? h1 l)
       (test #f hash-has-key? h1 (cdr l))
       (when hash-ref!

--- a/racket/src/racket/src/list.c
+++ b/racket/src/racket/src/list.c
@@ -2603,9 +2603,10 @@ static Scheme_Object *hash_failed(int argc, Scheme_Object *argv[])
 
   if (argc == 3) {
     v = argv[2];
-    if (SCHEME_PROCP(v))
+    if (SCHEME_PROCP(v)) {
+      scheme_check_proc_arity("hash-ref", 0, 2, argc, argv);
       return _scheme_tail_apply(v, 0, NULL);
-    else
+    } else
       return v;
   } else {
     scheme_contract_error("hash-ref",


### PR DESCRIPTION
Improve the `hash-ref` error message when the failure result does not
accept zero arguments. (This only changes what the error messages says.)

Example:
```(hash-ref #hash() 'a add1)```

Old message:
```
; add1: arity mismatch;
;  the expected number of arguments does not match the given number
;   expected: 1
;   given: 0
```

New message:
```
; hash-ref: contract violation
;   expected: (-> any)
;   given: #<procedure:add1>
;   argument position: 3rd
```