### PR TITLE
Add compilation with ubsan to test matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,9 @@ matrix:
       --disable-extflonum"
   - os: linux
     compiler: gcc
+    env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--enable-ubsan"
+  - os: linux
+    compiler: gcc
     env: PATH=./racket/bin:$PATH RACKET_CONFIGURE_ARGS="--disable-jit"
   - os: linux
     compiler: gcc


### PR DESCRIPTION
We should probably add compilation with ubsan to the test matrix since it will catch potentially relevant issues during the build, like the issue fixed in #2296.