### PR TITLE
add check for eof-object as read-json result in sendurl

### DIFF
--- a/pkgs/net-lib/net/sendurl.rkt
+++ b/pkgs/net-lib/net/sendurl.rkt
@@ -203,6 +203,8 @@
     (define json
       (with-handlers ([exn:fail? (λ (exn) (fail (exn-message exn)))])
         (read-json in)))
+    (when (eof-object? json)
+      (fail "didn't find LSHandlers key in (empty) json"))
     (define handlers (hash-ref json 'LSHandlers (λ () (fail "didn't find LSHandlers key in json"))))
     (unless ((listof hash?) handlers) (fail "confusing LSHandlers ~s" handlers))
     (define uri


### PR DESCRIPTION
It turns out 'read-json' can return an eof-object, which breaks the use of hash-ref in sendurl. This code adds a check for this, so you get a slightly better error message. This solves the direct problem I saw, but not the underlying issue, which was that the call to the system utility "plutil" failed to put any data on its pipe. The stack trace (which I'll include below) suggests that the underlying issue may have been a collection whose directory was deleted, but ... I still can't reproduce it.

Either way, this pull request looks right to me. 


console output following the error (hitting F1 while the cursor was on "remove"):
racket: chdir failed to: /tmp/racket-handin-client/
hash-ref: contract violation
  expected: hash?
  given: #<eof>
  argument position: 1st
  other arguments...:
   'LSHandlers
   #<procedure:.../net/sendurl.rkt:206:48>
  context...:
   /Users/clements/racket/pkgs/net-lib/net/sendurl.rkt:173:2
   /Users/clements/racket/pkgs/net-lib/net/sendurl.rkt:161:0: send-url/mac32
   /Users/clements/racket/pkgs/net-lib/net/sendurl.rkt:110:0: send-url/file15
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/keymap.rkt:739:2: core501
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/keymap.rkt:511:2: chain-handle-key-event method in keymap%
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/keymap.rkt:499:4: for-loop
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/keymap.rkt:511:2: chain-handle-key-event method in keymap%
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/keymap.rkt:462:2: handle-key-event method in keymap%
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/editor.rkt:214:2: on-local-char method in editor%
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wxme/editor-canvas.rkt:466:2: on-char method in editor-canvas%
   /Users/clements/racket/racket/collects/racket/private/more-scheme.rkt:148:2: call-with-break-parameterization
   /Users/clements/racket/racket/collects/racket/private/more-scheme.rkt:265:2: call-with-exception-handler
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wx/cocoa/window.rkt:810:4: dispatch-on-char method in window%
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wx/common/queue.rkt:435:6
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wx/common/queue.rkt:486:32
   /Users/clements/racket/racket/share/pkgs/gui-lib/mred/private/wx/common/queue.rkt:634:3
