### PR TITLE
Add set-filter to racket/set

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -25,7 +25,7 @@ datatypes are all sets:
 
 A @deftech{hash set} is a set whose elements are compared via @racket[equal?],
 @racket[eqv?], or @racket[eq?] and partitioned via @racket[equal-hash-code],
-@racket[eqv-hash-code], or @racket[eq-hash-code].  A hash set is either
+@racket[eqv-hash-code], or @racket[eq-hash-code]. A hash set is either
 immutable or mutable; mutable hash sets retain their elements either strongly
 or weakly.
 
@@ -51,12 +51,12 @@ certain algorithms.
 All hash sets @impl{implement} @racket[set->stream],
 @racket[set-empty?], @racket[set-member?], @racket[set-count],
 @racket[subset?], @racket[proper-subset?], @racket[set-map],
-@racket[set-for-each], @racket[set-copy], @racket[set-copy-clear],
-@racket[set->list], and @racket[set-first].  Immutable hash sets in
-addition @impl{implement} @racket[set-add], @racket[set-remove],
-@racket[set-clear], @racket[set-union], @racket[set-intersect],
-@racket[set-subtract], and @racket[set-symmetric-difference].  Mutable
-hash sets in addition @impl{implement} @racket[set-add!],
+@racket[set-filter], @racket[set-for-each], @racket[set-copy],
+@racket[set-copy-clear], @racket[set->list], and @racket[set-first]. 
+Immutable hash sets in addition @impl{implement} @racket[set-add],
+@racket[set-remove], @racket[set-clear], @racket[set-union],
+@racket[set-intersect], @racket[set-subtract], and @racket[set-symmetric-difference].
+Mutable hash sets in addition @impl{implement} @racket[set-add!],
 @racket[set-remove!], @racket[set-clear!], @racket[set-union!],
 @racket[set-intersect!], @racket[set-subtract!], and
 @racket[set-symmetric-difference!].
@@ -714,6 +714,18 @@ Supported for any @racket[st] that @supp{supports} @racket[set->stream].
 Applies the procedure @racket[proc] to each element in
 @racket[st] in an unspecified order, accumulating the results
 into a list.
