### PR TITLE
racket/contract: Fix (box/c #:immutable #f) failing on mutable boxes

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/box.rkt
+++ b/pkgs/racket-test/tests/racket/contract/box.rkt
@@ -173,4 +173,16 @@
                      (box (list values))
                      'pos 
                      'neg)])
-      ((car (unbox f)) 3))))
+      ((car (unbox f)) 3)))
+
+  (test/no-error
+   '(contract (box/c any/c #:immutable #f) (box 1) 'pos 'neg))
+
+  (test/spec-passed/result
+   'box/c-immutable-f2
+   '(unbox (contract (box/c any/c #:immutable #f) (box 1) 'pos 'neg))
+   1)
+
+  (test/pos-blame
+   'box/c-immutable-t
+   '(contract (box/c any/c #:immutable #f) (box-immutable 1) 'pos 'neg)))

--- a/racket/collects/racket/contract/private/box.rkt
+++ b/racket/collects/racket/contract/private/box.rkt
@@ -39,7 +39,7 @@
                                 val '(expected "an immutable box" given: "~e") val))])]
        [(#f)
         (cond
-          [(immutable? val) #F]
+          [(not (immutable? val)) #f]
           [else
            (λ (neg-party)
              (raise-blame-error blame #:missing-party neg-party


### PR DESCRIPTION
Example failure:
```
(define/contract _
  (box/c any/c
         #:immutable #f)
  (box 1))
;; =>
; _: broke its own contract;
; promised a mutable box
;  produced: '#&1
;  in: (box/c any/c #:immutable #f)
;  contract from: (definition _)
;  blaming: (definition _)
```