### PR TITLE
Ran tests/file/main as a program

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -113,7 +113,7 @@ test:ubsan:
     - raco test -l tests/racket/test 2>&1 | tee logs/test.log
     - racket -l tests/racket/contract/all 2>&1 | tee logs/contract-test.log
     - raco test -l tests/json/json 2>&1 | tee logs/json-test.log
-    - raco test -l tests/file/main 2>&1 | tee logs/file-test.log
+    - racket -l tests/file/main 2>&1 | tee logs/file-test.log
     - raco test -l tests/net/head 2>&1 | tee logs/net-head-test.log
     - raco test -l tests/net/uri-codec 2>&1 | tee logs/net-uri-codec-test.log
     - raco test -l tests/net/url 2>&1 | tee logs/net-url-test.log
@@ -146,7 +146,7 @@ test:ubsan:cs:
     - racocs test -l tests/racket/test 2>&1 | tee cs-logs/test.log
     - racketcs -l tests/racket/contract/all 2>&1 | tee cs-logs/contract-test.log
     - racocs test -l tests/json/json 2>&1 | tee cs-logs/json-test.log
-    - racocs test -l tests/file/main 2>&1 | tee cs-logs/file-test.log
+    - racketcs -l tests/file/main 2>&1 | tee cs-logs/file-test.log
     - racocs test -l tests/net/head 2>&1 | tee cs-logs/net-head-test.log
     - racocs test -l tests/net/uri-codec 2>&1 | tee cs-logs/net-uri-codec-test.log
     - racocs test -l tests/net/url 2>&1 | tee cs-logs/net-url-test.log

--- a/.gitlab/build-test.sh
+++ b/.gitlab/build-test.sh
@@ -269,7 +269,7 @@ ${RACKETEXE} -v
 annotate-output ${RACOEXE} test -l tests/racket/test
 annotate-output ${RACKETEXE} -l tests/racket/contract/all
 annotate-output ${RACOEXE} test -l tests/json/json
-annotate-output ${RACOEXE} test -l tests/file/main
+annotate-output ${RACKETEXE} -l tests/file/main
 annotate-output ${RACOEXE} test -l tests/net/head
 annotate-output ${RACOEXE} test -l tests/net/uri-codec
 annotate-output ${RACOEXE} test -l tests/net/url

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ script:
 - raco test -l tests/racket/test
 - racket -l tests/racket/contract/all
 - raco test -l tests/json/json
-- raco test -l tests/file/main
+- racket -l tests/file/main
 - raco test -l tests/net/head
 - raco test -l tests/net/uri-codec
 - raco test -l tests/net/url

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -21,7 +21,7 @@ jobs:
       raco test -l tests/racket/test
       racket -l tests/racket/contract/all
       raco test -l tests/json/json
-      raco test -l tests/file/main
+      racket -l tests/file/main
       raco test -l tests/net/head
       raco test -l tests/net/uri-codec
       raco test -l tests/net/url
@@ -56,7 +56,7 @@ jobs:
       racket\racket.exe -l tests/racket/test
       racket\racket.exe -l tests/racket/contract/all
       racket\raco.exe test -l tests/json/json
-      racket\raco.exe test -l tests/file/main
+      racket\racket.exe -l tests/file/main
       racket\raco.exe test -l tests/net/head
       racket\raco.exe test -l tests/net/uri-codec
       racket\raco.exe test -l tests/net/url
@@ -88,7 +88,7 @@ jobs:
       raco test -l tests/racket/test
       racket -l tests/racket/contract/all
       raco test -l tests/json/json
-      raco test -l tests/file/main
+      racket -l tests/file/main
       raco test -l tests/net/head
       raco test -l tests/net/uri-codec
       raco test -l tests/net/url


### PR DESCRIPTION
Somehow nobody noticed before file tests have not been running.
This enables the tests/file/main tests by running it as a program as suggested.

You can see from: 
https://travis-ci.org/racket/racket/jobs/559220863

```
$ raco test -l tests/file/main
raco test: (submod "/Users/travis/build/racket/racket/pkgs/racket-test/tests/file/main.rkt" test)
raco test: @(test-responsible '(eli mflatt))
run as program for tests
The command "raco test -l tests/file/main" exited with 0.
```
This should probably have failed with a non-zero exit so we could have noticed it earlier.

The reason I have created a PR for this change is that I want to give early warning that merging this will break CI because the file tests are currently failing with:
```
# racket -l tests/file/main
test: 1/134 test failures:
/root/.racket/7.4.0.1/pkgs/racket-test/tests/file/gzip.rkt:98:8: test failure in (sync/timeout 10 ch)
  expected: 'success
       got: 'didnt-fail-in-tar-gzip
  context...:
   "/root/.racket/7.4.0.1/pkgs/racket-test/tests/file/main.rkt": [running body]
   temp37_0
   for-loop
   run-module-instance!125
   perform-require!78
```