### PR TITLE
Fix unsyntax-splicing in vector templates in quasisyntax

### DIFF
--- a/pkgs/racket-test-core/tests/racket/stx.rktl
+++ b/pkgs/racket-test-core/tests/racket/stx.rktl
@@ -2289,8 +2289,9 @@
     (test '#(1 2 3 4 5) syntax->datum (quasisyntax #(a (unsyntax b) c ...)))
     (test '#s(PS 1 2) syntax->datum (quasisyntax #s(PS a (unsyntax b))))
     (test '#s(PS 1 2 3 4 5) syntax->datum (quasisyntax #s(PS a (unsyntax b) c ...)))
-    #|
     (test '#(1 2 3 4 5) syntax->datum (quasisyntax #(a (unsyntax b) (unsyntax-splicing ds))))
+    (test '#(3 4 5) syntax->datum (quasisyntax #((unsyntax-splicing ds))))
+    #|
     (test '#s(PS 1 2 3 4 5) syntax->datum
           (quasisyntax #s(PS a (unsyntax b) (unsyntax-splicing ds))))
     |#))

--- a/racket/collects/racket/private/qqstx.rkt
+++ b/racket/collects/racket/private/qqstx.rkt
@@ -241,12 +241,15 @@
                              depth
                              same-k
                              (lambda (v bindings)
-                               (convert-k (datum->syntax
-                                           stx
-                                           (list->vector (syntax->list v))
-                                           stx
-                                           stx)
-                                          bindings)))]
+                               (let ([stx-lst/#f (syntax->list v)])
+                                 (convert-k (datum->syntax
+                                             stx
+                                             (if stx-lst/#f
+                                                 (list->vector stx-lst/#f)
+                                                 (vector-immutable (cons #'~@! v)))
+                                             stx
+                                             stx)
+                                            bindings))))]
                       [(prefab-struct-key (syntax-e stx))
                        (let* ([d (syntax-e stx)]
                               [key (prefab-struct-key d)]


### PR DESCRIPTION
If the sub-template inside `#(...)` is `unsyntax-splicing` instead of list, produce the template `#((~@! . ????))` instead of calling `(datum->syntax o list->vector o syntax->list)`. Fixes #2402.