### PR TITLE
Restructure makefile variable definition

### DIFF
--- a/racket/src/racket/version.mak
+++ b/racket/src/racket/version.mak
@@ -4,10 +4,9 @@ FWVERSION_Y = $(shell grep 'define MZSCHEME_VERSION_Y ' $(mainsrcdir)/racket/src
 FWVERSION_Z = $(shell grep 'define MZSCHEME_VERSION_Z ' $(mainsrcdir)/racket/src/schvers.h | cut -d ' ' -f 3)
 FWVERSION_W = $(shell grep 'define MZSCHEME_VERSION_W ' $(mainsrcdir)/racket/src/schvers.h | cut -d ' ' -f 3)
 
-ifneq ($(FWVERSION_W),0)
-FWVERSION = $(FWVERSION_X).$(FWVERSION_Y).$(FWVERSION_Z).$(FWVERSION_W)
-else ifneq ($(FWVERSION_Z),0)
-FWVERSION = $(FWVERSION_X).$(FWVERSION_Y).$(FWVERSION_Z)
-else
-FWVERSION = $(FWVERSION_X).$(FWVERSION_Y)
-endif
+FWVERSION = $(shell \
+if [ $(FWVERSION_W) != 0 ]; \
+then echo $(FWVERSION_X).$(FWVERSION_Y).$(FWVERSION_Z).$(FWVERSION_W); \
+elif [ $(FWVERSION_Z) != 0 ]; then echo $(FWVERSION_X).$(FWVERSION_Y).$(FWVERSION_Z); \
+else echo $(FWVERSION_X).$(FWVERSION_Y); \
+fi)


### PR DESCRIPTION
The existing definition of FWVERSION has the toplevel
structure of an if-then-else, each terminal of which is an
assignment. With BSD makes, this is problematic (tested with
OpenBSD 6.5). To make such makes happe, the definition of
FWVERSION should have a traditional

  VAR = VAL

shape. In this commit, we achieve that by "shelling out",
putting the if-then-else logic into a $(shell ...)
expression.

Tested on OpenBSD 6.5 and macOS Mojave, both with its
built-in make and GNU Make.