### PR TITLE
fix use of raise-arguments-error

### DIFF
--- a/racket/collects/racket/private/set-types.rkt
+++ b/racket/collects/racket/private/set-types.rkt
@@ -521,8 +521,9 @@
     (when (null? args)
       (raise-arguments-error
        who
-       "when inject-proc, add-proc, shrink-proc, and extract-proc are #f,"
-       " at least one property must be supplied")))
+       (string-append
+        "when inject-proc, add-proc, shrink-proc, and extract-proc are #f,"
+        " at least one property must be supplied"))))
   (values clear-proc
           (or equal-key-proc (λ (s e) e))
           args))


### PR DESCRIPTION
There should be one message string and no field-value pairs in this call to `raise-arguments-error`. This changes the error message from this:
```
raise-arguments-error: missing value after field string
  field string: " at least one property must be supplied"
```
To this which was actually intended:
```
chaperone-hash-set: when inject-proc, add-proc, shrink-proc, and extract-proc are #f, at least one property must be supplied
```