### PR TITLE
Fix --enable-cify option

### DIFF
--- a/racket/src/cfg-racket
+++ b/racket/src/cfg-racket
@@ -829,6 +829,7 @@ enable_cgcdefault
 enable_sgc
 enable_sgcdebug
 enable_backtrace
+enable_cify
 enable_pthread
 enable_stackup
 enable_bigendian
@@ -2806,9 +2807,9 @@ if test "${enable_backtrace+set}" = set; then :
 fi
 
 
-# Check whether --enable-backtrace was given.
-if test "${enable_backtrace+set}" = set; then :
-  enableval=$enable_backtrace;
+# Check whether --enable-cify was given.
+if test "${enable_cify+set}" = set; then :
+  enableval=$enable_cify;
 fi
 
 

--- a/racket/src/racket/configure.ac
+++ b/racket/src/racket/configure.ac
@@ -62,7 +62,7 @@ AC_ARG_ENABLE(sgc,     [  --enable-sgc            use Senora GC instead of Boehm
 AC_ARG_ENABLE(sgcdebug,[  --enable-sgcdebug       use Senora GC for debugging (expensive; CGC only)])
 AC_ARG_ENABLE(backtrace, [  --enable-backtrace      3m: support GC backtrace dumps (expensive debug mode)])
 
-AC_ARG_ENABLE(backtrace, [  --enable-cify           compile startup code to C instead of bytecode])
+AC_ARG_ENABLE(cify, [  --enable-cify           compile startup code to C instead of bytecode])
 
 AC_ARG_ENABLE(pthread, [  --enable-pthread        link with pthreads (usually auto-enabled if needed)])
 AC_ARG_ENABLE(stackup, [  --enable-stackup        assume "up" if stack direction cannot be determined])


### PR DESCRIPTION
I guess, a previous copy-paste AC_ARG_ENABLE meant that cify never had
its own option.