### PR TITLE
 Avoid undefined behavior in unsafe-fxlshift test

### DIFF
--- a/pkgs/racket-test-core/tests/racket/fixnum.rktl
+++ b/pkgs/racket-test-core/tests/racket/fixnum.rktl
@@ -4,11 +4,30 @@
          scheme/unsafe/ops
          "for-util.rkt")
 
-(define 64-bit? (fixnum? (expt 2 33)))
+(test #t fixnum? (- (expt 2 (- 24 1))))
+(test #t fixnum? (- (expt 2 (- 24 1)) 1))
 
-(define (fixnum-width) (if 64-bit? 63 31))
-(define (least-fixnum) (if 64-bit? (- (expt 2 62)) -1073741824))
-(define (greatest-fixnum) (if 64-bit? (- (expt 2 62) 1) +1073741823))
+(define (fixnum-width)
+  (case (system-type 'word)
+    [(32) (case (system-type 'vm)
+            [(racket) 31]
+            [(chez-scheme) 30]
+            [else (error "unsuported vm value in system-type")])]
+    [(64) (case (system-type 'vm)
+            [(racket) 63]
+            [(chez-scheme) 61]
+            [else (error "unsuported vm value in system-type")])]
+    [else (error "unsuported word value in system-type")]))
+                      
+(define (least-fixnum) (- (expt 2 (- (fixnum-width) 1))))
+(define (greatest-fixnum) (- (expt 2 (- (fixnum-width) 1)) 1))
+
+(test #t fixnum? (least-fixnum))
+(test #t fixnum? (greatest-fixnum))
+(test #f fixnum? (- (least-fixnum) 1))
+(test #f fixnum? (+ (greatest-fixnum) 1))
+(test #t eq? (least-fixnum) (+ (- (least-fixnum) 1) 1))
+(test #t eq? (greatest-fixnum) (- (+ (greatest-fixnum) 1) 1))
 
 
 (define unary-table 

--- a/pkgs/racket-test-core/tests/racket/fixnum.rktl
+++ b/pkgs/racket-test-core/tests/racket/fixnum.rktl
@@ -154,6 +154,26 @@
 ;; check a small range
 (same-results/range/table)
 
+;; Check that constant folding doesn't go wrong for `unsafe-fxlshift`:
+
+(define-syntax-rule (test-unsafe-fxlshift i ...)
+  ; i must be a constant
+  (begin
+    (begin
+      (if (fixnum? (arithmetic-shift 1 i))
+          (test #t fixnum? (unsafe-fxlshift 1 i))
+          (unless (zero? (random 1))
+            ; This part never run, but the bytecode compiler can´t prove it,
+            (display (unsafe-fxlshift 1 i))))
+      (if (fixnum? (arithmetic-shift -1 i))
+          (test #t fixnum? (unsafe-fxlshift -1 i))
+          (unless (zero? (random 1))
+            ; This part never run, but the bytecode compiler can´t prove it,
+            (display (unsafe-fxlshift -1 i))))) ...))
+
+(test-unsafe-fxlshift 27 28 29 30 31 32 33 34)
+(test-unsafe-fxlshift 59 60 61 62 63 64 65 66)
+
 ;; ----------------------------------------
 
 ;; in-fxvector tests.

--- a/pkgs/racket-test-core/tests/racket/unsafe.rktl
+++ b/pkgs/racket-test-core/tests/racket/unsafe.rktl
@@ -925,16 +925,6 @@
       #:key cdr)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Check that constant folding doesn't go wrong for `unsafe-fxlshift`:
-
-(test #t fixnum? (if (eqv? 64 (system-type 'word))
-                     (unsafe-fxlshift 1 62)
-                     (unsafe-fxlshift 1 30)))
-(test #t zero? (if (eqv? 64 (system-type 'word))
-                   (unsafe-fxlshift 1 63)
-                   (unsafe-fxlshift 1 31)))
-
-;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check that allocation by inlined `unsafe-flrandom` is ok
 
 (test #t


### PR DESCRIPTION
The first commit should fix the second item in https://github.com/racket/racket/issues/2314 (@pmatos: can you check that it is really fixed?). I moved the test from _unsafe.rktl_ to _fixnum.rktl_ because it's more similar to the test there. Also, I changed the test because it was checking that the unspecified result was `0`. Anyway, I think it is important to check this in case something similar appears in a dead branch that is never run but it must be compiled without problems. In particular, it's not clear for me that the undefined cases in the RacketVM, RacketCS, and C are the same, so I made a few test above and below the tricky values.

The second commit is to extend the table of values of `(fixnum-width)` to be used in the CS version. This related to https://github.com/racket/racket/pull/2266 . I also added a few sanity checks at the beginning of the file.