### PR TITLE
gen:stream fix example code

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1245,7 +1245,7 @@ stream, but plain lists can be used as streams, and functions such as
        (define (stream-first stream)
          (first (list-stream-v stream)))
        (define (stream-rest stream)
-         (rest (list-stream-v stream)))])
+         (list-stream (rest (list-stream-v stream))))])
 
     (define l1 (list-stream '(1 2)))
     (stream? l1)


### PR DESCRIPTION
Fix example code to make another stream after the 'rest' operation.