### PR TITLE
untar: treat the tag \0 as a synonym for '0'

### DIFF
--- a/racket/collects/file/untar.rkt
+++ b/racket/collects/file/untar.rkt
@@ -62,7 +62,7 @@
   (define checksum-bytes (read-bytes* 8 in))
   (define type-byte (integer->char (read-byte in)))
   (define type (case type-byte
-                 [(#\0) 'file]
+                 [(#\0 #\nul) 'file]
                  [(#\1) 'hard-link]
                  [(#\2) 'link]
                  [(#\3) 'character-special]


### PR DESCRIPTION
I had a bit of trouble extracting an archive with `file/untar`. Apparently GNU tar (and presumably others) treat the type tag `0` as a synonym of `#\0`, where `file/untar` marks it as an unknown type tag.