### PR TITLE
Enable MZ_NORETURN annotation only if MZ_PRECISE_RETURN_SPEC is defined

### DIFF
--- a/racket/src/racket/include/scheme.h
+++ b/racket/src/racket/include/scheme.h
@@ -253,7 +253,9 @@ extern "C"
 #endif
 
 #if !defined(MZ_NORETURN)
-# if defined(__GNUC__) || defined(__clang__)
+# if !defined(MZ_PRECISE_RETURN_SPEC)
+#  define MZ_NORETURN
+# elif defined(__GNUC__) || defined(__clang__)
 #  define MZ_NORETURN __attribute__((noreturn))
 # elif defined(_MSC_VER)
 #  define MZ_NORETURN __declspec(noreturn)


### PR DESCRIPTION
Unfortunately, MZ_NORETURN spec is causing a few problems - see #2808
It would be great to fix these but due to lack of time, this is a
workaround that should keep things working until all supported
configurations accept MZ_NORETURN properly.