### PR TITLE
Update complexity discussion in hashes.scrbl

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -29,8 +29,9 @@ certain algorithms. Use @racket[immutable?] to check whether a hash
 table is immutable.
 
 @margin-note{Immutable hash tables actually provide @math{O(log N)}
-access and update. Since @math{N} is limited by the address space so
-that @math{log N} is limited to less than 30 or 62 (depending on the
+access and update (where the base of the @math{log} is 32.
+Since @math{N} is limited by the address space so
+that @math{log N} is limited to less than 7 or 13 (depending on the
 platform), @math{log N} can be treated reasonably as a constant.}
 
 For @racket[equal?]-based hashing, the built-in hash functions on


### PR DESCRIPTION
The current documentation is several years out of date (as of 6ac8bcd441ee23ecd604e431ce959cc2c33a6c3a).

Note that it's not uncommon for HAMTs to actually have bounded depth, and end in buckets, similar to a traditional hashtable, but my cursory read through didn't suggest that that was the case here. @mflatt can hopefully confirm one way or the other.