### PR TITLE
Add workflow for PR continuous integration

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,4 +1,4 @@
-name: CI: Pull Request
+name: CI Pull Request
 
 on: [pull_request]
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -32,7 +32,7 @@ jobs:
         raco test -l tests/match/main
         raco test -l tests/zo-path
         raco test -c tests/xml
-        raco test -c tests/db/all-tests
+        raco test -l tests/db/all-tests
         raco test -c tests/stxparse
 
   buildtest-win:
@@ -52,7 +52,7 @@ jobs:
         call msvcprep.bat x86_amd64
         call build.bat
         call ..\..\racket.exe csbuild.rkt
-        ..\..\raco.exe pkg install racket-lib
+        ..\..\raco.exe pkg install --auto racket-lib
     - name: Test
       shell: cmd
       run: |
@@ -70,5 +70,5 @@ jobs:
         call racket\raco.exe test -l tests/match/main
         call racket\raco.exe test -l tests/zo-path
         call racket\raco.exe test -c tests/xml
-        call racket\raco.exe test -c tests/db/all-tests
+        call racket\raco.exe test -l tests/db/all-tests
         racket\raco.exe test -c tests/stxparse

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Build
-      run: make CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test"
+      run: make CPUS="3" PKGS="racket-test db-test unstable-flonum-lib net-test"
     - name: Test
       run: |
         export PATH=$PATH:`pwd`/racket/bin

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,6 +1,6 @@
 name: CI Pull Request
 
-on: [pull_request, push]
+on: [pull_request]
 
 jobs:
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,7 +52,7 @@ jobs:
         call msvcprep.bat x86_amd64
         call build.bat
         call ..\..\racket.exe csbuild.rkt
-        ..\..\raco.exe pkg install --auto racket-lib
+        ..\..\raco.exe pkg install --auto racket-test unstable-flonum-lib net-test
     - name: Test
       shell: cmd
       run: |

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -38,12 +38,20 @@ jobs:
   buildtest-win:
     runs-on: windows-latest
 
+    # According to
+    # https://help.github.com/en/actions/automating-your-workflow-with-github-actions/software-installed-on-github-hosted-runners#windows-server-2019
+    # VS2019 is what is installed in the hosted runners:
+    #   Version: VisualStudio/16.3.6+29418.71
+    #   Location: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
     - uses: actions/checkout@v1
     - name: Build
+      working-directory: .\racket\src\worksp
       run: |
-        call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\vc\vcvarsall.bat" x86
-        nmake win32-in-place PKGS="racket-test unstable-flonum-lib net-test"
+        msvcprep.bat x86_amd64
+        build.bat
+        ..\..\racket.exe csbuild.rkt
+        ..\..\raco.exe pkg install racket-lib
     - name: Test
       run: |
         racket\raco.exe test -l tests/racket/test

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -52,7 +52,7 @@ jobs:
         call msvcprep.bat x86_amd64
         call build.bat
         call ..\..\racket.exe csbuild.rkt
-        ..\..\raco.exe pkg install --auto racket-test unstable-flonum-lib net-test
+        ..\..\raco.exe pkg install --auto --no-docs racket-test unstable-flonum-lib net-test
     - name: Test
       shell: cmd
       run: |

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -31,7 +31,7 @@ jobs:
         raco test -l tests/openssl/https
         raco test -l tests/match/main
         raco test -l tests/zo-path
-        raco test -c tests/xml/test
+        raco test -c tests/xml
         raco test -c tests/db/all-tests
         raco test -c tests/stxparse
 
@@ -47,12 +47,14 @@ jobs:
     - uses: actions/checkout@v1
     - name: Build
       working-directory: .\racket\src\worksp
+      shell: cmd
       run: |
         msvcprep.bat x86_amd64
         build.bat
         ..\..\racket.exe csbuild.rkt
         ..\..\raco.exe pkg install racket-lib
     - name: Test
+      shell: cmd
       run: |
         racket\raco.exe test -l tests/racket/test
         racket\racket.exe -l tests/racket/contract/all
@@ -67,6 +69,6 @@ jobs:
         racket\raco.exe test -l tests/openssl/https
         racket\raco.exe test -l tests/match/main
         racket\raco.exe test -l tests/zo-path
-        racket\raco.exe test -c tests/xml/test
+        racket\raco.exe test -c tests/xml
         racket\raco.exe test -c tests/db/all-tests
         racket\raco.exe test -c tests/stxparse

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -49,26 +49,26 @@ jobs:
       working-directory: .\racket\src\worksp
       shell: cmd
       run: |
