### PR TITLE
Ensure that src variable type to test mbsrtowcs is correct

### DIFF
--- a/racket/src/rktio/configure
+++ b/racket/src/rktio/configure
@@ -4256,7 +4256,7 @@ cat confdefs.h - <<_ACEOF >conftest.$ac_ext
    #include <strings.h>
    int main() {
      mbstate_t state;
-     char *src = "X";
+     const char *src = "X";
      bzero(&state, sizeof(mbstate_t));
      mbsrtowcs(0, &src, 0, &state);
      return 0;

--- a/racket/src/rktio/configure.ac
+++ b/racket/src/rktio/configure.ac
@@ -217,7 +217,7 @@ AC_LINK_IFELSE([AC_LANG_SOURCE([
    #include <strings.h>
    int main() {
      mbstate_t state;
-     char *src = "X";
+     const char *src = "X";
      bzero(&state, sizeof(mbstate_t));
      mbsrtowcs(0, &src, 0, &state);
      return 0;


### PR DESCRIPTION
When compiling with -Werror (./configure CFLAGS="-Werror" ...),
the test to see if mbsrtowcs exists
failed with pointer type of incompatible type, is char **, should be
const char **. It would proceed to assume mbsrtowcs didn't exist.