### PR TITLE
fix for (setup) when (current-library-collection-links) contains hash 

### DIFF
--- a/racket/collects/setup/setup-core.rkt
+++ b/racket/collects/setup/setup-core.rkt
@@ -521,11 +521,12 @@
               #:when (directory-exists? (build-path cp collection)))
           (cc! (list collection) #:path (build-path cp collection)))]
        [else ; must be a hash table that simulates a links file:
-        (for ([(coll-sym dir) (in-hash inst-links)])
+        (for* ([(coll-sym dir-list) (in-hash inst-links)]
+               [dir (in-list dir-list)])
           (cond
-           [coll-sym
-            ;; A single collection
-            (cc! (string-split "/" (symbol->string coll-sym)) #:path dir)]
+            [coll-sym
+             ;; A single collection
+             (cc! (map string->path (string-split (symbol->string coll-sym) "/")) #:path dir)]
            [(directory-exists? dir)
             ;; A directory that holds collections:
             (for ([collection (directory-list dir)]


### PR DESCRIPTION
setup/setup does not treat `current-library-collection-links` correctly when it contains a hash table.

`setup-core` expects hash table's values to be `path?`, but they are actually `(listof path?)`

Additionally, it uses `string-split` with incorrect parameter order, and calls `cc!` with a `(listof string?)` when `cc!` is expecting `(listof path?)`
