### PR TITLE
Add MZ_ prefix to macros NORETURN and UNREACHABLE

### DIFF
--- a/racket/src/racket/include/scheme.h
+++ b/racket/src/racket/include/scheme.h
@@ -252,25 +252,25 @@ extern "C"
 {
 #endif
 
-#if !defined(NORETURN)
+#if !defined(MZ_NORETURN)
 #if defined(__GNUC__) || defined(__clang__)
-#define NORETURN __attribute__((noreturn))
+#define MZ_NORETURN __attribute__((noreturn))
 #elif defined(_MSC_VER)
-#define NORETURN __declspec(noreturn)
+#define MZ_NORETURN __declspec(noreturn)
 #else
-#define NORETURN
+#define MZ_NORETURN
 #endif /* defined(__GNUC__) || defined(__clang__) */
-#endif /* !defined(NORETURN) */
+#endif /* !defined(MZ_NORETURN) */
 
-#if !defined(UNREACHABLE)
+#if !defined(MZ_UNREACHABLE)
 #if defined(__GNUC__) || defined(__clang__)
-#define UNREACHABLE __builtin_unreachable()
+#define MZ_UNREACHABLE __builtin_unreachable()
 #elif defined(_MSC_VER)
-#define UNREACHABLE __assume(0)
+#define MZ_UNREACHABLE __assume(0)
 #else
-#define UNREACHABLE
+#define MZ_UNREACHABLE
 #endif /* defined(__GNUC__) || defined(__clang__) */
-#endif /* !defined(NORETURN) */
+#endif /* !defined(MZ_UNREACHABLE) */
 
 /* Allowed by all configurations, currently: */
 #define MZ_CAN_ACCESS_THREAD_LOCAL_DIRECTLY
@@ -1684,7 +1684,7 @@ MZ_EXTERN Scheme_Object *scheme_eval_waiting;
 #endif
 
 #ifdef MZ_USE_JIT
-MZ_EXTERN NORETURN void scheme_jit_longjmp(mz_jit_jmp_buf b, int v);
+MZ_EXTERN MZ_NORETURN void scheme_jit_longjmp(mz_jit_jmp_buf b, int v);
 MZ_EXTERN void scheme_jit_setjmp_prepare(mz_jit_jmp_buf b);
 # define scheme_jit_setjmp(b) (scheme_jit_setjmp_prepare(b), scheme_call_mz_setjmp((b)->jb))
 #else

--- a/racket/src/racket/src/error.c
+++ b/racket/src/racket/src/error.c
@@ -90,7 +90,7 @@ static Scheme_Object *exe_yield_handler(int, Scheme_Object *[]);
 static Scheme_Object *error_print_width(int, Scheme_Object *[]);
 static Scheme_Object *error_print_context_length(int, Scheme_Object *[]);
 static Scheme_Object *error_print_srcloc(int, Scheme_Object *[]);
-static NORETURN void def_error_escape_proc(int, Scheme_Object *[]);
+static MZ_NORETURN void def_error_escape_proc(int, Scheme_Object *[]);
 static Scheme_Object *def_error_display_proc(int, Scheme_Object *[]);
 static Scheme_Object *emergency_error_display_proc(int, Scheme_Object *[]);
 static Scheme_Object *def_error_value_string_proc(int, Scheme_Object *[]);
@@ -114,8 +114,8 @@ static Scheme_Object *make_log_reader(int argc, Scheme_Object *argv[]);
 static Scheme_Object *log_reader_p(int argc, Scheme_Object *argv[]);
 static int log_reader_get(Scheme_Object *ch, Scheme_Schedule_Info *sinfo);
 
-static NORETURN void do_raise(Scheme_Object *arg, int need_debug, int barrier);
-static NORETURN void nested_exn_handler(void *old_exn, int argc, Scheme_Object *argv[]);
+static MZ_NORETURN void do_raise(Scheme_Object *arg, int need_debug, int barrier);
+static MZ_NORETURN void nested_exn_handler(void *old_exn, int argc, Scheme_Object *argv[]);
 
 static void update_want_level(Scheme_Logger *logger, Scheme_Object *name);
 
@@ -926,7 +926,7 @@ void scheme_init_logger_config() {
   scheme_set_root_param(MZCONFIG_LOGGER, (Scheme_Object *)scheme_main_logger);
 }
 
-static NORETURN void
+static MZ_NORETURN void
 call_error(char *buffer, int len, Scheme_Object *exn)
 {
   if (scheme_current_thread->constant_folding) {
@@ -3346,7 +3346,7 @@ def_error_value_string_proc(int argc, Scheme_Object *argv[])
   return scheme_make_sized_utf8_string(s, l);
 }
 
-static NORETURN void
+static MZ_NORETURN void
 def_error_escape_proc(int argc, Scheme_Object *argv[])
 {
   Scheme_Object *prompt;
@@ -4403,7 +4403,7 @@ scheme_raise_exn(int id, ...)
            1);
 }
 
-static NORETURN void
+static MZ_NORETURN void
 def_exn_handler(int argc, Scheme_Object *argv[])
 {
   char *s;
@@ -4441,7 +4441,7 @@ init_exn_handler(int argc, Scheme_Object *argv[])
 			     1, NULL, NULL, 0);
 }
 
-static NORETURN void
+static MZ_NORETURN void
 nested_exn_handler(void *old_exn, int argc, Scheme_Object *argv[])
 {
   Scheme_Object *arg = argv[0], *orig_arg = SCHEME_CDR((Scheme_Object *)old_exn);
@@ -4496,7 +4496,7 @@ nested_exn_handler(void *old_exn, int argc, Scheme_Object *argv[])
   call_error(buffer, blen, scheme_false);
 }
 
