### PR TITLE
Remove test for foff != 0

### DIFF
--- a/racket/src/foreign/foreign.c
+++ b/racket/src/foreign/foreign.c
@@ -2675,7 +2675,7 @@ static Scheme_Object *foreign_malloc(int argc, Scheme_Object *argv[])
   }
   res = scheme_malloc_fail_ok(mf,size);
   if (failok && (res == NULL)) scheme_signal_error("malloc: out of memory");
-  if (((from != NULL) || (foff != 0)) && (res != NULL))
+  if ((from != NULL) && (res != NULL))
     memcpy(res, W_OFFSET(from, foff), size);
   if (SAME_OBJ(mode, raw_sym))
     return scheme_make_foreign_external_cpointer(res);


### PR DESCRIPTION
Coverity complains here that we are calling malloc with an offset only. Looking at the code and the docs, makes it look like that the if condition is overworked and we can remove the test for `foff != 0`.

Fixes #2285.