### PR TITLE
Fix with-syntax* when it has no patterns

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -5216,6 +5216,10 @@
            (test #t equal? output
                  (bytes->string/utf-8 (get-output-bytes O #t)))))
   ;;
+  (define-inline (f0) (+ 1 0))
+  (test/output (f0)
+               1 "")
+  ;;
   (define-inline (f x) (+ x x))
   (test/output (f (show 'arg1 1))
                2 "arg1")

--- a/racket/collects/racket/private/with-stx.rkt
+++ b/racket/collects/racket/private/with-stx.rkt
@@ -25,7 +25,7 @@
        (lambda (x s-exp?)
          (syntax-case x ()
            ((_ () e1 e2 ...)
-            (syntax/loc x (begin e1 e2 ...)))
+            (syntax/loc x (let () e1 e2 ...)))
            ((_ ((out in) ...) e1 e2 ...)
             (let ([ins (syntax->list (syntax (in ...)))])
               ;; Check for duplicates or other syntax errors:

--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -205,6 +205,8 @@
 
 (define-syntax (with-syntax* stx)
   (syntax-case stx ()
-    [(_ (cl) body ...) #'(with-syntax (cl) body ...)]
+    [(_ () body ...) (syntax/loc stx (let () body ...))]
+    [(_ (cl) body ...) (syntax/loc stx (with-syntax (cl) body ...))]
     [(_ (cl cls ...) body ...)
-     #'(with-syntax (cl) (with-syntax* (cls ...) body ...))]))
+     (with-syntax ([with-syntax/rest (syntax/loc stx (with-syntax* (cls ...) body ...))])
+       (syntax/loc stx (with-syntax (cl) with-syntax/rest)))]))


### PR DESCRIPTION
Fix `with-syntax*` when it has no patterns. 

This also fix `define-inline` for 0-arity functions. See the bug reported in #2465.