### PR TITLE
Mark scheme_raise_exn as noreturn - regenerate schemex

### DIFF
--- a/racket/src/racket/include/scheme.h
+++ b/racket/src/racket/include/scheme.h
@@ -252,6 +252,15 @@ extern "C"
 {
 #endif
 
+/* The reason we need two preprocessor variables is that, in gcc/clang the 
+   function attribute comes after the function declaration. However,
+   in MSVC the function attribute comes before the function declaration. */
+#ifdef __GNUC__
+#define NORETURN __attribute__((__noreturn__))
+#else
+#define NORETURN
+#endif
+
 /* Allowed by all configurations, currently: */
 #define MZ_CAN_ACCESS_THREAD_LOCAL_DIRECTLY
 

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -198,7 +198,7 @@ MZ_EXTERN Scheme_On_Atomic_Timeout_Proc scheme_set_on_atomic_timeout(Scheme_On_A
 /*========================================================================*/
 
 MZ_EXTERN void scheme_signal_error(const char *msg, ...);
-MZ_EXTERN void scheme_raise_exn(int exnid, ...) __attribute__ ((noreturn));
+MZ_EXTERN void scheme_raise_exn(int exnid, ...) NORETURN;
 MZ_EXTERN void scheme_warning(char *msg, ...);
 
 MZ_EXTERN void scheme_raise(Scheme_Object *exn);

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -198,7 +198,7 @@ MZ_EXTERN Scheme_On_Atomic_Timeout_Proc scheme_set_on_atomic_timeout(Scheme_On_A
 /*========================================================================*/
 
 MZ_EXTERN void scheme_signal_error(const char *msg, ...);
-MZ_EXTERN void scheme_raise_exn(int exnid, ...);
+MZ_EXTERN void scheme_raise_exn(int exnid, ...) __attribute__ ((noreturn));
 MZ_EXTERN void scheme_warning(char *msg, ...);
 
 MZ_EXTERN void scheme_raise(Scheme_Object *exn);

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -139,7 +139,7 @@ Scheme_On_Atomic_Timeout_Proc (*scheme_set_on_atomic_timeout)(Scheme_On_Atomic_T
 /*                              error handling                            */
 /*========================================================================*/
 void (*scheme_signal_error)(const char *msg, ...);
-void (*scheme_raise_exn)(int exnid, ...) __attribute__ ((noreturn));
+void (*scheme_raise_exn)(int exnid, ...) NORETURN;
 void (*scheme_warning)(char *msg, ...);
 void (*scheme_raise)(Scheme_Object *exn);
 int (*scheme_log_level_p)(Scheme_Logger *logger, int level);

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -139,7 +139,7 @@ Scheme_On_Atomic_Timeout_Proc (*scheme_set_on_atomic_timeout)(Scheme_On_Atomic_T
 /*                              error handling                            */
 /*========================================================================*/
 void (*scheme_signal_error)(const char *msg, ...);
-void (*scheme_raise_exn)(int exnid, ...);
+void (*scheme_raise_exn)(int exnid, ...) __attribute__ ((noreturn));
 void (*scheme_warning)(char *msg, ...);
 void (*scheme_raise)(Scheme_Object *exn);
 int (*scheme_log_level_p)(Scheme_Logger *logger, int level);


### PR DESCRIPTION
scheme_raise_exn raises an exception and doesn't return.
Static analysis tools find a huge amount of problems with regards
to memory leaks that are actually false positives because the tools
are not aware the function does not return. Marking it as such aids
further inspection of real problems.