### PR TITLE
syntax/parse: Add prop:syntax-class

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/parse-common.rkt
+++ b/pkgs/racket-doc/syntax/scribblings/parse/parse-common.rkt
@@ -54,7 +54,8 @@
                                                   syntax/parse/experimental/reflect
                                                   syntax/parse/experimental/specialize
                                                   syntax/parse/experimental/template
-                                                  syntax/parse/experimental/eh)])
+                                                  syntax/parse/experimental/eh
+                                                  syntax/transformer)])
                                       `((for-syntax racket/base ,@mods)
                                         ,@mods)))))))
   (when short? (the-eval '(error-print-source-location #f)))
@@ -120,6 +121,7 @@
                     syntax/parse/experimental/specialize
                     syntax/parse/experimental/template
                     syntax/parse/experimental/eh
+                    syntax/transformer
                     "parse-dummy-bindings.rkt"))
 (provide (for-label (all-from-out racket/base)
                     (all-from-out racket/contract)
@@ -132,4 +134,5 @@
                     (all-from-out syntax/parse/experimental/specialize)
                     (all-from-out syntax/parse/experimental/template)
                     (all-from-out syntax/parse/experimental/eh)
+                    (all-from-out syntax/transformer)
                     (all-from-out "parse-dummy-bindings.rkt")))

--- a/pkgs/racket-doc/syntax/scribblings/parse/stxclasses.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/stxclasses.scrbl
@@ -188,6 +188,42 @@ including nested attributes produced by syntax classes associated with
 the pattern variables.
 }
 
+@defthing[prop:syntax-class (struct-type-property/c (or/c identifier?
+                                                          (-> any/c identifier?)))]{
+
+A @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{structure type property} to identify
+structure types that act as an alias for a @tech{syntax class} or @tech{splicing syntax class}. The
+property value must be an identifier or a procedure of one argument.
+
+When a @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{transformer} is bound to an
+instance of a struct with this property, then it may be used as a @tech{syntax class} or
+@tech{splicing syntax class} in the same way as the bindings created by @racket[define-syntax-class]
+or @racket[define-splicing-syntax-class]. If the value of the property is an identifier, then it
+should be bound to a @tech{syntax class} or @tech{splicing syntax class}, and the binding will be
+treated as an alias for the referenced syntax class. If the value of the property is a procedure, then
+it will be applied to the value with the @racket[prop:syntax-class] property to obtain an identifier,
+which will then be used as in the former case.
+
+@examples[#:eval the-eval
+(begin-for-syntax
+  (struct expr-and-stxclass (expr-id stxclass-id)
+    #:property prop:procedure
+    (lambda (this stx) ((set!-transformer-procedure
+                         (make-variable-like-transformer
+                          (expr-and-stxclass-expr-id this)))
+                        stx))
+    #:property prop:syntax-class
+    (lambda (this) (expr-and-stxclass-stxclass-id this))))
+(define-syntax is-id? (expr-and-stxclass #'identifier? #'id))
+(is-id? #'x)
+(syntax-parse #'x
+  [x:is-id? #t]
+  [_ #f])
+]
+
+@history[#:added "7.2.0.4"]
+}
+
 @;{--------}
 
 @section{Pattern Directives}

--- a/racket/collects/syntax/parse.rkt
+++ b/racket/collects/syntax/parse.rkt
@@ -15,6 +15,8 @@
            syntax/parse/private/residual-ct)
   (provide pattern-expander?
            (contract-out
+            [prop:syntax-class
+             (struct-type-property/c (or/c identifier? (-> any/c identifier?)))]
             [pattern-expander
              (-> (-> syntax? syntax?) pattern-expander?)]
             [prop:pattern-expander

--- a/racket/collects/syntax/parse/debug.rkt
+++ b/racket/collects/syntax/parse/debug.rkt
@@ -9,7 +9,9 @@
          racket/pretty
          "../parse.rkt"
          (except-in syntax/parse/private/residual
-                    prop:pattern-expander syntax-local-syntax-parse-pattern-introduce)
+                    prop:syntax-class
+                    prop:pattern-expander
+                    syntax-local-syntax-parse-pattern-introduce)
          "private/runtime.rkt"
          "private/runtime-progress.rkt"
          "private/runtime-report.rkt"

--- a/racket/collects/syntax/parse/private/rep.rkt
+++ b/racket/collects/syntax/parse/private/rep.rkt
@@ -780,17 +780,15 @@
 ;; ----
 
 (define (parse-stxclass-use stx allow-head? varname scname argu pfx role [parser* #f])
-  (cond [(and (memq (stxclass-lookup-config) '(yes try)) (get-stxclass scname #t))
+  (define config (stxclass-lookup-config))
+  (cond [(and (memq config '(yes try)) (get-stxclass scname (eq? config 'try)))
          => (lambda (sc)
               (unless parser*
                 (check-stxclass-arity sc stx (length (arguments-pargs argu)) (arguments-kws argu)))
               (parse-stxclass-use* stx allow-head? varname sc argu pfx role parser*))]
-        [(memq (stxclass-lookup-config) '(try no))
+        [else
          (define bind (name->bind varname))
-         (pat:fixup stx bind varname scname argu pfx role parser*)]
-        [else (wrong-syntax scname "not defined as syntax class (config=~s)"
-                            ;; XXX FIXME
-                            (stxclass-lookup-config))]))
+         (pat:fixup stx bind varname scname argu pfx role parser*)]))
 
 ;; ----
 
@@ -1658,7 +1656,7 @@
      (syntax->list #'(e ...))]
     [_
      (raise-syntax-error #f "expected list of expressions and definitions" ctx stx)]))
-     
+
 ;; Arguments and Arities
 
 ;; parse-argu : (listof stx) -> Arguments

--- a/racket/collects/syntax/parse/private/residual-ct.rkt
+++ b/racket/collects/syntax/parse/private/residual-ct.rkt
@@ -11,6 +11,9 @@
          (struct-out den:lit)
          (struct-out den:datum-lit)
          (struct-out den:delayed)
+         prop:syntax-class
+         has-stxclass-prop?
+         stxclass-prop-ref
          alt-stxclass-mapping
          log-syntax-parse-error
          log-syntax-parse-warning
@@ -38,6 +41,9 @@
    opts         ;; scopts
    inline       ;; Id/#f, reference to a predicate
    ) #:prefab)
+
+(define-values [prop:syntax-class has-stxclass-prop? stxclass-prop-ref]
+  (make-struct-type-property 'syntax-class))
 
 ;; alt-stxclass-mapping : (boxof (listof (pair Identifier Stxclass)))
 ;; Maps existing bindings (can't use syntax-local-value mechanism) to stxclasses.


### PR DESCRIPTION
This makes it possible for users to create bindings that function as both syntax classes and other things, in the usual way using struct type properties.