### PR TITLE
fold: fix err while erroring when 3rd (or greater) list arg isnt list

### DIFF
--- a/pkgs/racket-test-core/tests/racket/list.rktl
+++ b/pkgs/racket-test-core/tests/racket/list.rktl
@@ -27,6 +27,12 @@
 (err/rt-test (foldl cons 0 '() '()))
 (err/rt-test (foldl list 0 '() 10))
 (err/rt-test (foldl list 0 '() '() 10))
+(err/rt-test (foldl list 0 '() '() 10)
+             exn:fail:contract?
+             "expected.*list\\?.*5th")
+(err/rt-test (foldl list 0 '() '() '() 10)
+             exn:fail:contract?
+             "expected.*list\\?.*6th")
 (err/rt-test (let/ec k (foldl k 0 '(1 2) '(1 2 3))))
 (err/rt-test (let/ec k (foldl k 0 '(1 2) '(1 2) '(1 2 3))))
 (err/rt-test (foldr 'list 0 10))
@@ -35,6 +41,12 @@
 (err/rt-test (foldr cons 0 '() '()))
 (err/rt-test (foldr list 0 '() 10))
 (err/rt-test (foldr list 0 '() '() 10))
+(err/rt-test (foldr list 0 '() '() 10)
+             exn:fail:contract?
+             "expected.*list\\?.*5th")
+(err/rt-test (foldr list 0 '() '() '() 10)
+             exn:fail:contract?
+             "expected.*list\\?.*6th")
 (err/rt-test (let/ec k (foldr k 0 '(1 2) '(1 2 3))))
 (err/rt-test (let/ec k (foldr k 0 '(1 2) '(1 2) '(1 2 3))))
 

--- a/racket/collects/racket/private/list.rkt
+++ b/racket/collects/racket/private/list.rkt
@@ -210,15 +210,15 @@
         (unless (procedure-arity-includes? proc 2)
           (raise-mismatch-error name "given procedure does not accept 2 arguments: " proc))
         (let ([len (length l)])
-          (let loop ([more more][n 3])
-            (unless (null? more)
-              (unless (list? (car more))
+          (let loop ([remaining more][n 3])
+            (unless (null? remaining)
+              (unless (list? (car remaining))
                 (apply raise-argument-error name "list?" n proc init l more))
-              (unless (= len (length (car more)))
+              (unless (= len (length (car remaining)))
                 (raise-mismatch-error name 
                                       "given list does not have the same size as the first list: "
-                                      (car more)))
-              (loop (cdr more) (add1 n))))
+                                      (car remaining)))
+              (loop (cdr remaining) (add1 n))))
           (unless (procedure-arity-includes? proc (+ 2 (length more)))
             (raise-mismatch-error name 
                                   (format "given procedure does not accept ~a arguments: " 


### PR DESCRIPTION
`foldl` and `foldr` error when the 3rd (or greater) list arg is not a list

```racket
;; 2nd list arg is not list (err ok)
> (foldl list 0 '() 10)
; foldl: contract violation
;   expected: list?
;   given: 10
;   argument position: 4th
```

```racket
;; 3rd list arg is not list (errs when producing err)
> (foldl list 0 '() '() 10)
; raise-argument-error: position index >= provided argument count
;   position index: 4
;   provided argument count: 4
```

fixed:
```racket
> (foldl list 0 '() '() 10)
; foldl: contract violation
;   expected: list?
;   given: 10
;   argument position: 5th
```