### PR TITLE
Change which values are shown after the copying example

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/define-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/define-struct.scrbl
@@ -100,7 +100,7 @@ the value of the corresponding @racket[_expr].
 (define p1 (posn 1 2))
 (define p2 (struct-copy posn p1 [x 3]))
 (list (posn-x p2) (posn-y p2))
-(list (posn-x p1) (posn-x p2))
+(list (posn-x p1) (posn-y p1))
 ]
 
 


### PR DESCRIPTION
This fixes a possible typing error, as it doesn't make much sense to show the same value twice.
Show the elements of both structs instead.

See also #2671 