### PR TITLE
Preserve procedure name in single-argument make-keyword-procedure

### DIFF
--- a/pkgs/racket-test-core/tests/racket/name.rktl
+++ b/pkgs/racket-test-core/tests/racket/name.rktl
@@ -28,6 +28,24 @@
 (test #t src-name? (object-name (let ([x (cons (lambda () 10) 0)]) (car x))))
 (test #t src-name? (object-name (let ([x (let ([y (lambda (x) x)]) (y (lambda () 10)))]) x)))
 
+(define (false-or-unknown? v)
+  (or (not v)
+      (eq? v 'unknown)))
+
+; Test constructs that provide no name and no source location
+(test #t false-or-unknown? (let-syntax ([no-name (lambda (s)
+                                                   (datum->syntax #'here `(lambda (x) x)))])
+                             (object-name (no-name))))
+(test #t false-or-unknown? (let-syntax ([no-name (lambda (s)
+                                                   (datum->syntax #'here `(lambda ([x #f]) x)))])
+                             (object-name (no-name))))
+(test #t false-or-unknown? (let-syntax ([no-name (lambda (s)
+                                                   (datum->syntax #'here `(lambda (#:x x) x)))])
+                             (object-name (no-name))))
+(test #t false-or-unknown? (let-syntax ([no-name (lambda (s)
+                                                   (datum->syntax #'here `(lambda (#:x [x #f]) x)))])
+                             (object-name (no-name))))
+
 ; Test ok when name for proc
 (define f (lambda () 0))
 (define f2 (lambda (a) 0))
@@ -169,5 +187,13 @@
             (define x 8)
             (m)))
         norm))
+
+(test 'one object-name (let ([one (lambda args #f)]) (make-keyword-procedure one)))
+(test 'two object-name (let ([one (lambda args #f)]
+                             [two (lambda args #f)])
+                         (make-keyword-procedure one two)))
+(test #t false-or-unknown? (let-syntax ([no-name (lambda (s)
+                                                   (datum->syntax #'here '(lambda args #f)))])
+                             (object-name (make-keyword-procedure (no-name)))))
 
 (report-errs)


### PR DESCRIPTION
Currently, code that uses `make-keyword-procedure` with only one argument will end up with procedures whose names point inside `racket/private/kw.rkt`, which isn’t very helpful. This PR sticks a call to `procedure-rename` in the relevant place so that the procedure name from the first argument is used, instead.