### PR TITLE
Coerce the argument to a contract in contract-random-generate/choose

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -3554,8 +3554,14 @@ ended up returning @racket[contract-random-generate-fail].
          (or/c #f (-> c))]{
   This function is like @racket[contract-random-generate], but it is intended to
   be used with combinators that generate values based on sub-contracts
-  they have. It cannot be called, except during contract
-  generation. It will never fail, but it might escape back to an enclosing
+  they have. It must be called when @racket[contract-random-generate]
+  (and @racket[contract-exercise]) creates the generators. In other words,
+  @racket[contract-random-generate/choose] is available only after the
+  @racket[_generate] (and @racket[_exercise]) function received the
+  @racket[_fuel] and before it returned the thunk (or the exerciser).
+
+  @racket[contract-random-generate/choose] will never fail,
+  but it might escape back to an enclosing
   call or to the original call to @racket[contract-random-generate].
  
   It chooses one of several possible generation strategies, and thus it may not

--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -3555,10 +3555,14 @@ ended up returning @racket[contract-random-generate-fail].
   This function is like @racket[contract-random-generate], but it is intended to
   be used with combinators that generate values based on sub-contracts
   they have. It must be called when @racket[contract-random-generate]
-  (and @racket[contract-exercise]) creates the generators. In other words,
-  @racket[contract-random-generate/choose] is available only after the
-  @racket[_generate] (and @racket[_exercise]) function received the
-  @racket[_fuel] and before it returned the thunk (or the exerciser).
+  (and @racket[contract-exercise]) creates the generators.
+  To be more precise, @racket[contract-random-generate/choose] is available
+  only for the @racket[_generate] and @racket[_exercise] arguments in
+  @racket[build-contract-property], @racket[build-chaperone-contract-property]
+  or @racket[build-flat-contract-property] and only during the dynamic
+  extent of the call to @racket[_generate] (and @racket[_exercise]).
+  That is, after it receives the @racket[_c] and @racket[_fuel] arguments
+  and before it returns the thunk (or the exerciser).
 
   @racket[contract-random-generate/choose] will never fail,
   but it might escape back to an enclosing

--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -492,3 +492,14 @@
            (λ (_) 'thing)
            'pos
            'neg))
+
+;; a test for contract-random-generate/choose
+(let ()
+  (struct make-gen-choose/c ()
+    #:property prop:chaperone-contract
+    (build-chaperone-contract-property
+     #:late-neg-projection
+     (λ (ctc) (λ (b) (λ (v np) v)))
+     #:generate
+     (λ (ctc) (λ (fuel) (contract-random-generate/choose number? 10)))))
+  (check-not-exn (λ () (test-contract-generation (make-gen-choose/c)))))

--- a/racket/collects/racket/contract/private/generate.rkt
+++ b/racket/collects/racket/contract/private/generate.rkt
@@ -179,7 +179,8 @@
 ; #f if no value could be generated
 ;; if it returns a thunk, the thunk will not return contract-random-generate-fail?
 (define (contract-random-generate/choose ctc fuel)
-  (define direct ((contract-struct-generate ctc) fuel))
+  (define def-ctc (coerce-contract 'contract-random-generate/choose ctc))
+  (define direct ((contract-struct-generate def-ctc) fuel))
   (define env-can? (can-generate/env? ctc))
   (define env (generate-env))
   (unless (contract-random-generate-env? env)


### PR DESCRIPTION
I also tried to update the documentation of contract-random-generate/choose to clear things up, but I am not sure what is the best way to describe its constraint. The generators and exercisers for any contracts are of form

```
(λ (ctc)
  (λ (fuel)
    ;; A
    (λ ()
      ;; B
      ...)))

(λ (ctc)
  (λ (fuel)
    ;; A
    (values (λ (v)
              ;; B
              ...)
            ...)))
```

The function `contract-random-generate/choose` can only be used at point A. It cannot be used at point B (or any other places).