### PR TITLE
Add --no-docs command line to `raco pkg install`

### DIFF
--- a/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
@@ -616,6 +616,9 @@ sub-commands.
   @item{@DFlag{no-setup} --- Does not run @exec{raco setup} after installation. This behavior is also the case if the
         environment variable @envvar{PLT_PKG_NOSETUP} is set to any non-empty value.}
 
+  @item{@DFlag{no-docs} --- Does not render documentation during setup after installation. This flag has no effect 
+        with @DFlag{no-setup}.}
+
   @item{@DFlag{recompile-only} ---Constrains @exec{raco setup} to at most recompile a module from
         machine-independent form, reporting an error if compilation from source is needed. This
         behavior is useful as a sanity check when installing built packages (to ensure that they
@@ -638,7 +641,8 @@ sub-commands.
                                    the @DFlag{deps} default to depend only on interactive mode.}
          #:changed "6.1.1.8" @elem{Added the @DFlag{pull} flag.}
          #:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
-         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}]}
+         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
 
 
 @subcommand{@command/toc{update} @nonterm{option} ... @nonterm{pkg-source} ... 
@@ -753,6 +757,7 @@ the given @nonterm{pkg-source}s.
 
  @item{@DFlag{dry-run} --- Same as for @command-ref{install}.}
  @item{@DFlag{no-setup} --- Same as for @command-ref{install}.}
+ @item{@DFlag{no-docs} --- Same as for @command-ref{install}.}
  @item{@DFlag{recompile-only} --- Same as for @command-ref{install}.}
  @item{@DFlag{jobs} @nonterm{n} or @Flag{j} @nonterm{n} --- Same as for @command-ref{install}.}
  @item{@DFlag{batch} --- Same as for @command-ref{install}.}
@@ -768,7 +773,8 @@ the given @nonterm{pkg-source}s.
          #:changed "6.1.1.8" @elem{Added the @DFlag{skip-uninstalled} and @DFlag{pull} flags.}
          #:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
          #:changed "6.90.0.27" @elem{Added the @DFlag{unclone} flag.}
-         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}]}
+         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
 
 @subcommand{@command/toc{remove} @nonterm{option} ... @nonterm{pkg} ... 
 --- Attempts to remove the given packages. By default, if a package is the dependency
@@ -796,6 +802,7 @@ the given @nonterm{pkg}s.
  @item{@DFlag{scope-dir} @nonterm{dir} --- Selects @nonterm{dir} as the @tech{package scope}, the same as for @command-ref{install}.}
  @item{@DFlag{dry-run} --- Same as for @command-ref{install}.}
  @item{@DFlag{no-setup} --- Same as for @command-ref{install}.}
+ @item{@DFlag{no-docs} --- Same as for @command-ref{install}.}
  @item{@DFlag{recompile-only} --- Same as for @command-ref{install}.}
  @item{@DFlag{jobs} @nonterm{n} or @Flag{j} @nonterm{n} --- Same as for @command-ref{install}.}
  @item{@DFlag{batch} --- Same as for @command-ref{install}.}
@@ -805,7 +812,8 @@ the given @nonterm{pkg}s.
 @history[#:changed "6.1.1.5" @elem{Added the @DFlag{batch} flag.}
          #:changed "6.1.1.6" @elem{Added the @DFlag{no-trash} flag.}
          #:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
-         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}]}
+         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
 
 
 @subcommand{@command/toc{new} @nonterm{pkg} ---
@@ -889,12 +897,14 @@ package is created.
   @item{@DFlag{no-cache} --- Same as for @command-ref{install}.}
   @item{@DFlag{dry-run} --- Same as for @command-ref{install}.}
   @item{@DFlag{no-setup} --- Same as for @command-ref{install}.}
+  @item{@DFlag{no-docs} --- Same as for @command-ref{install}.}
   @item{@DFlag{recompile-only} --- Same as for @command-ref{install}.}
   @item{@DFlag{jobs} @nonterm{n} or @Flag{j} @nonterm{n} --- Same as for @command-ref{install}.}
  ]
 
 @history[#:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
-         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}]}
+         #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
 
 @subcommand{@command/toc{create} @nonterm{option} ... @nonterm{directory-or-package}
 --- Bundles a package into an archive. Bundling

--- a/racket/collects/pkg/main.rkt
+++ b/racket/collects/pkg/main.rkt
@@ -14,7 +14,7 @@
          (for-syntax racket/base
                      syntax/strip-context))
 
