### PR TITLE
Pkg fixes

### DIFF
--- a/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
@@ -516,10 +516,13 @@ sub-commands.
         @tech{package name} must be mapped by the @tech{package catalog} to a
         Git or GitHub @tech{package source}.}
 
+  @item{@DFlag{source} --- Strips built elements of a package before installing, and implies @DFlag{copy}.
+                           See also @secref["strip"].}
+
   @item{@DFlag{binary} --- Strips source elements of a package before installing, and implies @DFlag{copy}.
                            See also @secref["strip"].}
 
-  @item{@DFlag{source} --- Strips built elements of a package before installing, and implies @DFlag{copy}.
+  @item{@DFlag{binary-lib} --- Strips source and documentation elements of a package before installing, and implies @DFlag{copy}.
                            See also @secref["strip"].}
 
  @item{@DFlag{scope} @nonterm{scope} --- Selects the @tech{package scope} for installation, where @nonterm{scope} is one of
@@ -853,8 +856,10 @@ package is created.
 
  @item{@DFlag{deps} @nonterm{behavior} --- Same as for @command-ref{install}, except that @exec{search-auto} is
        the default.}
-  @item{@DFlag{binary} --- Same as for @command-ref{install}.}
+  
   @item{@DFlag{source} --- Same as for @command-ref{install}.}
+  @item{@DFlag{binary} --- Same as for @command-ref{install}.}
+  @item{@DFlag{binary-lib} --- Same as for @command-ref{install}.}
   @item{@DFlag{scope} @nonterm{scope} --- Same as for @command-ref{install}.}
   @item{@Flag{i} or @DFlag{installation} --- Shorthand for @exec{--scope installation}.}
   @item{@Flag{u} or @DFlag{user} --- Shorthand for @exec{--scope user}.}
@@ -899,6 +904,7 @@ package is created.
  @item{@DFlag{source} --- Bundles only sources in the package directory; see @secref["strip"].}
  @item{@DFlag{binary} --- Bundles compiled bytecode and rendered
        documentation in the package directory; see @secref["strip"].}
+ @item{@DFlag{binary-lib} --- Bundles compiled bytecode only in the package directory; see @secref["strip"].}
  @item{@DFlag{built} --- Bundles compiled sources, bytecode, and rendered
        documentation in the package directory, filtering repository elements; see @secref["strip"].}
   @item{@DFlag{dest} @nonterm{dest-dir} --- Writes generated bundles to @nonterm{dest-dir}.}

--- a/pkgs/racket-doc/pkg/scribblings/strip.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/strip.scrbl
@@ -215,19 +215,21 @@ with the same file/directory omissions and updates as
 @command-ref{create}.}
 
 @defproc[(generate-stripped-directory [mode (or/c 'source 'binary 'binary-lib 'built)]
-                                      [src-dir path-string?]
-                                      [dest-dir path-string?])
+                                      [src-dir (and/c path-string? directory-exists?)]
+                                      [dest-dir (and/c path-string? directory-exists?)])
           void?]{
 
 Copies @racket[src-dir] to @racket[dest-dir] with file/directory
-omissions and updates corresponding the creation of a @tech{source
+omissions and updates corresponding to the creation of a @tech{source
 package}, @tech{binary package}, @tech{binary library package}, or @tech{built package} as indicated
-by @racket[mode].}
+by @racket[mode].} Note, @racket[generate-stripped-directory] does not compile or render source files
+found in the @racket[src-dir]. To perform precompilation or rendering before stripping the source directory,
+use @command-ref{setup} or @command-ref{make}.
 
 
 @defproc[(check-strip-compatible [mode (or/c 'source 'binary 'binary-lib 'built)]
                                  [pkg-name string?]
-                                 [dir path-string?]
+                                 [dir (and/c path-string? directory-exists?)]
                                  [error (string? . -> . any)])
           any]{
 

--- a/pkgs/racket-doc/pkg/scribblings/strip.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/strip.scrbl
@@ -224,7 +224,7 @@ omissions and updates corresponding to the creation of a @tech{source
 package}, @tech{binary package}, @tech{binary library package}, or @tech{built package} as indicated
 by @racket[mode].} Note, @racket[generate-stripped-directory] does not compile or render source files
 found in the @racket[src-dir]. To perform precompilation or rendering before stripping the source directory,
