### PR TITLE
Add combine-output-ports

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
@@ -313,6 +313,7 @@ the second port to sync, so it cannot be guaranteed that both
 ports are ready at once. Closing the combined port is done
 after writing all remaining bytes to @racket[b-out].}
 
+@history[#:added "7.7.0.9"]
 
 @defproc[(merge-input [a-in input-port?]
                       [b-in input-port?]

--- a/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
@@ -297,16 +297,21 @@ The optional @racket[in-name] and @racket[out-name] arguments
 determine the names of the result ports.}
 
 
-@defproc[(combine-output-ports [what output-port?]
-                               [with output-port?] ...)
+@defproc[(combine-output [a-out output-port?]
+                         [b-out output-port?])
          output-port?]{
 
-Accepts a variable number of output ports and returns a new output port
-combining the original ports. When written to, the new port delegates
-the write operation to all the original ports. The combined port supports
-@racket[write-special] only when all the inner ports support it as well,
-and the combined port is ready when all inner ports are ready. Closing
-the combined output port does not close the original ports.}
+Accepts two output ports and returns a new output port
+combining the original ports. When written to, the combined port
+first writes as many bytes as possible to @racket[a-out], and then
+tries to write the same number of bytes to @racket[b-out]. If that
+doesn't succeed, what is left over is buffered and no further writes
+can go through until the ports are evened out. The port is ready (for
+the purposes of synchronization) when each port reports being ready.
+However, the first port may stop being ready while waiting on
+the second port to sync, so it cannot be guaranteed that both
+ports are ready at once. Closing the combined port is done
+after writing all remaining bytes to @racket[b-out].}
 
 
 @defproc[(merge-input [a-in input-port?]

--- a/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
@@ -297,6 +297,18 @@ The optional @racket[in-name] and @racket[out-name] arguments
 determine the names of the result ports.}
 
 
+@defproc[(combine-output-ports [what output-port?]
+                               [with output-port?] ...)
+         output-port?]{
+
+Accepts a variable number of output ports and returns a new output port
+combining the original ports. When written to, the new port delegates
+the write operation to all the original ports. The combined port supports
+@racket[write-special] only when all the inner ports support it as well,
+and the combined port is ready when all inner ports are ready. Closing
+the combined output port does not close the original ports.}
+
+
 @defproc[(merge-input [a-in input-port?]
                       [b-in input-port?]
                       [buffer-limit (or/c exact-nonnegative-integer? #f) 4096])

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -1030,6 +1030,19 @@
   (test (void) flush-output port-ab)
   (test "hello, world" get-output-string port-a)
   (test "hello, world" get-output-string port-b)
+  (define worker1 (thread
+                   (lambda ()
+                     (for ([i 10])
+                       (write-bytes (string->bytes/utf-8 (number->string i)) port-ab)))))
+  (define worker2 (thread
+                   (lambda ()
+                     (for ([i 10])
+                       (write-bytes (string->bytes/utf-8 (number->string (- 10 i))) port-ab)))))
+  (thread-wait worker1)
+  (thread-wait worker2)
+  (test #t or (equal? (get-output-string port-a) "hello, world109876543210123456789")
+              (equal? (get-output-string port-a) "hello, world012345678910987654321"))
+  (test (get-output-string port-a) get-output-string port-b)
   (test (void) close-output-port port-ab))
 
 ;; --------------------------------------------------

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -1036,13 +1036,11 @@
                        (write-bytes (string->bytes/utf-8 (number->string i)) port-ab)))))
   (define worker2 (thread
                    (lambda ()
-                     (for ([i 10])
-                       (write-bytes (string->bytes/utf-8 (number->string (- 10 i))) port-ab)))))
+                     (write-bytes-avail* #"0123456789" port-ab))))
   (thread-wait worker1)
   (thread-wait worker2)
-  (test #t or (equal? (get-output-string port-a) "hello, world109876543210123456789")
-              (equal? (get-output-string port-a) "hello, world012345678910987654321"))
-  (test (get-output-string port-a) get-output-string port-b)
+  (test "hello, world01234567890123456789" get-output-string port-a)
+  (test "hello, world01234567890123456789" get-output-string port-b)
   (test (void) close-output-port port-ab))
 
 ;; --------------------------------------------------

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -998,7 +998,7 @@
 ;; --------------------------------------------------
 ;; test combine-output-ports
 (let ([port-a (open-output-string)]
-      [port-d (open-output-string)])
+      [port-b (open-output-string)])
   (define port-ab (combine-output-ports port-a port-b))
   (test (void) display "hello, " port-abcd)
   (test 5  write-bytes-avail #"world" port-abcd)

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -998,16 +998,12 @@
 ;; --------------------------------------------------
 ;; test combine-output-ports
 (let ([port-a (open-output-string)]
-      [port-b (open-output-string)]
-      [port-c (open-output-string)]
       [port-d (open-output-string)])
-  (define port-abcd (combine-output-ports port-a port-b port-c port-d))
+  (define port-ab (combine-output-ports port-a port-b))
   (test (void) display "hello, " port-abcd)
-  (test 5 sync (write-bytes-avail-evt #"world" port-abcd))
+  (test 5  write-bytes-avail #"world" port-abcd)
   (test "hello, world" get-output-string port-a)
-  (test "hello, world" get-output-string port-b)
-  (test "hello, world" get-output-string port-c)
-  (test "hello, world" get-output-string port-d))
+  (test "hello, world" get-output-string port-b))
 
 ;; --------------------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -1000,8 +1000,8 @@
 (let ([port-a (open-output-string)]
       [port-b (open-output-string)])
   (define port-ab (combine-output-ports port-a port-b))
-  (test (void) display "hello, " port-abcd)
-  (test 5  write-bytes-avail #"world" port-abcd)
+  (test (void) display "hello, " port-ab)
+  (test 5  write-bytes-avail #"world" port-ab)
   (test "hello, world" get-output-string port-a)
   (test "hello, world" get-output-string port-b))
 

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -1002,12 +1002,12 @@
       [port-c (open-output-string)]
       [port-d (open-output-string)])
   (define port-abcd (combine-output-ports port-a port-b port-c port-d))
-  (test (void) (display "hello," port-abcd))
-  (test 5 (write-bytes-avail-evt #"world" port-abcd))
-  (test "hello, world" (get-output-string port-a))
-  (test "hello, world" (get-output-string port-b))
-  (test "hello, world" (get-output-string port-c))
-  (test "hello, world" (get-output-string port-d)))
+  (test (void) display "hello, " port-abcd)
+  (test 5 sync (write-bytes-avail-evt #"world" port-abcd))
+  (test "hello, world" get-output-string port-a)
+  (test "hello, world" get-output-string port-b)
+  (test "hello, world" get-output-string port-c)
+  (test "hello, world" get-output-string port-d))
 
 ;; --------------------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -1030,7 +1030,7 @@
   (test (void) flush-output port-ab)
   (test "hello, world" get-output-string port-a)
   (test "hello, world" get-output-string port-b)
-  (test (void) close port-ab))
+  (test (void) close-output-port port-ab))
 
 ;; --------------------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -996,6 +996,20 @@
   (test 0 file-position o2))
 
 ;; --------------------------------------------------
+;; test combine-output-ports
+(let ([port-a (open-output-string)]
+      [port-b (open-output-string)]
+      [port-c (open-output-string)]
+      [port-d (open-output-string)])
+  (define port-abcd (combine-output-ports port-a port-b port-c port-d))
+  (test (void) (display "hello," port-abcd))
+  (test 5 (write-bytes-avail-evt #"world" port-abcd))
+  (test "hello, world" (get-output-string port-a))
+  (test "hello, world" (get-output-string port-b))
+  (test "hello, world" (get-output-string port-c))
+  (test "hello, world" (get-output-string port-d)))
+
+;; --------------------------------------------------
 
 (let-values ([(in out) (make-pipe)])
   (let ([in2 (dup-input-port in #f)]

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -999,9 +999,14 @@
 ;; test combine-output-ports
 (let ([port-a (open-output-string)]
       [port-b (open-output-string)])
-  (define port-ab (combine-output-ports port-a port-b))
-  (test (void) display "hello, " port-ab)
-  (test 5  write-bytes-avail #"world" port-ab)
+  (define two-byte-port (make-output-port
+                          `two-byte-port
+                          port-b
+                          (lambda (s start end no-buffer&block? breakable?)
+                            (write-bytes-avail (subbytes s start (+ start 2)) port-b))
+                          void))
+  (define port-ab (combine-output-ports port-a two-byte-port))
+  (test 12  write-bytes #"hello, world" port-ab)
   (test "hello, world" get-output-string port-a)
   (test "hello, world" get-output-string port-b))
 

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -169,70 +169,70 @@
 (define (combine-output a-out b-out)
   (struct buffer (bstr out start end) #:authentic #:mutable)
   (define pending #f)
-
-  (define (write-pending/blocking!)
+  (define lock (make-semaphore 1))
+  (define ready-evt (replace-evt lock (λ (_) (replace-evt out1 (λ (_) out2)))))
+  (define retry-evt (handle-evt
+                     (replace-evt
+                      (semaphore-peek-evt lock)
+                      (λ (_) (replace-evt out1 (λ (_) out2))))
+                     (λ (_) #f)))
+  (define (write-pending!)
     (when pending
-      (write-bytes
-       (buffer-bstr pending)
-       (buffer-out pending)
-       (buffer-start pending)
-       (buffer-end pending))
-      (set! pending #f)))
-
-  (define (write-pending/non-blocking!)
-    (when pending
-      (define n
-        (write-bytes-avail*
-         (buffer-bstr pending)
-         (buffer-out pending)
-         (buffer-start pending)
-         (buffer-end pending)))
+      (define bstr  (buffer-bstr pending))
+      (define out   (buffer-out pending))
+      (define start (buffer-start pending))
+      (define end   (buffer-end pending))
+      (define n (write-bytes-avail* bstr out start end))
       (when n
         (cond
-          [(= n (- (buffer-end pending) (buffer-start pending)))
+          [(= n (- end start))
            (set! pending #f)]
           [(> n 0)
-           (set-buffer-start! pending (+ (buffer-start pending) n))]))))
-
-  (define (write-out bstr start end non-blocking? breakable?)
-    (cond
-      [non-blocking?
-       (write-pending/non-blocking!)
-       (and
-        (not pending)
-        (write-out* write-bytes-avail* bstr start end))]
-      [else
-       (write-pending/blocking!)
-       (cond
-         [(= start end)
-          (flush-output a-out)
-          (flush-output b-out)
-          0]
-         [breakable?
-          (write-out* write-bytes-avail/enable-break bstr start end)]
-         [else
-          (write-bytes bstr a-out start end)
-          (write-bytes bstr b-out start end)])]))
-
+           (set-buffer-start! pending (+ start n))]))))
+  (define (write-out bstr start end non-blocking? enable-break?)
+    (define result
+      (call-with-semaphore
+       lock
+       (λ ()
+         (write-pending!)
+         
+         (cond
+           [pending       retry-evt]
+           [(= start end) 0]
+           [enable-break? (write-out* write-bytes-avail/enable-break bstr start end)]
+           [else          (write-out* write-bytes-avail* bstr start end)]))
+       (λ () retry-evt)))
+    (when (eqv? result 0)
+      (flush-output out1)
+      (flush-output out2))
+    result)
   (define (write-out* write-initial bstr start end)
-    (define m (write-initial bstr a-out start end))
+    (define m (write-initial bstr out1 start end))
     (cond
       [(or (not m) (= m 0))
-       #f]
+       retry-evt]
       [else
        (define n
-         (or (write-bytes-avail* bstr b-out start (+ start m))
+         (or (write-bytes-avail* bstr out2 start (+ start m))
              0))
        (when (< n m)
-         (set! pending (buffer bstr b-out (+ start n) (+ start m))))
+         (set! pending (buffer bstr out2 (+ start n) (+ start m))))
        m]))
-
   (define (close)
-    (write-pending/blocking!))
-
+    (call-with-semaphore
+     lock
+     (λ ()
+       (when pending
+         (write-bytes (buffer-bstr pending)
+                      (buffer-out pending)
+                      (buffer-start pending)
+                      (buffer-end pending))
+         (set! pending #f))))
+    (flush-output out1)
+    (flush-output out2)) 
   (make-output-port
-   'tee-port
-   (replace-evt a-out (λ (_) b-out))
+   'tee
+   ready-evt
    write-out
    close))
 

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -170,7 +170,7 @@
   (struct buffer (bstr out start end) #:authentic #:mutable)
   (define pending #f)
   (define lock (make-semaphore 1))
-  (define ready-evt (replace-evt lock (λ (_) (replace-evt a-out (λ (_) b-out)))))
+  (define ready-evt (replace-evt a-out (λ (_) b-out)))
   (define retry-evt (handle-evt
                      (replace-evt
                       (semaphore-peek-evt lock)

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -168,6 +168,9 @@
 
 (define (combine-output-ports what . with)
   (define port-list (cons what with))
+  (map (lambda (p)
+         (or (output-port? p)
+             (raise-argument-error 'combine-output-ports "output-port?" p))) port-list)
   (define wrap-evt-with-evts
     (lambda (evt . evts)
       (if (equal? (length evts) 0)

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -24,6 +24,8 @@
          call-with-input-string
          call-with-input-bytes
 
+         combine-output-ports
+
          ;; `mzlib/port` exports
          open-output-nowhere
          make-pipe-with-specials
@@ -163,6 +165,18 @@
 
 (define (call-with-input-bytes str proc)
   (with-input-from-x 'call-with-input-bytes 1 #t str proc))
+
+
+(define (combine-output-ports what . with)
+  (map (lambda (p)
+         (or (output-port? p)
+             (raise-argument-error 'combine-output-ports "output-port?" p)))
+         (cons what with))
+  (let-values ([(pin pout) (make-pipe-with-specials)])
+    (thread
+      (lambda ()
+        (apply copy-port (cons pin (cons what with)))))
+    pout))
 
 ;; ----------------------------------------
 ;; the code below used to be in `mzlib/port`

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -170,7 +170,7 @@
   (define port-list (cons what with))
   (define wrap-evt-with-evts
     (lambda (evt . evts)
-      (if (empty? evts)
+      (if (equal? (length evts) 0)
           evt
           (wrap-evt evt (let ([wrapped-evts (apply wrap-evt-with-evts evts)])
                           (lambda (v)


### PR DESCRIPTION
This PR adds a `combine-output-ports` procedure to `racket/port`, as mentioned in #2724.

Usage (in REPL):
```
> (define port-a (open-output-string))
> (define port-b (open-output-string))
> (define port-c (open-output-string))
> (define port-d (open-output-string))
> (define port-abcd (combine-output-ports port-a port-b port-c port-d))
> (display "hello world" port-ab)
> (println (get-output-string port-a))
"hello world"
> (println (get-output-string port-b))
"hello world"
> (println (get-output-string port-c))
"hello world"
> (println (get-output-string port-d))
"hello world"
```

It is implemented using `make-pipe-specials` and `copy-port`, in a similar manner to `merge-input`. It works with a variable number of arguments (all of which need to be satisfy `output-port?`).

There is a bug, though, that I could use some help with.
The output of the above program is different depending on where it's run.
In REPL, it works as expected. In racket, when run as a file, all of the ports are empty. And in DrRacket, some of the ports are empty when their string is `println`ed, but they are all ok in the corresponding REPL.

I suspect it's a synchronization problem with:
```
(thread
  (lambda ()
    (apply copy-port (cons pin (cons what with)))))
```
But I didn't find a fix yet.

Any help would be appreciated.
