### PR TITLE
contract: collapsible, prune leaves if eq? and trusted

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/collapsible-arrow.rkt
+++ b/pkgs/racket-test/tests/racket/contract/collapsible-arrow.rkt
@@ -902,14 +902,16 @@
 
   (test/spec-passed/result
    'calculate-drops:untrusted-chaperone
-   '(let* ([ctc1 (coerce-contract/f (make-chaperone-contract))]
+   '(let* ([lnp (λ (v np) v)]
+           [ctc1 (coerce-contract/f (make-chaperone-contract #:late-neg-projection lnp))]
            [ctcs (list ctc1 ctc1 ctc1)])
       (calculate-drops ctcs))
    '())
 
   (test/spec-passed/result
    'calculate-drops:untrusted-impersonator
-   '(let* ([ctc1 (coerce-contract/f (make-contract))]
+   '(let* ([lnp (λ (v np) v)]
+           [ctc1 (coerce-contract/f (make-contract #:late-neg-projection lnp))]
            [ctcs (list ctc1 ctc1 ctc1)])
       (calculate-drops ctcs))
    '())

--- a/pkgs/racket-test/tests/racket/contract/collapsible-arrow.rkt
+++ b/pkgs/racket-test/tests/racket/contract/collapsible-arrow.rkt
@@ -887,9 +887,30 @@
    '(3 2 1))
 
   (test/spec-passed/result
-   'calculate-drops-2
+   'calculate-drops:trusted-chaperone
+   '(let* ([ctc1 (coerce-contract/f (box/c symbol?))]
+           [ctcs (list ctc1 ctc1 ctc1 ctc1 ctc1)])
+      (calculate-drops ctcs))
+   '(3 2 1))
+
+  (test/spec-passed/result
+   'calculate-drops:trusted-impersonator
    '(let* ([ctc1 (coerce-contract/f (object/c))]
            [ctcs (list ctc1 ctc1 ctc1 ctc1 ctc1)])
+      (calculate-drops ctcs))
+   '(3 2 1))
+
+  (test/spec-passed/result
+   'calculate-drops:untrusted-chaperone
+   '(let* ([ctc1 (coerce-contract/f (make-chaperone-contract))]
+           [ctcs (list ctc1 ctc1 ctc1)])
+      (calculate-drops ctcs))
+   '())
+
+  (test/spec-passed/result
+   'calculate-drops:untrusted-impersonator
+   '(let* ([ctc1 (coerce-contract/f (make-contract))]
+           [ctcs (list ctc1 ctc1 ctc1)])
       (calculate-drops ctcs))
    '())
 
@@ -918,7 +939,7 @@
            [c4 (coerce-contract/f (object/c))]
            [ctcs (list c1 c2 c3 c4 c4 c2 c3 c1 c3 c2 c4 c1 c4)])
       (calculate-drops ctcs))
-   '(7 5 6))
+   '(10 7 4 5 6))
 
   (test/spec-passed/result
    'calculate-drops-6

--- a/racket/collects/racket/contract/private/collapsible-common.rkt
+++ b/racket/collects/racket/contract/private/collapsible-common.rkt
@@ -183,7 +183,11 @@
                  ([flat (in-list flats)]
                   [i (in-naturals)])
          (cond
-           [(or (flat-contract-struct? flat) (chaperone-contract-struct? flat))
+           [(or (flat-contract-struct? flat)
+                (trusted-contract-struct? flat))
+            ;; Drop contracts that (1) do not change their behavior and (2) are
+            ;; between other eq? contracts. (Trusted chaperones and
+            ;; impersonators definitely don't change themselves.)
             (cond
               [(hash-ref seen flat #f)
                (define maybe-index (hash-ref maybe-drop flat #f))


### PR DESCRIPTION
Change the condition for filtering leaf contracts via `eq?`.
Before, we looked for flat or chaperone contracts.
After, we look for flat or trusted contracts.

This seems to be better in two ways:

1. Untrusted chaperones could have side effects, and now those will no
   longer be dropped
2. Trusted impersonator contracts can be removed

But maybe I missed something, and it's not safe to remove `eq?` and
trusted impersonators (i.e. `2` is bad).