### PR TITLE
Add native dark mode to macOS apps

### DIFF
--- a/racket/src/mac/osx_appl.rkt
+++ b/racket/src/mac/osx_appl.rkt
@@ -113,6 +113,7 @@
 		       ,(version))
 	   (assoc-pair "NSPrincipalClass" "NSApplicationMain")
            (assoc-pair "NSHighResolutionCapable" (true))
+	   (assoc-pair "NSRequiresAquaSystemAppearance" (false))
 	   (assoc-pair "NSSupportsAutomaticGraphicsSwitching" (true))))
 
     (create-app (build-path (current-directory) (if for-3m? 'up 'same))


### PR DESCRIPTION
Enables native dark mode UI elements in macOS 10.14 and above. Adds the
'NSRequiresAquaSystemAppearance' key with a value of 'false' to the
Info.plist file, while allows UI elements to match the system theme even
when not building against the latest SDK.

More information about the `NSRequiresAquaSystemAppearance` key [here](https://developer.apple.com/documentation/appkit/nsappearancecustomization/choosing_a_specific_appearance_for_your_macos_app).

I think if racket is built from a macOS system with 10.14 or above then this key isn't needed, however it looks like for the 7.3 release version on the website this isn't the case, as the apps open in light mode still.

I have not noticed any UI bugs specific to the macOS implementation of dark mode. There are a couple places where the font colors might not be ideal, but these bugs exist cross platform (tested on Fedora 30 running GNOME). Tested DrRacket, GRacket, PLTGames, and Slideshow.

First time contributing the the language, let me know if there is anything I need to change/help test. On first look it looks like the GUI library stuff will not need to be changed at all.

<details>
<summary>Screenshots</summary>

![image](https://user-images.githubusercontent.com/4574041/62414494-4f5d4c80-b5ea-11e9-9318-46117a4ce1ee.png)
![image](https://user-images.githubusercontent.com/4574041/62414503-61d78600-b5ea-11e9-8100-f23d8da22232.png)
![image](https://user-images.githubusercontent.com/4574041/62414505-6ac85780-b5ea-11e9-9e0f-fc1b9e71b6af.png)
![image](https://user-images.githubusercontent.com/4574041/62414510-7451bf80-b5ea-11e9-8f8e-23ae01fc417e.png)

</details>