### PR TITLE
rumble: add type check in bytes-append with more than two arguments

### DIFF
--- a/racket/src/cs/rumble/bytes.ss
+++ b/racket/src/cs/rumble/bytes.ss
@@ -81,12 +81,14 @@
      [(a b . l)
       (check who bytes? a)
       (check who bytes? b)
-      (and (bytevector=? a b)
+      (for-each (lambda (arg)
+                  (check who byte? arg))
+                l)
+      (and (do-name a b)
            (let loop ([a b] [l l])
              (cond
               [(null? l) #t]
               [else (let ([b (car l)])
-                      (check who bytes? b)
                       (and (do-name a b)
                            (loop b (cdr l))))])))])))
 
@@ -145,14 +147,17 @@
         c))]
    [(a)
     (check who bytes? a)
-    a]
+    (#2%bytevector-copy a)]
    [() #vu8()]
    [args
     (let* ([size (let loop ([args args])
                    (cond
                     [(null? args) 0]
-                    [else (+ (bytevector-length (car args))
-                             (loop (cdr args)))]))]
+                    [else
+                     (let ([arg (car args)])
+                       (check who bytes? arg)
+                       (+ (bytevector-length arg)
+                          (loop (cdr args))))]))]
            [c (make-bytevector size)])
       (let loop ([args args] [pos 0])
         (cond


### PR DESCRIPTION
The type of the argument was checked when `bytes-append` was called with 1 or 2 arguments, but the check was missing for the general case with more than 2 arguments. 

This was reported by @mbutterick in https://github.com/racket/racket/issues/2388 .