### PR TITLE
Improve gcc detection in configure script

### DIFF
--- a/racket/src/cfg-racket
+++ b/racket/src/cfg-racket
@@ -4612,7 +4612,11 @@ is_gmake=`make -v no-such-target-we-hope 2>&1 | grep "GNU Make"`
 # If using gcc, we want all warnings:
 is_gcc=`$CC -v 2>&1 | tail -n 1 | grep -E '^gcc version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ \([^\)]+\)[[:space:]]*$'`
 
-if test "$is_gcc" != "" ; then
+# We also need to test if $CC is gcc itself because on mac,
+# where clang impersonates gcc, although is_gcc is false, we want
+# to use it as if it was gcc.
+# See https://github.com/racket/racket/pull/2897#pullrequestreview-314906673
+if test "$is_gcc" != "" || test "`basename $CC`" = "gcc"; then
   COMPFLAGS="$COMPFLAGS -Wall"
 
   # Use -MMD when we have gcc and gnumake:

--- a/racket/src/cfg-racket
+++ b/racket/src/cfg-racket
@@ -4610,7 +4610,9 @@ SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} AR_FLAGS="'"'"${ARFLAGS}"'"'
 is_gmake=`make -v no-such-target-we-hope 2>&1 | grep "GNU Make"`
 
 # If using gcc, we want all warnings:
-if test "$CC" = "gcc" ; then
+is_gcc=`$CC -v 2>&1 | tail -n 1 | grep -E '^gcc version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ \([^\)]+\)[[:space:]]*$'`
+
+if test "$is_gcc" != "" ; then
   COMPFLAGS="$COMPFLAGS -Wall"
 
   # Use -MMD when we have gcc and gnumake:

--- a/racket/src/racket/configure.ac
+++ b/racket/src/racket/configure.ac
@@ -463,7 +463,11 @@ SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} AR_FLAGS="'"'"${ARFLAGS}"'"'
 is_gmake=`make -v no-such-target-we-hope 2>&1 | grep "GNU Make"`
 
 # If using gcc, we want all warnings:
-if test "$CC" = "gcc" ; then 
+changequote(<<, >>)dnl
+is_gcc=`$CC -v 2>&1 | tail -n 1 | grep -E '^gcc version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ \([^\)]+\)[[:space:]]*$'`
+changequote([, ])dnl
+
+if test "$is_gcc" != "" ; then
   COMPFLAGS="$COMPFLAGS -Wall"
 
   # Use -MMD when we have gcc and gnumake:

--- a/racket/src/racket/configure.ac
+++ b/racket/src/racket/configure.ac
@@ -467,7 +467,11 @@ changequote(<<, >>)dnl
 is_gcc=`$CC -v 2>&1 | tail -n 1 | grep -E '^gcc version [[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+ \([^\)]+\)[[:space:]]*$'`
 changequote([, ])dnl
 
-if test "$is_gcc" != "" ; then
+# We also need to test if $CC is gcc itself because on mac,
+# where clang impersonates gcc, although is_gcc is false, we want
+# to use it as if it was gcc.
+# See https://github.com/racket/racket/pull/2897#pullrequestreview-314906673
+if test "$is_gcc" != "" || test "`basename $CC`" = "gcc"; then
   COMPFLAGS="$COMPFLAGS -Wall"
 
   # Use -MMD when we have gcc and gnumake:


### PR DESCRIPTION
We have been detecting gcc by the CC variable but this fails under
ubuntu for example where you might specify CC='gcc-8' to ./configure.

Related to #2890