### PR TITLE
Specify that inbound contributions are licensed under MIT/Apache/LGPL.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+Contribute to Racket by submitting a pull request, joining the
+[development mailing list](https://lists.racket-lang.org), or visiting
+the IRC or Slack channels.
+
+By making a contribution, you are agreeing that your contribution is
+licensed under the LGPLv3, Apache 2.0, and MIT licenses. Those
+licenses are available in this repository in the files
+racket/src/COPYING_LESSER.txt, LICENSE-APACHE.txt, and
+LICENSE-MIT.txt.
+

--- a/COPYRIGHT.txt
+++ b/COPYRIGHT.txt
@@ -1,0 +1,60 @@
+Racket is distributed under the GNU Lesser General Public License
+(LGPL) version 3.  This implies that you may link Racket into
+proprietary applications, provided you follow the rules stated in the
+LGPL.  You can also modify Racket; if you distribute a modified
+version, you must distribute it under the terms of the LGPL, which in
+particular states that you must release the source code for the
+modified software.
+
+See the file racket/src/COPYING_LESSER.txt for the full text of the
+license.
+
+There may also be other licenses for code withing the Racket
+distribution with which you must comply. Some of them are listed
+below.
+
+* libscheme. Code from libscheme can be found in
+  racket/src/racket. See the file racket/src/COPYING-libscheme.txt
+
+* GNU Lightning. Code from GNU Lightning can be found in
+  racket/src/racket/src. GNU Lightning is distributed under the GNU
+  Lesser General Public License version 3.
+
+* GMP. Code from GMP can be found in racket/src/racket/src. The
+  version of GMP used is distributed under the GNU Lesser General
+  Public License version 2.1.
+
+* The Boehm Collector. Code for this package can be found in
+  racket/src/racket/gc. See the file racket/src/racket/gc/README.QUICK
+  for license information.
+
+* zlib. Code translated from earlier versions of zlib can be found in
+  racket/racket/collects/file/{gzip,gunzip}.rkt. Zlib is distributed
+  under a liberal license, see http://zlib.net/
+
+* libffi. Code from libffi can be found in racket/src/foreign/libffi.
+  See racket/src/foreign/libffi/LICENSE.
+
+* libunwind. Code from libunwind can be found in
+  racket/src/racket/src/unwind.
+
+* random.c. Code from random.c from FreeBSD 2.2 found in
+  racket/src/racket/src/random.inc.
+
+* install. Code from install can be found in racket/src/lt/install-sh
+  and is distributed under the MIT license.
+
+* psyntax. Code from psyntax can be found in
+  pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax.sch
+
+* SCM. Code from SCM can be found in
+  pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/pidigits1.rkt
+  SCM is available under the LGPL.
+
+* MemoryModule. Code from MemoryModule can be found in
+  racket/src/start/MemoryModule.c. MemoryModule is distributed under
+  the MPL v2.0.
+
+* mbed TLS. Code from mbed TLS can be found in
+  racket/src/rktio/rktio_sha2.c. mbed TLS is licensed under the Apache
+  v2.0 License.

--- a/LICENSE-APACHE.txt
+++ b/LICENSE-APACHE.txt
@@ -1,0 +1,201 @@
+                              Apache License
+                        Version 2.0, January 2004
+                     http://www.apache.org/licenses/
+
+TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+1. Definitions.
+
+   "License" shall mean the terms and conditions for use, reproduction,
+   and distribution as defined by Sections 1 through 9 of this document.
+
+   "Licensor" shall mean the copyright owner or entity authorized by
+   the copyright owner that is granting the License.
+
+   "Legal Entity" shall mean the union of the acting entity and all
+   other entities that control, are controlled by, or are under common
+   control with that entity. For the purposes of this definition,
+   "control" means (i) the power, direct or indirect, to cause the
+   direction or management of such entity, whether by contract or
+   otherwise, or (ii) ownership of fifty percent (50%) or more of the
+   outstanding shares, or (iii) beneficial ownership of such entity.
+
+   "You" (or "Your") shall mean an individual or Legal Entity
+   exercising permissions granted by this License.
+
+   "Source" form shall mean the preferred form for making modifications,
+   including but not limited to software source code, documentation
+   source, and configuration files.
+
+   "Object" form shall mean any form resulting from mechanical
+   transformation or translation of a Source form, including but
+   not limited to compiled object code, generated documentation,
+   and conversions to other media types.
+
+   "Work" shall mean the work of authorship, whether in Source or
+   Object form, made available under the License, as indicated by a
+   copyright notice that is included in or attached to the work
+   (an example is provided in the Appendix below).
+
+   "Derivative Works" shall mean any work, whether in Source or Object
+   form, that is based on (or derived from) the Work and for which the
+   editorial revisions, annotations, elaborations, or other modifications
+   represent, as a whole, an original work of authorship. For the purposes
+   of this License, Derivative Works shall not include works that remain
+   separable from, or merely link (or bind by name) to the interfaces of,
+   the Work and Derivative Works thereof.
+
+   "Contribution" shall mean any work of authorship, including
+   the original version of the Work and any modifications or additions
+   to that Work or Derivative Works thereof, that is intentionally
+   submitted to Licensor for inclusion in the Work by the copyright owner
+   or by an individual or Legal Entity authorized to submit on behalf of
+   the copyright owner. For the purposes of this definition, "submitted"
+   means any form of electronic, verbal, or written communication sent
+   to the Licensor or its representatives, including but not limited to
+   communication on electronic mailing lists, source code control systems,
+   and issue tracking systems that are managed by, or on behalf of, the
+   Licensor for the purpose of discussing and improving the Work, but
+   excluding communication that is conspicuously marked or otherwise
+   designated in writing by the copyright owner as "Not a Contribution."
+
+   "Contributor" shall mean Licensor and any individual or Legal Entity
+   on behalf of whom a Contribution has been received by Licensor and
+   subsequently incorporated within the Work.
+
+2. Grant of Copyright License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   copyright license to reproduce, prepare Derivative Works of,
+   publicly display, publicly perform, sublicense, and distribute the
+   Work and such Derivative Works in Source or Object form.
+
+3. Grant of Patent License. Subject to the terms and conditions of
+   this License, each Contributor hereby grants to You a perpetual,
+   worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+   (except as stated in this section) patent license to make, have made,
+   use, offer to sell, sell, import, and otherwise transfer the Work,
+   where such license applies only to those patent claims licensable
+   by such Contributor that are necessarily infringed by their
+   Contribution(s) alone or by combination of their Contribution(s)
+   with the Work to which such Contribution(s) was submitted. If You
+   institute patent litigation against any entity (including a
+   cross-claim or counterclaim in a lawsuit) alleging that the Work
+   or a Contribution incorporated within the Work constitutes direct
+   or contributory patent infringement, then any patent licenses
+   granted to You under this License for that Work shall terminate
+   as of the date such litigation is filed.
+
+4. Redistribution. You may reproduce and distribute copies of the
+   Work or Derivative Works thereof in any medium, with or without
+   modifications, and in Source or Object form, provided that You
+   meet the following conditions:
+
+   (a) You must give any other recipients of the Work or
+       Derivative Works a copy of this License; and
+
+   (b) You must cause any modified files to carry prominent notices
+       stating that You changed the files; and
+
+   (c) You must retain, in the Source form of any Derivative Works
+       that You distribute, all copyright, patent, trademark, and
+       attribution notices from the Source form of the Work,
+       excluding those notices that do not pertain to any part of
+       the Derivative Works; and
+
+   (d) If the Work includes a "NOTICE" text file as part of its
+       distribution, then any Derivative Works that You distribute must
+       include a readable copy of the attribution notices contained
+       within such NOTICE file, excluding those notices that do not
+       pertain to any part of the Derivative Works, in at least one
+       of the following places: within a NOTICE text file distributed
+       as part of the Derivative Works; within the Source form or
+       documentation, if provided along with the Derivative Works; or,
+       within a display generated by the Derivative Works, if and
+       wherever such third-party notices normally appear. The contents
+       of the NOTICE file are for informational purposes only and
+       do not modify the License. You may add Your own attribution
+       notices within Derivative Works that You distribute, alongside
+       or as an addendum to the NOTICE text from the Work, provided
+       that such additional attribution notices cannot be construed
+       as modifying the License.
+
+   You may add Your own copyright statement to Your modifications and
+   may provide additional or different license terms and conditions
+   for use, reproduction, or distribution of Your modifications, or
+   for any such Derivative Works as a whole, provided Your use,
+   reproduction, and distribution of the Work otherwise complies with
+   the conditions stated in this License.
+
+5. Submission of Contributions. Unless You explicitly state otherwise,
+   any Contribution intentionally submitted for inclusion in the Work
+   by You to the Licensor shall be under the terms and conditions of
+   this License, without any additional terms or conditions.
+   Notwithstanding the above, nothing herein shall supersede or modify
+   the terms of any separate license agreement you may have executed
+   with Licensor regarding such Contributions.
+
+6. Trademarks. This License does not grant permission to use the trade
+   names, trademarks, service marks, or product names of the Licensor,
+   except as required for reasonable and customary use in describing the
+   origin of the Work and reproducing the content of the NOTICE file.
+
+7. Disclaimer of Warranty. Unless required by applicable law or
+   agreed to in writing, Licensor provides the Work (and each
+   Contributor provides its Contributions) on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+   implied, including, without limitation, any warranties or conditions
+   of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+   PARTICULAR PURPOSE. You are solely responsible for determining the
+   appropriateness of using or redistributing the Work and assume any
+   risks associated with Your exercise of permissions under this License.
+
+8. Limitation of Liability. In no event and under no legal theory,
+   whether in tort (including negligence), contract, or otherwise,
+   unless required by applicable law (such as deliberate and grossly
+   negligent acts) or agreed to in writing, shall any Contributor be
+   liable to You for damages, including any direct, indirect, special,
+   incidental, or consequential damages of any character arising as a
+   result of this License or out of the use or inability to use the
+   Work (including but not limited to damages for loss of goodwill,
+   work stoppage, computer failure or malfunction, or any and all
+   other commercial damages or losses), even if such Contributor
+   has been advised of the possibility of such damages.
+
+9. Accepting Warranty or Additional Liability. While redistributing
+   the Work or Derivative Works thereof, You may choose to offer,
+   and charge a fee for, acceptance of support, warranty, indemnity,
+   or other liability obligations and/or rights consistent with this
+   License. However, in accepting such obligations, You may act only
+   on Your own behalf and on Your sole responsibility, not on behalf
+   of any other Contributor, and only if You agree to indemnify,
+   defend, and hold each Contributor harmless for any liability
+   incurred by, or claims asserted against, such Contributor by reason
+   of your accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+APPENDIX: How to apply the Apache License to your work.
+
+   To apply the Apache License to your work, attach the following
+   boilerplate notice, with the fields enclosed by brackets "[]"
+   replaced with your own identifying information. (Don't include
+   the brackets!)  The text should be enclosed in the appropriate
+   comment syntax for the file format. We also recommend that a
+   file or class name and description of purpose be included on the
+   same "printed page" as the copyright notice for easier
+   identification within third-party archives.
+
+Copyright [yyyy] [name of copyright owner]
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.

--- a/LICENSE-MIT.txt
+++ b/LICENSE-MIT.txt
@@ -1,0 +1,24 @@
+Permission is hereby granted, free of charge, to any
+person obtaining a copy of this software and associated
+documentation files (the "Software"), to deal in the
+Software without restriction, including without
+limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software
+is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice
+shall be included in all copies or substantial portions
+of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -10,16 +10,7 @@ organization](https://github.com/racket).
 
 Contribute to Racket by submitting a pull request, joining the
 [development mailing list](https://lists.racket-lang.org), or visiting
-the IRC channel.
+the IRC or Slack channels.
 
-License
--------
-
-Racket is distributed under the GNU Lesser General Public License
-(LGPL).  This implies that you may link Racket into proprietary
-applications, provided you follow the rules stated in the LGPL.  You can
-also modify Racket; if you distribute a modified version, you must
-distribute it under the terms of the LGPL, which in particular states
-that you must release the source code for the modified software.  
-
-See racket/src/COPYING_LESSER.txt for more information.
+Racket is free software; see "COPYRIGHT" and "CONTRIBUTING.md" for
+more details.

--- a/racket/collects/pkg/private/stage.rkt
+++ b/racket/collects/pkg/private/stage.rkt
@@ -904,10 +904,11 @@
 
 (define (drop-redundant-files pkg-dir)
   ;; Ad hoc space-saving rule: for an installation-wide package, remove
-  ;; any redundant "COPYING.txt" or "COPYING_LESSER.txt" files.
+  ;; any redundant license files.
   (when (and (eq? 'installation (current-pkg-scope))
              (find-share-dir))
-    (for ([i (in-list '("COPYING.txt" "COPYING_LESSER.txt"))])
+    (for ([i (in-list '("COPYING.txt" "COPYING_LESSER.txt" "COPYRIGHT.txt"
+                                      "LICENSE-APACHE" "LICENSE-MIT"))])
       (define pkg-file (build-path pkg-dir i))
       (define share-file (build-path (find-share-dir) i))
       (when (and (file-exists? pkg-file)


### PR DESCRIPTION
This is a step towards re-licensing, as described in #1570 but not an actual change in the license yet (we still need permission from some people). This simply states that contributions from here on are licensed by their contributors with _all of_ MIT, Apache 2, and LGPL. That way, further contributions after today don't require asking new people for permission.

This also adds a CONTRIBUTING.md file with minimal information other than licensing. It's not intended to stand in the way of other improvements to that file in the future.

The LGPL license stays in its current location to avoid having to modify the build right now, but the new licenses are at the top of the repository.

Thanks to our counsel from the SFC for help preparing this, and to @otherjoel and @zyrolasting for their assistance with this project.