-use @command-ref{setup} or @command-ref{make}.
+use @exec{raco setup} or @exec{raco make}.
 
 
 @defproc[(check-strip-compatible [mode (or/c 'source 'binary 'binary-lib 'built)]

--- a/pkgs/racket-test/tests/pkg/test-pkgs/pkg-strip/info.rkt
+++ b/pkgs/racket-test/tests/pkg/test-pkgs/pkg-strip/info.rkt
@@ -1,0 +1,2 @@
+#lang info
+(define pkg-desc "use this pkg to demonstrate different stripping modes.")

--- a/pkgs/racket-test/tests/pkg/test-pkgs/pkg-strip/main.rkt
+++ b/pkgs/racket-test/tests/pkg/test-pkgs/pkg-strip/main.rkt
@@ -1,0 +1,3 @@
+#lang racket/base
+(printf "this pkg can be stripped in multiple modes\n")
+

--- a/pkgs/racket-test/tests/pkg/test.rkt
+++ b/pkgs/racket-test/tests/pkg/test.rkt
@@ -61,7 +61,9 @@
    "raco"
    "binary"
    "catalogs"
-   "failure"))
+   "failure"
+
+   "api"))
 
 (module+ test
   (module config info

--- a/pkgs/racket-test/tests/pkg/tests-api.rkt
+++ b/pkgs/racket-test/tests/pkg/tests-api.rkt
@@ -1,0 +1,50 @@
+#lang racket/base
+(require rackunit
+         racket/file
+         pkg/strip
+         "util.rkt")
+
+(this-test-is-run-by-the-main-test)
+
+(pkg-tests
+
+ (parameterize ([current-directory test-source-directory])
+   (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+   (define pkg-path (build-path "test-pkgs" "pkg-strip"))
+   (define pkg-dest-path (build-path tmp-dir "pkg-strip"))
+   (make-directory pkg-dest-path)
+
+   ;; Giving path to nonexistent directory should raise a contract exception.
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (check-strip-compatible 'source "pkg-strip" "does not exist" error)))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (check-strip-compatible 'binary "pkg-strip" "does not exist" error)))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (check-strip-compatible 'binary-lib "pkg-strip" "does not exist" error)))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (check-strip-compatible 'built "pkg-strip" "does not exist" error)))
+
+   ;; Path to existing directory should succeed.
+   (check-not-exn (lambda () (check-strip-compatible 'source "pkg-strip" pkg-path error)))
+
+   ;; Giving path to nonexistent src directory should raise a contract exception.
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'source 5 pkg-dest-path)))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'binary "does not exist" pkg-dest-path)))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'binary-lib "does not exist" pkg-dest-path)))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'built "does not exist" pkg-dest-path)))
+
+   ;; Giving path to nonexistent dest directory should raise a contract exception.
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'source pkg-path "does not exist")))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'binary pkg-path "does not exist")))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'binary-lib pkg-path "does not exist")))
+
+   (check-exn #rx"expected: \\(and/c path-string\\? directory-exists\\?\\)" (lambda () (generate-stripped-directory 'built pkg-path "does not exist")))
+
+   ;; Paths to existing src and dest directories should succeed.
+   (check-not-exn (lambda () (generate-stripped-directory 'source pkg-path pkg-dest-path)))
+
+   ))

--- a/pkgs/racket-test/tests/pkg/tests-install.rkt
+++ b/pkgs/racket-test/tests/pkg/tests-install.rkt
@@ -261,4 +261,170 @@
      $ "raco pkg config --set git-checkout-credentials user:bad-password"
      $ "raco pkg install pkg-git" =exit> 1
      $ "raco pkg config --set git-checkout-credentials user:password"
-     $ "raco pkg install pkg-git")))))
+     $ "raco pkg install pkg-git"))
+
+   (parameterize ([current-directory test-source-directory])
+     (with-fake-root
+         (shelly-case
+          "install package in default mode using local directory catalog specified via pkg config --set catalogs"
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (copy-directory/files (build-path "test-pkgs" "pkg-strip") (build-path pkgs-dir "pkg-strip"))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install pkg-strip" =exit> 1
+          $ (format "raco pkg config --set catalogs file:///~a" (path->string catalog-dir))
+          $ "raco pkg install pkg-strip"
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in default mode using local directory catalog specified via pkg config --set catalogs"
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (copy-directory/files (build-path "test-pkgs" "pkg-strip") (build-path pkgs-dir "pkg-strip"))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install pkg-strip" =exit> 1
+          $ (format "raco pkg config --set catalogs file:///~a" (path->string catalog-dir))
+          $ "raco pkg install pkg-strip"
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in source mode using local directory catalog specified via pkg config --set catalogs"
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (copy-directory/files (build-path "test-pkgs" "pkg-strip") (build-path pkgs-dir "pkg-strip"))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install --source pkg-strip" =exit> 1
+          $ (format "raco pkg config --set catalogs file:///~a" (path->string catalog-dir))
+          $ "raco pkg install --source pkg-strip"
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in source mode using local directory catalog specified via pkg install --catalog"
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (copy-directory/files (build-path "test-pkgs" "pkg-strip") (build-path pkgs-dir "pkg-strip"))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install --source pkg-strip" =exit> 1
+          $ (format "raco pkg install --source --catalog file:///~a pkg-strip" (path->string catalog-dir))
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in binary mode using local directory catalog specified via pkg config --set catalogs"
+          (define pkg-strip-orig-dir (build-path "test-pkgs" "pkg-strip"))
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (define pkg-strip-dir (build-path tmp-dir "pkg-strip"))
+          (define pkg-strip-binary-dir (build-path pkgs-dir "pkg-strip"))
+          (make-directory pkg-strip-binary-dir)
+          (copy-directory/files pkg-strip-orig-dir pkg-strip-dir)
+          (parameterize ([current-directory pkg-strip-dir])
+            (shelly-begin
+             $ "raco make info.rkt main.rkt"))
+          $ (format "racket -e '(require pkg/strip) (generate-stripped-directory (quote binary) ~s ~s)'"
+                    (path->string pkg-strip-dir)
+                    (path->string pkg-strip-binary-dir))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install --binary pkg-strip" =exit> 1
+          $ (format "raco pkg config --set catalogs file:///~a" (path->string catalog-dir))
+          $ "raco pkg install --binary pkg-strip"
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in binary mode using local directory catalog specified via pkg install --catalog"
+          (define pkg-strip-orig-dir (build-path "test-pkgs" "pkg-strip"))
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (define pkg-strip-dir (build-path tmp-dir "pkg-strip"))
+          (define pkg-strip-binary-dir (build-path pkgs-dir "pkg-strip"))
+          (make-directory pkg-strip-binary-dir)
+          (copy-directory/files pkg-strip-orig-dir pkg-strip-dir)
+          (parameterize ([current-directory pkg-strip-dir])
+            (shelly-begin
+             $ "raco make info.rkt main.rkt"))
+          $ (format "racket -e '(require pkg/strip) (generate-stripped-directory (quote binary) ~s ~s)'"
+                    (path->string pkg-strip-dir)
+                    (path->string pkg-strip-binary-dir))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install --binary pkg-strip" =exit> 1
+          $ (format "raco pkg install --catalog file:///~a --binary pkg-strip" (path->string catalog-dir))
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in binary-lib mode using local directory catalog specified via pkg config --set catalogs"
+          (define pkg-strip-orig-dir (build-path "test-pkgs" "pkg-strip"))
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (define pkg-strip-dir (build-path tmp-dir "pkg-strip"))
+          (define pkg-strip-binary-lib-dir (build-path pkgs-dir "pkg-strip"))
+          (make-directory pkg-strip-binary-lib-dir)
+          (copy-directory/files pkg-strip-orig-dir pkg-strip-dir)
+          (parameterize ([current-directory pkg-strip-dir])
+            (shelly-begin
+             $ "raco make info.rkt main.rkt"))
+          $ (format "racket -e '(require pkg/strip) (generate-stripped-directory (quote binary-lib) ~s ~s)'"
+                    (path->string pkg-strip-dir)
+                    (path->string pkg-strip-binary-lib-dir))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install --binary-lib pkg-strip" =exit> 1
+          $ (format "raco pkg config --set catalogs file:///~a" (path->string catalog-dir))
+          $ "raco pkg install --binary-lib pkg-strip"
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))
+
+     (with-fake-root
+         (shelly-case
+          "install package in binary-lib mode using local directory catalog specified via pkg install --catalog"
+          (define pkg-strip-orig-dir (build-path "test-pkgs" "pkg-strip"))
+          (define tmp-dir (path->directory-path (make-temporary-file "tmp~a" 'directory)))
+          (define catalog-dir (build-path tmp-dir "catalog"))
+          (make-directory catalog-dir)
+          (define pkgs-dir (build-path tmp-dir "pkgs"))
+          (make-directory pkgs-dir)
+          (define pkg-strip-dir (build-path tmp-dir "pkg-strip"))
+          (define pkg-strip-binary-lib-dir (build-path pkgs-dir "pkg-strip"))
+          (make-directory pkg-strip-binary-lib-dir)
+          (copy-directory/files pkg-strip-orig-dir pkg-strip-dir)
+          (parameterize ([current-directory pkg-strip-dir])
+            (shelly-begin
+             $ "raco make info.rkt main.rkt"))
+          $ (format "racket -e '(require pkg/strip) (generate-stripped-directory (quote binary-lib) ~s ~s)'"
+                    (path->string pkg-strip-dir)
+                    (path->string pkg-strip-binary-lib-dir))
+          $ (format "racket -l pkg/dirs-catalog ~a ~a" catalog-dir pkgs-dir)
+          $ "raco pkg install --binary-lib pkg-strip" =exit> 1
+          $ (format "raco pkg install --catalog file:///~a --binary-lib pkg-strip" (path->string catalog-dir))
+          $ "racket -l pkg-strip" =stdout> "this pkg can be stripped in multiple modes\n"
+          (delete-directory/files tmp-dir)))))))

