### PR TITLE
Initialize fail-escape in contract-exercise

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -435,3 +435,11 @@
            (λ (x) (λ (y) #f))
            'pos
            'neg))
+
+(check-exercise
+ 5
+ void?
+ (contract (-> (and/c #f #t) any)
+           (λ (_) 'thing)
+           'pos
+           'neg))

--- a/racket/collects/racket/contract/private/generate.rkt
+++ b/racket/collects/racket/contract/private/generate.rkt
@@ -61,7 +61,9 @@
                           [(null? exers) (void)]
                           [(null? vals) (loop exers orig-vals)]
                           [else
-                           ((car exers) (car vals))
+                           (let/ec k
+                             (parameterize ([fail-escape (λ () (k))])
+                               ((car exers) (car vals))))
                            (loop (cdr exers) (cdr vals))])))
                     available-ctcs)]
            [else


### PR DESCRIPTION
Some exercise procedure might invoke `contract-random-generate/choose`. Therefore, `fail-escape` needs to be initialized.