### PR TITLE
json: fixing scientific notation exponent sign bug

### DIFF
--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -1,6 +1,6 @@
 #lang at-exp racket/base
 
-;; Mathias, added test for contracts on read-json 
+;; Mathias, added test for contracts on read-json
 
 (require json racket/string tests/eli-tester)
 (require racket/port)
@@ -106,8 +106,11 @@
         (string->jsexpr @T{ -1.3 }) => -1.3
         (string->jsexpr @T{-10.34}) => -10.34
         (string->jsexpr @T{-10.34e3}) => -10340.0
+        (string->jsexpr @T{-10.34e03}) => -10340.0
         (string->jsexpr @T{-10.34e+3}) => -10340.0
+        (string->jsexpr @T{-10.34e+03}) => -10340.0
         (string->jsexpr @T{-10.34e-3}) => -1.034e-2
+        (string->jsexpr @T{-10.34e-03}) => -1.034e-2
         (string->jsexpr @T{-10.34e+31}) => -1.034e32
         (string->jsexpr @T{ true  }) => #t
         (string->jsexpr @T{ false }) => #f
@@ -121,14 +124,14 @@
         (string->jsexpr @T{ {} }) => '#hasheq()
         (string->jsexpr @T{ {"x":1} }) => '#hasheq([x . 1])
         (string->jsexpr @T{ {"x":1,"y":2} }) => '#hasheq([x . 1] [y . 2])
-        (string->jsexpr @T{ [{"x": 1}, {"y": 2}] }) => 
+        (string->jsexpr @T{ [{"x": 1}, {"y": 2}] }) =>
                         '(#hasheq([x . 1]) #hasheq([y . 2]))
 
         ;; string escapes
         (string->jsexpr @T{ " \b\n\r\f\t\\\"\/ " }) => " \b\n\r\f\t\\\"/ "
         (string->jsexpr @T{ "\uD834\uDD1E" }) => "\U1D11E"
         (string->jsexpr @T{ "\ud834\udd1e" }) => "\U1d11e"
-	;; INPUT PORT is optional 
+	;; INPUT PORT is optional
 	(with-input-from-string "[]" read-json)
 	=> (parameterize ((json-null '())) (json-null))
         ;; EOF detection

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -5,7 +5,7 @@
 
 ;; edited:
 ;; -- Matthias, organization in preparation for pretty-print
-;; -- Matthias, contracts 
+;; -- Matthias, contracts
 
 ;; -----------------------------------------------------------------------------
 ;; DEPENDENCIES
@@ -14,7 +14,7 @@
 (require syntax/readerr
          racket/contract)
 
-;; tests in: 
+;; tests in:
 ;; ~plt/pkgs/racket-test/tests/json/
 
 ;; docs in:
@@ -24,12 +24,12 @@
 ;; SERVICES
 
 (provide
- ;; Parameter 
- json-null ;; Parameter 
- 
- ;; Any -> Boolean 
+ ;; Parameter
+ json-null ;; Parameter
+
+ ;; Any -> Boolean
  jsexpr?
- 
+
  (contract-out
   [write-json
    (->* (any/c) ;; jsexpr? but dependent on #:null arg
@@ -102,7 +102,7 @@
       [(#\tab) "\\t"]
       [(#\\) "\\\\"]
       [(#\") "\\\""]
-      [else 
+      [else
        (define (u-esc n)
          (define str (number->string n 16))
          (define pad (case (string-length str)
@@ -341,7 +341,7 @@
     ;; used to reconstruct input for error reporting:
     (define (n->string n exp)
       (define s (number->string n))
-      (string->bytes/utf-8 
+      (string->bytes/utf-8
        (cond
          [(zero? exp) s]
          [else
@@ -408,9 +408,11 @@
                                        (maybe-bytes c))
                          #:eof? (eof-object? c))]))
     ;; need at least one digit, still:
-    (define (read-exponent-more n mark mark2 exp sgn) 
+    (define (read-exponent-more n mark mark2 exp sgn)
       (define c (read-byte i))
       (cond
+        [(and (digit-byte? c) (zero? (to-number c)))
+         (read-exponent-more n mark mark2 exp sgn)]
         [(digit-byte? c)
          (read-exponent-rest n exp (* sgn (to-number c)))]
         [else (bad-input (bytes-append (n->string n exp)


### PR DESCRIPTION
if exponent contains leading zeroes sign will always be `+`. example:

```console
$ racket                                                                                                                                                                                                                                                      (6s 38ms)
Welcome to Racket v7.3.
> (require json)
> (jsexpr->string 0.000001)
"1e-06"
> (string->jsexpr (jsexpr->string 0.000001))
1000000.0
```

cons: we will miss leading zeroes from error message [here]( https://github.com/racket/racket/compare/master...corpix:fix/json-scientific-notation?expand=1#diff-8e8b6de3ce46d90c0bdf1c838b642aebR421), could we do better?