### PR TITLE
remove plumber flush callback when custodian closes fd output port 

### DIFF
--- a/racket/src/io/port/fd-port.rkt
+++ b/racket/src/io/port/fd-port.rkt
@@ -87,7 +87,7 @@
                         [() (buffer-control)]
                         [(pos) (buffer-control pos)]))))
   (define custodian-reference
-    (register-fd-close cust fd fd-refcount port))
+    (register-fd-close cust fd fd-refcount #f port))
   port)
 
 ;; ----------------------------------------
@@ -230,7 +230,7 @@
                      [(mode) (set! buffer-mode mode)])))
 
   (define custodian-reference
-    (register-fd-close cust fd fd-refcount port))
+    (register-fd-close cust fd fd-refcount flush-handle port))
 
   (set-fd-evt-closed! evt (core-port-closed port))
 
@@ -331,12 +331,14 @@
 
 ;; ----------------------------------------
 
-(define (register-fd-close custodian fd fd-refcount port)
+(define (register-fd-close custodian fd fd-refcount flush-handle port)
   (define closed (core-port-closed port))
   (unsafe-custodian-register custodian
                              fd
                              ;; in atomic mode
                              (lambda (fd)
+                               (when flush-handle
+                                 (plumber-flush-handle-remove! flush-handle))
                                (fd-close fd fd-refcount)
                                (set-closed-state! closed))
                              #f

--- a/racket/src/io/unsafe/port.rkt
+++ b/racket/src/io/unsafe/port.rkt
@@ -17,10 +17,10 @@
   (define write? (memq 'write mode))
   (define refcount (box (if (and read? write?) 2 1)))
   (define fd (rktio_system_fd rktio system-fd
-                              (bitwise-and
+                              (bitwise-ior
                                (if read? RKTIO_OPEN_READ 0)
                                (if write? RKTIO_OPEN_WRITE 0)
-                               (if (memq 'test mode) RKTIO_OPEN_TEXT 0)
+                               (if (memq 'text mode) RKTIO_OPEN_TEXT 0)
                                (if (memq 'regular-file mode) RKTIO_OPEN_REGFILE 0))))
   (define i (and read?
                  (open-input-fd fd name #:fd-refcount refcount)))


### PR DESCRIPTION
The main commit is the second one. See the commit for an example.

Is it a problem that the `on-close` callback is not called on custodian shutdown? So far, the only use seems to be for TCP ports to implement the "abandon" operations, which shouldn't matter if both ports are getting closed anyway.
