### PR TITLE
Fix libcrypto native-lib install on macOS 10.15

### DIFF
--- a/racket/collects/openssl/libcrypto.rkt
+++ b/racket/collects/openssl/libcrypto.rkt
@@ -30,26 +30,32 @@
 ;;   - Fedora 21: lib{crypto,ssl}.so.1.0.1j, also lib{crypto,ssl}.so.10
 ;;   - Fedora 22: lib{crypto,ssl}.so.1.0.1k, also lib{crypto,ssl}.so.10
 ;;   - Fedora also provides a versionless library in pkg "openssl-devel"
-;; - Mac OS includes 0.9.8, 0.9.7, and versionless
+;; - Mac OS includes 0.9.8, 0.9.7, and versionless, but as of 10.15 the
+;;   versionless dylib and will abort with the following error:
+;;   "Invalid dylib load. Clients should not load the unversioned libcrypto
+;;   dylib as it does not have a stable ABI."
 
 (define openssl-lib-versions
-  '(;; Versionless (eg from devel pkg)
-    ""
+  (let
+    ([versions
+      '("1.1"
+        "1.0.2"
 
-    "1.1"
-    "1.0.2"
+        ;; Compatibility-based version / SONAME
+        "10"     ;; Fedora
+        "1.0.0"  ;; Debian, Ubuntu
 
-    ;; Compatibility-based version / SONAME
-    "10"     ;; Fedora
-    "1.0.0"  ;; Debian, Ubuntu
+        ;; Other specific known versions
+        "1.0.1k" "1.0.1j" "1.0.1g" "1.0.1e"
+        "1.0" "1.0.0" "1.0.0e" "1.0.0d" "1.0.0c" "1.0.0b" "1.0.0a"
+        "0.9.8e" "0.9.8b" "0.9.8" "0.9.7"
 
-    ;; Other specific known versions
-    "1.0.1k" "1.0.1j" "1.0.1g" "1.0.1e"
-    "1.0" "1.0.0" "1.0.0e" "1.0.0d" "1.0.0c" "1.0.0b" "1.0.0a"
-    "0.9.8e" "0.9.8b" "0.9.8" "0.9.7"
-
-    ;; Known versions for *BSD variants
-    "111"))
+        ;; Known versions for *BSD variants
+        "111")])
+    ;; Don't use the versionless dylib on macOS, as it aborts on 10.15
+    (case (cross-system-type)
+      [(macosx) versions]
+      [else (cons "" versions)]))) ;; Versionless (eg from devel pkg)
 
 (define libcrypto-load-fail-reason #f)
 


### PR DESCRIPTION
Catalina now aborts when dlopen'ing the versionless libcrypto/libssl dylibs.
This removes the versionless libs on macOS from the list of versions.

https://forums.developer.apple.com/thread/119429
https://github.com/racket/racket/issues/2018#issuecomment-542835900