### PR TITLE
Define _GNU_SOURCE instead of __USE_GNU

### DIFF
--- a/racket/src/racket/src/unwind/libunwind.h
+++ b/racket/src/racket/src/unwind/libunwind.h
@@ -60,9 +60,9 @@ extern "C" {
 # ifdef __APPLE__
 #  define _XOPEN_SOURCE
 # endif
-# define __USE_GNU
+# define _GNU_SOURCE
 # include <ucontext.h>
-# undef __USE_GNU
+# undef _GNU_SOURCE
 #endif
 
   /* XXXXXXXXXXXXXXXXXXXX x86 Target XXXXXXXXXXXXXXXXXXXX */


### PR DESCRIPTION
__USE_GNU should only be used internally by features.h and never user-defined. _GNU_SOURCE is the user visible macro.

Related to #2797 