### PR TITLE
Mark struct-type properties as discouraged in favor of generic interfaces, not deprecated

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/booleans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/booleans.scrbl
@@ -97,9 +97,9 @@ in the case of @tech{complex numbers}. Two characters are
 @defproc[(eq? [v1 any/c] [v2 any/c]) boolean?]{
 
 Return @racket[#t] if @racket[v1] and @racket[v2] refer to the same
-object, @racket[#f] otherwise. As a special case among @tech{numbers}, 
-two @tech{fixnums} that are @racket[=] are also the same according 
-to @racket[eq?]. See also @secref["model-eq"]. 
+object, @racket[#f] otherwise. As a special case among @tech{numbers},
+two @tech{fixnums} that are @racket[=] are also the same according
+to @racket[eq?]. See also @secref["model-eq"].
 
 @examples[
 (eq? 'yes 'yes)
@@ -289,7 +289,7 @@ Returns @racket[(not v)].}
 @defform[(nand expr ...)]{
   Same as @racket[(not (and expr ...))].
 
-  @examples[#:eval 
+  @examples[#:eval
             bool-eval
             (nand #f #t)
             (nand #f (error 'ack "we don't get here"))]
@@ -300,22 +300,22 @@ Returns @racket[(not v)].}
 
   In the two argument case, returns @racket[#t] if neither of the
   arguments is a true value.
-  
-  @examples[#:eval 
+
+  @examples[#:eval
             bool-eval
             (nor #f #t)
             (nor #t (error 'ack "we don't get here"))]
 
-          
+
 }
 
 @defform[(implies expr1 expr2)]{
   Checks to be sure that the first
   expression implies the second.
-  
+
   Same as @racket[(if expr1 expr2 #t)].
-  
-  @examples[#:eval 
+
+  @examples[#:eval
             bool-eval
             (implies #f #t)
             (implies #f #f)

--- a/pkgs/racket-doc/scribblings/reference/booleans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/booleans.scrbl
@@ -259,11 +259,21 @@ non-@racket[#f] value when applied to the structure.
 
 @defthing[prop:equal+hash struct-type-property?]{
 
-A deprecated @tech{structure type property} (see @secref["structprops"])
+A @tech{structure type property} (see @secref["structprops"])
 that supplies an equality predicate and hashing functions for a structure
-type. The @racket[gen:equal+hash] @tech{generic interface} should be used,
-instead. A @racket[prop:equal+hash] property value is a list of
-three procedures that correspond to the methods of @racket[gen:equal+hash].
+type. Using the @racket[prop:equal+hash] property is discouraged; the
+@racket[gen:equal+hash] @tech{generic interface} should be used instead.
+A @racket[prop:equal+hash] property value is a list of three procedures
+that correspond to the methods of @racket[gen:equal+hash]:
+
+@itemize[
+ @item{@racket[_equal-proc : (any/c any/c (any/c any/c . ->
+        . boolean?)  . -> . any/c)]}
+ @item{@racket[_hash-proc : (any/c (any/c . -> . exact-integer?) . ->
+       . exact-integer?)]}
+ @item{@racket[_hash2-proc : (any/c (any/c . -> . exact-integer?) . ->
+       . exact-integer?)]}
+]
 }
 
 @section{Boolean Aliases}

--- a/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
@@ -96,9 +96,11 @@ This function is often used in conjunction with @racket[make-constructor-style-p
 }
 
 @defthing[prop:custom-write struct-type-property?]{
-A deprecated @tech{structure type property} (see @secref["structprops"])
+A @tech{structure type property} (see @secref["structprops"])
 that supplies a procedure that corresponds to @racket[gen:custom-write]'s
-@racket[write-proc]. Use @racket[gen:custom-write], instead.
+@racket[write-proc]. Using the @racket[prop:custom-write] property is
+discouraged; use the @racket[gen:custom-write] @tech{generic interface}
+instead.
 }
 
 @defproc[(custom-write? [v any/c]) boolean?]{

--- a/pkgs/racket-doc/scribblings/reference/dicts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/dicts.scrbl
@@ -198,7 +198,7 @@ only supported for dictionary types that directly implement them.
 
 Returns the value for @racket[key] in @racket[dict]. If no value
 is found for @racket[key], then @racket[failure-result] determines the
-result: 
+result:
 
 @itemize[
 
@@ -489,7 +489,7 @@ Supported for any @racket[dict] that implements @racket[dict-ref] and
 
 Composes @racket[dict-ref] and @racket[dict-set!] to update an
 existing mapping in @racket[dict], where the optional @racket[failure-result]
-argument is used as in @racket[dict-ref] when no mapping exists for 
+argument is used as in @racket[dict-ref] when no mapping exists for
 @racket[key] already.
 
 Supported for any @racket[dict] that implements @racket[dict-ref] and
@@ -516,7 +516,7 @@ v
 
 Composes @racket[dict-ref] and @racket[dict-set] to functionally
 update an existing mapping in @racket[dict], where the optional @racket[failure-result]
-argument is used as in @racket[dict-ref] when no mapping exists for 
+argument is used as in @racket[dict-ref] when no mapping exists for
 @racket[key] already.
 
 Supported for any @racket[dict] that implements @racket[dict-ref] and
@@ -563,7 +563,7 @@ Supported for any @racket[dict] that implements @racket[dict-iterate-first],
 
 @examples[
 #:eval dict-eval
-(dict-for-each #hash((a . "apple") (b . "banana")) 
+(dict-for-each #hash((a . "apple") (b . "banana"))
                (lambda (k v)
                  (printf "~a = ~s\n" k v)))
 ]}
@@ -656,7 +656,7 @@ table
 
 }
 
-@defproc[(dict-keys [dict dict?]) list?]{ 
+@defproc[(dict-keys [dict dict?]) list?]{
 Returns a list of the keys from
 @racket[dict] in an unspecified order.
 
@@ -669,7 +669,7 @@ Supported for any @racket[dict] that implements @racket[dict-iterate-first],
 (dict-keys h)
 ]}
 
-@defproc[(dict-values [dict dict?]) list?]{ 
+@defproc[(dict-values [dict dict?]) list?]{
 Returns a list of the values from
 @racket[dict] in an unspecified order.
 
@@ -682,7 +682,7 @@ Supported for any @racket[dict] that implements @racket[dict-iterate-first],
 (dict-values h)
 ]}
 
-@defproc[(dict->list [dict dict?]) list?]{ 
+@defproc[(dict->list [dict dict?]) list?]{
 Returns a list of the associations from
 @racket[dict] in an unspecified order.
 
@@ -794,7 +794,7 @@ iterators, respectively, if @racket[d] implements the
 
 @section{Custom Hash Tables}
 
-@defform[(define-custom-hash-types name 
+@defform[(define-custom-hash-types name
                                    optional-predicate
                                    comparison-expr
                                    optional-hash-functions)
@@ -998,7 +998,7 @@ See also @racket[define-custom-hash-types].
                               (string=? (format "~a" a)
                                         (format "~a" b)))
                             (lambda (a)
-                              (equal-hash-code 
+                              (equal-hash-code
                                (format "~a" a)))))
 (dict-set! h 1 'one)
 (dict-ref h "1")

--- a/pkgs/racket-doc/scribblings/reference/dicts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/dicts.scrbl
@@ -167,9 +167,10 @@ be used to implement any of the methods documented as
 }
 
 @defthing[prop:dict struct-type-property?]{
-  A deprecated structure type property used to define custom extensions
-  to the dictionary API. Use @racket[gen:dict] instead. Accepts a vector
-  of 10 method implementations:
+  A structure type property used to define custom extensions
+  to the dictionary API. Using the @racket[prop:dict] property is
+  discouraged; use the @racket[gen:dict] @tech{generic interface}
+  instead. Accepts a vector of 10 method implementations:
 
   @itemize[
            @item{@racket[dict-ref]}

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1254,10 +1254,11 @@ stream, but plain lists can be used as streams, and functions such as
 }
 
 @defthing[prop:stream struct-type-property?]{
-  A deprecated structure type property used to define custom
-  extensions to the stream API. Use @racket[gen:stream] instead.
-  Accepts a vector of three procedures taking the same arguments as
-  the methods in @racket[gen:stream].
+  A structure type property used to define custom
+  extensions to the stream API. Using the @racket[prop:stream] property
+  is discouraged; use the @racket[gen:stream] @tech{generic interface}
+  instead. Accepts a vector of three procedures taking the same arguments
+  as the methods in @racket[gen:stream].
 }
 
 @defproc[(stream/c [c contract?]) contract?]{

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -175,11 +175,11 @@ each element in the sequence.
   @racket[step] is non-negative, or less or equal to @racket[end] if
   @racket[step] is negative.  @speed[in-range "number"]
 
-  
+
   @examples[#:label "Example: gaussian sum" #:eval sequence-evaluator
     (for/sum ([x (in-range 10)]) x)]
 
-  
+
   @examples[#:label "Example: sum of even numbers" #:eval sequence-evaluator
     (for/sum ([x (in-range 0 100 2)]) x)]
 
@@ -259,7 +259,7 @@ each element in the sequence.
 
   If @racket[stop] is not in [-1, @racket[(vector-length vec)]],
   then the @exnraise[exn:fail:contract].
-  
+
   If @racket[start] is less than
   @racket[stop] and @racket[step] is negative, then the
   @exnraise[exn:fail:contract].  Similarly, if @racket[start]
@@ -403,7 +403,7 @@ each element in the sequence.
   Returns a sequence whose elements are pairs, each containing a key
   and its value from @racket[hash] (as opposed to using @racket[hash]
   directly as a sequence to get the key and value as separate values
-  for each element). 
+  for each element).
 
   The @racket[bad-index-v] argument, if supplied, is used in the same
   way as by @racket[in-hash]. When an invalid index is encountered,
@@ -418,39 +418,39 @@ each element in the sequence.
   @history[#:changed "7.0.0.10" @elem{Added the optional @racket[bad-index-v] argument.}]}
 
 @deftogether[(
-@defproc[(in-mutable-hash 
-          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))]) 
+@defproc[(in-mutable-hash
+          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))])
 	  sequence?]
 @defproc[#:link-target? #f
-         (in-mutable-hash 
-          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))] [bad-index-v any/c]) 
+         (in-mutable-hash
+          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-mutable-hash-keys
-          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))]) 
+          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))])
 	  sequence?]
 @defproc[#:link-target? #f
          (in-mutable-hash-keys
           [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-mutable-hash-values
-          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))]) 
+          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))])
 	  sequence?]
 @defproc[#:link-target? #f
          (in-mutable-hash-values
           [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-mutable-hash-pairs
-          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))]) 
+          [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))])
 	  sequence?]
 @defproc[#:link-target? #f
          (in-mutable-hash-pairs
           [hash (and/c hash? (not/c immutable?) (not/c hash-weak?))] [bad-index-v any/c])
 	  sequence?]
-@defproc[(in-immutable-hash 
+@defproc[(in-immutable-hash
           [hash (and/c hash? immutable?)])
 	  sequence?]
 @defproc[#:link-target? #f
-         (in-immutable-hash 
+         (in-immutable-hash
           [hash (and/c hash? immutable?)] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-immutable-hash-keys
@@ -474,29 +474,29 @@ each element in the sequence.
          (in-immutable-hash-pairs
           [hash (and/c hash? immutable?)] [bad-index-v any/c])
 	  sequence?]
-@defproc[(in-weak-hash 
-          [hash (and/c hash? hash-weak?)]) 
+@defproc[(in-weak-hash
+          [hash (and/c hash? hash-weak?)])
 	  sequence?]
 @defproc[#:link-target? #f
-         (in-weak-hash 
+         (in-weak-hash
           [hash (and/c hash? hash-weak?)] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-weak-hash-keys
-          [hash (and/c hash? hash-weak?)]) 
+          [hash (and/c hash? hash-weak?)])
 	  sequence?]
 @defproc[#:link-target? #f
          (in-weak-hash-keys
           [hash (and/c hash? hash-weak?)] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-weak-hash-values
-          [hash (and/c hash? hash-weak?)]) 
+          [hash (and/c hash? hash-weak?)])
 	  sequence?]
 @defproc[#:link-target? #f
          (in-weak-hash-keys
           [hash (and/c hash? hash-weak?)] [bad-index-v any/c])
 	  sequence?]
 @defproc[(in-weak-hash-pairs
-          [hash (and/c hash? hash-weak?)]) 
+          [hash (and/c hash? hash-weak?)])
 	  sequence?]
 @defproc[#:link-target? #f
          (in-weak-hash-pairs
@@ -504,9 +504,9 @@ each element in the sequence.
 	  sequence?]
 )]{
    Sequence constructors for specific kinds of hash tables.
-   These may perform better than the analogous @racket[in-hash] 
+   These may perform better than the analogous @racket[in-hash]
    forms.
-   
+
    @history[#:added "6.4.0.6"
             #:changed "7.0.0.10" @elem{Added the optional @racket[bad-index-v] argument.}]
 }
@@ -703,7 +703,7 @@ each element in the sequence.
   @itemize[
     @item{The first result is a @racket[_pos->element] procedure that
       takes the current position and returns the value(s) for the
-      current element.}      
+      current element.}
     @item{The optional second result is an @racket[_early-next-pos]
       procedure that is described further below. Alternatively, the
       optional second result can be @racket[#f], which is equivalent
@@ -1383,7 +1383,7 @@ values from the generator.
     (welcome)]}
 
 @defform/subs[(in-generator maybe-arity body ...+)
-              ([maybe-arity code:blank 
+              ([maybe-arity code:blank
                             (code:line #:arity arity-k)])]{
   Produces a @tech{sequence} that encapsulates the @tech{generator}
   formed by @racket[(generator () body ...+)]. The values produced by
@@ -1406,7 +1406,7 @@ values from the generator.
   values for each element, its arity should be declared with an
   @racket[#:arity arity-k] clause; the @racket[arity-k] must be a
   literal, exact, non-negative integer.
-  
+
   @examples[#:eval generator-eval
     (eval:error
      (let ([g (in-generator


### PR DESCRIPTION
This pull request changes the documentation for the struct-type-properties `prop:custom-write`, `prop:equal+hash`, `prop:stream`, and `prop:dict`, to mark them as "discouraged" in favor of their respective generic interfaces, but not "deprecated".

The word "deprecated" has implications that they are intended to be removed in the future and you should absolutely avoid using them and migrate existing code away. However this is not the case with these struct-type properties that have corresponding generic interfaces. The generic interfaces are a convenience layer on top, so the properties are fully compatible and no behavior is going away. We want to leave the possibility that in situations where using the convenient generic-interfaces isn't an option, falling back to the properties is valid and isn't dangerous for future racket versions.

A transcript of some discussion on Slack for context on why "discouraged" is a better word than "deprecated":

> AlexKnauth 7:46 PM
> In the documentation for prop:custom-write and prop:equal+hash, it says that they are “deprecated”. In some languages, this means that they are intended to be removed in the future and you should absolutely avoid using them and migrate existing code away. I have gotten the impression that that isn’t what “deprecated” means here for those two struct-type-properties.
So what does it mean in this context?

> AlexKnauth 8:20 PM
> On both of those it looks like @stamourv was the one to introduce that word in these two commits:
> - custom-write https://github.com/racket/racket/commit/cee88f05dd29c99f9edf7051401bfb6434780b64
> - equal+hash https://github.com/racket/racket/commit/390cd02b52648637802b3a72af95355e13bfde2c

> stamourv 8:18 AM
> @AlexKnauth: Your understanding of the word "deprecated" is indeed in line with the Racket meaning. My understanding at the time was not. I don't think there was ever a plan to remove them, but rather a desire to steer people away from the older way of doing things and towards the new one. There needs to be a word for that, but deprecated isn't it.

> sorawee 8:29 AM
> “discouraged”?

> Sancho 10:28 AM
> Especially if we say what is preferred