### PR TITLE
add set->hash

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -128,6 +128,13 @@ respectively.
 
 }
 
+@defproc[(set->hash [st (or/c set? set-mutable? set-weak?)]) hash?]{
+
+Converts a set to a hash table, if it is @tech{hash set}.
+
+@history[#:added "7.4.0.3"]
+}
+
 @deftogether[(
 @defform[(for/set (for-clause ...) body ...+)]
 @defform[(for/seteq (for-clause ...) body ...+)]

--- a/racket/collects/racket/private/set-types.rkt
+++ b/racket/collects/racket/private/set-types.rkt
@@ -34,6 +34,8 @@
          in-immutable-set
          in-mutable-set
          in-weak-set
+
+         set->hash
          
          chaperone-hash-set
          impersonate-hash-set)
@@ -109,6 +111,12 @@
 (define (custom-set->stream s)
   (dprintf "custom-set->stream\n")
   (sequence->stream (custom-in-set s)))
+
+(define (set->hash s)
+  (unless (custom-set? s)
+    (raise (exn:fail:contract (format "not a hash set: ~a" s)
+                              (current-continuation-marks))))
+  (custom-set-table s))
 
 (define (custom-set-first s)
   (dprintf "custom-set-first\n")

--- a/racket/collects/racket/set.rkt
+++ b/racket/collects/racket/set.rkt
@@ -26,6 +26,8 @@
          in-weak-set
          set-implements/c
 
+         set->hash
+
          set seteq seteqv
          weak-set weak-seteq weak-seteqv
          mutable-set mutable-seteq mutable-seteqv


### PR DESCRIPTION
Adds a `set->hash` function that returns the underlying hash table of a hash set.

Currently, it's impossible to efficiently iterate over a hash set manually, ie `in-mutable-set` and friends cannot be used when defining a custom iteration via `define-sequence-syntax` for a data structure that uses sets.

There's `set-first` and `set-rest` but those are an order of magnitude worse than the hash iteration functions. We could manually add `unsafe-immutable-set-first`, etc, analogous to `unsafe-immutable-hash-iterate-first`, but this is easier.