### PR TITLE
Clarify match's app pattern behavior

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -360,15 +360,22 @@ In more detail, patterns match as follows:
        ]}
 
  @item{@racket[(#,(racketidfont "app") _expr _pats ...)] --- applies
-       @racket[_expr] to the value to be matched; the result of the
-       application is matched against @racket[_pats].
+       @racket[_expr] to the value to be matched; each result of the
+       application is matched against one of the @racket[_pats],
+       respectively.
 
        @examples[
        #:eval match-eval
        (match '(1 2)
         [(app length 2) 'yes])
+       (match "3.14"
+        [(app string->number (? number? pi))
+         `(I got ,pi)])
        (match '(1 2)
         [(app (lambda (v) (split-at v 1)) '(1) '(2)) 'yes])
+       (match '(1 2 3)
+        [(app (λ (ls) (apply values ls)) x y (? odd? z))
+         (list 'yes x y z)])
        ]}
 
  @item{@racket[(#,(racketidfont "?") _expr _pat ...)] --- applies


### PR DESCRIPTION
If I have understood the behavior of ```app``` correctly, the documentation needs to be clarified. Currently it implies that match expects a single result, and one could reasonably infer that the matcher will require that single result to satisfy all ```_pat```s given. The error message resulting from a reasonable-but-wrong pattern like ```(app string->number (? number?) x)``` is inscrutable, so a doc fix is important here.

I have also added an example that illustrates a use case for ```app```, namely, the use case that led me to submit this PR.