### PR TITLE
Remove test causing left shift overflow

### DIFF
--- a/racket/src/racket/src/number.c
+++ b/racket/src/racket/src/number.c
@@ -5484,7 +5484,7 @@ static Scheme_Object *fold_fixnum_bitwise_shift(int argc, Scheme_Object *argv[])
 #define UNSAFE_FX(name, op, fold, type, no_args)             \
  static Scheme_Object *name(int argc, Scheme_Object *argv[]) \
  {                                                           \
-   intptr_t v;                                               \
+   type v;                                                   \
    int i;                                                    \
    if (!argc) return no_args;                                \
    if (scheme_current_thread->constant_folding) return fold(argc, argv);     \


### PR DESCRIPTION
Doing 1 << 31 and 1 << 63 on 32 and 64 bit archs respectively causes lshift overflow reported by ubsan.

I would like to open a discussion on this specific test. I am convinced, but not certain, that this is actually undefined behaviour and therefore the test should not rely on a zero result.

The respective code in `number.c` triggers ubsan:
```
src/number.c:5501:11: runtime error: left shift of 1 by 63 places cannot be represented in type 'long int'
```

I looked at `fold_fixnum_bitwise_shift` and this triggers the signal `scheme_signal_error("unsafe-fxlshift: shift is too large");`. However, we still go ahead and do the shift inside: `v = v op SCHEME_INT_VAL(argv[i]);` which is generated by the macro `UNSAFE_FX`. I understand from the comments this was added by @mflatt a year ago to test folding but this specific test shouldn't rely on an undef. behaviour since on other platforms the result might be non-zero. Maybe there's a better test for the constant folding that can replace this one instead?
