### PR TITLE
Fix path building in find-apps-dir and get-pkgs-search-dirs

### DIFF
--- a/racket/collects/setup/private/dirs.rkt
+++ b/racket/collects/setup/private/dirs.rkt
@@ -265,7 +265,9 @@
   config:apps-dir
   find-apps-dir
   find-user-apps-dir #:default (build-path "share" "applications")
-  (chain-to (lambda () (build-path (find-share-dir) "applications"))))
+  (chain-to (lambda ()
+              (let ([p (find-share-dir)])
+                (and p (build-path p "applications"))))))
 
 ;; ----------------------------------------
 ;; "man"
@@ -321,7 +323,9 @@
   get-false
   config:pkgs-search-dirs
   get-pkgs-search-dirs
-  (chain-to (lambda () (build-path (find-share-dir) "pkgs"))))
+  (chain-to (lambda ()
+              (let ([p (find-share-dir)])
+                (and p (build-path p "pkgs"))))))
 
 (provide find-user-pkgs-dir)
 (define (find-user-pkgs-dir [vers (get-installation-name)])


### PR DESCRIPTION
(This pull request is _not_ ready to be merged for the reasons described below.)

This bug is discovered in <https://groups.google.com/d/msg/racket-users/4hRtszcC7pw/eA9t5Xy1AAAJ>.

Both `find-apps-dir` and `get-pkgs-search-dirs` relies on `find-share-dir` to find the path, which can be `#f` if such path is not available. Therefore, checking the result before building the final path is necessary for these two functions.

To illustrate the problem, this program will crash when being packaged up into a distribution:

```
;; test.rkt
#lang racket/base
(require setup/dirs)
(find-apps-dir)
(find-pkgs-dir)
(get-pkgs-search-dirs)
(find-links-file)
```

```
$ raco exe test.rkt
$ raco dist dist test
$ ./dist/bin/test
build-path: contract violation
  expected: (or/c path-for-some-system? path-string? 'up 'same)
  given: #f
  argument position: 1st
  other arguments...:
   "applications"
  context...:
```

This pull request fixes `find-apps-dir` and `get-pkgs-search-dirs`. However, I don't know how to write a test case for this and I don't know how to deal with `find-pkgs-dir` and `find-links-file` yet.

For `find-pkgs-dir`, the doc requires it to return a path. Before this commit, this function just crashes. After this commit, it would return `#f` when being distributed. I think maybe a more sensible way is to set a default path, but I don't know which path will be suitable.

The function `find-links-file` is the same as above except that this commit didn't touch it. It still crashes when being distributed.