### PR TITLE
Fix JIT-inlining of struct primitives

### DIFF
--- a/pkgs/racket-test-core/tests/racket/jitinline.rktl
+++ b/pkgs/racket-test-core/tests/racket/jitinline.rktl
@@ -1074,6 +1074,18 @@
     (un 'b '(lambda (ht) (hash-ref ht 'a #f)) '#hash((a . b)) #t
         #:name 'hash-ref)
 
+    (un-exact 7 'arity-at-least-value (make-arity-at-least 7) #t)
+    (err/rt-test (let ([f (eval '(lambda () (arity-at-least-value)))]) (f)))
+
+    (un-exact 20 'date-day (make-date 0 0 0 20 1 0 0 0 #f 0) #t)
+    (err/rt-test (let ([f (eval '(lambda () (date-day)))]) (f)))
+
+    (un-exact 12345 'date*-nanosecond (make-date* 0 0 0 20 1 0 0 0 #f 0 12345 "UTC") #t)
+    (err/rt-test (let ([f (eval '(lambda () (date*-nanosecond)))]) (f)))
+
+    (un-exact 'here 'srcloc-source (make-srcloc 'here #f #f #f #f) #t)
+    (err/rt-test (let ([f (eval '(lambda () (srcloc-source)))]) (f)))
+
     ))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/racket/src/racket/src/jitinline.c
+++ b/racket/src/racket/src/jitinline.c
@@ -172,7 +172,7 @@ static int inlineable_struct_prim(Scheme_Object *o, mz_jit_state *jitter, int ex
     }
   }
 
-  return check_val_struct_prim(o, 1);
+  return check_val_struct_prim(o, arity);
 }
 
 int scheme_inlined_unary_prim(Scheme_Object *o, Scheme_Object *_app, mz_jit_state *jitter)


### PR DESCRIPTION
Some expressions like `(date-day)` give usually an arity error, but when they are inlined by the JIT the arity check is wrong, so they produce a segfault or a nonsensical result.

[I'm not familiar with this part of the code, but the change looks very sensible.] 

This fix https://github.com/racket/racket/issues/2611