### PR TITLE
changed get-lib-dirs to get-lib-search-dirs

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/libs.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/libs.scrbl
@@ -63,7 +63,7 @@ process:
 @itemlist[
 
  @item{If @racket[path] is not an absolute path, look in each
-       directory reported by the @racket[#:get-lib-dirs] optional keyword 
+       directories specified by the @racket[#:get-lib-dirs] optional keyword
        (which defaults to @racket[get-lib-search-dirs]). In each
        directory, try @racket[path] with the first version in
        @racket[version], adding a suitable suffix if @racket[path]

--- a/pkgs/racket-doc/scribblings/foreign/libs.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/libs.scrbl
@@ -63,7 +63,7 @@ process:
 @itemlist[
 
  @item{If @racket[path] is not an absolute path, look in each
-       directory reported by . In each
+       directory reported by @racket[get-lib-search-dirs]. In each
        directory, try @racket[path] with the first version in
        @racket[version], adding a suitable suffix if @racket[path]
        does not already end in the suffix, then try the second version
@@ -76,7 +76,7 @@ process:
        paths are tried in this step.)}
 
  @item{Try @racket[path] without adding any version or suffix, and
-       without converting to an absolute path.}@racket[get-lib-search-dirs]
+       without converting to an absolute path.}
 
  @item{Try the version-adjusted filenames again, but relative to the
        current directory. (If @racket[version] is an empty list, no

--- a/pkgs/racket-doc/scribblings/foreign/libs.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/libs.scrbl
@@ -63,7 +63,7 @@ process:
 @itemlist[
 
  @item{If @racket[path] is not an absolute path, look in each
-       directories specified by the @racket[#:get-lib-dirs] optional keyword
+       directories specified by the optional @racket[#:get-lib-dirs] keyword
        (which defaults to @racket[get-lib-search-dirs]). In each
        directory, try @racket[path] with the first version in
        @racket[version], adding a suitable suffix if @racket[path]

--- a/pkgs/racket-doc/scribblings/foreign/libs.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/libs.scrbl
@@ -63,7 +63,7 @@ process:
 @itemlist[
 
  @item{If @racket[path] is not an absolute path, look in each
-       directory reported by @racket[get-lib-dirs]. In each
+       directory reported by . In each
        directory, try @racket[path] with the first version in
        @racket[version], adding a suitable suffix if @racket[path]
        does not already end in the suffix, then try the second version
@@ -76,7 +76,7 @@ process:
        paths are tried in this step.)}
 
  @item{Try @racket[path] without adding any version or suffix, and
-       without converting to an absolute path.}
+       without converting to an absolute path.}@racket[get-lib-search-dirs]
 
  @item{Try the version-adjusted filenames again, but relative to the
        current directory. (If @racket[version] is an empty list, no

--- a/pkgs/racket-doc/scribblings/foreign/libs.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/libs.scrbl
@@ -63,7 +63,8 @@ process:
 @itemlist[
 
  @item{If @racket[path] is not an absolute path, look in each
-       directory reported by @racket[get-lib-search-dirs]. In each
+       directory reported by the @racket[#:get-lib-dirs] optional keyword 
+       (which defaults to @racket[get-lib-search-dirs]). In each
        directory, try @racket[path] with the first version in
        @racket[version], adding a suitable suffix if @racket[path]
        does not already end in the suffix, then try the second version


### PR DESCRIPTION
@racket[get-lib-dirs] does not exist in docs.
-replaced with get-lib-search-dirs

https://docs.racket-lang.org/search/index.html?q=get-lib-dirs

https://docs.racket-lang.org/raco/dirs.html?q=get-lib-dirs#%28def._%28%28lib._setup%2Fdirs..rkt%29._get-lib-search-dirs%29%29