### PR TITLE
Remove dead code

### DIFF
--- a/racket/src/rktio/rktio_sha1.c
+++ b/racket/src/rktio/rktio_sha1.c
@@ -184,9 +184,6 @@ SHA1_Transform(uint32_sha1_t state[5], const uint8_sha1_t buffer[64])
     state[2] += c;
     state[3] += d;
     state[4] += e;
-
-    /* Wipe variables */
-    a = b = c = d = e = 0;
 }
 
 /* SHA1Init - Initialize new context */
@@ -254,7 +251,6 @@ SHA1_Final(SHA1_CTX *context, uint8_sha1_t digest[RKTIO_SHA1_DIGEST_SIZE])
     }
 
     /* Wipe variables */
-    i = 0;
     memset(context->buffer, 0, 64);
     memset(context->state, 0, 20);
     memset(context->count, 0, 8);


### PR DESCRIPTION
I understand what the idea is in this file, except this code won't
work like the author expected it to. Variables marked for wiping won't
be wiped unless they are marked as volatile. The compiler will simply
remove the code wiping the variables and issue a warning, which is
what brought me to look into this code in the first place.