### PR TITLE
Do not add explicit return statement when it doesn't exist

### DIFF
--- a/racket/collects/compiler/private/xform.rkt
+++ b/racket/collects/compiler/private/xform.rkt
@@ -733,7 +733,7 @@
           ;; Replacement for non-value return:
           (printf "#define RET_NOTHING { SET_GC_VARIABLE_STACK((void **)__gc_var_stack__[0]); return; }\n")
           ;; A non-value return inserted at the end of a void-returning function:
-          (printf "#define RET_NOTHING_AT_END RET_NOTHING\n")
+          (printf "#define RET_NOTHING_AT_END { SET_GC_VARIABLE_STACK((void **)__gc_var_stack__[0]); }\n")
           
           ;; Declare a temp variable to hold the return value of the indicated type:
           (printf (if callee-restore?


### PR DESCRIPTION
Remove whitespace from empty lines as well.
Adding return statement where it doesn't exist, causes problems with
functions marked no return so it should be avoided.

Related to #2709 - with this PR, clang won't complain any longer about issues with xform generated sources about functions marked no return that do indeed return.