### PR TITLE
[WIP] core: enhance `raise-argument-error`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/exns.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/exns.scrbl
@@ -163,14 +163,16 @@ default @tech{error display handler} does not show a ``stack trace'' for
 for end users.}
 
 
-@defproc*[([(raise-argument-error [name symbol?] [expected string?] [v any/c]) any]
-           [(raise-argument-error [name symbol?] [expected string?] [bad-pos exact-nonnegative-integer?] [v any/c] ...) any])]{
+@defproc*[([(raise-argument-error [name symbol?] [expected string?] [v any/c] [#:more-info more-info string? #f]) any]
+           [(raise-argument-error [name symbol?] [expected string?] [bad-pos exact-nonnegative-integer?] [v any/c] ... [#:more-info more-info string? #f]) any])]{
 
 Creates an @racket[exn:fail:contract] value and @racket[raise]s it as
 an exception.  The @racket[name] argument is used as the source
 procedure's name in the error message. The @racket[expected] argument
 is used as a description of the expected contract (i.e., as a string,
-but the string is intended to contain a contract expression).
+but the string is intended to contain a contract expression). The optional
+@racket[more-info] argument is included in the exception's error message,
+its purpose is to provide more detail about the bad argument's role.
 
 In the first form, @racket[v] is the value received by the procedure
 that does not have the expected type.
@@ -198,7 +200,17 @@ message names the bad argument and also lists the other arguments. If
     (raise-argument-error 'feed-animals "'goose" 2 cow sheep goose cat)
     "fed the animals"))
 (eval:error (feed-animals 'cow 'sheep 'dog 'cat))
-]}
+(define (feed-calf kind)
+  (if (not (eq? kind 'milk))
+    (raise-argument-error 'feed-calf "'milk" kind
+                          #:more-info "what kind of food to feed the calf")
+    "fed the calf"))
+(eval:error (feed-calf 'seeds))
+]
+
+@history[#:changed "7.2.0.10" @elem{Added @racket[#:more-info]}]
+
+}
 
 
 @defproc*[([(raise-result-error [name symbol?] [expected string?] [v any/c]) any]

--- a/pkgs/racket-test-core/tests/racket/core-tests.rktl
+++ b/pkgs/racket-test-core/tests/racket/core-tests.rktl
@@ -44,3 +44,4 @@
 (unless building-flat-tests?
   (load-relative "name.rktl"))
 (load-relative "srcloc.rktl")
+(load-relative "error.rktl")

--- a/pkgs/racket-test-core/tests/racket/error.rktl
+++ b/pkgs/racket-test-core/tests/racket/error.rktl
@@ -1,0 +1,283 @@
+(load-relative "loadtest.rktl")
+
+(Section 'error)
+
+;; ----- raise-argument-error forms ----- ;;
+
+(err/rt-test (raise-argument-error 'form-1a "expected?" 'other) 
+             exn:fail:contract? 
+             #rx"form-1a: contract violation\n  expected: expected\\?\n  given: 'other")
+
+(err/rt-test (raise-argument-error 'form-1b #:more-info "informative sentence explaining more about the argument" "expected?" 'other) 
+             exn:fail:contract? 
+             #rx"form-1b: contract violation;\n informative sentence explaining more about the argument\n  expected: expected\\?\n  given: 'other")
+
+; make sure line break characters inside #:more-info string are properly handled
+(err/rt-test (raise-argument-error 'form-1c #:more-info "informative sentence explaining more about the argument\nanother sentence with even more details\none more sentence" "expected?" 'other) 
+             exn:fail:contract? 
+             #rx"form-1c: contract violation;\n informative sentence explaining more about the argument\n another sentence with even more details\n one more sentence\n  expected: expected\\?\n  given: 'other")
+
+; long detail on same line as label in a field should automatically move to next line and be indented
+(err/rt-test (raise-argument-error 'form-1d "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" 'other) 
+             exn:fail:contract? 
+             #rx"form-1d: contract violation\n  expected:\n   aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\n  given: 'other")
+
+(err/rt-test (raise-argument-error 'form-1e "expected?" 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa) 
+             exn:fail:contract? 
+             #rx"form-1e: contract violation\n  expected: expected\\?\n  given:\n   'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+
+(err/rt-test (raise-argument-error 'form-2a "expected?" 0 'other) 
+             exn:fail:contract? 
+             #rx"form-2a: contract violation\n  expected: expected\\?\n  given: 'other")
+
+(err/rt-test (raise-argument-error 'form-2b "expected?" 0 'other1 'other2 'other3) 
+             exn:fail:contract? 
+             #rx"form-2b: contract violation\n  expected: expected\\?\n  given: 'other1\n  argument position: 1st\n  other arguments...:\n   'other2\n   'other3")
+
+(err/rt-test (raise-argument-error 'form-2c "expected?" 1 'other1 'other2 'other3) 
+             exn:fail:contract? 
+             #rx"form-2c: contract violation\n  expected: expected\\?\n  given: 'other2\n  argument position: 2nd\n  other arguments...:\n   'other1\n   'other3")
+
+(err/rt-test (raise-argument-error 'form-2d "expected?" 2 'other1 'other2 'other3) 
+             exn:fail:contract? 
+             #rx"form-2d: contract violation\n  expected: expected\\?\n  given: 'other3\n  argument position: 3rd\n  other arguments...:\n   'other1\n   'other2")
+
+; make sure ordinal position names are correct for 11, 12, 13
+(err/rt-test (raise-argument-error 'form-2e "expected?" 10 'other1 'other2 'other3  'other4 'other5 'other6 'other7 'other8 'other9 'other10 'other11 'other12 'other13 'other14) 
+             exn:fail:contract? 
+             #rx"form-2e: contract violation\n  expected: expected\\?\n  given: 'other11\n  argument position: 11th\n")
+
+(err/rt-test (raise-argument-error 'form-2f "expected?" 11 'other1 'other2 'other3  'other4 'other5 'other6 'other7 'other8 'other9 'other10 'other11 'other12 'other13 'other14) 
+             exn:fail:contract? 
+             #rx"form-2f: contract violation\n  expected: expected\\?\n  given: 'other12\n  argument position: 12th\n")
+
+(err/rt-test (raise-argument-error 'form-2g "expected?" 12 'other1 'other2 'other3  'other4 'other5 'other6 'other7 'other8 'other9 'other10 'other11 'other12 'other13 'other14) 
+             exn:fail:contract? 
+             #rx"form-2g: contract violation\n  expected: expected\\?\n  given: 'other13\n  argument position: 13th\n")
+
+(err/rt-test (raise-argument-error 'form-2h #:more-info "informative sentence explaining more about the argument" "expected?" 0 'other) 
+             exn:fail:contract? 
+             #rx"form-2h: contract violation;\n informative sentence explaining more about the argument\n  expected: expected\\?\n  given: 'other")
+
+(err/rt-test (raise-argument-error 'form-2i "expected?" 2 'other1 'other2 'other3 #:more-info "informative sentence explaining more about the argument") 
+             exn:fail:contract? 
+             #rx"form-2i: contract violation;\n informative sentence explaining more about the argument\n  expected: expected\\?\n  given: 'other3\n  argument position: 3rd\n  other arguments...:\n   'other1\n   'other2")
+
+; make sure line break characters inside #:more-info string are properly handled
+(err/rt-test (raise-argument-error 'form-2j "expected?" 2 'other1 'other2 'other3 #:more-info "informative sentence explaining more about the argument\nanother sentence with even more details\none more sentence") 
+             exn:fail:contract? 
+             #rx"form-2j: contract violation;\n informative sentence explaining more about the argument\n another sentence with even more details\n one more sentence\n  expected: expected\\?\n  given: 'other3\n  argument position: 3rd\n  other arguments...:\n   'other1\n   'other2")
+
+(err/rt-test (raise-argument-error 'form-2k "expected?" 3 2 2 1 2 1 2) 
+             exn:fail:contract? 
+             #rx"form-2k: contract violation\n  expected: expected\\?\n  given: 2\n  argument position: 4th\n  other arguments...:\n   2\n   2\n   1\n   1\n   2")
+
+
+; Check expected exceptions when raise-argument-error is misused.
+
+(err/rt-test (raise-argument-error 'form-1a "expected?") 
+             exn:fail:contract:arity?
+             #rx"raise-argument-error: arity mismatch")
+
+(err/rt-test (raise-argument-error "form-1b" "expected?" 'other)
+             exn:fail:contract?
+             #rx"raise-argument-error: contract violation\n  expected: symbol\\?")
+
+(err/rt-test (raise-argument-error 'form-1c 'expected? 'other)
+             exn:fail:contract?
+             #rx"raise-argument-error: contract violation\n  expected: string\\?")
+
+(err/rt-test (raise-argument-error 'form-1d "expected?" 'other #:more-info 'not-string)
+             exn:fail:contract?
+             #rx"raise-argument-error: contract violation\n  expected: string\\?\n  given: 'not-string\n  keyword: #:more-info\n  arguments...:\n   'form-1d\n   \"expected\\?\"\n   'other")
+
+(err/rt-test (raise-argument-error "form-2a" "expected?" 0 'other) 
+             exn:fail:contract? 
+             #rx"raise-argument-error: contract violation\n  expected: symbol\\?")
+
+(err/rt-test (raise-argument-error 'form-2b 'expected? 0 'other1 'other2 'other3) 
+             exn:fail:contract? 
+             #rx"raise-argument-error: contract violation\n  expected: string\\?")
+
+(err/rt-test (raise-argument-error 'form-2c "expected?" 'NaN 'other) 
+             exn:fail:contract? 
+             #rx"raise-argument-error: contract violation\n  expected: exact-nonnegative-integer\\?\n  given: 'NaN")
+
+(err/rt-test (raise-argument-error 'form-2d "expected?" 5 'other1 'other2 'other3) 
+             exn:fail:contract? 
+             #rx"raise-argument-error: position index >= provided argument count\n  position index: 5\n  provided argument count: 3")
+
+(err/rt-test (raise-argument-error 'form-2e #:more-info 345 "expected?" 0 'other1 'other2 'other3) 
+             exn:fail:contract? 
+             #rx"raise-argument-error: contract violation\n  expected: string\\?\n  given: 345\n  keyword: #:more-info\n  arguments...:\n")
+
+; make sure keyword argument is properly reported in error output when raise-argument-error is misused
+(err/rt-test (raise-argument-error 'form-2f 'expected? 0 'other1 #:more-info "string") 
+             exn:fail:contract? 
+             #rx"raise-argument-error: contract violation\n  expected: string\\?\n  given: 'expected\\?\n  argument position: 2nd\n  other arguments...:\n   'form-2f\n   0\n   'other1\n  keyword arguments...:\n   #:more-info \"string\"")
+
+(require racket/private/error-reporting)
+
+(err/rt-test (error-report->string 'not-an-error-report)
+             exn:fail:contract?
+             #rx"expected: error-report\\?")
+
+(let ()
+  (define err-rpt (error-report (absent) (absent) (absent) (absent) (absent)))
+  (test #t string=? "" (error-report->string err-rpt)))
+
+(let ()
+  (define err-rpt (error-report (srcloc "file.rkt" 167 23 4 5) (absent) (absent) (absent) (absent)))
+  (test #t string=? "file.rkt:167:23: " (error-report->string err-rpt))
+
+  (err/rt-test (error-report "not a srcloc" (absent) (absent) (absent) (absent))
+             exn:fail:contract?
+             #rx"expected: \\(or/c srcloc\\? absent\\?\\)"))
+
+(let ()
+  (define err-rpt1 (error-report (absent) #f (absent) (absent) (absent)))
+  (test #t string=? "#f: " (error-report->string err-rpt1))
+
+  (define err-rpt2 (error-report (absent) 'name (absent) (absent) (absent)))
+  (test #t string=? "name: " (error-report->string err-rpt2))
+
+  (define err-rpt3 (error-report (absent) "name" (absent) (absent) (absent)))
+  (test #t string=? "name: " (error-report->string err-rpt3))
+
+  (define err-rpt4 (error-report (absent) (void) (absent) (absent) (absent)))
+  (test #t string=? "#<void>: " (error-report->string err-rpt4))
+
+  (define err-rpt5 (error-report (absent) 77 (absent) (absent) (absent)))
+  (test #t string=? "77: " (error-report->string err-rpt5)))
+
+(let ()
+  (define err-rpt1 (error-report (absent) (absent) "some string message" (absent) (absent)))
+  (test #t string=? "some string message" (error-report->string err-rpt1))
+
+  (define err-rpt2 (error-report (absent) (absent) #f (absent) (absent)))
+  (test #t string=? "#f" (error-report->string err-rpt2))
+
+  (define err-rpt3 (error-report (absent) (absent) 'message (absent) (absent)))
+  (test #t string=? "message" (error-report->string err-rpt3))
+
+  (define err-rpt4 (error-report (absent) (absent) 56 (absent) (absent)))
+  (test #t string=? "56" (error-report->string err-rpt4)))
+
+(let ()
+  (define err-rpt1 (error-report (absent) (absent) (absent) (list "a continued sentence") (absent)))
+  (test #t string=? " a continued sentence" (error-report->string err-rpt1))
+
+  (define err-rpt2 (error-report (absent) (absent) (absent) (list "a continued sentence" 453 'symbolic-message "another sentence") (absent)))
+  (test #t string=? " a continued sentence\n 453\n symbolic-message\n another sentence" (error-report->string err-rpt2))
+
+  (define err-rpt3 (error-report (absent) (absent) (absent) (list "a continued sentence" (void) "sentence with line break\n character in middle") (absent)))
+  (test #t string=? " a continued sentence\n #<void>\n sentence with line break\n  character in middle" (error-report->string err-rpt3))
+
+  (define err-rpt4 (error-report (absent) (absent) (absent) (list) (absent)))
+  (test #t string=? "" (error-report->string err-rpt4))
+
+  (err/rt-test (error-report (absent) (absent) (absent) "not a list" (absent))
+             exn:fail:contract?
+             #rx"expected: \\(or/c \\(listof any/c\\) absent\\?\\)"))
+
+(let ()
+  (define err-rpt1 (error-report (absent) (absent) (absent) (absent) (list)))
+  (test #t string=? "" (error-report->string err-rpt1))
+
+  (define err-rpt2 (error-report (absent) (absent) (absent) (absent) (list (error-field "expected" "something"))))
+  (test #t string=? "  expected: \"something\"" (error-report->string err-rpt2))
+
+  (define err-rpt3 (error-report (absent) (absent) (absent) (absent) (list (error-field "expected" "something" #:print-mode '~a))))
+  (test #t string=? "  expected: something" (error-report->string err-rpt3))
+
+  (define err-rpt4 (error-report (absent) (absent) (absent) (absent) (list (error-field "random label" 'something))))
+  (test #t string=? "  random label: 'something" (error-report->string err-rpt4))
+
+  (define err-rpt5 (error-report (absent) (absent) (absent) (absent) (list (error-field "random label" 'something #:print-mode '~a))))
+  (test #t string=? "  random label: something" (error-report->string err-rpt5))
+
+  (define err-rpt6 (error-report (absent) (absent) (absent) (absent) (list (error-field "expected" "something" 'something 45 #:indent-all? #t))))
+  (test #t string=? "  expected:\n   \"something\"\n   'something\n   45" (error-report->string err-rpt6))
+
+  (define err-rpt7 (error-report (absent) (absent) (absent) (absent) (list (error-field "expected" "something" 'something 45 #:print-mode '~a #:indent-all? 'yes))))
+  (test #t string=? "  expected:\n   something\n   something\n   45" (error-report->string err-rpt7))
+
+  (define err-rpt8 (error-report (absent) (absent) (absent) (absent) (list (error-field "expected"))))
+  (test #t string=? "  expected:" (error-report->string err-rpt8))
+
+  (define err-rpt9 (error-report (absent) (absent) (absent) (absent) (list (ellipsis-field "arguments" 'something "something"))))
+  (test #t string=? "  arguments...:\n   'something\n   \"something\"" (error-report->string err-rpt9))
+
+  (define err-rpt10 (error-report (absent) (absent) (absent) (absent) (list (ellipsis-field "arguments" 'something "something" #:print-mode '~a))))
+  (test #t string=? "  arguments...:\n   something\n   something" (error-report->string err-rpt10))
+
+  (define err-rpt11 (error-report (absent) (absent) (absent) (absent) (list (ellipsis-field "arguments"))))
+  (test #t string=? "  arguments...:" (error-report->string err-rpt11))
+
+  (define err-rpt12 (error-report (absent) (absent) (absent) (absent) (list (error-field "expected" "something" #:print-mode '~a)
+                                                                            (error-field "given" 'wrong-value)
+                                                                            (error-field "argument position" "3rd" #:print-mode '~a)
+                                                                            (ellipsis-field "other arguments" 'other "stuff" 345)
+                                                                            (error-field "doc" (string->path "path to documentation located somewhere in the universe, good luck finding it") #:indent-all? 'yes))))
+  (test #t
+        string=?
+        "  expected: something\n  given: 'wrong-value\n  argument position: 3rd\n  other arguments...:\n   'other\n   \"stuff\"\n   345\n  doc:\n   #<path:path to documentation located somewhere in the universe, good luck finding it>"
+        (error-report->string err-rpt12))
+
+  ; verify if error-field first detail printed error output exceeds limit then it's automatically moved to next line and indented
+  (define err-rpt13 (error-report (absent) (absent) (absent) (absent) (list (error-field "label" "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"))))
+  (test #t string=? "  label:\n   \"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\"" (error-report->string err-rpt13))
+
+  (define err-rpt14 (error-report (absent) (absent) (absent) (absent) (list (error-field "label" 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa))))
+  (test #t string=? "  label:\n   'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa" (error-report->string err-rpt14))  
+
+  (err/rt-test (error-report (absent) (absent) (absent) (absent) "not a list")
+             exn:fail:contract?
+             #rx"expected: \\(or/c \\(listof error-field\\?\\) absent\\?\\)")
+
+  (err/rt-test (error-report (absent) (absent) (absent) (absent) (list 'not-error-field? 43))
+             exn:fail:contract?
+             #rx"expected: \\(or/c \\(listof error-field\\?\\) absent\\?\\)"))
+
+(let ()
+  (define err-rpt1 (error-report (srcloc "file.rkt" 167 23 4 5)
+                                 'name
+                                 "some string message"
+                                 (list "a continued sentence" (void) "sentence with line break\n character in middle")
+                                 (list (error-field "expected" "something" #:print-mode '~a)
+                                       (error-field "given" 'wrong-value)
+                                       (error-field "explanation" "sentence1" 'example1 #:indent-all? 'yes))))
+  (test #t
+        string=?
+        "file.rkt:167:23: name: some string message;\n a continued sentence\n #<void>\n sentence with line break\n  character in middle\n  expected: something\n  given: 'wrong-value\n  explanation:\n   \"sentence1\"\n   'example1"
+        (error-report->string err-rpt1))
+
+  (define err-rpt2 (error-report (absent)
+                                 'name
+                                 "some string message"
+                                 (absent)
+                                 (list (error-field "expected" "something" #:print-mode '~a)
+                                       (error-field "given" 'wrong-value))))
+  (test #t
+        string=?
+        "name: some string message\n  expected: something\n  given: 'wrong-value"
+        (error-report->string err-rpt2)))
+
+(let ()
+  (err/rt-test (error-field 'not-a-string 'detail)
+             exn:fail:contract?
+             #rx"expected: string\\?")
+
+  (err/rt-test (ellipsis-field 'not-a-string 'something)
+             exn:fail:contract?
+             #rx"expected: string\\?")
+
+  (err/rt-test (error-field "label" 'detail #:print-mode 'invalid-style)
+             exn:fail:contract?
+             #rx"expected: \\(or/c '~a '~v\\)")
+
+  (err/rt-test (ellipsis-field "label" 'detail #:print-mode "~a")
+             exn:fail:contract?
+             #rx"expected: \\(or/c '~a '~v\\)"))
+
+(report-errs)

--- a/racket/collects/racket/private/base.rkt
+++ b/racket/collects/racket/private/base.rkt
@@ -1,6 +1,7 @@
 (module base "pre-base.rkt"
 
-  (#%require "hash.rkt"
+  (#%require "error.rkt" ; shadows `raise-argument-error`
+             "hash.rkt"
              "list.rkt" ; shadows `reverse', `mem{q,v,ber}'
              "string.rkt"
              "stxcase-scheme.rkt"
@@ -25,8 +26,9 @@
                               with-output-to-file
                               directory-list
                               regexp-replace*
-                              new-apply-proc)
+                              new-apply-proc)             
              struct
+             (all-from "error.rkt")
              (all-from-except "hash.rkt" paired-fold)
              (all-from "list.rkt")
              (all-from-except "string.rkt"

--- a/racket/collects/racket/private/error-reporting.rkt
+++ b/racket/collects/racket/private/error-reporting.rkt
@@ -70,19 +70,19 @@
   ;   ... 
   ;
   ; <error-field> :-
-  ; <field>: <detail>
+  ; <label>: <detail>
   ;  <detail>
   ;  ...
   ;
   ; <ellipsis-field> :-
-  ; <field>...:
+  ; <label>...:
   ;  <detail>
   ;  ...
 
   ; struct error-field
   ; label : string/c
   ; details : (listof any/c)
-  ; indent-all : (or/c #f (not #f)) if #f and details is not empty then first details
+  ; indent-all? : (or/c #f (not #f)) if #f and details is not empty then first detail
   ;                                 is printed on same line as label and all other details
   ;                                 are printed on separate lines and indented with respect
   ;                                 to the label line.
@@ -102,13 +102,12 @@
 
   ; ~v is the default print mode for the field detail but allow ~a to be specified
   ; instead if desired.
-  ; indent-all is #f by default.
+  ; indent-all? is #f by default.
   (define (make-error-field label #:indent-all? [indent-all? #f] #:print-mode [print-mode '~v] . details)
     (error-field label details indent-all? print-mode))
   
-  ; struct ellipsis-field  
-  ; details : (listof any/c)
-  ; all details are always indented so indent-all? is #t
+  ; struct ellipsis-field : error-field
+  ; all details are always indented so indent-all? is #t by default
   (struct ellipsis-field error-field () #:transparent)
 
   (define (make-ellipsis-field label #:print-mode [print-mode '~v] . details)
@@ -217,7 +216,7 @@
            formatted-label
            details))
 
-  ; too-long? : any/c -> boolean?
+  ; first-detail-too-long? : any/c -> boolean?
   ; checks to see if error-field's first detail when printed for error output would exceed
   ; (error-detail-print-width)
   (define (first-detail-too-long? ef)

--- a/racket/collects/racket/private/error-reporting.rkt
+++ b/racket/collects/racket/private/error-reporting.rkt
@@ -1,0 +1,290 @@
+(module error-reporting "pre-base.rkt"
+
+  ; module implements error reporting conforming to Racket error conventions
+
+  (provide
+   ;; structs
+ 
+   error-report
+   error-report?
+           
+   ; replaces error-field struct's constructor
+   (rename-out [make-error-field error-field])
+
+   ; predicate matching any error-field and ellipsis-field
+   error-field?
+   
+   ; replaces ellipsis-field struct's constructor
+   (rename-out [make-ellipsis-field ellipsis-field])
+   ellipsis-field?
+           
+   ; use to indicate lack of provided value for an error-report's field
+   ; since #f can be used in any of error-report's fields, need an alternative
+   ; to indicate lack of valid values.
+   absent
+   absent?)
+
+  (provide
+   ;; procedures
+
+   ; control how long detail can be printed on one line
+   error-detail-print-width
+   
+   ; convert error-report to string for use as exn's message field
+   error-report->string
+
+   ; construct exn:fail:contract using an error-report
+   exn:fail:contract/error-report
+
+   ; commonly used error fields so provide for convenience
+   expected-field
+   given-field)
+
+  ;;; -----------------------------------------------------------------------------------------
+  ;;; implementation section
+  
+  (require "struct.rkt"
+           "list.rkt")
+  
+
+  ; Control how long error details can be in error reporting output.
+  (define error-detail-print-width
+    (make-parameter 72
+                    (lambda (v)
+                      (if (exact-nonnegative-integer? v)
+                          v
+                          (raise-argument-error 'error-detail-print-width
+                                                "exact-nonnegative-integer?"
+                                                v)))))
+  
+  ; Assume that any/c and absent? are disjoint in rest of the module.
+  (define absent (let ([private (let () (struct absent ()) (absent))]) (lambda () private)))
+  (define (absent? v) (eq? (absent) v))
+  
+  ; Racket error reporting convention.
+  ;
+  ; <error-report> :-
+  ; [<srcloc>:] [<name>:] <message>[;
+  ;  <continued-message>] ...
+  ;   [<error-field> | <ellipsis-field>]
+  ;   ... 
+  ;
+  ; <error-field> :-
+  ; <field>: <detail>
+  ;  <detail>
+  ;  ...
+  ;
+  ; <ellipsis-field> :-
+  ; <field>...:
+  ;  <detail>
+  ;  ...
+
+  ; struct error-field
+  ; label : string/c
+  ; details : (listof any/c)
+  ; indent-all : (or/c #f (not #f)) if #f and details is not empty then first details
+  ;                                 is printed on same line as label and all other details
+  ;                                 are printed on separate lines and indented with respect
+  ;                                 to the label line.
+  ;                                 if not #f and details is not empty then all details
+  ;                                 are printed on new lines and indented.
+  ; print-mode (or/c '~a '~v) controls how detail is printed
+  (struct error-field (label details indent-all? print-mode)
+    #:transparent
+    #:guard (lambda (label details indent-all print-mode struct-name)
+              (unless (string? label)
+                (raise-argument-error struct-name "string?" 0 label details indent-all print-mode))
+              (unless (list? details)
+                (raise-argument-error struct-name "(listof any/c)" 1 label details indent-all print-mode))
+              (unless (or (eq? print-mode '~a) (eq? print-mode '~v))
+                (raise-argument-error struct-name "(or/c '~a '~v)" 3 label details indent-all print-mode))
+              (values label details indent-all print-mode)))
+
+  ; ~v is the default print mode for the field detail but allow ~a to be specified
+  ; instead if desired.
+  ; indent-all is #f by default.
+  (define (make-error-field label #:indent-all? [indent-all? #f] #:print-mode [print-mode '~v] . details)
+    (error-field label details indent-all? print-mode))
+  
+  ; struct ellipsis-field  
+  ; details : (listof any/c)
+  ; all details are always indented so indent-all? is #t
+  (struct ellipsis-field error-field () #:transparent)
+
+  (define (make-ellipsis-field label #:print-mode [print-mode '~v] . details)
+    (ellipsis-field label details #t print-mode))
+
+  ; struct error-report
+  ; srcloc : (or/c srcloc? absent?)
+  ; name : (or/c any/c absent?)
+  ; message : (or/c any/c absent?)
+  ; continued-messages : (or/c (listof any/c) absent?)
+  ; fields : (or/c (listof error-field?) absent?)
+  (struct error-report (srcloc name message continued-messages fields)
+    #:transparent
+    #:guard (lambda (srcloc name message continued-messages fields struct-name)
+              (unless (or (absent? srcloc) (srcloc? srcloc))
+                (raise-argument-error struct-name
+                                      "(or/c srcloc? absent?)"
+                                      0
+                                      srcloc
+                                      name
+                                      message
+                                      continued-messages
+                                      fields))
+                
+              (unless (or (absent? continued-messages) (list? continued-messages))
+                (raise-argument-error struct-name
+                                      "(or/c (listof any/c) absent?)"
+                                      3
+                                      srcloc
+                                      name
+                                      message
+                                      continued-messages
+                                      fields))
+              (unless (or (absent? fields) (and (list? fields) (andmap error-field? fields)))
+                (raise-argument-error struct-name
+                                      "(or/c (listof error-field?) absent?)"
+                                      4
+                                      srcloc
+                                      name
+                                      message
+                                      continued-messages
+                                      fields))
+              (values srcloc name message continued-messages fields)))
+
+  ; cms : (listof any/c)
+  ; Format continued-messages for error reporting output.
+  ; Strings get special handling. If a string has line break characters then each break
+  ; character is replaced by another break character that is postfixed with appropriate
+  ; amount of whitespace for <continued-message> grammar form.
+  (define (continued-messages-format cms)
+    (define cms-format-string " ~a")
+    (foldl (lambda (m result)
+             (define cm-format (cond
+                                 [(string? m) (lambda (m) (format cms-format-string
+                                                                  (regexp-replace* #rx"\n" m "\n ")))]
+                                 [else (lambda (m) (format cms-format-string m))]))
+             (if (string=? result "")
+                 (cm-format m)
+                 (string-append result "\n" (cm-format m))))
+           ""
+           cms))
+
+  ; error-field-format : error-field? -> string?
+  ; Format error-field for error reporting output.
+  ; If first detail is too long, meaning its printed
+  ; representation exceeds error-detail-print-width then it's
+  ; moved to next line with rest of other details.
+  (define (error-field-format ef)
+    (define formatted-label (format "  ~a:" (error-field-label ef)))
+    (define detail-format (if (eq? (error-field-print-mode ef) '~v)
+                              (lambda (d) (format "~v" d))
+                              (lambda (d) (format "~a" d))))
+    (define details (error-field-details ef))
+    (cond
+      [(null? details) formatted-label]
+      [(or (first-detail-too-long? ef) (error-field-indent-all? ef))
+       (foldl (lambda (d result)
+                (string-append result
+                               "\n"
+                               "   "
+                               (detail-format d)))
+              formatted-label
+              details)]
+      [else
+       (foldl (lambda (d result)
+                (string-append result
+                               "\n"
+                               "   "
+                               (detail-format d)))
+              (string-append formatted-label " " (detail-format (car details)))
+              (cdr details))]))
+
+  ; ellipsis-field-format : ellipsis-field? -> string?
+  ; Format ellipsis-field for error reporting output.
+  (define (ellipsis-field-format ef)
+    (define formatted-label (format "  ~a...:" (error-field-label ef)))
+    (define detail-format (if (eq? (error-field-print-mode ef) '~v)
+                              (lambda (d) (format "~v" d))
+                              (lambda (d) (format "~a" d))))
+    (define details (error-field-details ef))
+    (foldl (lambda (d result)
+             (string-append result
+                            "\n"
+                            "   "
+                            (detail-format d)))
+           formatted-label
+           details))
+
+  ; too-long? : any/c -> boolean?
+  ; checks to see if error-field's first detail when printed for error output would exceed
+  ; (error-detail-print-width)
+  (define (first-detail-too-long? ef)
+    (define details (error-field-details ef))
+    (cond
+      [(null? details) #f]
+      [else
+       (define first-detail (car details))
+       (cond [(and (symbol? first-detail)
+                   (> (string-length (symbol->string first-detail)) (error-detail-print-width)))
+              #t]
+             [(and (string? first-detail)
+                   (> (string-length first-detail) (error-detail-print-width)))
+              #t]
+             [else #f])]))
+
+  ; fields-format : (listof error-field?) -> string?
+  (define (fields-format fs)    
+    (foldl (lambda (f result)
+             (define field-format (cond
+                                    [(ellipsis-field? f) ellipsis-field-format]
+                                    [(error-field? f) error-field-format]))
+             (if (string=? result "")
+                 (field-format f)
+                 (string-append result "\n" (field-format f))))
+           ""
+           fs))
+
+  ; exn:fail:contract/error-report : error-report? continuation-mark-set? -> exn:fail:contract?
+  ; Make an exn:fail:contract using error-report as its message.
+  (define (exn:fail:contract/error-report err-rpt cmarks)
+    (exn:fail:contract (error-report->string err-rpt) cmarks))
+
+  (define (error-report->string err-rpt)
+    (unless (error-report? err-rpt) (raise-argument-error 'error-report->string "error-report?" err-rpt))
+    
+    (define srcloc (error-report-srcloc err-rpt))
+    (define name (error-report-name err-rpt))
+    (define message (error-report-message err-rpt))
+    (define continued-messages (error-report-continued-messages err-rpt))
+    (define fields (error-report-fields err-rpt))
+
+    (define srcloc-string (if (absent? srcloc) "" (format "~a: " (srcloc->string srcloc))))
+    (define name-string (if (absent? name) "" (format "~a: " name)))
+    (define message-string (if (absent? message) "" (string-append (format "~a" message) (if (absent? continued-messages) "" ";"))))
+    (define continued-messages-string (if (absent? continued-messages) "" (continued-messages-format continued-messages)))
+    (define fields-string (if (absent? fields) "" (fields-format fields)))
+
+    (define pieces (list (string-append srcloc-string name-string message-string)
+                         continued-messages-string
+                         fields-string))                  
+
+    (foldl (lambda (p result)
+             (cond
+               [(string=? p "") result]
+               [(string=? result "") p]     
+               [else (string-append result "\n" p)]))
+           ""
+           pieces))
+
+  ;; --------------------------------------------
+  ;; commonly used fields
+  
+  ; Expected fields always format detail using '~a print-mode.
+  (define (expected-field detail)
+    (make-error-field "expected" detail #:print-mode '~a))
+
+  (define (given-field detail)
+    (make-error-field "given" detail))
+  )

--- a/racket/collects/racket/private/error.rkt
+++ b/racket/collects/racket/private/error.rkt
@@ -24,14 +24,14 @@
   ; will return #f, same list identical to the original, and a flag #f to indicate no element was
   ; found and was not removed from the list.
   (define (remove-at-pos pos lst)
-    (define (iter found-item lst current-index)
+    (define (iter lst current-index)
       (cond
         [(null? lst) (values #f '() #f)]
         [(= current-index pos) (values (car lst) (cdr lst) #t)]
         [else
-         (define-values (found-item reduced-lst found?) (iter #f (cdr lst) (add1 current-index)))
+         (define-values (found-item reduced-lst found?) (iter (cdr lst) (add1 current-index)))
          (values found-item (cons (car lst) reduced-lst) found?)]))
-    (iter #f lst 0))
+    (iter lst 0))
   
   (define (raise-one-argument-error name expected v [more-info #f] [cmarks (current-continuation-marks)])
     (raise

--- a/racket/collects/racket/private/error.rkt
+++ b/racket/collects/racket/private/error.rkt
@@ -1,0 +1,259 @@
+(module error "pre-base.rkt"
+
+  ; module implements new raise-argument-error and its two forms and extends it with
+  ; #:more-info to support adding more details to the exception error output.
+
+  (provide raise-argument-error)
+
+  ;;; -----------------------------------------------------------------------------------------
+  ;;; implementation section
+  
+  (require "error-reporting.rkt"
+           "list.rkt")
+  
+
+  ;; --------------------------------------------
+  ;; helpers section
+
+  ; remove-at-pos : exact-nonnegative-integer (listof any/c) -> any/c (listof any/c) (or/c #t #f)
+  ;
+  ; Given a pos and a list, remove-at-pos will remove element from the list at position pos
+  ; and return three values: the found element, a new list without the found element, and #t which
+  ; is a flag indicating element was found and removed from list.
+  ; If the element was not found because pos was >= the length of the list then remove-at-pos
+  ; will return #f, same list identical to the original, and a flag #f to indicate no element was
+  ; found and was not removed from the list.
+  (define (remove-at-pos pos lst)
+    (define (iter found-item lst current-index)
+      (cond
+        [(null? lst) (values #f '() #f)]
+        [(= current-index pos) (values (car lst) (cdr lst) #t)]
+        [else
+         (define-values (found-item reduced-lst found?) (iter #f (cdr lst) (add1 current-index)))
+         (values found-item (cons (car lst) reduced-lst) found?)]))
+    (iter #f lst 0))
+  
+  (define (raise-one-argument-error name expected v [more-info #f] [cmarks (current-continuation-marks)])
+    (raise
+     (exn:fail:contract/error-report (error-report (absent)
+                                                   name
+                                                   "contract violation"
+                                                   (if more-info (list more-info) (absent))
+                                                   (list (expected-field expected)
+                                                         (given-field v)))
+                                     cmarks)))
+  
+
+  ; make-bad-positional-argument-section : string?
+  ;                                        exact-nonnegative-integer?
+  ;                                        (listof any/c)
+  ;                                        ->
+  ;                                        error-field?
+  ;                                        error-field?
+  ;                                        error-field?
+  ;                                        (or/c error-field? #f)
+  ;
+  ; Create four error-field? instances forming a error output reporting section for
+  ; bad positional argument and other positional arguments.
+  ; The fourth error-field? instance may actually be #f if only one positional argument
+  ; was given in args.
+  (define (make-bad-positional-argument-section expected bad-pos-0-based args)
+    (define-values (bad-value other-values found?) (remove-at-pos bad-pos-0-based args))
+    (define bad-pos-1-based (+ bad-pos-0-based 1))
+    (define pos-ordinal-str (let* ([pos-str (number->string bad-pos-1-based)]
+                                   [last-char (string-ref pos-str (- (string-length pos-str) 1))])
+                              (cond [(or (= bad-pos-1-based 11)
+                                         (= bad-pos-1-based 12)
+                                         (= bad-pos-1-based 13))
+                                     (string-append pos-str "th")]
+                                    [(char=? last-char #\1) (string-append pos-str "st")]
+                                    [(char=? last-char #\2) (string-append pos-str "nd")]
+                                    [(char=? last-char #\3) (string-append pos-str "rd")]
+                                    [else (string-append pos-str "th")])))
+    (values (expected-field expected)
+            (given-field bad-value)
+            (error-field "argument position" pos-ordinal-str #:print-mode '~a)
+            ; don't bother make ellipsis-field if other-values is '()
+            (if (not (null? other-values)) (apply ellipsis-field (list* "other arguments" other-values)) #f)))
+
+  ; make-positional-argument-section : (listof any/c) -> error-field?
+  (define (make-positional-argument-section args)
+    (apply ellipsis-field (list* "arguments" args)))
+
+  ; make-bad-keyword-argument-section : string?
+  ;                                     keyword?
+  ;                                     (listof (cons keyword? any/c))
+  ;                                     ->
+  ;                                     error-field?
+  ;                                     error-field?
+  ;                                     error-field?
+  ;                                     (or/c error-field? #f)
+  ;
+  ; Create four error-field? instances forming a error output reporting section for
+  ; bad keyword argument and other keyword arguments.
+  ; The fourth error-field? instance may actually be #f if only one keyword argument pair
+  ; was given in kw-args.
+  (define (make-bad-keyword-argument-section expected bad-kw kw-args)
+    (define bad-kw-pair (assq bad-kw kw-args))
+    (define other-kw-pairs (remq bad-kw-pair kw-args))
+    (values (expected-field expected)
+            (given-field (cdr bad-kw-pair))
+            (error-field "keyword" (car bad-kw-pair) #:print-mode '~a)
+            ; don't bother make ellipsis-field if other-kw-pairs is '()
+            (if (not (null? other-kw-pairs))
+                (apply ellipsis-field (list* "other keyword arguments"
+                                             (map (lambda (p)
+                                                    (format "~a ~v" (car p) (cdr p)))
+                                                  other-kw-pairs))
+                       #:print-mode '~a)
+                #f)))
+
+  ; make-keyword-argument-section : (listof (cons keyword? any/c)) -> error-field?
+  (define (make-keyword-argument-section kw-args)
+    (apply ellipsis-field (list* "keyword arguments"
+                                 (map (lambda (p)
+                                        (format "~a ~v" (car p) (cdr p)))
+                                      kw-args))
+           #:print-mode '~a))
+
+  ; raise-multiple-arguments-error : symbol?
+  ;                                  string?
+  ;                                  (or/c exact-nonnegative-integer? keyword?)
+  ;                                  (or/c (listof any/c) (listof (cons keyword? any/c)))
+  ;                                  (or/c (listof any/c) (listof (cons keyword? any/c)))
+  ;                                  (or/c string? #f)
+  ;                                  continuation-mark-set?
+  ;                                  ->
+  ;
+  ; raise contract exception containing detailed information about bad argument and other
+  ; arguments that can be a combination of posiitonal and keyword arguments.
+  ;
+  ; If bad is a exact-nonnegative-integer? then assumption is that vs represents
+  ; a list of positional arguments.
+  ; If bad is a keyword? then vs represents a list of keyword argument pairs.
+  ;
+  ; other-vs is either a list of positional or a list of keyword arguments that are to be reported
+  ; in the output along with the bad argument information. It is assumed if bad argument
+  ; is for a positional argument then other-vs must be a list of keyword arguments, or vice versa.
+  (define (raise-multiple-arguments-error name expected bad vs other-vs [more-info #f] [cmarks (current-continuation-marks)])
+    (define-values (expected-field given-field bad-arg-indicator-field other-args-field)
+      (cond [(keyword? bad) (make-bad-keyword-argument-section expected bad vs)]
+            [else (make-bad-positional-argument-section expected bad vs)]))
+    
+    (define other-vs-section (cond [(null? other-vs) #f]
+                                   [(keyword? bad) (make-positional-argument-section other-vs)]
+                                   [else (make-keyword-argument-section other-vs)]))
+
+    ; Assemble all the error-fields that will be reported in the error output
+    ; going backward from last field to the first.
+    (define error-fields (let* ([fields (if other-vs-section (list other-vs-section) (list))]
+                                [fields (if other-args-field (cons other-args-field fields) fields)]
+                                [fields (cons expected-field
+                                              (cons given-field
+                                                    (cons bad-arg-indicator-field fields)))])
+                           fields))
+   
+    (raise
+     (exn:fail:contract/error-report (error-report (absent)
+                                                   name
+                                                   "contract violation"
+                                                   (if more-info (list more-info) (absent))
+                                                   error-fields)
+                                     cmarks)))
+
+  ; raise-arguments-index-out-of-bounds : symbol?
+  ;                                       exact-nonnegative-integer?
+  ;                                       exact-nonnegative-integer?
+  ;                                       continuation-mark-set?
+  ;                                       ->
+  (define (raise-arguments-index-out-of-bounds-error name index args-c [cmarks (current-continuation-marks)])
+    (raise
+     (exn:fail:contract/error-report (error-report (absent)
+                                                   name
+                                                   "position index >= provided argument count"
+                                                   (absent)
+                                                   (list (error-field "position index" index)
+                                                         (error-field "provided argument count" args-c)))
+                                     cmarks)))
+
+  ;; --------------------------------------------
+  ;; raise-argument-error implementation section
+
+  ; raise-argument-error : symbol?
+  ;                        string?
+  ;                        any/c
+  ;                        [#:more-info (or/c string? #f)]
+  ;                        [(listof any/c)]
+  ;                        ->
+  ;
+  ; Replacement for the primitive `raise-argument-error`.
+  ; Enchanced with addition of #:more-info keyword to include more details about the
+  ; argument in the exception's reported error output.
+  (define (raise-argument-error name expected v #:more-info [more-info #f] . other-vs)
+    (unless (symbol? name)
+      (raise-multiple-arguments-error 'raise-argument-error
+                                      "symbol?"
+                                      0
+                                      ; report positional args
+                                      (list* name expected v other-vs)
+                                      ; also report #:more-info keyword arg if it was provided
+                                      (if more-info (list (cons '#:more-info more-info)) '())
+                                      #f
+                                      (current-continuation-marks)))
+    (unless (string? expected)
+      (raise-multiple-arguments-error 'raise-argument-error
+                                      "string?"
+                                      1
+                                      ; report positional args
+                                      (list* name expected v other-vs)
+                                      ; also report #:more-info keyword arg if it was provided
+                                      (if more-info (list (cons '#:more-info more-info)) '())
+                                      #f
+                                      (current-continuation-marks)))
+    (unless (or (not more-info) (string? more-info))
+      (raise-multiple-arguments-error 'raise-argument-error
+                                      "string?"
+                                      '#:more-info
+                                      ; report keyword args
+                                      (list (cons '#:more-info more-info))
+                                      ; also report positional args
+                                      (list* name expected v other-vs)
+                                      #f
+                                      (current-continuation-marks)))
+
+    ; define one (current-continuation-marks) set for all possible ways
+    ; exn:fail:contract can be produced.
+    (define cmarks (current-continuation-marks))
+    (cond [(null? other-vs)
+           ; no extra vs supplied so assume first form of `raise-argument-error`
+           (raise-one-argument-error name expected v more-info cmarks)]
+          [else
+           ; else assume second form of `raise-argument-error` so
+           ; v must be exact-nonnegative-integer? representing position of the bad argument.
+           (unless (exact-nonnegative-integer? v)
+             (raise-multiple-arguments-error 'raise-argument-error
+                                             "exact-nonnegative-integer?"
+                                             2
+                                             ; report positional args
+                                             (list* name expected v other-vs)
+                                             ; also report #:more-info keyword arg if it was provided
+                                             (if more-info (list (cons '#:more-info more-info)) '())
+                                             #f
+                                             (current-continuation-marks)))
+           (define other-vs-length (length other-vs))
+           (unless (< v other-vs-length)
+             (raise-arguments-index-out-of-bounds-error 'raise-argument-error v other-vs-length (current-continuation-marks)))
+           (if (= other-vs-length 1)
+               (raise-one-argument-error name
+                                         expected
+                                         (car other-vs)
+                                         more-info
+                                         cmarks)
+               (raise-multiple-arguments-error name
+                                               expected
+                                               v
+                                               other-vs
+                                               '()
+                                               more-info
+                                               cmarks))]))
+  )


### PR DESCRIPTION
I've created an enhanced version of the primitive `raise-argument-error` with an optional keyword argument `#:more-info` which is intended to allow users to include more information about the bad argument's role in the error output. The extra information is typeset as `<continued-message>` according to the convention defined at https://docs.racket-lang.org/reference/exns.html?q=conventions#%28part._err-msg-conventions%29

As of now this commit causes problems for various packages using Typed Racket so this commit shouldn't be merged without discussion with the TR maintainers. The problem, as far as I was able to tell, seems to be that the new `raise-argument-error`'s function signature doesn't conform to the defined types for the original primitive one at https://github.com/racket/typed-racket/blob/ade0dff65ed89c435205c5bfc17fee7f0837083c/typed-racket-lib/typed-racket/base-env/base-env-indexing-abs.rkt#L331

Here's a motivating example with a function defined with two arguments having identical contracts.

```
; src-dir : path-string?
; dest-dir : path-string?
(define (copy-directory src-dir dest-dir)
     (unless (path-string? src-dir)
          (raise-argument-error 'copy-directory "path-string?" src-dir
                                             #:more-info "the source directory to be copied"))
          (unless (path-string? dest-dir)
          (raise-argument-error 'copy-directory "path-string?" dest-dir
                                             #:more-info "the destination path to copy the source directory to"))
     ... )
```

```
(copy-directory 'bad "/usr/home/destination")
copy-directory: contract violation;
 the source directory to be copied
  expected: path-string?
  given: 'bad
```

```
(copy-directory "/usr/home/source" 'bad)
copy-directory: contract violation;
 the destination path to copy the source directory to
  expected: path-string?
  given: 'bad
```
`#:more-info` used in `copy-directory` makes it easy to tell at an immediate glance which argument with the same contract is the bad one.

I thought of this enhancement when I was doing system programming with multiple arguments having identical contracts. It was a pain identifying which argument was the faulting one in the error output simply by reading the error message, especially if the bad input is being passed through a chain of callers.

This commit also includes a simple error reporting infrastructure used to construct error messages for various ways `raise-argument-error` can be used and also displays error messages about misuses of keyword arguments in a consistent manner similar to how bad positional arguments are reported.

Reference documentation is also updated with an explanation and example of using `#:more-info` and a history annotation is included as well.

Test cases included to verify backward compatibility and new functionality.
