### PR TITLE
openssl: add key and cert-chain args to ssl-make-{client,server}-context, and other fixes

### DIFF
--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -328,7 +328,8 @@ Analogous to @racket[tcp-abandon-port].}
 
 @defproc[(ssl-addresses [p (or/c ssl-port? ssl-listener?)]
                         [port-numbers? any/c #f])
-         void?]{
+         (or/c (values string? string?)
+               (values string? port-number? string? listen-port-number?))]{
 
 Analogous to @racket[tcp-addresses].}
 
@@ -398,7 +399,7 @@ current platform for server connections.
 @defproc[(ports->ssl-ports
            [input-port input-port?]
 	   [output-port output-port?]
-           [#:mode mode symbol? 'accept]
+           [#:mode mode (or/c 'connect 'accept) 'accept]
 	   [#:context context
                       (or/c ssl-client-context? ssl-server-context?)
                       ((if (eq? mode 'accept)

--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -161,13 +161,24 @@ essentially equivalent to the following:
 The context is cached, so different calls to
 @racket[ssl-secure-client-context] return the same context unless
 @racket[(ssl-default-verify-sources)] has changed.
+
+Note that @racket[(ssl-secure-client-context)] returns a sealed
+context, so it is not possible to add a private key and certificate
+chain to it. If client credentials are required, use
+@racket[ssl-make-client-context] instead.
 }
 
 
 @defproc[(ssl-make-client-context
           [protocol (or/c 'secure 'auto
                           'sslv2-or-v3 'sslv2 'sslv3 'tls 'tls11 'tls12)
-                    'auto])
+                    'auto]
+          [#:private-key private-key
+                         (or/c (list/c 'pem path-string?)
+                               (list/c 'der path-string?)
+                               #f)
+                         #f]
+          [#:certificate-chain certificate-chain (or/c path-string? #f) #f])
          ssl-client-context?]{
 
 Creates a context to be supplied to @racket[ssl-connect]. The context
@@ -208,11 +219,19 @@ details. See also
 @racket[supported-client-protocols] and
 @racket[supported-server-protocols].
 
+If @racket[private-key] and @racket[certificate-chain] are provided,
+they are loaded into the context using @racket[ssl-load-private-key!]
+and @racket[ssl-load-certificate-chain!], respectively. Client
+credentials are rarely used with HTTPS, but they are occasionally used
+in other kind of servers.
+
 @history[
 #:changed "6.1" @elem{Added @racket['tls11] and @racket['tls12].}
 #:changed "6.1.1.3" @elem{Default to new @racket['auto] and disabled SSL
                           2.0 and 3.0 by default.}
 #:changed "6.3.0.12" @elem{Added @racket['secure].}
+#:changed "7.3.0.10" @elem{Added @racket[#:private-key] and @racket[#:certificate-chain]
+arguments.}
 ]}
 
 
@@ -325,14 +344,28 @@ Returns @racket[#t] of @racket[v] is an SSL port produced by
 @defproc[(ssl-make-server-context
           [protocol (or/c 'secure 'auto
                           'sslv2-or-v3 'sslv2 'sslv3 'tls 'tls11 'tls12)
-                    'auto])
+                    'auto]
+          [#:private-key private-key
+                         (or/c (list/c 'pem path-string?)
+                               (list/c 'der path-string?)
+                               #f)
+                         #f]
+          [#:certificate-chain certificate-chain (or/c path-string? #f) #f])
          ssl-server-context?]{
 
 Like @racket[ssl-make-client-context], but creates a server context.
 For a server context, the @racket['secure] protocol is the same as
 @racket['auto].
 
-@history[#:changed "6.3.0.12" @elem{Added @racket['secure].}]}
+If @racket[private-key] and @racket[certificate-chain] are provided,
+they are loaded into the context using @racket[ssl-load-private-key!]
+and @racket[ssl-load-certificate-chain!], respectively.
+
+@history[
+#:changed "6.3.0.12" @elem{Added @racket['secure].}
+#:changed "7.3.0.10" @elem{Added @racket[#:private-key] and @racket[#:certificate-chain]
+arguments.}
+]}
 
 
 @defproc[(ssl-server-context? [v any/c]) boolean?]{

--- a/pkgs/racket-test/tests/openssl/peer-verif2.rkt
+++ b/pkgs/racket-test/tests/openssl/peer-verif2.rkt
@@ -1,0 +1,120 @@
+#lang racket/base
+(require openssl
+         ffi/unsafe
+         racket/tcp
+         racket/runtime-path)
+
+(define (check fmt got expect)
+  (unless (equal? got expect)
+    (error 'check fmt got)))
+
+(define (check-fail thunk)
+  (define s
+    (with-handlers ([exn? (lambda (exn) (exn-message exn))])
+      (thunk)
+      "success"))
+  (unless (regexp-match?  #rx"connect failed" s)
+    (error 'test "failed: ~s" s)))
+
+(define-runtime-path server-key "server_key.pem")
+(define-runtime-path server-crt "server_crt.pem")
+(define-runtime-path client-key "client_key.pem")
+(define-runtime-path client-crt "client_crt.pem")
+(define-runtime-path cacert     "cacert.pem")
+
+(define server-hostname "server.example.com")
+(define client-id
+  #"/C=US/ST=Racketa/O=Testing Examples/OU=Testing/CN=client.example.com/emailAddress=client@example.com")
+
+(define (call/custodian proc)
+  (define cust (make-custodian))
+  (parameterize ((current-custodian cust))
+    (dynamic-wind void proc (lambda () (custodian-shutdown-all cust)))))
+
+;; test-conn : ServerCtx ClientCtx -> (U #f Bytes)
+(define (test-conn server-ctx client-ctx)
+  (call/custodian
+   (lambda ()
+     (define chan (make-channel))
+     (define listener (ssl-listen 55000 4 #t "localhost" server-ctx))
+     (thread (lambda ()
+               (ssl-try-verify! listener #t)
+               (define-values (in out) (ssl-accept listener))
+               (channel-put chan (and (ssl-peer-verified? in) (ssl-peer-subject-name in)))))
+     ;; Use ports->ssl-ports instead of ssl-connect so we can supply a fake hostname.
+     ;; (ssl-connect "localhost" 55000 client-ctx)
+     (define-values (in out) (tcp-connect "localhost" 55000))
+     (if (symbol? client-ctx)
+         (ports->ssl-ports in out #:mode 'connect #:encrypt client-ctx #:hostname server-hostname)
+         (ports->ssl-ports in out #:mode 'connect #:context client-ctx #:hostname server-hostname))
+     (channel-get chan))))
+
+(define server-ctx1
+  (ssl-make-server-context 'auto #:private-key `(pem ,server-key) #:certificate-chain server-crt))
+(define server-ctx2
+  (let ([ctx (ssl-make-server-context)])
+    (ssl-load-certificate-chain! ctx server-crt)
+    (ssl-load-private-key! ctx server-key #f #f)
+    ctx))
+;; Set 
+(parameterize ((ssl-default-verify-sources (list cacert)))
+  (ssl-load-default-verify-sources! server-ctx1)
+  (ssl-load-default-verify-sources! server-ctx2))
+
+(define client-ctx/standard-trust
+  (ssl-secure-client-context))
+(define client-ctx/no-trust
+  (parameterize ((ssl-default-verify-sources null))
+    (ssl-secure-client-context)))
+
+(define client-ctx/trust-ca1
+  (parameterize ((ssl-default-verify-sources (list cacert)))
+    (ssl-secure-client-context)))
+
+(define client-ctx/trust-ca2
+  (parameterize ((ssl-default-verify-sources (list cacert)))
+    (ssl-make-client-context 'secure)))
+
+(define client-ctx/auto/cred
+  (let ([ctx (ssl-make-client-context 'auto)])
+    (ssl-load-private-key! ctx client-key #f #f)
+    (ssl-load-certificate-chain! ctx client-crt)
+    ctx))
+
+(define client-ctx/trust-ca/cred
+  (parameterize ((ssl-default-verify-sources (list cacert)))
+    (ssl-make-client-context 'secure
+                             #:private-key `(pem ,client-key)
+                             #:certificate-chain client-crt)))
+
+(for ([server-ctx (list server-ctx1 server-ctx2)])
+
+  ;; Test that the client fails to verify the server (server's CA not trusted).
+  (for ([client-ctx (list client-ctx/standard-trust
+                          client-ctx/no-trust)])
+    (check-fail (lambda () (test-conn server-ctx client-ctx))))
+
+  ;; Test that the client verifies the server, and the server does not
+  ;; get a client identity (no key/cert loaded).
+  (for ([client-ctx (list client-ctx/trust-ca1
+                          client-ctx/trust-ca2)])
+    (check "connection w/o client creds; got ~e"
+           (test-conn server-ctx client-ctx)
+           #f))
+
+  ;; Test that the client verifies the server, and the server verify
+  ;; the client and gets the right client identity.
+  (for ([client-ctx (list client-ctx/auto/cred
+                          client-ctx/trust-ca/cred)])
+    (check "connection with client creds; got ~e"
+           (test-conn server-ctx client-ctx)
+           client-id))
+
+  ;; Test that an implicit 'secure client context does verification.
+  (parameterize ((ssl-default-verify-sources null))
+    (check-fail (lambda () (test-conn server-ctx 'secure))))
+  (parameterize ((ssl-default-verify-sources null))
+    (check-fail (lambda () (test-conn server-ctx 'secure))))
+  (parameterize ((ssl-default-verify-sources (list cacert)))
+    (check "implicit, got ~e" (test-conn server-ctx 'secure) #f))
+  (void))

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -1543,10 +1543,12 @@ TO DO:
 
 (define (ssl-addresses p [port-numbers? #f])
   (let-values ([(mzssl input?) (lookup 'ssl-addresses p)])
-    (tcp-addresses (if (eq? 'listener input?)
-                       (ssl-listener-l mzssl)
-                       (if input? (mzssl-i mzssl) (mzssl-o mzssl)))
-                   port-numbers?)))
+    (define port
+      (if (eq? 'listener input?)
+          (ssl-listener-l mzssl)
+          (if input? (mzssl-i mzssl) (mzssl-o mzssl))))
+    (cond [(tcp-port? port) (tcp-addresses port port-numbers?)]
+          [else (error 'ssl-addresses "not connected to TCP port")])))
 
 (define (ssl-abandon-port p)
   (let-values ([(mzssl input?) (lookup 'ssl-abandon-port p)])


### PR DESCRIPTION
This PR makes it easier to create a server-verifying ("secure") client context with client credentials. It is rare for https clients to need client credentials, but some database servers use TLS client credentials for authentication.
