### PR TITLE
fix flush-output when write-out is port indirection

### DIFF
--- a/racket/src/io/port/flush-output.rkt
+++ b/racket/src/io/port/flush-output.rkt
@@ -10,10 +10,15 @@
 
 (define/who (flush-output [p (current-output-port)])
   (check who output-port? p)
-  (let ([p (->core-output-port p)])
+  (let ([write-out
+         (let wo-loop ([p p])
+           (let ([write-out (core-output-port-write-out (->core-output-port p))])
+             (cond
+               [(procedure? write-out) write-out]
+               [else (wo-loop write-out)])))])
     (let loop ()
       (define r (atomically
-                 ((core-output-port-write-out p) #"" 0 0 #f #f #f)))
+                 (write-out #"" 0 0 #f #f #f)))
       (let r-loop ([r r])
         (cond
           [(eq? r 0) (void)]

--- a/racket/src/io/port/output-port.rkt
+++ b/racket/src/io/port/output-port.rkt
@@ -33,7 +33,7 @@
       (output-port-via-property? p)))
 
 ;; This function should not be called in atomic mode,
-;; since it can invoke an artitrary function
+;; since it can invoke an arbitrary function
 (define (->core-output-port v)
   (cond
     [(core-output-port? v) (if (impersonator? v)
@@ -58,7 +58,7 @@
 
    evt ; An evt that is ready when writing a byte won't block
    
-   write-out ; (bstr start-k end-k no-block/buffer? enable-break? copy? -> ...)
+   write-out ; port or (bstr start-k end-k no-block/buffer? enable-break? copy? -> ...)
    ;;          Called in atomic mode.
    ;;          Doesn't block if `no-block/buffer?` is true.
    ;;          Does enable breaks while blocking if `enable-break?` is true.


### PR DESCRIPTION
On RacketCS, `flush-output` currently fails on ports where the write-out field is another output port. For example, the following program raises an error:

    #lang racket/base
    (define real-out (open-output-bytes))
    (define wrapped-out (make-output-port 'wrapper real-out real-out void))
    (write-bytes #"hello" wrapped-out)
    (flush-output wrapped-out)
    (get-output-bytes real-out)
    ;; application: not a procedure;
    ;;  expected a procedure that can be applied to arguments
    ;;   given: #<output-port:string>
