### PR TITLE
fasl: find shared values in hash tables.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/fasl.rktl
+++ b/pkgs/racket-test-core/tests/racket/fasl.rktl
@@ -54,6 +54,14 @@
   (test #t eq? u (car s-exp))
   (test #t eq? u (cadr s-exp)))
 
+
+(let* ([u (string->uninterned-symbol "unread")])
+  (define vs-exp (vector-ref (fasl->s-exp (s-exp->fasl (vector (cons u u)))) 0))
+  ;; these are not `eq?` to the original symbol, but are `eq? to each other
+  (test #t eq? (car vs-exp) (cdr vs-exp))
+  (define hs-exp (hash-ref (fasl->s-exp (s-exp->fasl (hasheq 0 (cons u u)))) 0))
+  (test #t eq? (car hs-exp) (cdr hs-exp)))
+
 ;; check uses datum-intern-literal:
 (test #t eq? "hello" (fasl->s-exp (s-exp->fasl "hello")))
 (test #t eq? #"hello" (fasl->s-exp (s-exp->fasl #"hello")))

--- a/racket/collects/racket/fasl.rkt
+++ b/racket/collects/racket/fasl.rkt
@@ -122,6 +122,9 @@
       [(vector? v)
        (for ([e (in-vector v)])
          (loop e))]
+      [(hash? v)
+       (for ([(k v) (in-hash v)])
+         (loop k) (loop v))]
       [(box? v)
        (loop (unbox v))]
       [(prefab-struct-key v)


### PR DESCRIPTION
Also, add test to check sharing of uninterned symbols.