### PR TITLE
Fix error of malformed in-values in a for clause

### DIFF
--- a/pkgs/racket-test-core/tests/racket/file.rktl
+++ b/pkgs/racket-test-core/tests/racket/file.rktl
@@ -1979,6 +1979,8 @@
           (parameterize ([current-directory tmp-dir])
             (for/hash ([f (mk)])
               (values f #t)))))
+  (err/rt-test (for/list ([f (in-directory tmp-dir #f '?)]) f))
+  (err/rt-test (in-directory tmp-dir #f '?))
   (delete-directory/files tmp-dir))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/pkgs/racket-test-core/tests/racket/fixnum.rktl
+++ b/pkgs/racket-test-core/tests/racket/fixnum.rktl
@@ -245,6 +245,10 @@
 (test-sequence [(2 4 6)] (in-fxvector (fxvector 1 2 3 4 5 6 7 8) 1 6 2))
 (test-sequence [(8 6 4)] (in-fxvector (fxvector 1 2 3 4 5 6 7 8) 7 2 -2))
 
+;; test malformed in-fxvector
+(err/rt-test (for/list ([x (in-fxvector)]) x))
+(err/rt-test (in-fxvector))
+
 ;; fxvector sequence tests
 (test-sequence [(1 2 3)] (fxvector 1 2 3))
 (test '() 'empty-fxvector-sequence (for/list ([i (fxvector)]) i))

--- a/pkgs/racket-test-core/tests/racket/flonum.rktl
+++ b/pkgs/racket-test-core/tests/racket/flonum.rktl
@@ -195,6 +195,10 @@
 (test-sequence [(2.0 4.0 6.0)] (in-flvector (flvector 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0) 1 6 2))
 (test-sequence [(8.0 6.0 4.0)] (in-flvector (flvector 1.0 2.0 3.0 4.0 5.0 6.0 7.0 8.0) 7 2 -2))
 
+;; test malformed in-flvector
+(err/rt-test (for/list ([x (in-flvector)]) x))
+(err/rt-test (in-flvector))
+
 ;; flvector sequence tests
 
 (test-sequence [(1.0 2.0 3.0)] (flvector 1.0 2.0 3.0))

--- a/pkgs/racket-test-core/tests/racket/for-util.rkt
+++ b/pkgs/racket-test-core/tests/racket/for-util.rkt
@@ -3,7 +3,8 @@
 (require (for-syntax racket/base))
 
 (provide test-multi-sequence
-         test-sequence)
+         test-sequence
+         err/rt-test-sequence)
 
 ;; Utilities used by various tests of sequences
 
@@ -125,3 +126,14 @@
        (test-multi-sequence [seq] gen))]
     [(_ seqs gen)
      (test-multi-sequence seqs gen)]))
+
+(define-syntax err/rt-test-sequence
+  (syntax-rules ()
+    [(_ gen . rest)
+     (begin
+       ;; Tests specific to single-values:
+       (err/rt-test (for ([i gen]) i) . rest)
+       (err/rt-test (for/list ([i gen]) i) . rest)
+       (err/rt-test (for/list~ ([i gen]) i) . rest)
+       (err/rt-test gen . rest)
+       (err/rt-test (for ([(i j) gen]) i) . rest))]))

--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -12,11 +12,19 @@
 (test-sequence [(3.0 4.0 5.0)] (in-range 3.0 6.0))
 (test-sequence [(3.0 3.5 4.0 4.5 5.0 5.5)] (in-range 3.0 6.0 0.5))
 (test-sequence [(3.0 3.1 3.2)] (in-range 3.0 3.3 0.1))
+(err/rt-test (for/list ([x (in-range)]) x))
+(err/rt-test (in-range))
+(err/rt-test (for/list ([x (in-naturals 0 1)]) x))
+(err/rt-test (in-naturals 0 1))
 
 (test-sequence [(a b c)] '(a b c))
 (test-sequence [(a b c)] (in-list '(a b c)))
+(err/rt-test (for/list ([x (in-list '(a b c) '?)]) x))
+(err/rt-test (in-list '(a b c) '?))
 (test-sequence [(a b c)] (mcons 'a (mcons 'b (mcons 'c empty))))
 (test-sequence [(a b c)] (in-mlist (mcons 'a (mcons 'b (mcons 'c empty)))))
+(err/rt-test (for/list ([x (in-mlist (mcons 'a (mcons 'b (mcons 'c empty))) '?)]) x))
+(err/rt-test (in-mlist (mcons 'a (mcons 'b (mcons 'c empty))) '?))
 (test-sequence [(a b c)] #(a b c))
 (test-sequence [(a b c)] (in-vector #(a b c)))
 (test-sequence [(a b c)] (in-vector (chaperone-vector #(a b c) (lambda (vec i val) val) (lambda (vec i val) val))))
@@ -30,6 +38,8 @@
 ;; Test indices out of bounds
 (err/rt-test (for/list ([x (in-vector #(a b c d) 0 6 2)]) x) exn:fail:contract?)
 (err/rt-test (for/list ([x (in-vector #(a b c d) 6 0 -2)]) x) exn:fail:contract?)
+(err/rt-test (for/list ([x (in-vector)]) x))
+(err/rt-test (in-vector))
 (test-sequence [(#\a #\b #\c)] "abc")
 (test-sequence [(#\a #\u3bb #\c)] "a\u03BBc")
 (test-sequence [(#\a #\b #\c)] (in-string "abc"))
@@ -39,6 +49,8 @@
 (test-sequence [(#\a #\b #\c)] (in-string "zzabcqq" 2 5))
 (test-sequence [(#\a #\b #\c)] (in-string "zzaxbyc" 2 #f 2))
 (test-sequence [(#\a #\b #\c)] (in-string "zzaxbycy" 2 #f 2))
+(err/rt-test (for/list ([x (in-string)]) x))
+(err/rt-test (in-string))
 (test-sequence [(65 66 67)] #"ABC")
 (test-sequence [(65 66 67)] (in-bytes #"ABC"))
 (test-sequence [(65 66 67)] (in-bytes #"ZZABC" 2))
@@ -46,9 +58,15 @@
 (test-sequence [(65 66 67)] (in-bytes #"ZZABCQQ" 2 5))
 (test-sequence [(65 66 67)] (in-bytes #"ZZAXBYC" 2 #f 2))
 (test-sequence [(65 66 67)] (in-bytes #"ZZAXBYCY" 2 #f 2))
+(err/rt-test (for/list ([x (in-bytes)]) x))
+(err/rt-test (in-bytes))
 (test-sequence [(#\a #\b #\c)] (in-input-port-chars (open-input-string "abc")))
+(err/rt-test (for/list ([c (in-input-port-chars (open-input-string "abc") '?)]) c))
+(err/rt-test (in-input-port-chars (open-input-string "abc") '?))
 (test-sequence [(65 66 67)] (open-input-bytes #"ABC"))
 (test-sequence [(65 66 67)] (in-input-port-bytes (open-input-bytes #"ABC")))
+(err/rt-test (for/list ([b (in-input-port-bytes (open-input-bytes #"ABC") '?)]) b))
+(err/rt-test (in-input-port-bytes (open-input-bytes #"ABC") '?))
 
 ;; Test optimized:
 (test '(2) 'in-list-of-list (for/list ([v (in-list (list 1))]) (add1 v)))
@@ -59,7 +77,13 @@
 (test-sequence [(65 66 67)] (in-port read-byte (open-input-string "ABC")))
 
 (test-sequence [("abc" "def")] (in-lines (open-input-string "abc\ndef")))
+(test-sequence [("abc" "def")] (in-lines (open-input-string "abc\ndef") 'any))
+(err/rt-test (for/list ([l (in-lines (open-input-string "abc\ndef") 'any '?)]) l))
+(err/rt-test (in-lines (open-input-string "abc\ndef") 'any '?))
 (test-sequence [(#"abc" #"def")] (in-bytes-lines (open-input-string "abc\ndef")))
+(test-sequence [(#"abc" #"def")] (in-bytes-lines (open-input-string "abc\ndef") 'any))
+(err/rt-test (for/list ([l (in-bytes-lines (open-input-string "abc\ndef") 'any '?)]) l))
+(err/rt-test (in-bytes-lines (open-input-string "abc\ndef") 'any '?))
 
 (test-sequence [(0 1 2 3 4 5)] (in-sequences (in-range 6)))
 (test-sequence [(0 1 2 3 4 5)] (in-sequences (in-range 4) '(4 5)))
@@ -97,6 +121,10 @@
 (test-sequence [(3 4 5)] (stop-before (in-naturals 3) (lambda (x) (= x 6))))
 
 (test-sequence [(a b c) (0 1 2)] (in-indexed '(a b c)))
+(err/rt-test (for/list ([(x y) (in-indexed '(a b c) '?)]) x))
+(err/rt-test (for/list ([(x y) (in-indexed '(a b c) '?)]) x))
+(err/rt-test (for/list ([x (in-indexed '(a b c))]) x))
+(err/rt-test (in-indexed '(a b c) '?))
 
 ;; Make sure `in-indexed` doesn't provide a bad position to the underlying
 ;; sequence
@@ -123,7 +151,9 @@
   (test-sequence [(1/2 1 3/2 2 5/2 3 7/2 4 9/2)]
     (for/list ([x (in-producer (counter) 5 1/2)]) x))
   ;; test in-producer outside of for loops
-  (test 6 sequence-ref (in-producer (counter)) 5))
+  (test 6 sequence-ref (in-producer (counter)) 5)
+  (err/rt-test (for/list ([x (in-producer)]) x))
+  (err/rt-test (in-producer)))
 
 (test-sequence [(1 2 3 4 5)]
   (parameterize ([current-input-port (open-input-string "1 2 3\n4 5")])
@@ -398,6 +428,8 @@
               a))
 
 (test '(11) 'in-value (for/list ([i (in-value 11)]) i))
+(err/rt-test (for/list ([i (in-value 1 2)]) i))
+(err/rt-test (in-value 1 2))
 (let-values ([(more? next) (sequence-generate (in-value 13))])
   (test #t more?)
   (test 13 next)

--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -12,10 +12,8 @@
 (test-sequence [(3.0 4.0 5.0)] (in-range 3.0 6.0))
 (test-sequence [(3.0 3.5 4.0 4.5 5.0 5.5)] (in-range 3.0 6.0 0.5))
 (test-sequence [(3.0 3.1 3.2)] (in-range 3.0 3.3 0.1))
-(err/rt-test (for/list ([x (in-range)]) x))
-(err/rt-test (in-range))
-(err/rt-test (for/list ([x (in-naturals 0 1)]) x))
-(err/rt-test (in-naturals 0 1))
+(err/rt-test-sequence (in-range))
+(err/rt-test-sequence (in-naturals 0 1))
 
 (test-sequence [(a b c)] '(a b c))
 (test-sequence [(a b c)] (in-list '(a b c)))

--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -3,7 +3,8 @@
 
 (Section 'stream)
 
-(require racket/stream)
+(require racket/stream
+         "for-util.rkt")
 
 ;; >>> Many basic stream tests are in "sequence.rktl" <<<
 
@@ -75,6 +76,9 @@
 (test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)]) #:break (> i 5) i))
 (test '(0 1 2 3 4 5) stream->list (for/stream ([i (in-naturals)])
                                     (define ii (sqr i)) #:break (> ii 30) i))
+(test-sequence [(1 2 3)] (for/list ([x (in-stream (stream 1 2 3))]) x))
+(err/rt-test (for/list ([x (in-stream)]) x))
+(err/rt-test (in-stream))
 
 ;; stream-take works on infinite streams with lazy-delayed errors later
 (test '(1 4/3 4/2 4/1) stream->list

--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -71,7 +71,7 @@
              in-weak-hash-values
              in-weak-hash-pairs
 
-             in-directory
+             (rename *in-directory in-directory)
 
              in-sequences
              in-cycle
@@ -2200,14 +2200,16 @@
     (lambda (stx)
       (syntax-case stx ()
         [[(id1 id2) (_ gen-expr)]
-         #'[(id1 id2) (in-parallel gen-expr (*in-naturals))]])))
+         #'[(id1 id2) (in-parallel gen-expr (*in-naturals))]]
+        [_ #f])))
 
   (define-sequence-syntax *in-value
     (lambda () #'in-value)
     (lambda (stx)
       (syntax-case stx ()
         [[(id) (_ expr)]
-         #'[(id) (:do-in ([(id) expr]) #t () #t () #t #f ())]])))
+         #'[(id) (:do-in ([(id) expr]) #t () #t () #t #f ())]]
+        [_ #f])))
 
   (define-sequence-syntax *in-producer
     (lambda () #'in-producer)
@@ -2247,7 +2249,8 @@
                ;; post guard
                #t
                ;; loop args
-               ())])])))
+               ())])]
+        [_ #f])))
 
   ;; Some iterators that are implemented using `*in-producer' (note: do not use
   ;; `in-producer', since in this module it is the procedure version).
@@ -2263,7 +2266,8 @@
                   (let ([r* r] [p* p])
                     (check-in-port r* p*)
                     (lambda () (r* p*)))
-                  eof)]])))
+                  eof)]]
+        [_ #f])))
 
   (define-sequence-syntax *in-lines
     (lambda () #'in-lines)
@@ -2276,7 +2280,8 @@
                   (let ([p* p] [mode* mode])
                     (check-in-lines p* mode*)
                     (lambda () (read-line p* mode*)))
-                  eof)]])))
+                  eof)]]
+        [_ #f])))
 
   (define-sequence-syntax *in-bytes-lines
     (lambda () #'in-bytes-lines)
@@ -2289,7 +2294,8 @@
                   (let ([p* p] [mode* mode])
                     (check-in-bytes-lines p* mode*)
                     (lambda () (read-bytes-line p* mode*)))
-                  eof)]])))
+                  eof)]]
+        [_ #f])))
 
   (define-sequence-syntax *in-input-port-bytes
     (lambda () #'in-input-port-bytes)
@@ -2300,7 +2306,8 @@
                   (let ([p* p])
                     (unless (input-port? p*) (in-input-port-bytes p*))
                     (lambda () (read-byte p*)))
-                  eof)]])))
+                  eof)]]
+        [_ #f])))
 
   (define-sequence-syntax *in-input-port-chars
     (lambda () #'in-input-port-chars)
@@ -2311,7 +2318,8 @@
                   (let ([p* p])
                     (unless (input-port? p*) (in-input-port-chars p*))
                     (lambda () (read-char p*)))
-                  eof)]])))
+                  eof)]]
+        [_ #f])))
 
   (define (dir-list full-d d acc)
     (for/fold ([acc acc]) ([f (in-list (reverse (sort (directory-list full-d) path<?)))])
@@ -2330,10 +2338,10 @@
 		  orig-dir null)
 	(directory-list init-dir)))
 
-  (define *in-directory
+  (define in-directory
     (case-lambda 
-     [() (*in-directory #f (lambda (d) #t))]
-     [(orig-dir) (*in-directory orig-dir (lambda (d) #t))]
+     [() (in-directory #f (lambda (d) #t))]
+     [(orig-dir) (in-directory orig-dir (lambda (d) #t))]
      [(orig-dir use-dir?)
       (define init-dir (current-directory))
       ;; current state of the sequence is a list of paths to produce; when
@@ -2352,12 +2360,12 @@
 	  #f
 	  #f)))]))
      
-  (define-sequence-syntax in-directory
-    (λ () #'*in-directory)
+  (define-sequence-syntax *in-directory
+    (λ () #'in-directory)
     (λ (stx)
        (syntax-case stx ()
-	 [((d) (_)) #'[(d) (*in-directory #f)]]
-	 [((d) (_ dir)) #'[(d) (*in-directory dir (lambda (d) #t))]]
+	 [((d) (_)) #'[(d) (in-directory #f)]]
+	 [((d) (_ dir)) #'[(d) (in-directory dir (lambda (d) #t))]]
 	 [((d) (_ dir use-dir?-expr))
 	  #'[(d) 
 	     (:do-in
@@ -2370,6 +2378,7 @@
 	      ([(d) (car l)])
 	      #true
 	      #true
-	      [(next-body l d init-dir use-dir?)])]])))
+	      [(next-body l d init-dir use-dir?)])]]
+	 [_ #f])))
 
   )


### PR DESCRIPTION
Fix error of malformed `in-values` in a `for` clause.

For example

    (for ([x (in-value 1 2)]) x)

should raises a run time error, not a syntax error.

Fix similar error in other `in-something` macros, and add test for all of them.

Closes https://github.com/racket/racket/issues/2563

---

Also, fix name the of `in-directory`, when used as a function outside a `for`.

---

There is a second commit I'll post shortly. I tried to move the repeated pattern of test for the bad sequences generators to a macro in for-utlil.rkt . The problem is that I get an error 

    ERROR: err/rt-test: undefined;
     cannot reference an identifier before its definition
      in module: top-level

For the successful cases there is similar code with `test`. I think the problem is that `test` is a function but `err/rt-test` is a macro. I don't know how to solve this, but the easy solution is to ignore the second commit.