### PR TITLE
Update unixstyle-install.rkt

### DIFF
--- a/racket/collects/setup/unixstyle-install.rkt
+++ b/racket/collects/setup/unixstyle-install.rkt
@@ -243,7 +243,7 @@
                                (regexp-replace* #rx"/" file "_"))])
              (with-handlers ([exn? (lambda (e) (rm temp) (raise e))])
                ;; always copy so we never change the running executable
-               (rm temp)
+               (and (file-exists? temp)(rm temp))
                (copy-file file temp)
                (fix-binary temp)
                (rm file)


### PR DESCRIPTION
When installing from a racket snapshot installation failed (for me) because mred-temp-for-install does not exist before it is being removed. Checking if the temporary file exists solves this.