### PR TITLE
Check that `=>` is followed by an identifier in `match` clauses.

### DIFF
--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -515,6 +515,10 @@
 
    (comp 'yes (with-handlers ([exn:fail:syntax? (lambda _ 'yes)]) (expand #'(match-lambda ((a ?) #f))) 'no))
    (comp 'yes (with-handlers ([exn:fail:syntax? (lambda _ 'yes)]) (expand #'(match-lambda ((?) #f))) 'no))
+   (comp 'yes (with-handlers ([exn:fail:syntax? (lambda _ 'yes)]
+                              [exn:fail? (lambda _ 'no)])
+                (expand #'(match 1 [1 (=> (fail)) 1]))
+                'no))
 
    (comp
     'yes

--- a/racket/collects/racket/match/gen-match.rkt
+++ b/racket/collects/racket/match/gen-match.rkt
@@ -69,7 +69,11 @@
                "expected at least one expression on the right-hand side after #:when clause"
                clause)]
              [(#:when e rest ...) (mk #f #'((if e (let () rest ...) (fail))))]
-             [(((~datum =>) unm) . rhs) (mk #'unm #'rhs)]
+             [(((~datum =>) unm:id) . rhs) (mk #'unm #'rhs)]
+             [(((~datum =>) unm) . rhs)
+              (raise-syntax-error 'match
+                                  "expected an identifier after `=>`"
+                                  #'unm)]
              [_ (mk #f rhs)])))
        (define/with-syntax body 
          (compile* (syntax->list #'(xs ...)) parsed-clauses #'outer-fail))


### PR DESCRIPTION
Closes #2830.