### PR TITLE
Note that _enum in Racket and enum in C use different backings.

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/types.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/types.scrbl
@@ -1738,10 +1738,10 @@ is to throw an exception.
              buffer_too_small)))
 ]
 
-Note that the default basetype is @racket[_fixint]. This
+Note that the default basetype is @racket[_ufixint]. This
 differs from C enumerations that can use any value in
-@racket[_ufixint]. Any @racket[_enum] using negative values
-should use @racket[_ufixint] for the base type.
+@racket[_fixint]. Any @racket[_enum] using negative values
+should use @racket[_fixint] for the base type.
 
 @examples[#:eval ffi-eval
   (define @#,racketidfont{_negative_enum}

--- a/pkgs/racket-doc/scribblings/foreign/types.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/types.scrbl
@@ -1736,7 +1736,19 @@ is to throw an exception.
     (_enum '(ok = 0
              invalid_input
              buffer_too_small)))
-]}
+]
+
+Note that the default basetype is @racket[_fixint]. This
+differs from C enumerations that can use any value in
+@racket[_ufixint]. Any @racket[_enum] using negative values
+should use @racket[_ufixint] for the base type.
+
+@examples[#:eval ffi-eval
+  (define @#,racketidfont{_negative_enum}
+    (_enum '(unkown = -1
+             error = 0
+             ok = 1)
+           _ufixint))]}
 
 @defproc[(_bitmask [symbols (or symbol? list?)] [basetype ctype? _uint])
          ctype?]{

--- a/pkgs/racket-doc/scribblings/foreign/types.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/types.scrbl
@@ -1748,7 +1748,7 @@ should use @racket[_fixint] for the base type.
     (_enum '(unkown = -1
              error = 0
              ok = 1)
-           _ufixint))]}
+           _fixint))]}
 
 @defproc[(_bitmask [symbols (or symbol? list?)] [basetype ctype? _uint])
          ctype?]{


### PR DESCRIPTION
(It is worth noting that C does not specify the backing for enum, but
does say its range is that of a uint.)