### PR TITLE
Remove SCHEME_NO_EXN block

### DIFF
--- a/racket/src/racket/src/error.c
+++ b/racket/src/racket/src/error.c
@@ -1087,11 +1087,7 @@ scheme_signal_error (const char *msg, ...)
     exit(0);
   }
 
-#ifndef SCHEME_NO_EXN
   scheme_raise_exn(MZEXN_FAIL, "%t", buffer, len);
-#else
-  call_error(buffer, len, scheme_false);
-#endif
 }
 
 void scheme_warning(char *msg, ...)


### PR DESCRIPTION
This is probably related to #2712.
It's the only occurrence of SCHEME_NO_EXN pointing to the fact that
this is an historical artifact that can be removed.