### PR TITLE
Add `syntax/format`, which contains `~id`, `~id/1`, and `~symbol`

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/format.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/format.scrbl
@@ -16,8 +16,7 @@
               [#:context context (or/c syntax? #f) #f]
               [#:source source source-location? context]
               [#:props props (or/c syntax? #f 'infer) 'infer]
-              [#:track track (or/c #t (-> identifier? identifier?) #f) #t]
-              [#:binder? binder? any/c #t])
+              [#:track track (or/c #t (-> identifier? identifier?) #f) #t])
          identifier?]{
 
 Builds an @tech[#:doc refman]{identifier} with a name constructed from the @racket[v]s, using
@@ -64,23 +63,13 @@ inside the @racket['sub-range-binders] property. If @racket[track] is @racket[#t
 @racket[identity] is used. (This default corresponds to the correct behavior when each @racket[_v-id]
 comes from the input to a @tech[#:doc refman]{syntax transformer}.)
 
-If @racket[binder?] is @racket[#f], then the new identifier is treated as a use rather than a binder,
-which swaps the order of @racket[_result-id] and @racket[_v-id] in the vectors attached to the
-@racket['sub-range-binders] property. If @racket[track] is @racket[#f], then the value of
-@racket[binder?] has no effect.
-
-@(examples
-  #:eval (make-format-eval) #:once
-  (syntax-property (~id #'foo "-" #'bar #:binder? #f) 'sub-range-binders))
-
-@history[#:added "7.3.0.1"]}
+@history[#:added "7.3.0.3"]}
 
 @defproc[(~id/1 [v (or/c identifier? string? symbol? keyword? char? number?)] ...
                 [#:context context (or/c syntax? #f 'infer) 'infer]
                 [#:source source (or/c source-location? 'infer) 'infer]
                 [#:props props (or/c syntax? #f 'infer) 'infer]
-                [#:track track (or/c #t (-> identifier? identifier?) #f) #t]
-                [#:binder? binder? any/c #t])
+                [#:track track (or/c #t (-> identifier? identifier?) #f) #t])
          identifier?]{
 
 Like @racket[~id], but exactly one @racket[v] must be an @tech[#:doc refman]{identifier}, which is
@@ -91,7 +80,7 @@ automatically used in place of @racket[context] and/or @racket[source] if their 
   #:eval (make-format-eval) #:once
   (~id/1 "prefixed-" #'and "-suffixed"))
 
-@history[#:added "7.3.0.1"]}
+@history[#:added "7.3.0.3"]}
 
 @defproc[(~symbol [v (or/c identifier? string? symbol? keyword? char? number?)] ...) symbol?]{
 
@@ -103,4 +92,4 @@ Like @racket[~id], but produces a @tech[#:doc refman]{symbol} instead of an
   (eval:check (~symbol #'hyphenated "-" #'symbol) 'hyphenated-symbol)
   (eval:check (~symbol #'made #\- 'from #\- '#:many #\- "pieces") 'made-from-many-pieces))
                                                                                               
-@history[#:added "7.3.0.1"]}
+@history[#:added "7.3.0.3"]}

--- a/pkgs/racket-doc/syntax/scribblings/format.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/format.scrbl
@@ -1,0 +1,106 @@
+#lang scribble/manual
+
+@(require scribble/example
+          "common.rkt"
+          (for-label racket/function
+                     racket/format
+                     syntax/format
+                     syntax/srcloc))
+
+@(define make-format-eval (make-eval-factory '[syntax/format]))
+
+@title[#:tag "format"]{Creating Formatted Identifiers}
+@defmodule[syntax/format]
+
+@defproc[(~id [v (or/c identifier? string? symbol? keyword? char? number?)] ...
+              [#:context context (or/c syntax? #f) #f]
+              [#:source source source-location? context]
+              [#:props props (or/c syntax? #f 'infer) 'infer]
+              [#:track track (or/c #t (-> identifier? identifier?) #f) #t]
+              [#:binder? binder? any/c #t])
+         identifier?]{
+
+Builds an @tech[#:doc refman]{identifier} with a name constructed from the @racket[v]s, using
+@racket[context] for the @tech[#:doc refman]{lexical information} and @racket[source] for the source
+location. Each @racket[v] is converted to a symbol made up of the same characters that would be
+produced by @racket[~a], except for @tech[#:doc refman]{identifiers}, which use their symbolic name,
+and @tech[#:doc refman]{keywords}, which are converted using @racket[keyword->string] (i.e. the
+preceeding @litchar{#:} characters are not included).
+
+@(examples
+  #:eval (make-format-eval) #:once
+  (~id #'hyphenated "-" #'id)
+  (~id #'made #\- 'from #\- '#:many #\- "pieces"))
+
+If @racket[props] is a @tech[#:doc refman]{syntax object} or @racket[#f], then
+@tech[#:doc refman #:key "syntax property"]{syntax properties} from @racket[props] are copied to the
+new identifier in the same way as for @racket[datum->syntax]. If @racket[props] is @racket['infer],
+then the properties of the new identifier are copied from @racket[context] if @racket[track] is
+@racket[#f]; if @racket[track] is not @racket[#f], then no properties are copied.
+
+If @racket[track] is not @racket[#f], then a @racket['sub-range-binders] @tech[#:doc refman]{syntax
+property} is added to the new identifier. The property value is a list containing an element for each
+@tech[#:doc refman]{identifier} @racket[_v-id] provided for @racket[v], and each element is an
+immutable @tech[#:doc refman]{vector} with the shape
+
+@(racketblock
+  (vector-immutable _result-id _v-id-position _v-id-length 0.5 0.5
+                    _v-id 0 _v-id-length 0.5 0.5))
+
+where @racket[_result-id] is the new identifier, @racket[_v-id-position] is the position that
+@racket[_v-id]'s name appears in @racket[_result-id], and @racket[_v-id-length] is the length in
+characters of @racket[_v-id]'s symbolic name. This protocol helps Check Syntax understand that uses of
+the identifier should be treated as uses of the @racket[_v-id]s; see
+@seclink["Syntax_Properties_that_Check_Syntax_Looks_For" #:doc '(lib "scribblings/tools/tools.scrbl")
+#:indirect? #t]{Syntax Properties that Check Syntax Looks For} for more details.
+
+@(examples
+  #:eval (make-format-eval) #:once
+  (syntax-property (~id #'foo "-" #'bar) 'sub-range-binders))
+
+If @racket[track] is a procedure, then it is applied to @racket[_result-id] and to each @racket[_v-id]
+inside the @racket['sub-range-binders] property. If @racket[track] is @racket[#t], then
+@racket[syntax-local-introduce] is used if @racket[(syntax-transforming?)] is @racket[#t], otherwise
+@racket[identity] is used. (This default corresponds to the correct behavior when each @racket[_v-id]
+comes from the input to a @tech[#:doc refman]{syntax transformer}.)
+
+If @racket[binder?] is @racket[#f], then the new identifier is treated as a use rather than a binder,
+which swaps the order of @racket[_result-id] and @racket[_v-id] in the vectors attached to the
+@racket['sub-range-binders] property. If @racket[track] is @racket[#f], then the value of
+@racket[binder?] has no effect.
+
+@(examples
+  #:eval (make-format-eval) #:once
+  (syntax-property (~id #'foo "-" #'bar #:binder? #f) 'sub-range-binders))
+
+@history[#:added "7.3.0.1"]}
+
+@defproc[(~id/1 [v (or/c identifier? string? symbol? keyword? char? number?)] ...
+                [#:context context (or/c syntax? #f 'infer) 'infer]
+                [#:source source (or/c source-location? 'infer) 'infer]
+                [#:props props (or/c syntax? #f 'infer) 'infer]
+                [#:track track (or/c #t (-> identifier? identifier?) #f) #t]
+                [#:binder? binder? any/c #t])
+         identifier?]{
+
+Like @racket[~id], but exactly one @racket[v] must be an @tech[#:doc refman]{identifier}, which is
+automatically used in place of @racket[context] and/or @racket[source] if their value is
+@racket['infer]. All other arguments are handled the same way as for @racket[~id].
+
+@(examples
+  #:eval (make-format-eval) #:once
+  (~id/1 "prefixed-" #'and "-suffixed"))
+
+@history[#:added "7.3.0.1"]}
+
+@defproc[(~symbol [v (or/c identifier? string? symbol? keyword? char? number?)] ...) symbol?]{
+
+Like @racket[~id], but produces a @tech[#:doc refman]{symbol} instead of an
+@tech[#:doc refman]{identifier}.
+
+@(examples
+  #:eval (make-format-eval) #:once
+  (eval:check (~symbol #'hyphenated "-" #'symbol) 'hyphenated-symbol)
+  (eval:check (~symbol #'made #\- 'from #\- '#:many #\- "pieces") 'made-from-many-pieces))
+                                                                                              
+@history[#:added "7.3.0.1"]}

--- a/pkgs/racket-doc/syntax/scribblings/syntax-object-helpers.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/syntax-object-helpers.scrbl
@@ -4,6 +4,7 @@
 @title[#:tag "syntax-helpers"]{Syntax Object Helpers}
 
 @include-section["stx.scrbl"]
+@include-section["format.scrbl"]
 @include-section["kerncase.scrbl"]
 @include-section["id-table.scrbl"]
 @include-section["id-set.scrbl"]

--- a/pkgs/racket-test/tests/syntax/format.rkt
+++ b/pkgs/racket-test/tests/syntax/format.rkt
@@ -1,0 +1,78 @@
+#lang racket/base
+
+(require rackunit
+         syntax/format
+         syntax/srcloc
+         (submod syntax/private/format for-test))
+
+(check-equal? (syntax-e (~id #'ab "cd" 'hi '#:jk #\l 0)) 'abcdhijkl0)
+(check-equal? (syntax-e (~id/1 #'ab "cd" 'hi '#:jk #\l 0)) 'abcdhijkl0)
+(check-equal? (~symbol #'ab "cd" 'hi '#:jk #\l 0) 'abcdhijkl0)
+
+(check-equal? (syntax-e (~id #'more-than "-" #'one-identifier)) 'more-than-one-identifier)
+(check-exn exn:fail:contract? (λ () (~id/1 #'more-than "-" #'one-identifier)))
+
+(define (do-check-id=? who actual expected)
+  (unless (bound-identifier=? actual expected)
+    (with-check-info (['actual-context (hash-ref (syntax-debug-info actual) 'context #f)]
+                      ['expected-context (hash-ref (syntax-debug-info expected) 'context #f)])
+      (fail-check (format "~a identifiers are not ‘bound-identifier=?’" who))))
+  (define actual-src (build-source-location actual))
+  (define expected-src (build-source-location expected))
+  (unless (equal? actual-src expected-src)
+    (with-check-info (['actual-src actual-src]
+                      ['expected-src expected-src])
+      (fail-check (format "~a source locations differ" who)))))
+
+(define (do-check-sub-range-leaf=? who offset actual expected)
+  (do-check-id=? who (vector-ref actual offset) (vector-ref expected offset))
+  (unless (for/and ([actual-elem (in-vector actual (+ offset 1) (+ offset 5))]
+                    [expected-elem (in-vector expected (+ offset 1) (+ offset 5))])
+            (equal? actual-elem expected-elem))
+    (fail-check (format "~a offsets do not match" who))))
+
+(define-check (check-~id actual-id expected-id expected-sub-range-binders)
+  (unless (identifier? actual-id)
+    (fail-check "actual-id is not an identifier"))
+  (do-check-id=? 'result actual-id expected-id)
+  (define actual-sub-range-binders (syntax-property actual-id 'sub-range-binders))
+  (with-check-info (['actual-sub-range-binders actual-sub-range-binders])
+    (cond
+      [expected-sub-range-binders
+       (unless (list? actual-sub-range-binders)
+         (fail-check "'sub-range-binders property value is not a list"))
+       (unless (= (length actual-sub-range-binders) (length expected-sub-range-binders))
+         (fail-check "'sub-range-binders properties differ in length"))
+       (for ([actual-leaf (in-list actual-sub-range-binders)]
+             [expected-leaf (in-list expected-sub-range-binders)])
+         (with-check-info (['actual-leaf actual-leaf]
+                           ['expected-leaf expected-leaf])
+           (unless (sub-range-binder-leaf? actual-leaf)
+             (fail-check "'sub-range-binders property leaf has the wrong shape"))
+           (do-check-sub-range-leaf=? 'source 0 actual-leaf expected-leaf)
+           (do-check-sub-range-leaf=? 'target 5 actual-leaf expected-leaf)))]
+      [else
+       (unless (not actual-sub-range-binders)
+         (fail-check "'sub-range-binders property has a value"))])))
+
+(let ([some #'some]
+      [id #'id]
+      [some-new-id (datum->syntax #f 'some-new-id)])
+  (check-~id (~id some "-new-" id)
+             some-new-id
+             (list (vector some-new-id 0 4 0.5 0.5 some 0 4 0.5 0.5)
+                   (vector some-new-id 9 2 0.5 0.5 id 0 2 0.5 0.5))))
+
+(let* ([lctx #'lctx]
+       [srclocs #'srclocs]
+       [id-with-lctx+srclocs (datum->syntax lctx 'id-with-lctx+srclocs srclocs)])
+  (check-~id (~id "id-with-" lctx "+" srclocs #:context lctx #:source srclocs)
+             id-with-lctx+srclocs
+             (list (vector id-with-lctx+srclocs 8 4 0.5 0.5 lctx 0 4 0.5 0.5)
+                   (vector id-with-lctx+srclocs 13 7 0.5 0.5 srclocs 0 7 0.5 0.5))))
+
+(let* ([base #'base]
+       [prefix-base-suffix (datum->syntax base 'prefix-base-suffix base)])
+  (check-~id (~id/1 "prefix-" base "-suffix")
+             prefix-base-suffix
+             (list (vector prefix-base-suffix 7 4 0.5 0.5 base 0 4 0.5 0.5))))

--- a/racket/collects/syntax/format.rkt
+++ b/racket/collects/syntax/format.rkt
@@ -9,15 +9,13 @@
           [~id (->* [] [#:context (or/c syntax? #f)
                         #:source source-location?
                         #:props (or/c syntax? #f 'infer)
-                        #:track (or/c #t (-> identifier? identifier?) #f)
-                        #:binder? any/c]
+                        #:track (or/c #t (-> identifier? identifier?) #f)]
                     #:rest (listof piece/c)
                     identifier?)]
           [~id/1 (->* [] [#:context (or/c syntax? #f 'infer)
                           #:source (or/c source-location? 'infer)
                           #:props (or/c syntax? #f 'infer)
-                          #:track (or/c #t (-> identifier? identifier?) #f)
-                          #:binder? any/c]
+                          #:track (or/c #t (-> identifier? identifier?) #f)]
                       #:rest (and/c (listof piece/c) list-contains-exactly-one-identifier?)
                       identifier?)]
           [~symbol (-> piece/c ... symbol?)]))

--- a/racket/collects/syntax/format.rkt
+++ b/racket/collects/syntax/format.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+(require racket/contract/base
+         racket/list
+         syntax/srcloc
+         "private/format.rkt")
+
+(provide (contract-out
+          [~id (->* [] [#:context (or/c syntax? #f)
+                        #:source source-location?
+                        #:props (or/c syntax? #f 'infer)
+                        #:track (or/c #t (-> identifier? identifier?) #f)
+                        #:binder? any/c]
+                    #:rest (listof piece/c)
+                    identifier?)]
+          [~id/1 (->* [] [#:context (or/c syntax? #f 'infer)
+                          #:source (or/c source-location? 'infer)
+                          #:props (or/c syntax? #f 'infer)
+                          #:track (or/c #t (-> identifier? identifier?) #f)
+                          #:binder? any/c]
+                      #:rest (and/c (listof piece/c) list-contains-exactly-one-identifier?)
+                      identifier?)]
+          [~symbol (-> piece/c ... symbol?)]))
+
+(define piece/c (or/c identifier? string? symbol? keyword? char? number?))
+
+(define (list-contains-exactly-one-identifier? lst)
+  (= (count identifier? lst) 1))

--- a/racket/collects/syntax/private/format.rkt
+++ b/racket/collects/syntax/private/format.rkt
@@ -11,7 +11,6 @@
              #:source [source context]
              #:props [props 'infer]
              #:track [track #t]
-             #:binder? [binder? #t]
              . pieces)
   ; Convert all the pieces to strings; hold onto the identifiers for attaching sub-range-binders.
   (define-values [symbol id-pieces] (pieces->symbol pieces #:keep-id-pieces? track))
@@ -73,12 +72,8 @@
                                         sub-range-binder-leaf?))
        (define relocated-old-leaves (filter-map relocate-old-leaf old-leaves))
 
-       (define new-value
-         (if binder?
-             (vector-immutable new-id-introduced new-id-start old-id-length 0.5 0.5
-                               old-id 0 old-id-length 0.5 0.5)
-             (vector-immutable old-id 0 old-id-length 0.5 0.5
-                               new-id-introduced new-id-start old-id-length 0.5 0.5)))
+       (define new-value (vector-immutable new-id-introduced new-id-start old-id-length 0.5 0.5
+                                           old-id 0 old-id-length 0.5 0.5))
        (if (empty? relocated-old-leaves) new-value (cons new-value relocated-old-leaves)))
 
      (syntax-property new-id 'sub-range-binders (map build-prop-leaf id-pieces))]
@@ -90,7 +85,6 @@
                #:source [source 'infer]
                #:props [props 'infer]
                #:track [track #t]
-               #:binder? [binder? #t]
                . pieces)
   (define the-id (first (filter identifier? pieces)))
   (define (infer-or x) (if (eq? x 'infer) the-id x))
@@ -98,8 +92,7 @@
          #:context (infer-or context)
          #:source (infer-or source)
          #:props props
-         #:track track
-         #:binder? binder?))
+         #:track track))
 
 (define (~symbol . pieces)
   (define-values [symbol id-pieces] (pieces->symbol pieces #:keep-id-pieces? #f))

--- a/racket/collects/syntax/private/format.rkt
+++ b/racket/collects/syntax/private/format.rkt
@@ -1,0 +1,163 @@
+#lang racket/base
+
+(require racket/list
+         syntax/srcloc)
+
+(provide ~id ~id/1 ~symbol)
+
+;; ---------------------------------------------------------------------------------------------------
+
+(define (~id #:context [context #f]
+             #:source [source context]
+             #:props [props 'infer]
+             #:track [track #t]
+             #:binder? [binder? #t]
+             . pieces)
+  ; Convert all the pieces to strings; hold onto the identifiers for attaching sub-range-binders.
+  (define-values [symbol id-pieces] (pieces->symbol pieces #:keep-id-pieces? track))
+
+  ; Build the new identifier.
+  (define new-id (datum->syntax context
+                                symbol
+                                (build-source-location-vector source)
+                                (if (eq? props 'infer)
+                                    ; If we’re attaching 'sub-range-binders, then we don’t want to
+                                    ; copy properties, since 'sub-range-binders doesn’t care about
+                                    ; originalness, and in fact it will probably do more harm than
+                                    ; good. But if context is provided and we’re not attaching
+                                    ; 'sub-range-binders, then we probably want to copy originalness,
+                                    ; after all.
+                                    (if track #f context)
+                                    props)))
+  (cond
+    ; Attach 'sub-range-binders if relevant.
+    [(and track (not (empty? id-pieces)))
+     (define track-introduce (and track (if (procedure? track)
+                                            track
+                                            (if (syntax-transforming?)
+                                                syntax-local-introduce
+                                                values))))
+     (define new-id-introduced (track-introduce new-id))
+
+     ; Builds a 'sub-range-binders leaf from a given input identifier.
+     (define (build-prop-leaf piece)
+       (define old-id (track-introduce (id-piece-id piece)))
+       (define old-id-length (id-piece-length piece))
+       (define new-id-start (id-piece-position piece))
+
+       ; If the identifier already has a 'sub-range-binders property on it, then in all likelihood
+       ; that means it was just created in the dynamic extent of the same macro transformer that
+       ; added it in the first place. This means that the identifier may be being built in several
+       ; steps, using multiple calls to ~id in sequence. Therefore, we want to copy over old
+       ; 'sub-range-binders values that are already present if one side of the binding arrow points
+       ; to the old identifier.
+       ;
+       ; Conservatively, we use bound-identifier=? to check if the identifier is, in fact, the
+       ; “same”, since if we’re really in the same macro transformer, it’s unlikely other scopes
+       ; have been added in between, anyway.
+       (define (relocate-old-leaf val)
+         (define-values [binder-id binder-id-start binder-id-range binder-id-x binder-id-y
+                                   use-id use-id-start use-id-range use-id-x use-id-y]
+           (vector->values val))
+         (cond
+           [(bound-identifier=? binder-id old-id)
+            (vector-immutable new-id-introduced (+ binder-id-start new-id-start) binder-id-range
+                              binder-id-x binder-id-y
+                              use-id use-id-start use-id-range use-id-x use-id-y)]
+           [(bound-identifier=? use-id old-id)
+            (vector-immutable binder-id binder-id-start binder-id-range binder-id-x binder-id-y
+                              new-id-introduced (+ use-id-start new-id-start) use-id-range
+                              use-id-x use-id-y)]
+           [else #f]))
+       (define old-leaves (jumble->list (syntax-property old-id 'sub-range-binders)
+                                        sub-range-binder-leaf?))
+       (define relocated-old-leaves (filter-map relocate-old-leaf old-leaves))
+
+       (define new-value
+         (if binder?
+             (vector-immutable new-id-introduced new-id-start old-id-length 0.5 0.5
+                               old-id 0 old-id-length 0.5 0.5)
+             (vector-immutable old-id 0 old-id-length 0.5 0.5
+                               new-id-introduced new-id-start old-id-length 0.5 0.5)))
+       (if (empty? relocated-old-leaves) new-value (cons new-value relocated-old-leaves)))
+
+     (syntax-property new-id 'sub-range-binders (map build-prop-leaf id-pieces))]
+
+    [else
+     new-id]))
+
+(define (~id/1 #:context [context 'infer]
+               #:source [source 'infer]
+               #:props [props 'infer]
+               #:track [track #t]
+               #:binder? [binder? #t]
+               . pieces)
+  (define the-id (first (filter identifier? pieces)))
+  (define (infer-or x) (if (eq? x 'infer) the-id x))
+  (apply ~id pieces
+         #:context (infer-or context)
+         #:source (infer-or source)
+         #:props props
+         #:track track
+         #:binder? binder?))
+
+(define (~symbol . pieces)
+  (define-values [symbol id-pieces] (pieces->symbol pieces #:keep-id-pieces? #f))
+  symbol)
+
+;; ---------------------------------------------------------------------------------------------------
+
+(struct id-piece (id length position) #:transparent)
+
+(define (pieces->symbol pieces #:keep-id-pieces? keep-id-pieces?)
+  (for/fold ([string-pieces '()]
+             [position 0]
+             [id-pieces (and keep-id-pieces? '())]
+             #:result (values (string->symbol (apply string-append (reverse string-pieces)))
+                              (and keep-id-pieces? (reverse id-pieces))))
+            ([piece (in-list pieces)])
+    (define string-piece (cond
+                           [(string? piece)
+                            piece]
+                           [(identifier? piece)
+                            (symbol->string (syntax-e piece))]
+                           [(symbol? piece)
+                            (symbol->string piece)]
+                           [(char? piece)
+                            (string piece)]
+                           [(number? piece)
+                            (number->string piece)]
+                           [(keyword? piece)
+                            (keyword->string piece)]))
+    (define piece-length (string-length string-piece))
+    (values (cons string-piece string-pieces)
+            (+ position piece-length)
+            (if (and keep-id-pieces? (identifier? piece))
+                (cons (id-piece piece piece-length position) id-pieces)
+                id-pieces))))
+
+;; ---------------------------------------------------------------------------------------------------
+
+(define (jumble->list v leaf?)
+  (let recur ([v v])
+    (cond
+      [(leaf? v) (list v)]
+      [(list? v) (append-map recur v)]
+      [(pair? v) (append (recur (car v)) (recur (cdr v)))]
+      [else '()])))
+
+(define (sub-range-binder-leaf? v)
+  (define (offset? n)
+    (and (real? n) (<= 0 n 1)))
+  (define (id-spec? a b c d e)
+    (and (identifier? a)
+         (exact-nonnegative-integer? b)
+         (exact-nonnegative-integer? c)
+         (offset? d)
+         (offset? e)))
+  (and (vector? v)
+       (= (vector-length v) 10)
+       (call-with-values (λ () (vector->values v 0 5)) id-spec?)
+       (call-with-values (λ () (vector->values v 5 10)) id-spec?)))
+
+(module+ for-test (provide sub-range-binder-leaf?))


### PR DESCRIPTION
This PR adds a new library, `syntax/format`, which provides a `racket/format`-like interface to the functionality of `format-id` and `format-symbol` from `racket/syntax`. The chief difference between the two is that `~id` automatically adds `'sub-range-binders` properties as appropriate by default, which helps macro authors cooperate with Check Syntax.

Examples:

```racket
> (~id #'hyphenated "-" #'id)
#<syntax hyphenated-id>
> (~id #'made #\- 'from #\- '#:many #\- "pieces")
#<syntax made-from-many-pieces>
> (syntax-property (~id #'foo "-" #'bar) 'sub-range-binders)
'(#(#<syntax foo-bar> 0 3 0.5 0.5 #<syntax:eval:1:0 foo> 0 3 0.5 0.5)
  #(#<syntax foo-bar> 4 3 0.5 0.5 #<syntax:eval:1:0 bar> 0 3 0.5 0.5))
```

The main reason this PR creates a new module instead of adding to `racket/syntax` is to avoid making `racket/syntax` depend on the contract system. If people dislike that decision, it would be possible to either adjust the implementation to do the checks manually, without using the contract system, or to move most of `racket/syntax` into a new `racket/private/syntax` module to break any circular dependencies in `collects/`. Any of those is fine with me; I don’t have a strong opinion on the matter. (In general I think it’s nice to have syntax helpers go in the `syntax/` collection, but the existing `format-id` and `format-symbol` bindings are already in `racket/syntax`, so it could make sense for them to go together.)