### PR TITLE
In autoconf 2.70 variable runstatedir was added - ignore

### DIFF
--- a/racket/src/ac/make-configure
+++ b/racket/src/ac/make-configure
@@ -45,6 +45,7 @@ exit 0
 	 sharedstatedir
 	 localstatedir
 	 oldincludedir
+	 runstatedir
 	 infodir
          htmldir
          ;; dvidir - converted to "collectsdir"


### PR DESCRIPTION
Ignore new autoconf variable added in 2.70.
The interesting thing is that debian decided to backport this variable
to their 2.69 release so in some 2.69 autoconf this variable does not
exist but in debian ports 2.69 generates this variable. It is
nonetheless not useful for Racket, so add to ignore list.