### PR TITLE
Fix domain exerciser order in randomly generated function

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -176,6 +176,7 @@
 
 (check-exn exn:fail? (λ () ((test-contract-generation (-> char? integer?)) 0)))
 (check-not-exn (λ () ((test-contract-generation (-> integer? integer?)) 1)))
+(check-not-exn (λ () ((test-contract-generation (-> any/c (-> any) any)) 0 void)))
 (check-not-exn (λ () ((test-contract-generation (-> integer? any)) 1)))
 (check-not-exn (λ () ((test-contract-generation (-> integer? (-> integer? any))) 1)))
 (check-not-exn (λ () ((test-contract-generation (-> (-> integer? any) integer?))

--- a/racket/collects/racket/contract/private/arrow-val-first.rkt
+++ b/racket/collects/racket/contract/private/arrow-val-first.rkt
@@ -1335,6 +1335,7 @@
          (define-values (exer ctcs) ((contract-struct-exercise c) fuel))
          (set! dom-exers (cons exer dom-exers))
          (set! addl-available (append ctcs addl-available)))
+       (set! dom-exers (reverse dom-exers))
        (define rngs-gens 
          (if (base->-rngs ctc)
              (with-definitely-available-contracts


### PR DESCRIPTION
Also, common uses like `(   (contract-random-generate (-> integer? boolean? any))   0   #f)` won't expose the problem since contracts coerced from predicates (e.g. `integer?`) have no exerciser.