### PR TITLE
json: improve 'bad input' error message

### DIFF
--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -248,7 +248,7 @@
               (cond [(equal? m #"\"") (read-string)]
                     [(equal? m #"[")  (read-list 'array #rx#"^\\]" read-json)]
                     [(equal? m #"{")  (read-hash)])))]
-      [else (err "bad input")]))
+      [else (err (format "bad input~n ~e" (peek-bytes (sub1 (error-print-width)) 0 i)))]))
   ;;
   (read-json #t))
 


### PR DESCRIPTION
When 'read-json' finds "bad input", print the input to try to show what
went wrong.

- - -

I'm not sure if `peek-bytes` and/or `error-print-width` are the right things to use here

But anyway here's an example:

```
#lang racket
(require json)
(string->jsexpr "[notastring")
;; string::2: string->jsexpr: bad input
;;  #"notastring"
;;   context...:
;;   ....
```