### PR TITLE
typo: reword install/clone error message

### DIFF
--- a/racket/collects/pkg/private/install.rkt
+++ b/racket/collects/pkg/private/install.rkt
@@ -705,7 +705,7 @@
             (hash-set ht git-dir (cons checksum prev-checksums)))]
        [else ht])))
 
-  ;; relevant commits have been fecthed to the repos, and now we need
+  ;; relevant commits have been fetched to the repos, and now we need
   ;; to check them out; if a checkout fails, then we've left the
   ;; package installation in no worse shape than if a manual `git
   ;; pull` failed
@@ -716,7 +716,7 @@
                          git-dir
                          (dry-run-explain dry-run?))
         (when ((length checksums) . > . 1)
-          (download-printf (~a "Multiple packages in the of the clone\n"
+          (download-printf (~a "Multiple packages in the cloned repository\n"
                                "  " git-dir "\n"
                                " have different target commits; will try each commit, which will work\n"
                                " as long as some commit is a fast-forward of all of them\n")))


### PR DESCRIPTION
This PR identifiers, and maybe fixes, a confusing error message.

I'm not sure how this error can occur or what it means. So, this change is basically a guess at a better wording.