### PR TITLE
Add make-constant-like-transformer

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/transformer.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/transformer.scrbl
@@ -37,4 +37,28 @@ op
 @history[#:added "6.3"]{}
 }
 
+@defproc[(make-constant-like-transformer [reference-stx syntax?])
+         (-> syntax? syntax?)]{
+
+Creates a transformer that replaces references to the macro identifier
+with @racket[reference-stx]. Uses of the macro in operator position
+are interpreted as an application with @racket[reference-stx] as the
+function and the arguments as given.
+
+Note that this does not necessarily behave like a constant
+if the @racket[reference-stx] expression produces different
+values at different times.
+
+@examples[#:eval the-eval
+(define the-box (box add1))
+(define-syntax op
+  (make-constant-like-transformer
+   #'(unbox the-box)))
+(op 5)
+op
+]
+
+@history[#:added "7.2.0.10"]
+}
+
 @close-eval[the-eval]

--- a/racket/collects/syntax/transformer.rkt
+++ b/racket/collects/syntax/transformer.rkt
@@ -6,8 +6,8 @@
          make-constant-like-transformer)
 
 (define (make-variable-like-transformer ref-stx [set!-handler #f])
-  (unless (syntax? ref-stx)
-    (raise-type-error 'make-variable-like-transformer "syntax?" ref-stx))
+  (unless (or (syntax? ref-stx) (procedure? ref-stx))
+    (raise-type-error 'make-variable-like-transformer "(or/c syntax? procedure?)" ref-stx))
   (unless (or (syntax? set!-handler) (procedure? set!-handler) (eq? set!-handler #f))
     (raise-type-error 'make-variable-like-transformer "(or/c syntax? procedure? #f)" set!-handler))
   (define ref-f
@@ -27,13 +27,14 @@
         (ref-f stx)]))))
 
 (define (make-constant-like-transformer ref-stx)
-  (unless (syntax? ref-stx)
-    (raise-type-error 'make-constant-like-transformer "syntax?" ref-stx))
+  (unless (or (syntax? ref-stx) (procedure? ref-stx))
+    (raise-type-error 'make-constant-like-transformer "(or/c syntax? procedure?)" ref-stx))
   (lambda (stx)
     (syntax-case stx ()
       [id
        (identifier? #'id)
-       ref-stx]
+       (cond [(syntax? ref-stx) ref-stx]
+             [else              (ref-stx stx)])]
       [(id . args)
        (let ([stx* (cons #'(#%expression id) (cdr (syntax-e stx)))])
          (datum->syntax stx stx* stx))])))


### PR DESCRIPTION
This is just like `make-variable-like-transformer`, except that it doesn't allow a `setter-stx`, and produces a `procedure?` instead of a `set!-transformer?`.

This allows `make-constant-like-transformer` to be used in places that require a procedure, such as structs with `prop:procedure` on them. Those places currently can't use `make-variable-like-transformer` (or if they can they have to extract the procedure from the set-transformer first), so they would use `make-constant-like-transformer` instead.

The main problem I'm having with this is the name. You can pass an expression as the `reference-stx`, and that expression can depend on side-effects that would change the value. So it always produces the same constant expression, but what that expression evaluates to might change.