### PR TITLE
clarify examples in docs of take and drop

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -265,7 +265,7 @@ The @racket[lst] argument need not actually be a list; @racket[lst]
 must merely start with a chain of at least @racket[pos] pairs.
 
 @mz-examples[
-  (list-tail (list 1 2 3 4) 2)
+  (list-tail (list 1 2 3 4 5) 2)
   (list-tail (cons 1 2) 1)
   (eval:error (list-tail (cons 1 2) 2))
   (list-tail 'not-a-pair 0)]}
@@ -952,7 +952,7 @@ The @racket[lst] argument need not actually be a list; @racket[lst]
 must merely start with a chain of at least @racket[pos] pairs.
 
 @mz-examples[#:eval list-eval
-  (take '(1 2 3 4) 2)
+  (take '(1 2 3 4 5) 2)
   (take 'non-list 0)]}
 
 
@@ -1021,7 +1021,7 @@ The @racket[lst] argument need not actually be a list; @racket[lst]
 must merely end with a chain of at least @racket[pos] pairs.
 
 @mz-examples[#:eval list-eval
-  (take-right '(1 2 3 4) 2)
+  (take-right '(1 2 3 4 5) 2)
   (take-right 'non-list 0)]}
 
 
@@ -1036,7 +1036,7 @@ The @racket[lst] argument need not actually be a list; @racket[lst] must
 merely end with a chain of at least @racket[pos] pairs.
 
 @mz-examples[#:eval list-eval
-  (drop-right '(1 2 3 4) 2)
+  (drop-right '(1 2 3 4 5) 2)
   (drop-right 'non-list 0)]}
 
 


### PR DESCRIPTION
I think that 

    (take '(1 2 3 4 5) 2) ;==> '(1 2)

is more clear than 

    (take '(1 2 3 4) 2)   ;==> '(1 2)

because in the second case there are `2` items that are keep and `2` items that disappear.
