### PR TITLE
Fix sizeof argument

### DIFF
--- a/racket/src/racket/src/hash.c
+++ b/racket/src/racket/src/hash.c
@@ -770,7 +770,7 @@ void scheme_clear_bucket_table(Scheme_Bucket_Table *bt)
 
   bt->count = 0;
   bt->size = 4;
-  ba = (Scheme_Bucket **)scheme_malloc(bt->size * sizeof(Scheme_Bucket **));
+  ba = (Scheme_Bucket **)scheme_malloc(bt->size * sizeof(Scheme_Bucket *));
   bt->buckets = ba;
 }
 


### PR DESCRIPTION
This code looks suspicious. It's calculating the wrong size with `bt->size * sizeof(Scheme_Bucket **)`, and then casting the malloced object to `Scheme_Bucket **`. It should be `bt->size * sizeof(Scheme_Bucket *)`. Interestingly enough I think, in general, `sizeof(Scheme_Bucket*) == sizeof(Scheme_Bucket **)` but it's better not to rely on it.