### PR TITLE
rackunit/docs-complete: accept any `module-path?`

### DIFF
--- a/pkgs/racket-index/rackunit/docs-complete.rkt
+++ b/pkgs/racket-index/rackunit/docs-complete.rkt
@@ -9,7 +9,7 @@
 
 ;; checks to make sure that all of the exports of
 ;; the 'what' library are documented
-(provide/contract [check-docs (->* (symbol?) 
+(provide/contract [check-docs (->* (module-path?) 
                                    (#:skip (or/c regexp? 
                                                  symbol? 
                                                  #f


### PR DESCRIPTION
The contract on `check-docs` was unnecessarily restricted to `symbol?`
module paths, which prevents using `check-docs` with submodules.