### PR TITLE
Return a procedure from make-variable-like-transformer

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/transformer.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/transformer.scrbl
@@ -8,20 +8,24 @@
 
 @defmodule[syntax/transformer]
 
-@defproc[(make-variable-like-transformer [reference-stx syntax?]
-                                         [setter-stx (or/c syntax? #f) #f])
-         set!-transformer?]{
+@defproc[(make-variable-like-transformer
+          [reference-stx (or/c syntax? (-> identifier? syntax?))]
+          [setter-stx (or/c syntax? (-> syntax? syntax?) #f) #f])
+         (and/c set!-transformer? (-> syntax? syntax?))]{
 
 Creates a transformer that replaces references to the macro identifier
 with @racket[reference-stx]. Uses of the macro in operator position
 are interpreted as an application with @racket[reference-stx] as the
-function and the arguments as given.
+function and the arguments as given. If the @racket[reference-stx] is
+a procedure, it is applied to the macro identifier.
 
 If the macro identifier is used as the target of a @racket[set!] form,
 then the @racket[set!] form expands into the application of
 @racket[setter-stx] to the @racket[set!] expression's right-hand side,
 if @racket[setter-stx] is syntax; otherwise, the identifier is
-considered immutable and a syntax error is raised.
+considered immutable and a syntax error is raised. If
+@racket[setter-stx] is a procedure, it is applied to the entire
+@racket[set!] expression.
 
 @examples[#:eval the-eval
 (define the-box (box add1))

--- a/racket/collects/syntax/transformer.rkt
+++ b/racket/collects/syntax/transformer.rkt
@@ -4,17 +4,22 @@
 
 (provide make-variable-like-transformer)
 
+(struct variable-like-transformer [procedure]
+  #:property prop:procedure (struct-field-index procedure)
+  #:property prop:set!-transformer (struct-field-index procedure))
+
 (define (make-variable-like-transformer ref-stx [set!-handler #f])
-  (unless (syntax? ref-stx)
-    (raise-type-error 'make-variable-like-transformer "syntax?" ref-stx))
+  (unless (or (syntax? ref-stx) (procedure? ref-stx))
+    (raise-type-error 'make-variable-like-transformer "(or/c syntax? procedure?)" ref-stx))
   (unless (or (syntax? set!-handler) (procedure? set!-handler) (eq? set!-handler #f))
     (raise-type-error 'make-variable-like-transformer "(or/c syntax? procedure? #f)" set!-handler))
-  (make-set!-transformer
+  (variable-like-transformer
    (lambda (stx)
      (syntax-case stx (set!)
        [id
         (identifier? #'id)
-        ref-stx]
+        (cond [(procedure? ref-stx) (ref-stx stx)]
+              [else                 ref-stx])]
        [(set! id val)
         (cond [(procedure? set!-handler)
                (set!-handler stx)]


### PR DESCRIPTION
So that make-variable-like-transformer produces a value that passes both `procedure?` and `set!-transformer?`.