### PR TITLE
net/url: Adds patch-pure-port and patch-impure-port 

### DIFF
--- a/pkgs/net-doc/net/scribblings/url.scrbl
+++ b/pkgs/net-doc/net/scribblings/url.scrbl
@@ -361,7 +361,6 @@ port} contains both the returned headers and the body. The
                         [post bytes?]
                         [header (listof string?) null])
          input-port?]
-)]
 @defproc[(patch-pure-port [URL url?]
                           [post bytes?]
                           [header (listof string?) null])
@@ -386,7 +385,6 @@ strings can be used to send header lines to the server.
                           [post bytes?]
                           [header (listof string?) null])
          input-port?]
-)]
 @defproc[(patch-impure-port [URL url?]
                             [post bytes?]
                             [header (listof string?) null])

--- a/pkgs/net-doc/net/scribblings/url.scrbl
+++ b/pkgs/net-doc/net/scribblings/url.scrbl
@@ -361,9 +361,14 @@ port} contains both the returned headers and the body. The
                         [post bytes?]
                         [header (listof string?) null])
          input-port?]
+)]
+@defproc[(patch-pure-port [URL url?]
+                          [post bytes?]
+                          [header (listof string?) null])
+         input-port?]
 )]{
 
-Initiates a POST/PUT request for @racket[URL] and sends the
+Initiates a POST/PUT/PATCH request for @racket[URL] and sends the
 @racket[post] byte string.  The result is a @tech{pure port}, which
 contains the body of the response is returned.  The optional list of
 strings can be used to send header lines to the server.
@@ -380,6 +385,11 @@ strings can be used to send header lines to the server.
 @defproc[(put-impure-port [URL url?]
                           [post bytes?]
                           [header (listof string?) null])
+         input-port?]
+)]
+@defproc[(patch-impure-port [URL url?]
+                            [post bytes?]
+                            [header (listof string?) null])
          input-port?]
 )]{
 

--- a/pkgs/net-test/tests/net/url-port.rkt
+++ b/pkgs/net-test/tests/net/url-port.rkt
@@ -61,6 +61,10 @@
     (make-tester (lambda (url) (put-pure-port url #"data"))))
   (define put-impure
     (make-tester (lambda (url) (put-impure-port url #"data"))))
+  (define patch-pure
+    (make-tester (lambda (url) (patch-pure-port url #"data"))))
+  (define patch-impure
+    (make-tester (lambda (url) (patch-impure-port url #"data"))))
 
   (test
    (get-pure

--- a/racket/collects/net/url.rkt
+++ b/racket/collects/net/url.rkt
@@ -407,6 +407,14 @@
 (define (put-impure-port url put-data [strings '()])
   (method-impure-port 'put url put-data strings))
 
+;; patch-pure-port : url bytes [x list (str)] -> in-port
+(define (patch-pure-port url patch-data [strings '()])
+  (method-pure-port 'patch url patch-data strings))
+
+;; patch-impure-port : url x bytes [x list (str)] -> in-port
+(define (patch-impure-port url patch-data [strings '()])
+  (method-impure-port 'patch url patch-data strings))
+
 ;; options-pure-port : url [x list (str)] -> in-port
 (define (options-pure-port url [strings '()])
   (method-pure-port 'options url #f strings))
@@ -439,11 +447,12 @@
            (file://get-pure-port url)]
           [else (url-error "Scheme ~a unsupported" scheme)])))
 
-;; http://metod-impure-port : symbol x url x union (str, #f) x list (str) -> in-port
+;; http://method-impure-port : symbol x url x union (str, #f) x list (str) -> in-port
 (define (http://method-impure-port method url data strings)
   (let* ([method (case method
                    [(get) "GET"] [(post) "POST"] [(head) "HEAD"]
-                   [(put) "PUT"] [(delete) "DELETE"] [(options) "OPTIONS"] 
+                   [(put) "PUT"] [(patch) "PATCH"] [(delete) "DELETE"]
+                   [(options) "OPTIONS"]
                    [else (url-error "unsupported method: ~a" method)])]
          [proxy (proxy-server-for (url-scheme url) (url-host url))]
          [hc (make-ports url proxy)]
@@ -483,6 +492,8 @@
  (delete-impure-port (->* (url?) ((listof string?)) input-port?))
  (put-pure-port (->* (url? (or/c false/c bytes?)) ((listof string?)) input-port?))
  (put-impure-port (->* (url? bytes?) ((listof string?)) input-port?))
+ (patch-pure-port (->* (url? (or/c false/c bytes?)) ((listof string?)) input-port?))
+ (patch-impure-port (->* (url? bytes?) ((listof string?)) input-port?))
  (options-pure-port (->* (url?) ((listof string?)) input-port?))
  (options-impure-port (->* (url?) ((listof string?)) input-port?))
  (display-pure-port (input-port? . -> . void?))


### PR DESCRIPTION
## Background

[`net/url`](https://docs.racket-lang.org/net/url.html?q=net%2Furl) was missing functions to make HTTP requests with the [`PATCH`](https://en.wikipedia.org/wiki/Patch_verb) verb. API endpoints accepting `PATCH` are becoming more common.

This PR adds `patch-pure-port` and `patch-impure-port`.