### PR TITLE
fix syntax->string

### DIFF
--- a/pkgs/racket-test/tests/syntax/to-string.rkt
+++ b/pkgs/racket-test/tests/syntax/to-string.rkt
@@ -1,0 +1,9 @@
+#lang racket
+(require syntax/to-string
+         rackunit)
+
+(check-equal? (syntax->string #'((a . 
+                                      b))) "(a . \n     b)")
+(check-equal? (syntax->string #'((a b c d))) "(a b c d)")
+(check-equal? (syntax->string #'(a 'b #(a b c) c)) "a 'b #(a b c) c")
+(check-equal? (syntax->string #'((a b  _   d))) "(a b  _   d)")

--- a/racket/collects/syntax/to-string.rkt
+++ b/racket/collects/syntax/to-string.rkt
@@ -27,7 +27,10 @@
             (cond
               [(eq? 'code:blank (syntax-e c))
                (advance c init-line!)]
-              [(eq? '_ (syntax-e c)) (void)]
+              [(eq? '_ (syntax-e c)) 
+               (advance c init-line!)
+               (printf "_")
+               (set! col (+ col 1))]
               [(eq? '... (syntax-e c))
                (void)]
               [(and (pair? (syntax-e c))
@@ -58,7 +61,19 @@
                (define c-paren-shape (syntax-property c 'paren-shape))
                (printf "~a" (or c-paren-shape #\())
                (set! col (+ col 1))
-               (map (loop init-line!) (syntax->list c))
+               (define se (syntax-e c))
+               (define (build-string-from-pair sp)
+                 (cond
+                   [(syntax? sp)
+                    (printf " . ")
+                    (set! col (+ col 3))
+                    ((loop init-line!) sp)]
+                   [else
+                    ((loop init-line!) (car sp))
+                    (build-string-from-pair (cdr sp))]))
+               (if (list? se)
+                   (map (loop init-line!) se)
+                   (build-string-from-pair se))
                (printf (case c-paren-shape
                          [(#\[) "]"]
                          [(#\{) "}"]


### PR DESCRIPTION
This pull request solves #1629.

```
> (syntax->string #'((a . b)))
"(a . b)"
```
It also fixes an undocumented issue that happens when called on a list with dot notation. This was the output before:
```
> (syntax->string #'((a . (b c))))
"(a    b c)"
``` 
And it now works like this:
```
> (syntax->string #'((a . (b c))))
"(a . (b c))"
```
There are a couple more issues, I think. In order to preserve the formatting in the resulting string, sometimes it is necessary to find the location of the `.` in a pair, but I haven't found a way to do that yet. 
For example:
```
> (syntax->string #'((a        . b))
"(a . b)"
> (syntax->string #'((a   .      b))
"(a .      b)"
```
With that in mind, this is still a work in progress.