### PR TITLE
Guard `free-identifier=?` comparisons in `shared`.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/shared.rktl
+++ b/pkgs/racket-test-core/tests/racket/shared.rktl
@@ -49,4 +49,6 @@
   (test an-a 'an-a (shared ([t (a 1 t)])
                      t)))
 
+(test 42 values (shared ((b ((thunk 42)))) b))
+(test 42 unbox (shared ((b (box-immutable ((thunk 42))))) b))
 (report-errs)

--- a/racket/collects/racket/private/shared-body.rkt
+++ b/racket/collects/racket/private/shared-body.rkt
@@ -76,18 +76,20 @@
              [same-special-id? (lambda (a b)
                                  ;; Almost module-or-top-identifier=?,
                                  ;; but handle `the-cons' specially
-                                 (or (free-identifier=?
-                                      a
-                                      (if (eq? 'the-cons (syntax-e b))
-                                          cons-id
-                                          b))
-                                     (free-identifier=? 
-                                      a 
-                                      (datum->syntax
-                                       #f
-                                       (if (eq? 'the-cons (syntax-e b))
-                                           'cons
-                                           (syntax-e b))))))]
+                                 (and (identifier? a)
+                                      (identifier? b)
+                                      (or (free-identifier=?
+                                           a
+                                           (if (eq? 'the-cons (syntax-e b))
+                                               cons-id
+                                               b))
+                                          (free-identifier=?
+                                           a
+                                           (datum->syntax
+                                            #f
+                                            (if (eq? 'the-cons (syntax-e b))
+                                                'cons
+                                                (syntax-e b)))))))]
              [remove-all (lambda (lst rmv-lst)
                            (define (remove e l)
                              (cond


### PR DESCRIPTION
Fixes #2381.