### PR TITLE
Add make rule for gmp_arch_gcc sources to gc2 Makefile.in

### DIFF
--- a/racket/src/racket/gc2/Makefile.in
+++ b/racket/src/racket/gc2/Makefile.in
@@ -502,6 +502,11 @@ foreign.@LTO@: $(XSRCDIR)/foreign.c
 main.@LTO@: $(XSRCDIR)/main.c
 	$(CC) $(ALL_CFLAGS) -c $(XSRCDIR)/main.c -o main.@LTO@
 
+$(SRCDIR)/gmp_alpha_gcc.@LTO@: $(SRCDIR)/gmp/gmp_alpha_gcc.s
+	$(AS) -o $(SRCDIR)/gmp_alpha_gcc.@LTO@ $(SRCDIR)/gmp/gmp_alpha_gcc.s
+$(SRCDIR)/gmp_arm_gcc.@LTO@: $(SRCDIR)/gmp/gmp_arm_gcc.s
+	$(AS) -o $(SRCDIR)/gmp_arm_gcc.@LTO@ $(SRCDIR)/gmp/gmp_arm_gcc.s
+
 mzcom.@LTO@: $(srcdir)/../../mzcom/mzcom.cxx
 	$(CC) -DMZCOM_3M $(ALL_CFLAGS) -fno-exceptions -c $(srcdir)/../../mzcom/mzcom.cxx -o mzcom.@LTO@
 mzobj.@LTO@: $(XSRCDIR)/mzobj.cxx
@@ -576,7 +581,7 @@ LIBRKTIO_FOR_DLL = $(LIBRKTIO_FOR_DLL_@LIBSFX@)
 LIBRKTIO_FOR_LIB = $(LIBRKTIO_FOR_LIB_@LIBSFX@)
 LIBRKTIO_UP_FOR_LIB = $(LIBRKTIO_UP_FOR_LIB_@LIBSFX@)
 
-EXTRA_GMP_DEP_FILE = ../src/@EXTRA_GMP_OBJ@
+EXTRA_GMP_DEP_FILE = $(SRCDIR)/@EXTRA_GMP_OBJ@
 EXTRA_GMP = @EXTRA_GMP_DEP@
 
 EXTRA_OBJS_T = $(EXTRA_GMP) ../src/unwind.@LTO@ $(@FOREIGN_IF_USED@_LIB) $(LIBRKTIO_FOR_DLL)


### PR DESCRIPTION
This avoid a split build (first build cgc and then 3m based on cgc)
failing on arm/alpha.