+
+Supported for any @racket[st] that @supp{supports} @racket[set->stream].
+
+}
+
+@defproc[(set-filter [st generic-set?]
+                     [pred (any/c . -> . any/c)])
+         (listof any/c)]{
+
+Returns a list with the elements of @racket[st] for which @racket[pred]
+produces a true value. The @racket[pred] procedure is applied to each
+element in an unspecified order.
 
 Supported for any @racket[st] that @supp{supports} @racket[set->stream].
 

--- a/pkgs/racket-test-core/tests/racket/set.rktl
+++ b/pkgs/racket-test-core/tests/racket/set.rktl
@@ -142,6 +142,14 @@
 (test #t equal? (set) (let ([a (set 1 2 3)]) (set-symmetric-difference a a)))
 (test #t equal? (set) (let ([a (set 1 2 3)] [b (set 1 2 3)]) (set-symmetric-difference a b)))
 
+(test (filter even? '(1 2 3 4 5))
+      'set-filter/mutable
+      (sort (set-filter (mutable-set 1 2 3 4 5) even?) <))
+
+(test (filter even? '(1 2 3 4 5))
+      'set-filter/immutable
+      (sort (set-filter (set 1 2 3 4 5) even?) <))
+
 (let ([s (set 1 2 3)])
   (test #t equal? s (set-add (set-add (set-add (set) 1) 2) 3))
   (test #t equal? (seteq 1 2 3) (seteq 1 2 3))
@@ -201,6 +209,11 @@
 
   (test #t andmap negative? (set-map s -))
   (test 3 length (set-map s +))
+
+  (test 0 length (set-filter s negative?))
+  (test 1 length (set-filter s even?))
+  (test 2 length (set-filter s odd?))
+  (test 3 length (set-filter s positive?))
 
   (let ([v 0])
     (set-for-each s (lambda (n) (set! v (+ v n))))

--- a/racket/collects/racket/private/set-types.rkt
+++ b/racket/collects/racket/private/set-types.rkt
@@ -92,6 +92,11 @@
   (for/fold ([xs '()]) ([k (in-hash-keys (custom-set-table s))])
     (cons (f (set-unwrap-key s k)) xs)))
 
+(define (custom-set-filter s f)
+  (dprintf "custom-set-filter\n")
+  (for/fold ([xs '()]) ([k (in-hash-keys (custom-set-table s))])
+    (if (f (set-unwrap-key s k)) (cons (set-unwrap-key s k) xs) xs)))
+
 (define (custom-set-for-each s f)
   (dprintf "custom-set-for-each\n")
   (for ([k (in-hash-keys (custom-set-table s))])
@@ -702,6 +707,7 @@
    (define subset? custom-subset?)
    (define proper-subset? custom-proper-subset?)
    (define set-map custom-set-map)
+   (define set-filter custom-set-filter)
    (define set-for-each custom-set-for-each)
    (define set-copy custom-set-copy)
    (define set-copy-clear custom-set-copy-clear)
@@ -735,6 +741,7 @@
    (define subset? custom-subset?)
    (define proper-subset? custom-proper-subset?)
    (define set-map custom-set-map)
+   (define set-filter custom-set-filter)
    (define set-for-each custom-set-for-each)
    (define set-copy custom-set-copy)
    (define set-copy-clear custom-set-copy-clear)

--- a/racket/collects/racket/private/set.rkt
+++ b/racket/collects/racket/private/set.rkt
@@ -8,7 +8,7 @@
 
          set-empty? set-member? set-count
          set=? subset? proper-subset?
-         set-map set-for-each
+         set-map set-filter set-for-each
          set-copy set-copy-clear
          set->list set->stream set-first set-rest
          set-add set-remove set-clear
@@ -44,6 +44,8 @@
        #t))
 
 (define (list-map s f) (map f s))
+
+(define (list-filter s f) (filter f s))
 
 (define (list-for-each s f) (for-each f s))
 
@@ -218,6 +220,10 @@
 (define (fallback-map s f)
   (for/list ([x (*in-set s)])
     (f x)))
+
+(define (fallback-filter s f)
+  (for/fold ([xs '()] [x (*in-set s)])
+    (if (f x) (cons x xs) xs)))
 
 (define (fallback-for-each s f)
   (for ([x (*in-set s)])
@@ -422,6 +428,7 @@
   (subset? set set2)
   (proper-subset? set set2)
   (set-map set f)
+  (set-filter set f)
   (set-for-each set f)
   (set-copy set)
   (set-copy-clear set)
@@ -454,6 +461,7 @@
     (define subset? list-subset?)
     (define proper-subset? list-proper-subset?)
     (define set-map list-map)
+    (define set-filter list-filter)
     (define set-for-each list-for-each)
     (define set-copy-clear list-clear)
     (define in-set in-list)
@@ -476,6 +484,7 @@
    (define subset? fallback-subset?)
    (define proper-subset? fallback-proper-subset?)
    (define set-map fallback-map)
+   (define set-filter fallback-filter)
    (define set-for-each fallback-for-each)
    (define set-copy fallback-copy)
    (define in-set fallback-in-set)

--- a/racket/collects/racket/set.rkt
+++ b/racket/collects/racket/set.rkt
@@ -12,7 +12,7 @@
 
          set-empty? set-member? set-count
          set=? subset? proper-subset?
-         set-map set-for-each
+         set-map set-filter set-for-each
          set-copy set-copy-clear
          set->list set->stream set-first set-rest
          set-add set-remove set-clear
@@ -310,6 +310,7 @@
        [subset? (or/c (-> generic-set? me boolean?) #f)]
        [proper-subset? (or/c (-> generic-set? me boolean?) #f)]
        [set-map (or/c (-> generic-set? (-> elem/c any/c) list?) #f)]
+       [set-filter (or/c (-> generic-set? (-> elem/c any/c) list?) #f)]
        [set-for-each (or/c (-> generic-set? (-> elem/c any) void?) #f)]
        [set-copy (or/c (-> generic-set? generic-set?) #f)]
        [in-set (or/c (-> generic-set? sequence?) #f)]


### PR DESCRIPTION
This PR adds `set-filter` to `racket/set`.