### PR TITLE
Mark variables as used so they are not removed by LTO

### DIFF
--- a/racket/src/start/config.inc
+++ b/racket/src/start/config.inc
@@ -3,6 +3,7 @@
 
 #pragma GCC diagnostic ignored "-Wwrite-strings"
 
+__attribute__((used))
 char * volatile scheme_cmdline_exe_hack = (char *)
   ("[Replace me for EXE hack                                       "
    "                                                              ]");
@@ -14,6 +15,7 @@ char * volatile scheme_cmdline_exe_hack = (char *)
 #else
 # define GC_PRECISION_TYPE "c"
 #endif
+__attribute__((used))
 char * volatile scheme_binary_type_hack = "bINARy tYPe:" INITIAL_BIN_TYPE GC_PRECISION_TYPE;
 /* The format of bINARy tYPe is e?[zr]i[3cs].
    e indicates a starter executable
@@ -29,6 +31,7 @@ char * volatile scheme_binary_type_hack = "bINARy tYPe:" INITIAL_BIN_TYPE GC_PRE
 # endif
 #endif
 
+__attribute__((used))
 char * volatile scheme_coldir = "coLLECTs dIRECTORy:" /* <- this tag stays, so we can find it again */
                        INITIAL_COLLECTS_DIRECTORY 
                        "\0\0" /* <- 1st nul terminates path, 2nd terminates path list */
@@ -59,6 +62,7 @@ static int _coldir_offset = 19; /* Skip permanent tag */
 # endif
 #endif
 
+__attribute__((used))
 char * volatile scheme_configdir = "coNFIg dIRECTORy:" /* <- this tag stays, so we can find it again */
                        INITIAL_CONFIG_DIRECTORY
                        "\0"

--- a/racket/src/start/ustart.c
+++ b/racket/src/start/ustart.c
@@ -33,14 +33,17 @@
    adjusted. Using a seciton offset allows linking tools (such as
    `strip') to move the data in the executable.
 */
+__attribute__((used))
 char *config = "cOnFiG:[***************************";
 
+__attribute__((used))
 char *binary_type_hack = "bINARy tYPe:ezic";
 
 /* This path list is used instead of the one in the Racket/GRacket
    binary. That way, the same Racket/GRacket binary can be shared
    among embedding exectuables that have different collection
    paths. */
+__attribute__((used))
 char *_coldir = "coLLECTs dIRECTORy:" /* <- this tag stays, so we can find it again */
                 "../collects"
                 "\0\0" /* <- 1st nul terminates path, 2nd terminates path list */
@@ -63,6 +66,7 @@ char *_coldir = "coLLECTs dIRECTORy:" /* <- this tag stays, so we can find it ag
 		"****************************************************************";
 static int _coldir_offset = 19; /* Skip permanent tag */
 
+__attribute__((used))
 char * volatile _configdir = "coNFIg dIRECTORy:" /* <- this tag stays, so we can find it again */
                        "../etc"
                        "\0"


### PR DESCRIPTION
Fixes #2324 

By marking variables as used they can't be removed by LTO. 