### PR TITLE
syntax/parse: fix Check-Syntax arrows within syntax classes

### DIFF
--- a/racket/collects/syntax/parse/private/parse.rkt
+++ b/racket/collects/syntax/parse/private/parse.rkt
@@ -104,7 +104,8 @@
       (let ()
         (define the-rhs
           (parameterize ((current-syntax-context #'ctx))
-            (fixup-rhs (syntax-local-eval #'the-rhs-expr)
+            (fixup-rhs (syntax-local-eval
+                        (syntax-local-introduce #'the-rhs-expr))
                        (syntax-e #'splicing?)
                        (syntax->datum #'relsattrs))))
         (rhs->parser #'name #'formals #'relsattrs the-rhs (syntax-e #'splicing?) #'ctx)))]))


### PR DESCRIPTION
Fixes #2320. This puts Check-Syntax arrows back in syntax class definitions.
<img width="383" alt="screenshot-issue-2320" src="https://user-images.githubusercontent.com/6600123/47309994-d74a0b00-d603-11e8-8ec1-ce2f3a2e6204.png">
