### PR TITLE
Typo: missing 'of'

### DIFF
--- a/pkgs/racket-doc/scribblings/style/style.scrbl
+++ b/pkgs/racket-doc/scribblings/style/style.scrbl
@@ -16,7 +16,7 @@ Since 1995 the number of ``repository contributors'' has grown from a small hand
  help us, the developers, and our users, who use the open source code in
  our repository as an implicit guide to Racket programming.
 
-To help manage the growth our code and showcase good Racket style, we need
+To help manage the growth of our code and showcase good Racket style, we need
  guidelines that shape the contributions to the code base. These guidelines should
  achieve some level of consistency across the different portions of the
  code base so that everyone who opens files can easily find their way


### PR DESCRIPTION
"the growth our code" -> "the growth of our code"