-        msvcprep.bat x86_amd64
-        build.bat
-        ..\..\racket.exe csbuild.rkt
+        call msvcprep.bat x86_amd64
+        call build.bat
+        call ..\..\racket.exe csbuild.rkt
         ..\..\raco.exe pkg install racket-lib
     - name: Test
       shell: cmd
       run: |
-        racket\raco.exe test -l tests/racket/test
-        racket\racket.exe -l tests/racket/contract/all
-        racket\raco.exe test -l tests/json/json
-        racket\raco.exe test -l tests/file/main
-        racket\raco.exe test -l tests/net/head
-        racket\raco.exe test -l tests/net/uri-codec
-        racket\raco.exe test -l tests/net/url
-        racket\raco.exe test -l tests/net/url-port
-        racket\raco.exe test -l tests/net/encoders
-        racket\raco.exe test -l tests/openssl/basic
-        racket\raco.exe test -l tests/openssl/https
-        racket\raco.exe test -l tests/match/main
-        racket\raco.exe test -l tests/zo-path
-        racket\raco.exe test -c tests/xml
-        racket\raco.exe test -c tests/db/all-tests
+        call racket\raco.exe test -l tests/racket/test
+        call racket\racket.exe -l tests/racket/contract/all
+        call racket\raco.exe test -l tests/json/json
+        call racket\raco.exe test -l tests/file/main
+        call racket\raco.exe test -l tests/net/head
+        call racket\raco.exe test -l tests/net/uri-codec
+        call racket\raco.exe test -l tests/net/url
+        call racket\raco.exe test -l tests/net/url-port
+        call racket\raco.exe test -l tests/net/encoders
+        call racket\raco.exe test -l tests/openssl/basic
+        call racket\raco.exe test -l tests/openssl/https
+        call racket\raco.exe test -l tests/match/main
+        call racket\raco.exe test -l tests/zo-path
+        call racket\raco.exe test -c tests/xml
+        call racket\raco.exe test -c tests/db/all-tests
         racket\raco.exe test -c tests/stxparse

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,6 +1,6 @@
 name: CI Pull Request
 
-on: [pull_request]
+on: [pull_request, push]
 
 jobs:
 

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -1,0 +1,64 @@
+name: CI: Pull Request
+
+on: [pull_request]
+
+jobs:
+
+  buildtest-unixstyle:
+    strategy:
+      matrix:
+        os: [ubuntu-18.04, macos-latest]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: make CPUS="2" PKGS="racket-test db-test unstable-flonum-lib net-test"
+    - name: Test
+      run: |
+        export PATH=$PATH:`pwd`/racket/bin
+        raco test -l tests/racket/test
+        racket -l tests/racket/contract/all
+        raco test -l tests/json/json
+        raco test -l tests/file/main
+        raco test -l tests/net/head
+        raco test -l tests/net/uri-codec
+        raco test -l tests/net/url
+        raco test -l tests/net/url-port
+        raco test -l tests/net/encoders
+        raco test -l tests/openssl/basic
+        raco test -l tests/openssl/https
+        raco test -l tests/match/main
+        raco test -l tests/zo-path
+        raco test -c tests/xml/test
+        raco test -c tests/db/all-tests
+        raco test -c tests/stxparse
+
+  buildtest-win:
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Build
+      run: |
+        call "C:\Program Files (x86)\Microsoft Visual Studio 12.0\vc\vcvarsall.bat" x86
+        nmake win32-in-place PKGS="racket-test unstable-flonum-lib net-test"
+    - name: Test
+      run: |
+        racket\raco.exe test -l tests/racket/test
+        racket\racket.exe -l tests/racket/contract/all
+        racket\raco.exe test -l tests/json/json
+        racket\raco.exe test -l tests/file/main
+        racket\raco.exe test -l tests/net/head
+        racket\raco.exe test -l tests/net/uri-codec
+        racket\raco.exe test -l tests/net/url
+        racket\raco.exe test -l tests/net/url-port
+        racket\raco.exe test -l tests/net/encoders
+        racket\raco.exe test -l tests/openssl/basic
+        racket\raco.exe test -l tests/openssl/https
+        racket\raco.exe test -l tests/match/main
+        racket\raco.exe test -l tests/zo-path
+        racket\raco.exe test -c tests/xml/test
+        racket\raco.exe test -c tests/db/all-tests
+        racket\raco.exe test -c tests/stxparse


### PR DESCRIPTION
Here's a workflow for PRs - my point of view here is that this should be quick while covering most of the features we regularly use. Once commit happens, we run a normal workflow taking more variations into consideration.

If the normal workflow fails but passed this workflow, we can always revert the commit. Having a PR workflow taking a multiple of hours makes no sense. I think we should help contributors here by allowing them to use our CI by creating draft PRs (which automatically run our CI) and get a development turnaround that's as quick as possible. 