-(define (setup what no-setup? recompile-only? fail-fast? setup-collects jobs)
+(define (setup what no-setup? no-docs? recompile-only? fail-fast? setup-collects jobs)
   (unless (or (eq? setup-collects 'skip)
               no-setup?
               (not (member (getenv "PLT_PKG_NOSETUP") '(#f ""))))
@@ -22,6 +22,7 @@
     (unless (setup:setup
              #:make-user? (not installation?)
              #:avoid-main? (not installation?)
+             #:make-docs? (not no-docs?)
              #:collections (and setup-collects
                                 (map (lambda (s)
                                        (if (list? s) s (list s)))
@@ -52,7 +53,7 @@
        (cond
         [installation 'installation]
         [user 'user]
-        [(path-string? given-scope) 
+        [(path-string? given-scope)
          ;; This can happens when a #:scope value is given a path programmatically.
          ;; Make it easier on clients by alloing that.
          (path->complete-path given-scope)]
@@ -71,7 +72,7 @@
                             [given-name (values given-name #f)]
                             [(and (eq? pkgs-type 'clone)
                                   clone-type-can-be-name?
-                                  (let-values ([(pkg-name pkg-type) 
+                                  (let-values ([(pkg-name pkg-type)
                                                 (package-source->name+type pkg #f)])
                                     (and (eq? pkg-type 'name)
                                          pkg-name)))
@@ -82,7 +83,7 @@
                                                         #:must-infer-name? #t
                                                         #:complain
                                                         (lambda (s msg)
-                                                          ((current-pkg-error) 
+                                                          ((current-pkg-error)
                                                            (~a "~a\n"
                                                                "  given: ~a")
                                                            msg s)))]))
@@ -122,7 +123,7 @@
   (define-values (base name dir?) (split-path clone))
   (cond
    [(and (path? name)
-         (let-values ([(pkg-name pkg-type) 
+         (let-values ([(pkg-name pkg-type)
                        (package-source->name+type (path-element->string name) #f)])
            (eq? pkg-type 'name)))
     (define pkg (path-element->string name))
@@ -170,7 +171,7 @@
              install-type-flags ...
              #:once-any
              [install-dep-flags ...
-                                (dep-desc ... 
+                                (dep-desc ...
                                           install-dep-desc ...)]
              [#:bool auto () "Shorthand for `--deps search-auto'"]
              #:once-each
@@ -228,7 +229,7 @@
                                        #:dep-behavior (or (and auto 'search-auto)
                                                           deps
                                                           (cond
-                                                           [batch 'fail]                                                           
+                                                           [batch 'fail]
                                                            [else 'search-ask]))
                                        #:all-platforms? all-platforms
                                        #:force? force
@@ -242,7 +243,7 @@
                                                    (and binary 'binary)
                                                    (and binary-lib 'binary-lib))
                                        #:force-strip? force
-                                       #:multi-clone-behavior (or multi-clone 
+                                       #:multi-clone-behavior (or multi-clone
                                                                   (if batch
                                                                       'fail
                                                                       'ask))
@@ -254,7 +255,7 @@
                                          (pkg-desc p a-type* name checksum #f
                                                    #:path (and (eq? a-type* 'clone)
                                                                (path->complete-path clone))))))))
-                  (setup "installed" no-setup recompile-only fail-fast setup-collects jobs))))]
+                  (setup "installed" no-setup no-docs recompile-only fail-fast setup-collects jobs))))]
             ;; ----------------------------------------
             [update
              "Update packages"
@@ -267,7 +268,7 @@
              install-type-flags ...
              #:once-any
              [install-dep-flags ...
-                                (dep-desc ... 
+                                (dep-desc ...
                                           install-dep-desc ...)]
              [#:bool auto () "Shorthand for `--deps search-auto' plus `--update-deps'"]
              #:once-each
@@ -323,7 +324,7 @@
                                           (pkg-desc pkg-source a-type name checksum #f
                                                     #:path clone-path)]
                                          [else
-                                          (define-values (pkg-name pkg-type) 
+                                          (define-values (pkg-name pkg-type)
                                             (package-source->name+type pkg-source a-type))
                                           (if (eq? pkg-type 'name)
                                               pkg-name
@@ -358,7 +359,7 @@
                                       #:infer-clone-from-dir? (not (or link static-link copy))
                                       #:dry-run? dry-run
                                       #:use-trash? (not no-trash)))))
-                  (setup "updated" no-setup recompile-only #f setup-collects jobs))))]
+                  (setup "updated" no-setup no-docs recompile-only #f setup-collects jobs))))]
             ;; ----------------------------------------
             [remove
              "Remove packages"
@@ -386,7 +387,7 @@
                                #:force? force
                                #:dry-run? dry-run
                                #:use-trash? (not no-trash))))
-                (setup "removed" no-setup recompile-only #f setup-collects jobs)))]
+                (setup "removed" no-setup no-docs recompile-only #f setup-collects jobs)))]
             ;; ----------------------------------------
             [new
              "Populate a new directory with the stubs of a package"
@@ -485,7 +486,7 @@
                                               (and binary-lib 'binary-lib))
                                   #:force-strip? force
                                   #:dry-run? dry-run))))
-                (setup "migrated" no-setup recompile-only #f setup-collects jobs)))]
+                (setup "migrated" no-setup no-docs recompile-only #f setup-collects jobs)))]
             ;; ----------------------------------------
             [create
              "Bundle package from a directory or installed package"
@@ -507,10 +508,10 @@
              [(#:str dest-dir #f) dest () "Create output files in <dest-dir>"]
              #:args (directory-or-package)
              (parameterize ([current-pkg-error (pkg-error 'create)])
-               (pkg-create (if manifest 'MANIFEST (or format 'zip)) 
+               (pkg-create (if manifest 'MANIFEST (or format 'zip))
                            directory-or-package
                            #:from-command-line? #t
-                           #:dest (and dest 
+                           #:dest (and dest
                                        (path->complete-path dest))
                            #:source (cond
                                      [from-install 'name]
@@ -562,7 +563,7 @@
                             [current-pkg-error (pkg-error 'catalog-show)]
                             [current-pkg-lookup-version (or version
                                                             (current-pkg-lookup-version))])
-               (pkg-catalog-show pkg-name 
+               (pkg-catalog-show pkg-name
                                  #:all? all
                                  #:only-names? only-names
                                  #:modules? modules))]
@@ -676,6 +677,7 @@
    ([#:bool dry-run () ("Don't actually change package installation")])
    #:job-flags
    ([#:bool no-setup () ("Don't `raco setup` after changing packages (usually a bad idea)")]
+    [#:bool no-docs () "Do not compile .scrbl files and do not build documentation"]
     [#:bool recompile-only () ("Expect built packages, possibly machine-independent")]
     [(#:num n #f) jobs ("-j") "Setup with <n> parallel jobs"]
     [#:bool batch () ("Disable interactive mode and all prompts")])
@@ -684,7 +686,7 @@
    #:catalog-flags
    ([(#:str catalog #f) catalog () "Use <catalog> instead of configured catalogs"])
    #:install-type-flags
-   ([(#:sym type [file dir file-url dir-url git github name] #f) type ("-t") 
+   ([(#:sym type [file dir file-url dir-url git github name] #f) type ("-t")
      ("Specify type of <pkg-source>, instead of inferred;"
       "valid <types>s are: file, dir, file-url, dir-url, git, github, or name")]
     [(#:str name #f) name ("-n") ("Specify name of package, instead of inferred;"
@@ -731,7 +733,7 @@
     [#:bool binary-lib () ("Strip source & documentation before installing; implies --copy")])
    #:install-copy-defns
    [(define link-dirs? (not (or copy source binary binary-lib)))
-    (define link-type (or (and link 'link) 
+    (define link-type (or (and link 'link)
                           (and static-link 'static-link)
                           (and (eq? type 'dir) link-dirs? 'link)
                           (and clone 'clone)))


### PR DESCRIPTION
This simply passes the same flag to setup, which already knows how to
run setup without rendering the documentation.