### PR TITLE
contract-out: struct, keep original struct id

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/contract-out.rkt
+++ b/pkgs/racket-test/tests/racket/contract/contract-out.rkt
@@ -1232,6 +1232,7 @@
 
   (test/spec-passed
    'provide/contract67
+   ;; https://github.com/racket/racket/issues/2469
    '(let ()
       (eval '(module provide/contract67-a racket/base
                (require racket/contract/base)
@@ -1241,6 +1242,23 @@
       (eval '(module provide/contract67-b racket/base
                (require 'provide/contract67-a racket/contract/base)
                (provide (contract-out (struct stream ([x any/c] [y any/c]))))))))
+
+  (test/spec-passed
+   'provide/contract68
+   ;; https://github.com/racket/racket/issues/2572
+   '(let ()
+      (eval '(module provide/contract68-a racket/base
+               (require racket/contract/base)
+               (struct stream (x [y #:mutable]))
+               (provide (contract-out (struct stream ([x any/c] [y any/c]))))))
+
+      (eval '(module provide/contract68-b racket/base
+               (require 'provide/contract68-a racket/contract/base)
+               (provide (contract-out (struct stream ([x any/c] [y any/c]))))))
+
+      (eval '(module provide/contract68-c racket/base
+               (require 'provide/contract68-b racket/contract/base)
+               (void stream stream? stream-x stream-y set-stream-y!)))))
 
   (contract-error-test
    'provide/contract-struct-out

--- a/racket/collects/racket/contract/private/helpers.rkt
+++ b/racket/collects/racket/contract/private/helpers.rkt
@@ -21,7 +21,7 @@
 (define (update-loc stx loc)
   (datum->syntax stx (syntax-e stx) loc))
 
-;; lookup-struct-info : syntax -> (union #f (list syntax syntax (listof syntax) ...))
+;; lookup-struct-info : syntax -> (union #f struct-info?)
 (define (lookup-struct-info stx provide-stx)
   (define id (syntax-case stx ()
                [(a b) (syntax a)]
@@ -34,7 +34,7 @@
        (syntax-e #'x)]
       [_ 'provide/contract]))
   (if (struct-info? v)
-      (extract-struct-info v)
+      v
       (raise-syntax-error error-name
                           "expected a struct name"
                           provide-stx


### PR DESCRIPTION
Possible fix for #2572

The idea is to use the original struct id to recover the original names.

This seemed like the most reliable way to un-mangle the names.

(now lets see if the tests pass --- I've only tested on the example from the issue)

Edit: also, I replaced `map/count` with `for/list ... in-naturals ...`