### PR TITLE
Fix cosmetic error in code example

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/concurrency.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/concurrency.scrbl
@@ -101,8 +101,9 @@ items then send the results to the main thread.
               (match (thread-receive)
                 [(list oper1 oper2 result-thread)
                  (thread-send result-thread
-                              (format "~a + ~a = ~a"
+                              (format "~a ~a ~a = ~a"
                                       oper1
+                                      (if (equal? operation +) '+ '-)
                                       oper2
                                       (operation oper1 oper2)))
                  (loop)])))))

--- a/pkgs/racket-doc/scribblings/guide/concurrency.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/concurrency.scrbl
@@ -103,7 +103,7 @@ items then send the results to the main thread.
                  (thread-send result-thread
                               (format "~a ~a ~a = ~a"
                                       oper1
-                                      (if (equal? operation +) '+ '-)
+                                      (object-name operation)
                                       oper2
                                       (operation oper1 oper2)))
                  (loop)])))))


### PR DESCRIPTION
For the second example in thread mailboxes (Section 18.2) in the Racket Guide the formatted output always shows `+` even if the operation is something else.
This patch fixes the output to show the right operation.