-static NORETURN void *do_raise_inside_barrier(void)
+static MZ_NORETURN void *do_raise_inside_barrier(void)
 {
   Scheme_Object *arg;
   Scheme_Object *v, *p[1], *h, *marks;
@@ -4606,13 +4606,13 @@ do_raise(Scheme_Object *arg, int need_debug, int eb)
 
   if (eb) {
     scheme_top_level_do(do_raise_inside_barrier, 1);
-    UNREACHABLE;
+    MZ_UNREACHABLE;
   }
   else
     do_raise_inside_barrier();
 }
 
-static NORETURN void
+static MZ_NORETURN void
 sch_raise(int argc, Scheme_Object *argv[])
 {
   if ((argc > 1) && SCHEME_FALSEP(argv[1]))

--- a/racket/src/racket/src/makex.rkt
+++ b/racket/src/racket/src/makex.rkt
@@ -62,7 +62,7 @@
                      [l (regexp-replace #rx"^XFORM_NONGCING " l "")]
                      [l (regexp-replace #rx"^XFORM_NONGCING_NONALIASING " l "")]
                      [l (regexp-replace #rx"^MZ_EXTERN " l "")]
-                     [l (regexp-replace #rx"^NORETURN " l "")]
+                     [l (regexp-replace #rx"^MZ_NORETURN " l "")]
                      [l (regexp-replace #rx"^THREAD_LOCAL " l "")]
                      [l2 (regexp-replace #rx"^volatile " l "")]
                      [volatile (if (equal? l l2) "" "volatile ")]

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -197,8 +197,8 @@ MZ_EXTERN Scheme_On_Atomic_Timeout_Proc scheme_set_on_atomic_timeout(Scheme_On_A
 /*                              error handling                            */
 /*========================================================================*/
 
-MZ_EXTERN NORETURN void scheme_signal_error(const char *msg, ...);
-MZ_EXTERN NORETURN void scheme_raise_exn(int exnid, ...);
+MZ_EXTERN MZ_NORETURN void scheme_signal_error(const char *msg, ...);
+MZ_EXTERN MZ_NORETURN void scheme_raise_exn(int exnid, ...);
 MZ_EXTERN void scheme_warning(char *msg, ...);
 
 MZ_EXTERN void scheme_raise(Scheme_Object *exn);
@@ -221,17 +221,17 @@ MZ_EXTERN void scheme_glib_log_message(const char *log_domain, int log_level, co
 MZ_EXTERN void *scheme_glib_log_message_test(char *str);
 MZ_EXTERN void scheme_out_of_memory_abort();
 
-MZ_EXTERN NORETURN void scheme_wrong_count(const char *name, int minc, int maxc, int argc, Scheme_Object **argv);
-MZ_EXTERN NORETURN void scheme_wrong_count_m(const char *name, int minc, int maxc, int argc, Scheme_Object **argv, int is_method);
-MZ_EXTERN NORETURN void scheme_case_lambda_wrong_count(const char *name, int argc, Scheme_Object **argv, int is_method, int count, ...);
-MZ_EXTERN NORETURN void scheme_wrong_type(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
-MZ_EXTERN NORETURN void scheme_wrong_contract(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
-MZ_EXTERN NORETURN void scheme_wrong_field_type(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
-MZ_EXTERN NORETURN void scheme_wrong_field_contract(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
-MZ_EXTERN NORETURN void scheme_arg_mismatch(const char *name, const char *msg, Scheme_Object *o);
-MZ_EXTERN NORETURN void scheme_contract_error(const char *name, const char *msg, ...);
-MZ_EXTERN NORETURN void scheme_wrong_return_arity(const char *where, int expected, int got, Scheme_Object **argv, const char *context_detail, ...);
-MZ_EXTERN NORETURN void scheme_unbound_global(Scheme_Bucket *b);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_count(const char *name, int minc, int maxc, int argc, Scheme_Object **argv);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_count_m(const char *name, int minc, int maxc, int argc, Scheme_Object **argv, int is_method);
+MZ_EXTERN MZ_NORETURN void scheme_case_lambda_wrong_count(const char *name, int argc, Scheme_Object **argv, int is_method, int count, ...);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_type(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_contract(const char *name, const char *expected, int which, int argc, Scheme_Object **argv);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_field_type(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_field_contract(Scheme_Object *c_name, const char *expected, Scheme_Object *o);
+MZ_EXTERN MZ_NORETURN void scheme_arg_mismatch(const char *name, const char *msg, Scheme_Object *o);
+MZ_EXTERN MZ_NORETURN void scheme_contract_error(const char *name, const char *msg, ...);
+MZ_EXTERN MZ_NORETURN void scheme_wrong_return_arity(const char *where, int expected, int got, Scheme_Object **argv, const char *context_detail, ...);
+MZ_EXTERN MZ_NORETURN void scheme_unbound_global(Scheme_Bucket *b);
 
 MZ_EXTERN Scheme_Object *scheme_dynamic_wind(void (*pre)(void *),
 					     Scheme_Object *(* volatile act)(void *),

--- a/racket/src/racket/src/schpriv.h
+++ b/racket/src/racket/src/schpriv.h
@@ -3392,7 +3392,7 @@ void scheme_rktio_error(const char *name, const char *what);
 
 void scheme_non_fixnum_result(const char *name, Scheme_Object *o);
 
-NORETURN void scheme_raise_out_of_memory(const char *where, const char *msg, ...);
+MZ_NORETURN void scheme_raise_out_of_memory(const char *where, const char *msg, ...);
 
 char *scheme_make_srcloc_string(Scheme_Object *stx, intptr_t *len);
 


### PR DESCRIPTION
Since the definitions of these live in the public header scheme.h,
adding this prefix reduces clashes with other related macros.