### PR TITLE
Fix processor-count for windows systems

### DIFF
--- a/racket/src/rktio/rktio_cpu.c
+++ b/racket/src/rktio/rktio_cpu.c
@@ -6,7 +6,7 @@
 #elif defined(OS_X)
 # include <sys/param.h>
 # include <sys/sysctl.h>
-#elif defined(DOS_FILE_SYSTEM)
+#elif defined(RKTIO_SYSTEM_WINDOWS)
 # include <windows.h>
 #endif 
 
@@ -21,7 +21,7 @@ void rktio_init_cpu(rktio_t *rktio)
 
   if (sysctlbyname("hw.ncpu", &processor_count, &size, NULL, 0))
     processor_count = 2;
-#elif defined(DOS_FILE_SYSTEM)
+#elif defined(RKTIO_SYSTEM_WINDOWS)
   SYSTEM_INFO sysinfo;
   GetSystemInfo(&sysinfo);
   processor_count = sysinfo.dwNumberOfProcessors;


### PR DESCRIPTION
`DOS_FILE_SYSTEM` is not defined in rktio, use `RKTIO_SYSTEM_WINDOWS` instead

Fixes #2674