### PR TITLE
Fix instructions to run benchmarks

### DIFF
--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/README.txt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/README.txt
@@ -2,4 +2,4 @@
 The program "run" should know how to run each benchmark with its
 standard input value. So run <benchmark.ss> like this:
 
-   racket run.rkt <benchmark.ss> [racket|typed-scheme|typed-scheme-optimizing]
+   racket run.rkt <benchmark.ss> [racket|typed-racket|typed-racket-non-optimizing]


### PR DESCRIPTION
According to https://github.com/racket/racket/blob/842769c501c3d904b0c258ee4f177d4d9d837b3a/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/run.rkt#L140 the option might now be `typed-racket-non-optimizing`. Can you confirm and merge / delete branch if ok?