### PR TITLE
Update syntax-model.scrbl

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -78,7 +78,7 @@ identifier's @tech{symbol} and @tech{scope set} to its meaning: a
 @tech{variable}, a @tech{syntactic form}, or a @tech{transformer}. An
 identifier refers to a particular binding when the reference's symbol
 and the identifier's symbol are the same, and when the reference's
-@tech{scope set} is a subset of the binding's
+@tech{scope set} is a superset of the binding's
 @tech{scope set}. For a given identifier, multiple bindings may have
 @tech{scope sets} that are subsets of the identifier's; in that case,
 the identifier refers to the binding whose set is a superset of all


### PR DESCRIPTION
Fix what looks to me as incorrect explanation of how identifier bindings are resolved. Could've used an alternative wording, but it'd make for a bigger diff:

> An identifier refers to a particular binding when the reference’s symbol and the identifier’s symbol are the same, and when the binding’s scope set is a subset of the reference’s scope set.

Was discovered in [this discussion](https://groups.google.com/d/msg/racket-users/9nVJxSVSdng/Yg28Bc8QBgAJ)