### PR TITLE
Make second argument of scheme_os_getcwd a size_t

### DIFF
--- a/racket/src/racket/src/file.c
+++ b/racket/src/racket/src/file.c
@@ -884,7 +884,7 @@ static Scheme_Object *string_to_path_element(int argc, Scheme_Object **argv)
 /*                                                                    */
 /**********************************************************************/
 
-char *scheme_os_getcwd(char *buf, int buflen, int *actlen, int noexn)
+char *scheme_os_getcwd(char *buf, size_t buflen, int *actlen, int noexn)
 {
   char *s;
   int slen;

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -919,7 +919,7 @@ MZ_EXTERN char *scheme_expand_filename(char* filename, int ilen, const char *err
 MZ_EXTERN char *scheme_expand_user_filename(char* filename, int ilen, const char *errorin, int *ex, int guards);
 MZ_EXTERN char *scheme_expand_string_filename(Scheme_Object *f, const char *errorin, int *ex, int guards);
 
-MZ_EXTERN char *scheme_os_getcwd(char *buf, int buflen, int *actlen, int noexn);
+MZ_EXTERN char *scheme_os_getcwd(char *buf, size_t buflen, int *actlen, int noexn);
 MZ_EXTERN int scheme_os_setcwd(char *buf, int noexn);
 MZ_EXTERN char *scheme_getdrive(void);
 

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -757,7 +757,7 @@ int (*scheme_directory_exists)(char *dirname);
 char *(*scheme_expand_filename)(char* filename, int ilen, const char *errorin, int *ex, int guards);
 char *(*scheme_expand_user_filename)(char* filename, int ilen, const char *errorin, int *ex, int guards);
 char *(*scheme_expand_string_filename)(Scheme_Object *f, const char *errorin, int *ex, int guards);
-char *(*scheme_os_getcwd)(char *buf, int buflen, int *actlen, int noexn);
+char *(*scheme_os_getcwd)(char *buf, size_t buflen, int *actlen, int noexn);
 int (*scheme_os_setcwd)(char *buf, int noexn);
 char *(*scheme_getdrive)(void);
 Scheme_Object *(*scheme_split_path)(const char *path, int len, Scheme_Object **base, int *isdir, int kind);


### PR DESCRIPTION
By being an unsigned type, we ensure that when 0 is passed the compiler and static analyzer knows that there's no smaller number. 

This not only aids the static analyzer but provides semantic information for those reading the code. Lengths should in general be `size_t`. Setting them as `int` means we do not enforce the fact that the variable needs to be positive. 

I remember @mflatt mentioning sometime ago that Racket is meant to support some older C compilers. Hopefully these older C compilers have `size_t` - after all this is C99 stuff which is now a 20 year old standard. However, I think we already require `size_t` support since there are a few occurences of `size_t` in the codebase.