### PR TITLE
file/untar: allow leading as well as trailing blanks

### DIFF
--- a/racket/collects/file/untar.rkt
+++ b/racket/collects/file/untar.rkt
@@ -212,6 +212,12 @@
     #f]
    [else
     ;; traditional:
+    (define skip-head
+      (or (for/or ([i (in-range len)])
+            (case (integer->char (bytes-ref bstr i))
+              [(#\space #\nul) #f]
+              [else i]))
+          (error 'untar "bad number ~e at ~a" bstr (file-position in))))
     (define skip-tail
       (- len
          (or (for/or ([i (in-range len 0 -1)])
@@ -219,7 +225,7 @@
                  [(#\space #\nul) #f]
                  [else i]))
              (error 'untar "bad number ~e at ~a" bstr (file-position in)))))
-    (for/fold ([v 0]) ([i (in-range (- len skip-tail))])
+    (for/fold ([v 0]) ([i (in-range skip-head (- len skip-tail))])
       (define b (bytes-ref bstr i))
       (if (<= (char->integer #\0) b (char->integer #\7))
           (+ (* v 8) (- b (char->integer #\0)))


### PR DESCRIPTION
Some really old tar files can have both leading and trailing blanks (nul/space characters) in the same octal number field in the header.

Here are examples of such tar files:

* https://groups.csail.mit.edu/mac/ftpdir/scheme-reports/r4rs.tar.gz
* https://groups.csail.mit.edu/mac/ftpdir/scheme-reports/r5rs.tar.gz