### PR TITLE
Support chaperoning tcp-listeners as evts.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/iostream.rktl
+++ b/pkgs/racket-test-core/tests/racket/iostream.rktl
@@ -307,6 +307,13 @@
 (close-input-port r2)
 (end)
 
+;; ----------------------------------------
+;; TCP listeners as events
+
+(chaperone-evt (tcp-listen 0)
+               (lambda (e) (values e values)))
+
+
 (start "TCP Echo, faster...\n")
 (define-values (r w r2 w2) (setup-mzscheme-echo #t))
 (close-input-port r)

--- a/racket/src/io/network/tcp-listen.rkt
+++ b/racket/src/io/network/tcp-listen.rkt
@@ -19,7 +19,6 @@
 (struct tcp-listener (lnr
                       closed ; boxed boolean
                       custodian-reference)
-  #:authentic
   #:property prop:evt (poller (lambda (l ctx) (poll-listener l ctx))))
 
 (define/who (tcp-listen port-no [max-allow-wait 4] [reuse? #f] [hostname #f])


### PR DESCRIPTION
Found by the Typed Racket test suite.