### PR TITLE
Remove gcc osx matrix entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ language: c
 matrix:
   include:
   - os: osx
-    compiler: gcc
-    env: PATH=./racket/bin:$PATH
-  - os: osx
     compiler: clang
     env: PATH=./racket/bin:$PATH
   - os: linux


### PR DESCRIPTION
I never used MacOS but I had heard of this particular issue and this is an interesting one... If you look at the logs you'll see this (for example: https://travis-ci.org/racket/racket/jobs/442839697):
```
$ gcc --version
Configured with: --prefix=/Applications/Xcode-9.4.1.app/Contents/Developer/usr --with-gxx-include-dir=/usr/include/c++/4.2.1
Apple LLVM version 9.1.0 (clang-902.0.39.2)
Target: x86_64-apple-darwin17.4.0
Thread model: posix
InstalledDir: /Applications/Xcode-9.4.1.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin
```

So, there's no `gcc` on the mac. It's just an alias to clang and we already have an entry for clang on the matrix so this entry is just wasted compute power and time since it fills one of the parallel builders that racket could be using for something else.

I tried to look for a way online to install gcc on macosx here:
https://github.com/LinkiTools/racket/tree/osx-real-gcc-build

but I have failed. I don't know enough about this specific mac version (or any other for that matter) to have any kind of success. I also think that having to compile gcc from scratch just to then compile racket is a no-go since it would take a long time to finish on the very slow machines offered to us by travis. 