### PR TITLE
fix documentation for custom-write-accessor mode

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
@@ -89,7 +89,7 @@ This function is often used in conjunction with @racket[make-constructor-style-p
        (make-constructor-style-printer
         (lambda (obj) 'point)
         (lambda (obj) (list (point-x obj) (point-y obj)))))]))
- 
+
   (print (point 1 2))
 
   (write (point 1 2))]
@@ -108,7 +108,7 @@ property, @racket[#f] otherwise.}
 
 
 @defproc[(custom-write-accessor [v custom-write?])
-         (custom-write? output-port? (or/c boolean? (integer-in 0 1)) . -> . any)]{
+         (custom-write? output-port? (or/c #t #f 0 1) . -> . any)]{
 
 Returns the custom-write procedure associated with @racket[v].}
 

--- a/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
@@ -108,7 +108,7 @@ property, @racket[#f] otherwise.}
 
 
 @defproc[(custom-write-accessor [v custom-write?])
-         (custom-write? output-port? boolean? . -> . any)]{
+         (custom-write? output-port? (or/c boolean? (integer-in 0 1)) . -> . any)]{
 
 Returns the custom-write procedure associated with @racket[v].}
 


### PR DESCRIPTION
The `write-proc` mode argument can be `#t`, `#f`, `0`, or `1`. The 0 and 1 represent print mode and quote depth.

The documentation for [`gen:custom-write`](https://docs.racket-lang.org/reference/Printer_Extension.html#%28def._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._gen~3acustom-write%29%29) specifies that the `write-proc`

> takes three arguments: the structure to be printed, the target port, and an argument that is `#t` for write mode, `#f` for display mode, or `0` or `1` indicating the current quoting depth for print mode.

The `0` and `1` are missing in the documentation for `custom-write-accessor`.