### PR TITLE
Create "for/append-list" macro

### DIFF
--- a/racket/collects/racket/list.rkt
+++ b/racket/collects/racket/list.rkt
@@ -59,10 +59,17 @@
          group-by
          cartesian-product
          remf
-         remf*)
+         remf*
+
+         ;; for loops
+         for/append-list
+         for/append-lists
+         for*/append-list
+         for*/append-lists)
 
 (require (for-syntax racket/base)
-         racket/private/list-predicates)
+         racket/private/list-predicates
+         racket/private/for-append-list)
 
 (define (first x)
   (if (and (pair? x) (list? x))

--- a/racket/collects/racket/private/for-append-list.rkt
+++ b/racket/collects/racket/private/for-append-list.rkt
@@ -1,0 +1,60 @@
+#lang racket/base
+(provide for/append-list
+         for/append-lists
+         for*/append-list
+         for*/append-lists)
+
+(require
+ (for-syntax racket/base
+             syntax/for-body))
+
+;; ---------------------------------------------------------------------------------------------------
+
+(define-syntaxes [for/append-lists for/append-list for*/append-lists for*/append-list]
+  (let ()
+    (define ((make-for/append-lists macro for/derived-id) stx)
+      (syntax-case stx ()
+        [(_ (name ...) (clause ...) . body)
+         (with-syntax ([([pre-body ...] body*) (split-for-body stx #'body)]
+                       [[tmp ...] (generate-temporaries #'[name ...])])
+           #`(let-values ([(tmp ...)
+                           (#,for/derived-id
+                            #,stx
+                            ([name '()] ...)
+                            (clause ...)
+                            pre-body ...
+                            (let-values ([(tmp ...) (let-values () . body*)])
+                              (values (rev-append '#,macro tmp name)
+                                      ...)))])
+               (values (reverse tmp)
+                       ...)))]))
+
+    (define ((make-for/append-list macro for/derived-id) stx)
+      (syntax-case stx ()
+        [(_ (clause ...) . body)
+         (with-syntax ([([pre-body ...] body*) (split-for-body stx #'body)])
+           #`(reverse
+              (#,for/derived-id
+               #,stx
+               ([tmp '()])
+               (clause ...)
+               pre-body ...
+               (rev-append '#,macro
+                           (let-values () . body*)
+                           tmp))))]))
+
+    (values (make-for/append-lists 'for/append-lists  #'for/fold/derived)
+            (make-for/append-list  'for/append-list   #'for/fold/derived)
+            (make-for/append-lists 'for*/append-lists #'for*/fold/derived)
+            (make-for/append-list  'for*/append-list  #'for*/fold/derived))))
+
+;; symbol [listof X] [listof X] -> [listof X]
+(define (rev-append blame xs tl)
+  (unless (list? xs)
+    (raise-argument-error blame "list?" xs))
+  (let loop ([acc tl]
+             [xs xs])
+    (if (null? xs)
+      acc
+      (loop (cons (car xs) acc)
+            (cdr xs)))))


### PR DESCRIPTION
If `for/list` is analogous to `map`, then this form is analogous to `append-map`.

```racket
  (check-equal? (for/append-list ([x (in-range 4)])
                  (list x (number->string x)))
                '(0 "0" 1 "1" 2 "2" 3 "3"))
```

I have found the need for this function a few times lately, especially since most of my code avoids `map` in favor of `for/list`.

Defines the following macros:
* `(for/append-list (clause ...) body-or-break ...)`
* `(for*/append-list (clause ...) body-or-break ...)`
* `(for/append-lists (id ...) (clause ...) body-or-break ...)`
* `(for*/append-lists (id ...) (clause ...) body-or-break ...)`

--- 

1. We can bikeshed the name, not sure if `append-list` is clear enough.
2. I am providing this from `racket/list`, but maybe it should just be in its own module.
3. I have some tests written but I'm not entirely sure where I should put them.