### PR TITLE
Fix doc typo "debuG" -> "debug"

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/performance.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/performance.scrbl
@@ -680,7 +680,7 @@ To check whether incremental mode is in use and how it affects pause
 times, enable @tt{debug}-level logging output for the
 @racketidfont{GC} topic. For example,
 
-@commandline{racket -W "debuG@"@"GC error" main.rkt}
+@commandline{racket -W "debug@"@"GC error" main.rkt}
 
 runs @filepath{main.rkt} with garbage-collection logging to stderr
 (while preserving @tt{error}-level logging for all topics). Minor


### PR DESCRIPTION
`debuG@GC error` is not a valid Racket flag, e.g.,
```
> racket -W 'debuG@GC error'
racket: stderr <levels> after -W switch must be one of the following
 <level>s:
   none fatal error warning info debug
 or up to one such <level> in whitespace-separated sequence of
   <level>@<name>
 given: debuG@GC error
Use the --help or -h flag for help.
```

The fixed version has the expected behavior:
```
> racket -W 'debug@GC error'
Welcome to Racket v7.3.
GC: 0:min @ 5,031K(+1,096K)[+0K]; free 351K(-8,543K) 14ms @ 26
GC: 0:min @ 8,605K(+5,714K)[+252K]; free 2,697K(-3,993K) 5ms @ 54
GC: 0:min @ 10,272K(+5,343K)[+752K]; free 3,802K(-3,802K) 2ms @ 81
GC: 0:min @ 11,736K(+4,503K)[+1,004K]; free 4,002K(-5,298K) 4ms @ 99
GC: 0:min @ 13,616K(+3,919K)[+1,024K]; free 5,098K(-13,290K) 3ms @ 112
GC: 0:min @ 14,160K(+11,567K)[+1,028K]; free 4,509K(-5,805K) 4ms @ 126
GC: 0:min @ 16,565K(+10,458K)[+1,084K]; free 4,573K(-5,869K) 5ms @ 152
GC: 0:min @ 19,883K(+8,436K)[+1,300K]; free 4,158K(-6,478K) 9ms @ 191
GC: 0:min @ 25,864K(+6,759K)[+1,380K]; free 5,598K(-12,270K) 8ms @ 231
GC: 0:min @ 31,852K(+8,627K)[+1,412K]; free 7,195K(-26,155K) 11ms @ 277
GC: 0:min @ 38,306K(+22,653K)[+2,164K]; free 8,378K(-12,266K) 13ms @ 348
GC: 0:min @ 47,951K(+16,896K)[+2,900K]; free 11,196K(-31,660K) 21ms @ 460
> 
```
