### PR TITLE
Gitlab integration for ubsan compilation

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,72 @@
+image: ubuntu:18.04
+
+.prepare:
+  before_script:
+    - apt-get update && apt-get install -y git lsb-release gcc gcc-8 g++ g++-8 make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev
+    - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
+    - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
+    - export PATH=$PWD/racket/bin:$PATH
+
+envinfo:
+  extends: .prepare
+  script:
+    - cat /proc/cpuinfo
+    - lsb_release -a
+    - gcc -v
+    - export
+
+test:ubsan:
+  extends: .prepare    
+  script:
+    - mkdir logs
+    - make CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test" CONFIGURE_ARGS_qq="--enable-ubsan CFLAGS="-fno-var-tracking-assignments"" in-place 2>&1 | tee logs/build.log
+    - raco test -l tests/racket/test 2>&1 | tee logs/test.log
+    - racket -l tests/racket/contract/all 2>&1 | tee logs/contract-test.log
+    - raco test -l tests/json/json 2>&1 | tee logs/json-test.log
+    - raco test -l tests/file/main 2>&1 | tee logs/file-test.log
+    - raco test -l tests/net/head 2>&1 | tee logs/net-head-test.log
+    - raco test -l tests/net/uri-codec 2>&1 | tee logs/net-uri-codec-test.log
+    - raco test -l tests/net/url 2>&1 | tee logs/net-url-test.log
+    - raco test -l tests/net/url-port 2>&1 | tee logs/net-url-port-test.log
+    - raco test -l tests/net/encoders 2>&1 | tee logs/net-encoders-test.log
+    - raco test -l tests/openssl/basic 2>&1 | tee logs/openssl-basic-test.log
+    - raco test -l tests/openssl/https 2>&1 | tee logs/openssl-https-test.log
+    - raco test -l tests/match/main 2>&1 | tee logs/match-main-test.log
+    - raco test -l tests/zo-path 2>&1 | tee logs/zo-path-test.log
+    - raco test -l tests/xml/test 2>&1 | tee logs/xml-test.log
+    - raco test -l tests/db/all-tests 2>&1 | tee logs/db-test.log
+    - raco test -c tests/stxparse 2>&1 | tee logs/stxparse-test.log
+  after_script:
+    - grep 'runtime error' logs/*.log > runtime-errors.log
+  artifacts:
+    paths:
+      - logs/
+      - runtime-errors.log
+    
+test:ubsan:cs:
+  extends: .prepare    
+  script:
+    - mkdir cs-logs
+    - make CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test" CONFIGURE_ARGS_qq="--enable-ubsan CFLAGS="-fno-var-tracking-assignments"" cs 2>&1 | tee cs-logs/build.log
+    - raco test -l tests/racket/test 2>&1 | tee cs-logs/test.log
+    - racket -l tests/racket/contract/all 2>&1 | tee cs-logs/contract-test.log
+    - raco test -l tests/json/json 2>&1 | tee cs-logs/json-test.log
+    - raco test -l tests/file/main 2>&1 | tee cs-logs/file-test.log
+    - raco test -l tests/net/head 2>&1 | tee cs-logs/net-head-test.log
+    - raco test -l tests/net/uri-codec 2>&1 | tee cs-logs/net-uri-codec-test.log
+    - raco test -l tests/net/url 2>&1 | tee cs-logs/net-url-test.log
+    - raco test -l tests/net/url-port 2>&1 | tee cs-logs/net-url-port-test.log
+    - raco test -l tests/net/encoders 2>&1 | tee cs-logs/net-encoders-test.log
+    - raco test -l tests/openssl/basic 2>&1 | tee cs-logs/openssl-basic-test.log
+    - raco test -l tests/openssl/https 2>&1 | tee cs-logs/openssl-https-test.log
+    - raco test -l tests/match/main 2>&1 | tee cs-logs/match-main-test.log
+    - raco test -l tests/zo-path 2>&1 | tee cs-logs/zo-path-test.log
+    - raco test -l tests/xml/test 2>&1 | tee cs-logs/xml-test.log
+    - raco test -l tests/db/all-tests 2>&1 | tee cs-logs/db-test.log
+    - raco test -c tests/stxparse 2>&1 | tee cs-logs/stxparse-test.log
+  after_script:
+    - grep 'runtime error' cs-logs/*.log > runtime-errors.log
+  artifacts:
+    paths:
+      - cs-logs/
+      - runtime-errors.log

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -8,6 +8,7 @@ image: ubuntu:18.04
     - export PATH=$PWD/racket/bin:$PATH
 
 .prepare:llvm:
+  before_script:
     - apt-get update && apt-get install -y git lsb-release make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev wget gnupg
     - echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main' >> /etc/apt/sources.list
     - echo 'deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main' >> /etc/apt/sources.list

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -2,14 +2,14 @@ image: ubuntu:18.04
 
 .prepare:
   before_script:
-    - apt-get update && apt-get install -y git lsb-release gcc gcc-8 g++ g++-8 make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev
+    - apt-get update && apt-get install -y git lsb-release gcc gcc-8 g++ g++-8 make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev uuid-dev
     - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-7 700 --slave /usr/bin/g++ g++ /usr/bin/g++-7
     - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
     - export PATH=$PWD/racket/bin:$PATH
 
 .prepare:llvm:
   before_script:
-    - apt-get update && apt-get install -y git lsb-release make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev wget gnupg
+    - apt-get update && apt-get install -y git lsb-release make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev wget gnupg uuid-dev
     - echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main' >> /etc/apt/sources.list
     - echo 'deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main' >> /etc/apt/sources.list
     - wget -O /tmp/llvm.key https://apt.llvm.org/llvm-snapshot.gpg.key

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,6 +7,16 @@ image: ubuntu:18.04
     - update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-8 800 --slave /usr/bin/g++ g++ /usr/bin/g++-8
     - export PATH=$PWD/racket/bin:$PATH
 
+.prepare:llvm:
+    - apt-get update && apt-get install -y git lsb-release make libfontconfig1-dev libcairo2-dev openssl libpango1.0-dev libjpeg-turbo8-dev libncurses5-dev wget gnupg
+    - echo 'deb http://apt.llvm.org/bionic/ llvm-toolchain-bionic main' >> /etc/apt/sources.list
+    - echo 'deb-src http://apt.llvm.org/bionic/ llvm-toolchain-bionic main' >> /etc/apt/sources.list
+    - wget -O /tmp/llvm.key https://apt.llvm.org/llvm-snapshot.gpg.key
+    - apt-key add /tmp/llvm.key
+    - apt-get update
+    - apt-get install -y clang-8 clang-tools-8 clang-8-doc libclang-common-8-dev libclang-8-dev libclang1-8 clang-format-8 python-clang-8 libz3-dev
+    - export PATH=$PWD/racket/bin:$PATH
+    
 envinfo:
   extends: .prepare
   script:
@@ -14,6 +24,38 @@ envinfo:
     - lsb_release -a
     - gcc -v
     - export
+
+scan-build:racket:
+  extends: .prepare:llvm
+  script:
+    - scan-build-8 -o scan-report make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' in-place
+  artifacts:
+    paths:
+      - scan-report/
+
+scan-build:racket:crosscheck:
+  extends: .prepare:llvm
+  script:
+    - scan-build-8 -o scan-report_cc -analyzer-config 'crosscheck-with-z3=true' make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' in-place
+  artifacts:
+    paths:
+      - scan-report_cc/
+
+scan-build:racketcs:
+  extends: .prepare:llvm
+  script:
+    - scan-build-8 -o scan-report-cs make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' cs
+  artifacts:
+    paths:
+      - scan-report-cs/
+
+scan-build:racketcs:crosscheck:
+  extends: .prepare:llvm
+  script:
+    - scan-build-8 -o scan-report-cs_cc -analyzer-config 'crosscheck-with-z3=true' make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' cs
+  artifacts:
+    paths:
+      - scan-report-cs_cc/
 
 test:ubsan:
   extends: .prepare    

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -29,7 +29,7 @@ envinfo:
 scan-build:racket:
   extends: .prepare:llvm
   script:
-    - scan-build-8 -o scan-report make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' in-place
+    - scan-build-9 -o scan-report make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' in-place
   artifacts:
     paths:
       - scan-report/
@@ -37,7 +37,7 @@ scan-build:racket:
 scan-build:racket:crosscheck:
   extends: .prepare:llvm
   script:
-    - scan-build-8 -o scan-report_cc -analyzer-config 'crosscheck-with-z3=true' make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' in-place
+    - scan-build-9 -o scan-report_cc -analyzer-config 'crosscheck-with-z3=true' make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' in-place
   artifacts:
     paths:
       - scan-report_cc/
@@ -45,7 +45,7 @@ scan-build:racket:crosscheck:
 scan-build:racketcs:
   extends: .prepare:llvm
   script:
-    - scan-build-8 -o scan-report-cs make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' cs
+    - scan-build-9 -o scan-report-cs make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' cs
   artifacts:
     paths:
       - scan-report-cs/
@@ -53,7 +53,7 @@ scan-build:racketcs:
 scan-build:racketcs:crosscheck:
   extends: .prepare:llvm
   script:
-    - scan-build-8 -o scan-report-cs_cc -analyzer-config 'crosscheck-with-z3=true' make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' cs
+    - scan-build-9 -o scan-report-cs_cc -analyzer-config 'crosscheck-with-z3=true' make PKGS="" CPUS=2 CONFIGURE_ARGS_qq='CFLAGS="-O0 -g" --disable-strip' cs
   artifacts:
     paths:
       - scan-report-cs_cc/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ image: ubuntu:18.04
     - wget -O /tmp/llvm.key https://apt.llvm.org/llvm-snapshot.gpg.key
     - apt-key add /tmp/llvm.key
     - apt-get update
-    - apt-get install -y clang-8 clang-tools-8 clang-8-doc libclang-common-8-dev libclang-8-dev libclang1-8 clang-format-8 python-clang-8 libz3-dev
+    - apt-get install -y clang-9 clang-tools-9 clang-9-doc libclang-common-9-dev libclang-9-dev libclang1-9 clang-format-9 python-clang-9 libz3-dev
     - export PATH=$PWD/racket/bin:$PATH
     
 envinfo:
@@ -91,22 +91,22 @@ test:ubsan:cs:
   script:
     - mkdir cs-logs
     - make CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test" CONFIGURE_ARGS_qq="--enable-ubsan CFLAGS="-fno-var-tracking-assignments"" cs 2>&1 | tee cs-logs/build.log
-    - raco test -l tests/racket/test 2>&1 | tee cs-logs/test.log
-    - racket -l tests/racket/contract/all 2>&1 | tee cs-logs/contract-test.log
-    - raco test -l tests/json/json 2>&1 | tee cs-logs/json-test.log
-    - raco test -l tests/file/main 2>&1 | tee cs-logs/file-test.log
-    - raco test -l tests/net/head 2>&1 | tee cs-logs/net-head-test.log
-    - raco test -l tests/net/uri-codec 2>&1 | tee cs-logs/net-uri-codec-test.log
-    - raco test -l tests/net/url 2>&1 | tee cs-logs/net-url-test.log
-    - raco test -l tests/net/url-port 2>&1 | tee cs-logs/net-url-port-test.log
-    - raco test -l tests/net/encoders 2>&1 | tee cs-logs/net-encoders-test.log
-    - raco test -l tests/openssl/basic 2>&1 | tee cs-logs/openssl-basic-test.log
-    - raco test -l tests/openssl/https 2>&1 | tee cs-logs/openssl-https-test.log
-    - raco test -l tests/match/main 2>&1 | tee cs-logs/match-main-test.log
-    - raco test -l tests/zo-path 2>&1 | tee cs-logs/zo-path-test.log
-    - raco test -l tests/xml/test 2>&1 | tee cs-logs/xml-test.log
-    - raco test -l tests/db/all-tests 2>&1 | tee cs-logs/db-test.log
-    - raco test -c tests/stxparse 2>&1 | tee cs-logs/stxparse-test.log
+    - racocs test -l tests/racket/test 2>&1 | tee cs-logs/test.log
+    - racketcs -l tests/racket/contract/all 2>&1 | tee cs-logs/contract-test.log
+    - racocs test -l tests/json/json 2>&1 | tee cs-logs/json-test.log
+    - racocs test -l tests/file/main 2>&1 | tee cs-logs/file-test.log
+    - racocs test -l tests/net/head 2>&1 | tee cs-logs/net-head-test.log
+    - racocs test -l tests/net/uri-codec 2>&1 | tee cs-logs/net-uri-codec-test.log
+    - racocs test -l tests/net/url 2>&1 | tee cs-logs/net-url-test.log
+    - racocs test -l tests/net/url-port 2>&1 | tee cs-logs/net-url-port-test.log
+    - racocs test -l tests/net/encoders 2>&1 | tee cs-logs/net-encoders-test.log
+    - racocs test -l tests/openssl/basic 2>&1 | tee cs-logs/openssl-basic-test.log
+    - racocs test -l tests/openssl/https 2>&1 | tee cs-logs/openssl-https-test.log
+    - racocs test -l tests/match/main 2>&1 | tee cs-logs/match-main-test.log
+    - racocs test -l tests/zo-path 2>&1 | tee cs-logs/zo-path-test.log
+    - racocs test -l tests/xml/test 2>&1 | tee cs-logs/xml-test.log
+    - racocs test -l tests/db/all-tests 2>&1 | tee cs-logs/db-test.log
+    - racocs test -c tests/stxparse 2>&1 | tee cs-logs/stxparse-test.log
   after_script:
     - grep 'runtime error' cs-logs/*.log > runtime-errors.log
   artifacts:


### PR DESCRIPTION
In order to solve:
1. compilation/testing of racket using ubsan (see #2297); 
2. compilation/testing of racket using qemu (see #2018);

I have tried several approaches through the last few weeks - from installing new versions of qemu and gcc inside travis ci to doing the same things in azure. Unfortunately both platforms are relatively old. We can of course, go the path of trying to create `apt-repos` (ubuntu package repos) with recent versions of qemu and gcc but that's just too much work. 

I have large experience with Gitlab and Gitlab CI as I use it for many years for work and pleasure and at Linki Tools I manage our own self-hosted instance, so going this way was easy for me once I remembered that recently Gitlab added the option to use Gitlab CI on Github projects.

There are many advantages of using Gitlab but for this specific user case I will mention only one: in gitlab ci, you can use whatever docker image you want. Therefore you can, in this specific case, just test on ubuntu 18.04 LTS which has all the tools we need out of the box. 

The only thing that the racket repo needs is a .gitlab-ci.yml which is similar to what other CI systems need. But for this to work someone on the racket side (@samth are you the PLT CI manager?) we need the following done once:
1. Go to https://gitlab.com/users/sign_in and create a user or sign in;
2. Create a racket group in gitlab.com  so you own `gitlab.com/racket`;
3. Create a project but when doing so choose to create 'From Github for CI` - this will create a read-only mirror that just uses the CI runners of gitlab;
4. Connect the Gitlab and Github instances so that Gitlab tests run for PRs in github - you've surely done something similar for azure and appveyour;

More information here: https://docs.gitlab.com/ee/ci/ci_cd_for_external_repos/github_integration.html

I have done this for my LinkiTools/racket repo here:
https://gitlab.com/LinkiTools/racket
 and the results of the CI performed by Gitlab are here:
https://gitlab.com/LinkiTools/racket/pipelines/33538582

As you can see each ubsan and ubsan-cs job create an artifact with the ubsan warning. If we go forward with this, we can mark the job as failing if there are runtime errors and mark it also as allowing failure so it's an amber instead of red. Hopefully it'll be green once #2314 is fixed.

I could do all the steps above except 4. because I don't have access to the racket github application token. I am happy to help, let me know if there's anything else you need.

Once this file is in place, the next step is to add qemu cross-platform testing.