### PR TITLE
Implements negated unicode categories in pregexps

### DIFF
--- a/racket/src/regexp/demo.rkt
+++ b/racket/src/regexp/demo.rkt
@@ -160,6 +160,10 @@
        #"aB"
        1)
 
+(check #"\\p{^Ll}"
+       #"aB"
+       1)
+
 (check #".*"
        #"abaacacaaacacaaacd"
        100000)


### PR DESCRIPTION
The grammar for pregexps includes:
```
   | \p{‹property›} Match (UTF-8 encoded) in ‹property›
   | \P{‹property›} Match (UTF-8 encoded) not in ‹property›
```
and ‹property› is defined as:
```
   ‹property› ::= ‹category› Includes all characters in ‹category›
               |  ^‹category› Includes all characters not in ‹category›
```
That is to say, there are two independent ways to negate one of
these character classes. The Racket implementation of regexps
(as opposed to the C implementation) does not recognize negated
categories. This PR fixes that.