### PR TITLE
local-require: Remove last remaining use of syntax-local-get-shadower

### DIFF
--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -1202,9 +1202,7 @@
                           (list* #'only-meta-in 0 (syntax->list #'(spec ...)))
                           stx))]
                        [(names) (map import-local-id imports)]
-                       [(reqd-names)
-                        (let ([ctx (syntax-local-get-shadower (datum->syntax #f (gensym)))])
-                          (map (lambda (n) (datum->syntax ctx (syntax-e n) n)) names))]
+                       [(reqd-names) (generate-temporaries names)]
                        [(renamed-imports) (map rename-import imports reqd-names)]
                        [(raw-specs) (map import->raw-require-spec renamed-imports)]
                        [(lifts) (map syntax-local-lift-require raw-specs reqd-names)])


### PR DESCRIPTION
I heard for a long time that `syntax-local-get-shadower` was a necessary evil that ought to be removed, but I never really looked into what it actually did. I finally did so tonight, and I found its last remaining use inside `local-require`. I puzzled for a few moments over why it was necessary there, then eventually decided it wasn’t and removed it. All the tests still passed.

Maybe there’s something I’m missing, but `syntax-local-get-shadower` seems like it isn’t necessary for `local-require` and hasn’t been necessary since the switch to the sets-of-scopes expander. So this PR just goes ahead and removes it.