### PR TITLE
doc: change 'syntax->string' doc to match implementation

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/to-string.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/to-string.scrbl
@@ -1,13 +1,14 @@
 #lang scribble/doc
 @(require "common.rkt"
-          (for-label syntax/stx
+          (for-label racket/contract
+                     syntax/stx
                      syntax/to-string))
 
 @title[#:tag "to-string"]{Rendering Syntax Objects with Formatting}
 
 @defmodule[syntax/to-string]
 
-@defproc[(syntax->string [stx-list stx-list?]) string?]{
+@defproc[(syntax->string [stx-list (and/c syntax? stx-list?)]) string?]{
 
 Builds a string with newlines and indenting according to the source
 locations in @racket[stx-list]; the outer pair of parens are not


### PR DESCRIPTION
The implementation requires a more specific input than the documentation
suggests.

Closes #1627 