--- a/racket/collects/pkg/private/stage.rkt
+++ b/racket/collects/pkg/private/stage.rkt
@@ -632,9 +632,9 @@
               (if strip-mode
                   (begin
                     (unless force-strip?
-                      (check-strip-compatible strip-mode pkg-name pkg pkg-error))
+                      (check-strip-compatible strip-mode pkg-name pkg-path pkg-error))
                     (make-directory* pkg-dir)
-                    (generate-stripped-directory strip-mode pkg pkg-dir))
+                    (generate-stripped-directory strip-mode pkg-path pkg-dir))
                   (begin
                     (make-parent-directory* pkg-dir)
                     (copy-directory/files pkg-path pkg-dir #:keep-modify-seconds? #t)))

--- a/racket/collects/pkg/strip.rkt
+++ b/racket/collects/pkg/strip.rkt
@@ -21,6 +21,12 @@
 (define strip-binary-compile-info (make-parameter #t))
 
 (define (check-strip-compatible mode pkg dir error)
+  (unless (and (path-string? dir) (directory-exists? dir))
+    (raise-argument-error
+     'check-strip-compatible
+     "(and/c path-string? directory-exists?)"
+     dir))
+
   (define i (get-info/full dir))
   (define raw-status (and i
                           (i 'package-content-state (lambda () #f))))
@@ -58,6 +64,18 @@
 
 (define (generate-stripped-directory mode dir dest-dir
                                      #:check-status? [check-status? #t])
+  (unless (and (path-string? dir) (directory-exists? dir))
+    (raise-argument-error
+     'generate-stripped-directory
+     "(and/c path-string? directory-exists?)"
+     dir))
+
+  (unless (and (path-string? dest-dir) (directory-exists? dest-dir))
+    (raise-argument-error
+     'generate-stripped-directory
+     "(and/c path-string? directory-exists?)"
+     dest-dir))
+
   (define drop-keep-ns (make-base-namespace))
   (define (add-drop+keeps dir base drops keeps)
     (define get-info (get-info/full dir #:namespace drop-keep-ns))


### PR DESCRIPTION
Various fixes for the `pkg` collection.

Fixes file:// URL handling when installing in alternative strip modes.

Added `directory-exists?` checks to `generate-stripped-directory` and `check-strip-compatible`

Test cases added for all the changes.

Documentation also updated with notes and missing information.

I have more `pkg` fixes in the pipeline but thought I'd best push these out in the hope of making the deadline before the latest Racket release is finalized.