### PR TITLE
for/stream: delay finding first element

### DIFF
--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -67,6 +67,10 @@
 (test 1 'for/stream (stream-first (for*/stream ([x '(1 0)]) (/ x))))
 (test 625 'for/stream (stream-ref (for/stream ([x (in-naturals)]) (* x x)) 25))
 
+;; for/stream should be lazy https://github.com/racket/racket/issues/2812
+(test #true stream? (for/stream ((x '(0)) #:when (/ x x)) (void)))
+(test #true stream? (for*/stream ((x '(0)) #:when (/ x x)) (void)))
+
 (test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)] #:break (> i 5)) i))
 (test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)]) #:break (> i 5) i))
 (test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)])

--- a/racket/collects/racket/private/stream-cons.rkt
+++ b/racket/collects/racket/private/stream-cons.rkt
@@ -22,7 +22,7 @@
 (require (prefix-in for: racket/private/for))
 
 (provide stream-null stream-cons stream? stream-null? stream-pair?
-         stream-car stream-cdr stream-lambda)
+         stream-car stream-cdr stream-lambda stream-lazy)
 
 (define-syntax stream-lazy
  (syntax-rules ()

--- a/racket/collects/racket/stream.rkt
+++ b/racket/collects/racket/stream.rkt
@@ -10,7 +10,8 @@
                     [stream-ref stream-get-generics])
          "private/sequence.rkt"
          (only-in "private/stream-cons.rkt"
-                  stream-cons)
+                  stream-cons
+                  stream-lazy)
          "private/generic-methods.rkt"
          (for-syntax racket/base))
 
@@ -338,11 +339,12 @@
         [(_ clauses . body)
          (with-syntax ([((pre-body ...) (post-body ...)) (split-for-body stx #'body)])
            (quasisyntax/loc stx
-             (#,derived-stx #,stx
-                            ([get-rest empty-stream]
-                             #:delay-with thunk)
-               clauses
-               pre-body ...
-               (stream-cons (let () post-body ...) (get-rest)))))]))
+             (stream-lazy
+               (#,derived-stx #,stx
+                              ([get-rest empty-stream]
+                               #:delay-with thunk)
+                 clauses
+                 pre-body ...
+                 (stream-cons (let () post-body ...) (get-rest))))))]))
     (values (make-for/stream #'for/foldr/derived)
             (make-for/stream #'for*/foldr/derived))))


### PR DESCRIPTION
Fixes #2812

- - -

I'm not sure if `stream-lazy` is the right way to do this, but it seems to work