### PR TITLE
Enable ubsan configure argument for CS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -129,6 +129,7 @@ test:ubsan:
   after_script:
     - grep 'runtime error' logs/*.log > runtime-errors.log
   artifacts:
+    when: always
     paths:
       - logs/
       - runtime-errors.log
@@ -161,6 +162,7 @@ test:ubsan:cs:
   after_script:
     - grep 'runtime error' cs-logs/*.log > runtime-errors.log
   artifacts:
+    when: always
     paths:
       - cs-logs/
       - runtime-errors.log

--- a/racket/src/ac/ubsan.m4
+++ b/racket/src/ac/ubsan.m4
@@ -1,0 +1,7 @@
+if test "${enable_ubsan}" = "yes" ; then
+   UBSAN="-fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=float-divide-by-zero"
+   CFLAGS="$CFLAGS $UBSAN"
+   CPPFLAGS="$CPPFLAGS $UBSAN"
+   PREFLAGS="$PREFLAGS $UBSAN"
+   LDFLAGS="$LDFLAGS $UBSAN"
+fi

--- a/racket/src/ac/ubsan_arg.m4
+++ b/racket/src/ac/ubsan_arg.m4
@@ -1,0 +1,1 @@
+AC_ARG_ENABLE(ubsan,   [  --enable-ubsan          compile with -fsanitize=undefined)])

--- a/racket/src/cfg-racket
+++ b/racket/src/cfg-racket
@@ -2880,6 +2880,7 @@ if test "${enable_ubsan+set}" = set; then :
   enableval=$enable_ubsan;
 fi
 
+
 # Check whether --enable-jitframe was given.
 if test "${enable_jitframe+set}" = set; then :
   enableval=$enable_jitframe;
@@ -6760,6 +6761,7 @@ if test "${enable_ubsan}" = "yes" ; then
    PREFLAGS="$PREFLAGS $UBSAN"
    LDFLAGS="$LDFLAGS $UBSAN"
 fi
+
 
 ############## usersetup ################
 

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -780,6 +780,7 @@ enable_libfw
 enable_userfw
 enable_mac64
 enable_noopt
+enable_ubsan
 enable_csdefault
 enable_csonly
 enable_parent
@@ -1422,6 +1423,7 @@ Optional Features:
   --enable-userfw         install Mac OS frameworks to ~/Library/Frameworks
   --enable-mac64          allow 64-bit Mac OS build (enabled by default)
   --enable-strip          strip debug on install (usually enabled by default)
+  --enable-ubsan          compile with -fsanitize=undefined)
   --enable-csdefault      use CS as default build
   --enable-csonly         build CS only
   --enable-parent         Create "../Makefile" (internal use)
@@ -2436,6 +2438,12 @@ STRIP_LIB_DEBUG=":"
 strip_debug_flags=""
 enable_strip_by_default=yes
 strip_needs_dash_s=no
+
+# Check whether --enable-ubsan was given.
+if test "${enable_ubsan+set}" = set; then :
+  enableval=$enable_ubsan;
+fi
+
 
 # Check whether --enable-csdefault was given.
 if test "${enable_csdefault+set}" = set; then :
@@ -4312,6 +4320,17 @@ fi
 if test "${enable_natipkg}" = "yes" ; then
   CONFIGURE_RACKET_SO_COMPILE="${CONFIGURE_RACKET_SO_COMPILE} env PLT_CS_SLSP_SUFFIX=-natipkg"
 fi
+
+############## ubsan ################
+
+if test "${enable_ubsan}" = "yes" ; then
+   UBSAN="-fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=float-divide-by-zero"
+   CFLAGS="$CFLAGS $UBSAN"
+   CPPFLAGS="$CPPFLAGS $UBSAN"
+   PREFLAGS="$PREFLAGS $UBSAN"
+   LDFLAGS="$LDFLAGS $UBSAN"
+fi
+
 
 ############## Makefile includes ################
 

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -25,6 +25,7 @@ AC_ARG_ENABLE(target,     [  --enable-target=<mach>  Cross-build for Chez Scheme
 m4_include(../ac/natipkg_arg.m4)
 m4_include(../ac/sdk_arg.m4)
 m4_include(../ac/strip_arg.m4)
+m4_include(../ac/ubsan_arg.m4)
 AC_ARG_ENABLE(csdefault,  [  --enable-csdefault      use CS as default build])
 AC_ARG_ENABLE(csonly,     [  --enable-csonly         build CS only])
 AC_ARG_ENABLE(parent,     [  --enable-parent         Create "../Makefile" (internal use)])
@@ -414,6 +415,10 @@ m4_include(../ac/strip.m4)
 if test "${enable_natipkg}" = "yes" ; then
   CONFIGURE_RACKET_SO_COMPILE="${CONFIGURE_RACKET_SO_COMPILE} env PLT_CS_SLSP_SUFFIX=-natipkg"
 fi
+
+############## ubsan ################
+
+m4_include(../ac/ubsan.m4)
 
 ############## Makefile includes ################
 

--- a/racket/src/racket/configure.ac
+++ b/racket/src/racket/configure.ac
@@ -78,7 +78,7 @@ AC_ARG_ENABLE(gcov,    [  --enable-gcov           compile to gather gcov statist
 
 m4_include(../ac/strip_arg.m4)
 AC_ARG_ENABLE(noopt,   [  --enable-noopt          drop -O C flags (useful for low-level debugging)])
-AC_ARG_ENABLE(ubsan,   [  --enable-ubsan          compile with -fsanitize=undefined)])
+m4_include(../ac/ubsan_arg.m4)
 AC_ARG_ENABLE(jitframe,[  --enable-jitframe       x86_64: use frame pointer for internal calls])
 
 m4_include(../ac/crossany_arg.m4)
@@ -1289,13 +1289,7 @@ fi
 
 ############## ubsan ################
 
-if test "${enable_ubsan}" = "yes" ; then
-   UBSAN="-fsanitize=undefined -fno-sanitize=alignment -fno-sanitize=float-divide-by-zero"
-   CFLAGS="$CFLAGS $UBSAN"
-   CPPFLAGS="$CPPFLAGS $UBSAN"
-   PREFLAGS="$PREFLAGS $UBSAN"
-   LDFLAGS="$LDFLAGS $UBSAN"
-fi
+m4_include(../ac/ubsan.m4)
 
 ############## usersetup ################
 


### PR DESCRIPTION
I noticed that CS ubsan build never had errors and I started digging to try to understand if the code is that good or if something was going on and noticed that although `--enable-ubsan` was being passed down to CS, it was not being recognized. I have now added the `--enable-ubsan` option to racket and can already see a few runtime errors in CS code.

First CI run here:
https://gitlab.com/LinkiTools/racket/-/jobs/213967743