### PR TITLE
recursive contract: add else-branch to a cond

### DIFF
--- a/racket/collects/racket/contract/private/base.rkt
+++ b/racket/collects/racket/contract/private/base.rkt
@@ -210,7 +210,9 @@
          [(chaperone-recursive-contract? ctc)
           (coerce-chaperone-contract 'recursive-contract (thunk))]
          [(impersonator-recursive-contract? ctc)
-          (coerce-contract 'recursive-contract (thunk))]))
+          (coerce-contract 'recursive-contract (thunk))]
+         [else ;; internal error
+          (raise-argument-error 'force-recursive-contract "recursive-contract?" ctc)]))
      (when (recursive-contract-list-contract? ctc)
        (unless (list-contract? forced-ctc)
          (raise-argument-error 'recursive-contract "list-contract?" forced-ctc)))


### PR DESCRIPTION
Raise an exception if none of the other cases match, instead of
returning `(void)` where a contract is expected

- - -

Why? Because today I was playing with the contract library internals,
and added a new sub-struct of `recursive-contract` (among other changes)
and spent a long time wondering where the `(void)` was coming from that was causing `(contract-name (void))` to happen.