### PR TITLE
Add configure option --enable-generations (enabled by default).

### DIFF
--- a/racket/src/cfg-racket
+++ b/racket/src/cfg-racket
@@ -828,6 +828,7 @@ enable_csdefault
 enable_cgcdefault
 enable_sgc
 enable_sgcdebug
+enable_generations
 enable_backtrace
 enable_cify
 enable_pthread
@@ -1487,6 +1488,7 @@ Optional Features:
   --enable-cgcdefault     use CGC as default build (NOT RECOMMENDED)
   --enable-sgc            use Senora GC instead of Boehm GC (enabled by default)
   --enable-sgcdebug       use Senora GC for debugging (expensive; CGC only)
+  --enable-generations    3m: compile with support for GC generations (enabled by default)
   --enable-backtrace      3m: support GC backtrace dumps (expensive debug mode)
   --enable-cify           compile startup code to C instead of bytecode
   --enable-pthread        link with pthreads (usually auto-enabled if needed)
@@ -2799,6 +2801,13 @@ fi
 # Check whether --enable-sgcdebug was given.
 if test "${enable_sgcdebug+set}" = set; then :
   enableval=$enable_sgcdebug;
+fi
+
+# Check whether --enable-generations was given.
+if test "${enable_generations+set}" = set; then :
+  enableval=$enable_generations;
+else
+  enable_generations=yes
 fi
 
 # Check whether --enable-backtrace was given.
@@ -5057,6 +5066,16 @@ fi
 if test "${enable_sgc}" = "yes" ; then
   GCDIR=sgc
   OPTIONS="$OPTIONS -DUSE_SENORA_GC"
+fi
+
+if test "${enable_generations}" = "yes" ; then
+
+$as_echo "#define USE_GC_GENS 1" >>confdefs.h
+
+else
+
+$as_echo "#define USE_GC_GENS 0" >>confdefs.h
+
 fi
 
 ############## Strip tool ################

--- a/racket/src/racket/configure.ac
+++ b/racket/src/racket/configure.ac
@@ -60,9 +60,10 @@ AC_ARG_ENABLE(csdefault,  [  --enable-csdefault      use CS as default build])
 AC_ARG_ENABLE(cgcdefault, [  --enable-cgcdefault     use CGC as default build (NOT RECOMMENDED)])
 AC_ARG_ENABLE(sgc,     [  --enable-sgc            use Senora GC instead of Boehm GC (enabled by default)], , enable_sgc=yes)
 AC_ARG_ENABLE(sgcdebug,[  --enable-sgcdebug       use Senora GC for debugging (expensive; CGC only)])
+AC_ARG_ENABLE(generations,  [  --enable-generations    3m: compile with support for GC generations (enabled by default)], , enable_generations=yes)
 AC_ARG_ENABLE(backtrace, [  --enable-backtrace      3m: support GC backtrace dumps (expensive debug mode)])
 
-AC_ARG_ENABLE(cify, [  --enable-cify           compile startup code to C instead of bytecode])
+AC_ARG_ENABLE(cify,            [  --enable-cify           compile startup code to C instead of bytecode])
 
 AC_ARG_ENABLE(pthread, [  --enable-pthread        link with pthreads (usually auto-enabled if needed)])
 AC_ARG_ENABLE(stackup, [  --enable-stackup        assume "up" if stack direction cannot be determined])
@@ -785,6 +786,12 @@ fi
 if test "${enable_sgc}" = "yes" ; then
   GCDIR=sgc
   OPTIONS="$OPTIONS -DUSE_SENORA_GC"
+fi
+
+if test "${enable_generations}" = "yes" ; then
+  AC_DEFINE(USE_GC_GENS, 1,[GC Generations])
+else
+  AC_DEFINE(USE_GC_GENS, 0,[GC Generations])
 fi
 
 ############## Strip tool ################

--- a/racket/src/racket/gc2/newgc.c
+++ b/racket/src/racket/gc2/newgc.c
@@ -768,8 +768,9 @@ static void NewGC_initialize(NewGC *newgc, NewGC *inheritgc, NewGC *parentgc) {
 #endif
 
   newgc->mmu = mmu_create(newgc);
-  
-  newgc->generations_available = 1;
+
+  newgc->generations_available = USE_GC_GENS;
+
   newgc->last_full_mem_use = INITIAL_FULL_MEMORY_USE;
   newgc->new_btc_mark = 1;
 

--- a/racket/src/racket/mzconfig.h.in
+++ b/racket/src/racket/mzconfig.h.in
@@ -92,4 +92,7 @@ typedef unsigned long uintptr_t;
 /* Library subpath */
 #undef SPLS_SUFFIX
 
+/* Use Generations with the GC */
+#undef USE_GC_GENS
+
 #endif

--- a/racket/src/worksp/mzconfig.h
+++ b/racket/src/worksp/mzconfig.h
@@ -46,6 +46,7 @@
 /* Enable single-precision floats: */
 #define USE_SINGLE_FLOATS
 
-#define USE_GC_GENS
+/* Always enable generations in GC */
+#define USE_GC_GENS 1
 
 #endif

--- a/racket/src/worksp/mzconfig.h
+++ b/racket/src/worksp/mzconfig.h
@@ -46,4 +46,6 @@
 /* Enable single-precision floats: */
 #define USE_SINGLE_FLOATS
 
+#define USE_GC_GENS
+
 #endif


### PR DESCRIPTION
This option allows the user to enable or disable (with
--disable-generations or --enable-generations=no) generations in
gc2. This is, in most cases, a bad idea.