### PR TITLE
Repairs for syntax/template on Racket CS

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/template.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/template.scrbl
@@ -13,7 +13,7 @@
                              [#:leaf-datum-stx leaf-datum-proc-stx syntax? #'(lambda (v) v)]
                              [#:pvar-save pvar-save-proc (identifier? . -> . any/c) (lambda (x) #f)]
                              [#:pvar-restore-stx pvar-restore-stx syntax? #'(lambda (d stx) stx)]
-                             [#:cons-stx cons-proc-stx syntax? cons]
+                             [#:cons-stx cons-proc-stx syntax? #'cons]
                              [#:ellipses-end-stx ellipses-end-stx syntax? #'values]
                              [#:constant-as-leaf? constant-as-leaf? boolean? #f])
          syntax?]{

--- a/pkgs/racket-test-core/tests/racket/syntaxlibs.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntaxlibs.rktl
@@ -11,8 +11,8 @@
       [(_ tmpl)
        (let ([v (transform-template #'tmpl
                            #:save (lambda (stx) stx)
-                           #:restore-stx (lambda (v stx datum)
-                                           (datum->syntax stx datum stx stx stx)))])
+                           #:restore-stx #'(lambda (v stx datum)
+                                             (datum->syntax stx datum stx stx stx)))])
          v)]))
 
   (test '(1 #s(x "a" 1/2 8 9)

--- a/racket/collects/syntax/template.rkt
+++ b/racket/collects/syntax/template.rkt
@@ -175,7 +175,7 @@
                             #:leaf-datum-stx [leaf-datum #'values]
                             #:pvar-save [pvar->d (lambda (x) #f)]
                             #:pvar-restore-stx [pvar->s #'(lambda (d s) s)]
-                            #:cons-stx [pcons cons]
+                            #:cons-stx [pcons #'cons]
                             #:ellipses-end-stx [ellipses-end #'values]
                             #:constant-as-leaf? [const-leaf? #f])
   (let* ([tmap (make-template-map template-stx const-leaf?)]


### PR DESCRIPTION
Consider this program, which is just a simplified version of the test in [syntaxlibs.rktl](https://github.com/racket/racket/blob/c397dba1450d5955e2347bdfe43e19500701dfa8/pkgs/racket-test-core/tests/racket/syntaxlibs.rktl):

```racket
#lang racket

(require (for-syntax syntax/template))

(define-syntax (a-template-test stx)
  (syntax-case stx ()
    [(_ tmpl)
     (transform-template #'tmpl
                #:save (lambda (stx) stx)
                #:restore-stx (lambda (v stx datum)
                                (datum->syntax stx datum stx stx stx)))]))

(equal? '(1) (syntax->datum (a-template-test (1))))
```

There are two problems that prevent compiling this program to bytecode (i.e., `raco make` fails) on both 3m and CS:

1. The argument to `#:restore-stx` should be a syntax object, not a literal procedure. Bytecode compilation fails on Racket 3m:
    ```
    $ raco make thing.rkt
    write: cannot marshal value that is embedded in compiled code
      value: #<procedure:...racket/thing.rkt:11:30>
    ```
    In other words, the test isn't right (although we never actually test bytecode marshalling of that test, just its run-time behavior).

2. The default argument to `#:cons-stx` in `transform-template` should also be a syntax object, not a literal procedure. This seems to still work on 3m, but on CS, compilation fails trying to serialize `cons`:
    ```
    $ racocs make thing.rkt
    fasl-write: invalid fasl object #<procedure:cons>
      compilation context...:
       /Users/james/code/racket/thing.rkt
    ```

The second issue prevents Rosette installing correctly on Racket CS. After the fix, Rosette's tests that involve `transform-template` work correctly even after bytecode compilation.