### PR TITLE
Add -D to pkg install as an alternative to --no-docs

### DIFF
--- a/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
@@ -616,7 +616,7 @@ sub-commands.
   @item{@DFlag{no-setup} --- Does not run @exec{raco setup} after installation. This behavior is also the case if the
         environment variable @envvar{PLT_PKG_NOSETUP} is set to any non-empty value.}
 
-  @item{@DFlag{no-docs} --- Does not render documentation during setup after installation. This flag has no effect 
+  @item{@DFlag{no-docs} or @Flag{D} --- Does not render documentation during setup after installation. This flag has no effect 
         with @DFlag{no-setup}.}
 
   @item{@DFlag{recompile-only} ---Constrains @exec{raco setup} to at most recompile a module from
@@ -642,7 +642,7 @@ sub-commands.
          #:changed "6.1.1.8" @elem{Added the @DFlag{pull} flag.}
          #:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
          #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
-         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs}, @Flag{D} flags.}]}
 
 
 @subcommand{@command/toc{update} @nonterm{option} ... @nonterm{pkg-source} ... 
@@ -757,7 +757,7 @@ the given @nonterm{pkg-source}s.
 
  @item{@DFlag{dry-run} --- Same as for @command-ref{install}.}
  @item{@DFlag{no-setup} --- Same as for @command-ref{install}.}
- @item{@DFlag{no-docs} --- Same as for @command-ref{install}.}
+ @item{@DFlag{no-docs} or @Flag{D} --- Same as for @command-ref{install}.}
  @item{@DFlag{recompile-only} --- Same as for @command-ref{install}.}
  @item{@DFlag{jobs} @nonterm{n} or @Flag{j} @nonterm{n} --- Same as for @command-ref{install}.}
  @item{@DFlag{batch} --- Same as for @command-ref{install}.}
@@ -774,7 +774,7 @@ the given @nonterm{pkg-source}s.
          #:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
          #:changed "6.90.0.27" @elem{Added the @DFlag{unclone} flag.}
          #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
-         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs}, @Flag{D} flags.}]}
 
 @subcommand{@command/toc{remove} @nonterm{option} ... @nonterm{pkg} ... 
 --- Attempts to remove the given packages. By default, if a package is the dependency
@@ -802,7 +802,7 @@ the given @nonterm{pkg}s.
  @item{@DFlag{scope-dir} @nonterm{dir} --- Selects @nonterm{dir} as the @tech{package scope}, the same as for @command-ref{install}.}
  @item{@DFlag{dry-run} --- Same as for @command-ref{install}.}
  @item{@DFlag{no-setup} --- Same as for @command-ref{install}.}
- @item{@DFlag{no-docs} --- Same as for @command-ref{install}.}
+ @item{@DFlag{no-docs} or @Flag{D} --- Same as for @command-ref{install}.}
  @item{@DFlag{recompile-only} --- Same as for @command-ref{install}.}
  @item{@DFlag{jobs} @nonterm{n} or @Flag{j} @nonterm{n} --- Same as for @command-ref{install}.}
  @item{@DFlag{batch} --- Same as for @command-ref{install}.}
@@ -813,7 +813,7 @@ the given @nonterm{pkg}s.
          #:changed "6.1.1.6" @elem{Added the @DFlag{no-trash} flag.}
          #:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
          #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
-         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs}, @Flag{D} flags.}]}
 
 
 @subcommand{@command/toc{new} @nonterm{pkg} ---
@@ -897,14 +897,14 @@ package is created.
   @item{@DFlag{no-cache} --- Same as for @command-ref{install}.}
   @item{@DFlag{dry-run} --- Same as for @command-ref{install}.}
   @item{@DFlag{no-setup} --- Same as for @command-ref{install}.}
-  @item{@DFlag{no-docs} --- Same as for @command-ref{install}.}
+  @item{@DFlag{no-docs} or @Flag{D} --- Same as for @command-ref{install}.}
   @item{@DFlag{recompile-only} --- Same as for @command-ref{install}.}
   @item{@DFlag{jobs} @nonterm{n} or @Flag{j} @nonterm{n} --- Same as for @command-ref{install}.}
  ]
 
 @history[#:changed "6.4.0.14" @elem{Added the @DFlag{dry-run} flag.}
          #:changed "7.2.0.8" @elem{Added the @DFlag{recompile-only} flag.}
-         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs} flags.}]}
+         #:changed "7.4.0.4" @elem{Added the @DFlag{no-docs}, @Flag{D} flags.}]}
 
 @subcommand{@command/toc{create} @nonterm{option} ... @nonterm{directory-or-package}
 --- Bundles a package into an archive. Bundling

--- a/racket/collects/pkg/main.rkt
+++ b/racket/collects/pkg/main.rkt
@@ -677,7 +677,7 @@
    ([#:bool dry-run () ("Don't actually change package installation")])
    #:job-flags
    ([#:bool no-setup () ("Don't `raco setup` after changing packages (usually a bad idea)")]
-    [#:bool no-docs () "Do not compile .scrbl files and do not build documentation"]
+    [#:bool no-docs ("-D") "Do not compile .scrbl files and do not build documentation"]
     [#:bool recompile-only () ("Expect built packages, possibly machine-independent")]
     [(#:num n #f) jobs ("-j") "Setup with <n> parallel jobs"]
     [#:bool batch () ("Disable interactive mode and all prompts")])


### PR DESCRIPTION
raco setup already provides --no-docs and -D so we should too.
Followup to #2776