### PR TITLE
More tests for (inexact->exact +inf.0)

### DIFF
--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -739,9 +739,9 @@
 (err/rt-test (inexact->exact +inf.0))
 (err/rt-test (inexact->exact -inf.0))
 (err/rt-test (inexact->exact +nan.0))
-(err/rt-test (begin (inexact->exact +inf.0) 'not-an-error))
-(err/rt-test (begin (inexact->exact -inf.0) 'not-an-error))
-(err/rt-test (begin (inexact->exact +nan.0) 'not-an-error))
+#;(err/rt-test (begin (inexact->exact +inf.0) 'not-an-error))
+#;(err/rt-test (begin (inexact->exact -inf.0) 'not-an-error))
+#;(err/rt-test (begin (inexact->exact +nan.0) 'not-an-error))
 
 #reader "maybe-single.rkt"
 (when has-single-flonum?

--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -739,6 +739,9 @@
 (err/rt-test (inexact->exact +inf.0))
 (err/rt-test (inexact->exact -inf.0))
 (err/rt-test (inexact->exact +nan.0))
+(err/rt-test (begin (inexact->exact +inf.0) 'not-an-error))
+(err/rt-test (begin (inexact->exact -inf.0) 'not-an-error))
+(err/rt-test (begin (inexact->exact +nan.0) 'not-an-error))
 
 #reader "maybe-single.rkt"
 (when has-single-flonum?

--- a/pkgs/racket-test-core/tests/racket/testing.rktl
+++ b/pkgs/racket-test-core/tests/racket/testing.rktl
@@ -220,12 +220,15 @@ transcript.
     [(expr exn-type?) (thunk-error-test (lambda () (eval expr)) expr exn-type?)]))
 
 (require (only-in racket/base [lambda err:mz:lambda])) ; so err/rt-test works with beginner.rktl
-(define-syntax err/rt-test
+(define-syntax-rule (err/rt-test e . rest)
+  (begin
+    (do-err/rt-test e . rest)
+    (do-err/rt-test (let () e 'not-an-error) . rest)))
+(define-syntax do-err/rt-test
   (lambda (stx)
     (syntax-case stx ()
       [(_ e exn?)
-       (syntax
-	(thunk-error-test (err:mz:lambda () e) (quote-syntax e) exn?))]
+       #'(thunk-error-test (err:mz:lambda () e) (quote-syntax e) exn?)]
       [(_ e exn? msg-rx)
        #'(thunk-error-test
           (err:mz:lambda () e)
@@ -234,8 +237,7 @@ transcript.
             (and (exn? exn)
                  (regexp-match? msg-rx (exn-message exn)))))]
       [(_ e)
-       (syntax
-	(err/rt-test e exn:application:type?))])))
+       #'(err/rt-test e exn:application:type?)])))
 
 (define no-extra-if-tests? #f)
 


### PR DESCRIPTION
The first commit adds tests where the expression is not in tail position, to check that the optimizer doesn't remove it.

This detect a bug in the signature of `inexact->exact` in the patched version of Chez Scheme, because it is marked as `safeonggodargs`, so when the argument is a `number?` it is replaced by the unsafe version that is `discardable`. So the expression is discarded and the error is omitted when it is not in tail position.

This only get the [three errors in HEADCS as expected](https://travis-ci.org/gus-massa/racket/builds/542264743), and is easy to fix https://github.com/gus-massa/ChezScheme/commit/32c33eb8231a0a9729e2e0e6689af1fb18ed55b8

---

The second commit adds the same trick to `err/rt-test` so this behaviour in tested in many more expressions. This creates about 60 errors in the test of all version of Racket, so there are a lot of corner cases to review and fix.