### PR TITLE
Simplify conditionals after removing dead store of has_space

### DIFF
--- a/racket/src/racket/src/symbol.c
+++ b/racket/src/racket/src/symbol.c
@@ -675,9 +675,7 @@ const char *scheme_symbol_name_and_size(Scheme_Object *sym, uintptr_t *length, i
 	&& (SCHEME_TRUEP(scheme_read_number(cs, clen, 0, 0, 1, 10, 0, NULL, &dz, 1))
 	    || dz)) {
       /* Need quoting: */
-      if (pipe_quote)
-	has_space = 1; /* Use normal */
-      else {
+      if (!pipe_quote) {
 	/* Just need a leading backslash: */
 	result = (char *)scheme_malloc_atomic(len + 2);
 	total_length = len + 1;

--- a/racket/src/racket/src/symbol.c
+++ b/racket/src/racket/src/symbol.c
@@ -673,18 +673,14 @@ const char *scheme_symbol_name_and_size(Scheme_Object *sym, uintptr_t *length, i
 	&& digit_start
 	&& !(flags & SCHEME_SNF_FOR_TS)
 	&& (SCHEME_TRUEP(scheme_read_number(cs, clen, 0, 0, 1, 10, 0, NULL, &dz, 1))
-	    || dz)) {
-      /* Need quoting: */
-      if (pipe_quote)
-	has_space = 1; /* Use normal */
-      else {
-	/* Just need a leading backslash: */
-	result = (char *)scheme_malloc_atomic(len + 2);
-	total_length = len + 1;
-	memcpy(result + 1, s, len);
-	result[0] = '\\';
-	result[len + 1] = 0;
-      }
+	    || dz)
+        && !pipe_quote) {
+      /* Just need a leading backslash: */
+      result = (char *)scheme_malloc_atomic(len + 2);
+      total_length = len + 1;
+      memcpy(result + 1, s, len);
+      result[0] = '\\';
+      result[len + 1] = 0;
     } else {
       total_length = len;
       result = s;

--- a/racket/src/racket/src/symbol.c
+++ b/racket/src/racket/src/symbol.c
@@ -673,14 +673,18 @@ const char *scheme_symbol_name_and_size(Scheme_Object *sym, uintptr_t *length, i
 	&& digit_start
 	&& !(flags & SCHEME_SNF_FOR_TS)
 	&& (SCHEME_TRUEP(scheme_read_number(cs, clen, 0, 0, 1, 10, 0, NULL, &dz, 1))
-	    || dz)
-        && !pipe_quote) {
-      /* Just need a leading backslash: */
-      result = (char *)scheme_malloc_atomic(len + 2);
-      total_length = len + 1;
-      memcpy(result + 1, s, len);
-      result[0] = '\\';
-      result[len + 1] = 0;
+	    || dz)) {
+      /* Need quoting: */
+      if (pipe_quote)
+	has_space = 1; /* Use normal */
+      else {
+	/* Just need a leading backslash: */
+	result = (char *)scheme_malloc_atomic(len + 2);
+	total_length = len + 1;
+	memcpy(result + 1, s, len);
+	result[0] = '\\';
+	result[len + 1] = 0;
+      }
     } else {
       total_length = len;
       result = s;


### PR DESCRIPTION
The conditional simplification looks good to me. The biggest issue
here was to understand if when `pipe_quote` is true, we can and should
go to the else clause. Actually the more I look at it the more I think
this uncovers and earlier bug where if pipe_quote is true, result and
total_length are left at NULL and 0 respectively after the block.