### PR TITLE
Ensure interned_key is initialized

### DIFF
--- a/racket/src/racket/src/list.c
+++ b/racket/src/racket/src/list.c
@@ -3402,7 +3402,7 @@ static Scheme_Object *chaperone_hash_op(const char *who, Scheme_Object *o, Schem
         key_wraps = scheme_make_raw_pair((Scheme_Object *)who, key_wraps);
       if (mode == 0 || mode == 5) {
         /* hash-ref or hash-ref-key */
-        Scheme_Object *interned_key;
+        Scheme_Object *interned_key = NULL;
         if (SCHEME_HASHTP(o)) {
           Scheme_Hash_Table *t = (Scheme_Hash_Table *)o;
           if (t->mutex) scheme_wait_sema(t->mutex, 0);


### PR DESCRIPTION
I'm actually a bit puzzled here, because I'm not sure why the tests for absent keys at the end of `chaperone.rktl` pass currently.

The `interned_key` pointer is only set when a key is found (or, alternatively, when the returned _value_ is non-NULL). So I'd expect this to be an uninitialized pointer when a key isn't found. But the test passes consistently, so maybe I'm missing something.