### PR TITLE
typo: change error messages for vectorof contract

### DIFF
--- a/racket/collects/racket/contract/private/vector-common.rkt
+++ b/racket/collects/racket/contract/private/vector-common.rkt
@@ -39,7 +39,7 @@
             blame
             #:missing-party neg-party
             val
-            '(expected "an mutable vector" given: "~e")
+            '(expected "a mutable vector" given: "~e")
             val)]
           [else #f])]
        [else #t])]
@@ -48,7 +48,7 @@
       blame
       #:missing-party neg-party
       val
-      '(expected "an immutable vector" given: "~e")
+      '(expected "a vector" given: "~e")
       val)]
     [else #f]))
 

--- a/racket/collects/racket/contract/private/vector.rkt
+++ b/racket/collects/racket/contract/private/vector.rkt
@@ -94,7 +94,7 @@
       [else
        (raise-blame-error blame #:missing-party neg-party
                           val
-                          '(expected "a vector," given: "~e") 
+                          '(expected "a vector" given: "~e")
                           val)])))
 
 (define (vectorof-first-order ctc)


### PR DESCRIPTION
- change an 'an' to 'a'
- remove 'immutable' where expecting either mutable or immutable (don't
  bother to specify which, because `vector-common.rkt` doesn't bother)
- remove extra ','