### PR TITLE
Do not run subprocess test unless cc or gcc exist

### DIFF
--- a/pkgs/racket-test-core/tests/racket/subprocess.rktl
+++ b/pkgs/racket-test-core/tests/racket/subprocess.rktl
@@ -558,13 +558,15 @@
 
 (unless (eq? (system-type) 'windows)
   (let* ([dir (make-temporary-file "sub~a" 'directory)]
-         [exe (build-path dir "check")])
-    (when (system* (or (find-executable-path "cc")
-                       (find-executable-path "gcc"))
-                   "-o"
-                   exe
-                   (path->complete-path "unix_check.c" (or (current-load-relative-directory)
-                                                           (current-directory))))
+         [exe (build-path dir "check")]
+         [cc-path (or (find-executable-path "cc")
+                      (find-executable-path "gcc"))])
+    (when (and cc-path
+               (system* cc-path
+                        "-o"
+                        exe
+                        (path->complete-path "unix_check.c" (or (current-load-relative-directory)
+                                                                (current-directory)))))
       (test #t 'subprocess-state (system* exe)))
     (delete-directory/files dir)))
 


### PR DESCRIPTION
Running this test in a linux docker without cc or gcc installed,
caused a failure.