### PR TITLE
Fix ubsan runtime error due to large shift

### DIFF
--- a/racket/src/racket/src/number.c
+++ b/racket/src/racket/src/number.c
@@ -5477,8 +5477,8 @@ static Scheme_Object *fold_fixnum_bitwise_shift(int argc, Scheme_Object *argv[])
 
   base = SCHEME_INT_VAL(argv[0]);
   /* Consistent if potentially unkept bits are all 0 or 1 */
-  if (!(base - (base & ((1 << kept) - 1)))
-      || !(~(base | ((1 << kept) - 1)))) {
+  if (!(base - (base & ((1UL << kept) - 1)))
+      || !(~(base | ((1UL << kept) - 1)))) {
     v = base << amt;
     
     return scheme_make_integer(v);


### PR DESCRIPTION
If one attempts to compile racket with `--enable-ubsan`, there's a single runtime error in `numbers.c` about shift of 61 too large for 32 bit 'int'. This PR fixes this.