### PR TITLE
Move NORETURN to the correct place

### DIFF
--- a/racket/collects/compiler/private/xform.rkt
+++ b/racket/collects/compiler/private/xform.rkt
@@ -734,7 +734,7 @@
           (printf "#define RET_NOTHING { SET_GC_VARIABLE_STACK((void **)__gc_var_stack__[0]); return; }\n")
           ;; A non-value return inserted at the end of a void-returning function:
           (printf "#define RET_NOTHING_AT_END { SET_GC_VARIABLE_STACK((void **)__gc_var_stack__[0]); }\n")
-          
+
           ;; Declare a temp variable to hold the return value of the indicated type:
           (printf (if callee-restore?
                       "#define DECL_RET_SAVE(type) type __ret__val__;\n"

--- a/racket/src/racket/include/scheme.h
+++ b/racket/src/racket/include/scheme.h
@@ -252,11 +252,25 @@ extern "C"
 {
 #endif
 
-#if defined(MZ_DECLARE_NORETURN) && defined(__GNUC__)
-#define NORETURN __attribute__((__noreturn__))
+#if !defined(NORETURN)
+#if defined(__GNUC__) || defined(__clang__)
+#define NORETURN __attribute__((noreturn))
+#elif defined(_MSC_VER)
+#define NORETURN __declspec(noreturn)
 #else
 #define NORETURN
-#endif
+#endif /* defined(__GNUC__) || defined(__clang__) */
+#endif /* !defined(NORETURN) */
+
+#if !defined(UNREACHABLE)
+#if defined(__GNUC__) || defined(__clang__)
+#define UNREACHABLE __builtin_unreachable()
+#elif defined(_MSC_VER)
+#define UNREACHABLE __assume(0)
+#else
+#define UNREACHABLE
+#endif /* defined(__GNUC__) || defined(__clang__) */
+#endif /* !defined(NORETURN) */
 
 /* Allowed by all configurations, currently: */
 #define MZ_CAN_ACCESS_THREAD_LOCAL_DIRECTLY
@@ -1670,7 +1684,7 @@ MZ_EXTERN Scheme_Object *scheme_eval_waiting;
 #endif
 
 #ifdef MZ_USE_JIT
-MZ_EXTERN void scheme_jit_longjmp(mz_jit_jmp_buf b, int v);
+MZ_EXTERN NORETURN void scheme_jit_longjmp(mz_jit_jmp_buf b, int v);
 MZ_EXTERN void scheme_jit_setjmp_prepare(mz_jit_jmp_buf b);
 # define scheme_jit_setjmp(b) (scheme_jit_setjmp_prepare(b), scheme_call_mz_setjmp((b)->jb))
 #else

--- a/racket/src/racket/src/makex.rkt
+++ b/racket/src/racket/src/makex.rkt
@@ -62,6 +62,7 @@
                      [l (regexp-replace #rx"^XFORM_NONGCING " l "")]
                      [l (regexp-replace #rx"^XFORM_NONGCING_NONALIASING " l "")]
                      [l (regexp-replace #rx"^MZ_EXTERN " l "")]
+                     [l (regexp-replace #rx"^NORETURN " l "")]
                      [l (regexp-replace #rx"^THREAD_LOCAL " l "")]
                      [l2 (regexp-replace #rx"^volatile " l "")]
                      [volatile (if (equal? l l2) "" "volatile ")]

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -197,8 +197,8 @@ MZ_EXTERN Scheme_On_Atomic_Timeout_Proc scheme_set_on_atomic_timeout(Scheme_On_A
 /*                              error handling                            */
 /*========================================================================*/
 
-MZ_EXTERN void scheme_signal_error(const char *msg, ...) NORETURN;
-MZ_EXTERN void scheme_raise_exn(int exnid, ...) NORETURN;
+MZ_EXTERN NORETURN void scheme_signal_error(const char *msg, ...);
+MZ_EXTERN NORETURN void scheme_raise_exn(int exnid, ...);
 MZ_EXTERN void scheme_warning(char *msg, ...);
 
 MZ_EXTERN void scheme_raise(Scheme_Object *exn);
@@ -221,17 +221,17 @@ MZ_EXTERN void scheme_glib_log_message(const char *log_domain, int log_level, co
 MZ_EXTERN void *scheme_glib_log_message_test(char *str);
 MZ_EXTERN void scheme_out_of_memory_abort();
 
-MZ_EXTERN void scheme_wrong_count(const char *name, int minc, int maxc, int argc, Scheme_Object **argv) NORETURN;
-MZ_EXTERN void scheme_wrong_count_m(const char *name, int minc, int maxc, int argc, Scheme_Object **argv, int is_method) NORETURN;
-MZ_EXTERN void scheme_case_lambda_wrong_count(const char *name, int argc, Scheme_Object **argv, int is_method, int count, ...) NORETURN;
-MZ_EXTERN void scheme_wrong_type(const char *name, const char *expected, int which, int argc, Scheme_Object **argv) NORETURN;
-MZ_EXTERN void scheme_wrong_contract(const char *name, const char *expected, int which, int argc, Scheme_Object **argv) NORETURN;
-MZ_EXTERN void scheme_wrong_field_type(Scheme_Object *c_name, const char *expected, Scheme_Object *o) NORETURN;
-MZ_EXTERN void scheme_wrong_field_contract(Scheme_Object *c_name, const char *expected, Scheme_Object *o) NORETURN;
-MZ_EXTERN void scheme_arg_mismatch(const char *name, const char *msg, Scheme_Object *o) NORETURN;
-MZ_EXTERN void scheme_contract_error(const char *name, const char *msg, ...) NORETURN;
-MZ_EXTERN void scheme_wrong_return_arity(const char *where, int expected, int got, Scheme_Object **argv, const char *context_detail, ...) NORETURN;
-MZ_EXTERN void scheme_unbound_global(Scheme_Bucket *b) NORETURN;
+MZ_EXTERN NORETURN void scheme_wrong_count(const char *name, int minc, int maxc, int argc, Scheme_Object **argv);
+MZ_EXTERN NORETURN void scheme_wrong_count_m(const char *name, int minc, int maxc, int argc, Scheme_Object **argv, int is_method);
+MZ_EXTERN NORETURN void scheme_case_lambda_wrong_count(const char *name, int argc, Scheme_Object **argv, int is_method, int count, ...);
+MZ_EXTERN NORETURN void scheme_wrong_type(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
+MZ_EXTERN NORETURN void scheme_wrong_contract(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
+MZ_EXTERN NORETURN void scheme_wrong_field_type(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
+MZ_EXTERN NORETURN void scheme_wrong_field_contract(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
+MZ_EXTERN NORETURN void scheme_arg_mismatch(const char *name, const char *msg, Scheme_Object *o);
+MZ_EXTERN NORETURN void scheme_contract_error(const char *name, const char *msg, ...);
+MZ_EXTERN NORETURN void scheme_wrong_return_arity(const char *where, int expected, int got, Scheme_Object **argv, const char *context_detail, ...);
+MZ_EXTERN NORETURN void scheme_unbound_global(Scheme_Bucket *b);
 
 MZ_EXTERN Scheme_Object *scheme_dynamic_wind(void (*pre)(void *),
 					     Scheme_Object *(* volatile act)(void *),

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -138,8 +138,8 @@ Scheme_On_Atomic_Timeout_Proc (*scheme_set_on_atomic_timeout)(Scheme_On_Atomic_T
 /*========================================================================*/
 /*                              error handling                            */
 /*========================================================================*/
-void (*scheme_signal_error)(const char *msg, ...) NORETURN;
-void (*scheme_raise_exn)(int exnid, ...) NORETURN;
+void (*scheme_signal_error)(const char *msg, ...);
+void (*scheme_raise_exn)(int exnid, ...);
 void (*scheme_warning)(char *msg, ...);
 void (*scheme_raise)(Scheme_Object *exn);
 int (*scheme_log_level_p)(Scheme_Logger *logger, int level);
@@ -159,17 +159,17 @@ void (*scheme_log_warning)(char *buffer);
 void (*scheme_glib_log_message)(const char *log_domain, int log_level, const char *message, void *user_data);
 void *(*scheme_glib_log_message_test)(char *str);
 void (*scheme_out_of_memory_abort)();
-void (*scheme_wrong_count)(const char *name, int minc, int maxc, int argc, Scheme_Object **argv) NORETURN;
-void (*scheme_wrong_count_m)(const char *name, int minc, int maxc, int argc, Scheme_Object **argv, int is_method) NORETURN;
-void (*scheme_case_lambda_wrong_count)(const char *name, int argc, Scheme_Object **argv, int is_method, int count, ...) NORETURN;
-void (*scheme_wrong_type)(const char *name, const char *expected, int which, int argc, Scheme_Object **argv) NORETURN;
-void (*scheme_wrong_contract)(const char *name, const char *expected, int which, int argc, Scheme_Object **argv) NORETURN;
-void (*scheme_wrong_field_type)(Scheme_Object *c_name, const char *expected, Scheme_Object *o) NORETURN;
-void (*scheme_wrong_field_contract)(Scheme_Object *c_name, const char *expected, Scheme_Object *o) NORETURN;
-void (*scheme_arg_mismatch)(const char *name, const char *msg, Scheme_Object *o) NORETURN;
-void (*scheme_contract_error)(const char *name, const char *msg, ...) NORETURN;
-void (*scheme_wrong_return_arity)(const char *where, int expected, int got, Scheme_Object **argv, const char *context_detail, ...) NORETURN;
-void (*scheme_unbound_global)(Scheme_Bucket *b) NORETURN;
+void (*scheme_wrong_count)(const char *name, int minc, int maxc, int argc, Scheme_Object **argv);
+void (*scheme_wrong_count_m)(const char *name, int minc, int maxc, int argc, Scheme_Object **argv, int is_method);
+void (*scheme_case_lambda_wrong_count)(const char *name, int argc, Scheme_Object **argv, int is_method, int count, ...);
+void (*scheme_wrong_type)(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
+void (*scheme_wrong_contract)(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
+void (*scheme_wrong_field_type)(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
+void (*scheme_wrong_field_contract)(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
+void (*scheme_arg_mismatch)(const char *name, const char *msg, Scheme_Object *o);
+void (*scheme_contract_error)(const char *name, const char *msg, ...);
+void (*scheme_wrong_return_arity)(const char *where, int expected, int got, Scheme_Object **argv, const char *context_detail, ...);
+void (*scheme_unbound_global)(Scheme_Bucket *b);
 Scheme_Object *(*scheme_dynamic_wind)(void (*pre)(void *),
 					     Scheme_Object *(* volatile act)(void *),
 					     void (* volatile post)(void *),

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -3392,7 +3392,7 @@ void scheme_rktio_error(const char *name, const char *what);
 
 void scheme_non_fixnum_result(const char *name, Scheme_Object *o);
 
-void scheme_raise_out_of_memory(const char *where, const char *msg, ...);
+NORETURN void scheme_raise_out_of_memory(const char *where, const char *msg, ...);
 
 char *scheme_make_srcloc_string(Scheme_Object *stx, intptr_t *len);
 


### PR DESCRIPTION
This follows change to https://github.com/racket/ChezScheme/commit/2e3a618b0072d547b6c5abe6dd8dbac36a98c10e. 
It removes `MZ_DECLARE_NORETURN`, and implements `NORETURN` for all supported compilers.

In the prototypes, the `NORETURN` keyword has to be added to the head of the prototype in order to work with MSVC. For this to work, it was necessary to fix `makex.rkt` script as well.