### PR TITLE
change `datum` to work with syntax variables too

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/datum.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/datum.scrbl
@@ -2,7 +2,8 @@
 @(require "common.rkt"
           scribble/eval
           (for-label racket/base 
-                     syntax/datum))
+                     syntax/datum
+                     syntax/parse))
 
 @(define datum-eval (make-base-eval))
 @interaction-eval[#:eval datum-eval (require syntax/datum)]
@@ -32,23 +33,65 @@ in @racket[datum-case] should produce a @tech[#:doc refman]{datum}
 (i.e., plain S-expression) instead of a @tech[#:doc refman]{syntax
 object} to be matched in @racket[clause]s, and @racket[datum]
 similarly produces a datum.  Pattern variables bound in each
-@racket[clause] of @racket[datum-case] are accessible via
-@racket[datum] instead of @racket[syntax]. When a @racket[literal-id]
-appears in a @racket[clause]'s pattern, it matches the corresponding
-symbol (using @racket[eq?]).
+@racket[clause] of @racket[datum-case] (or @racket[syntax-case], see
+below) are accessible via @racket[datum] instead of
+@racket[syntax]. When a @racket[literal-id] appears in a
+@racket[clause]'s pattern, it matches the corresponding symbol (using
+@racket[eq?]).
 
-
-Using @racket[datum-case] and @racket[datum] is essentially equivalent
+Using @racket[datum-case] and @racket[datum] is similar
 to converting the input to @racket[syntax-case] using
 @racket[datum->syntax] and then wrapping each use of @racket[syntax]
 with @racket[syntax->datum], but @racket[datum-case] and
-@racket[datum] to not create intermediate syntax objects.
+@racket[datum] do not create intermediate syntax objects, and they do
+not destroy existing syntax objects within the S-expression structure
+of @racket[datum-expr].
 
 @examples[
 #:eval datum-eval
 (datum-case '(1 "x" -> y) (->)
   [(a ... -> b) (datum (b (+ a) ...))])
-]}
+]
+
+The @racket[datum] form also cooperates with @tech[#:key "pattern
+variable" #:doc '(lib "scribblings/reference/reference.scrbl")]{syntax
+pattern variables} such as those bound by @racket[syntax-case] and
+@tech{attributes} bound by @racket[syntax-parse] (see
+@secref["stxparse-attrs"] for more information about attributes). As
+one consequence, @racket[datum] provides a convenient way of getting
+the list of syntax objects bound to a syntax pattern variable of depth
+1. For example, the following expressions are equivalent, except that
+the @racket[datum] version avoids creating and eliminating a
+superfluous syntax object wrapper:
+
+@interaction[#:eval datum-eval
+(with-syntax ([(x ...) #'(a b c)])
+  (syntax->list #'(x ...)))
+(with-syntax ([(x ...) #'(a b c)])
+  (datum (x ...)))
+]
+
+A template can also use multiple syntax or datum pattern variables and
+datum constants, and it can use the @racket[~@] and @racket[~?]
+template forms:
+
+@interaction[#:eval datum-eval
+(with-syntax ([(x ...) #'(a b c)])
+  (with-datum ([(y ...) (list 1 2 3)])
+    (datum ([x -> y] ...))))
+(with-syntax ([(x ...) #'(a b c)])
+  (with-datum ([(y ...) (list 1 2 3)])
+    (datum ((~@ x y) ...))))
+]
+
+See @secref["attributes-and-datum"] for examples of @racket[~?] with
+@racket[datum].
+
+If a datum variable is used in a syntax template, a compile-time error
+is raised.
+
+@history[#:changed "7.8.0.9" @elem{Changed @racket[datum] to
+cooperate with @racket[syntax-case], @racket[syntax-parse], etc.}]}
 
 
 @defform[(with-datum ([pattern datum-expr] ...)

--- a/pkgs/racket-doc/syntax/scribblings/parse/parse-common.rkt
+++ b/pkgs/racket-doc/syntax/scribblings/parse/parse-common.rkt
@@ -47,6 +47,7 @@
                                  (thunk))))])
          (make-evaluator 'racket/base
                          #:requires (let ([mods '(racket/promise
+                                                  racket/pretty
                                                   syntax/parse
                                                   syntax/parse/debug
                                                   syntax/parse/experimental/splicing
@@ -58,7 +59,10 @@
                                                   syntax/transformer)])
                                       `((for-syntax racket/base ,@mods)
                                         ,@mods)))))))
-  (when short? (the-eval '(error-print-source-location #f)))
+  (call-in-sandbox-context the-eval
+    (lambda ()
+      (current-print (dynamic-require 'racket/pretty 'pretty-print-handler))
+      (when short? (error-print-source-location #f))))
   the-eval)
 
 ;; ----

--- a/pkgs/racket-test/tests/stxparse/test-datum.rkt
+++ b/pkgs/racket-test/tests/stxparse/test-datum.rkt
@@ -1,0 +1,94 @@
+#lang racket/base
+(require rackunit syntax/parse syntax/datum)
+
+(define (equalish? a b)
+  (cond [(and (syntax? a) (syntax? b))
+         (equal? (syntax->datum a) (syntax->datum b))]
+        [else (equal?/recur a b equalish?)]))
+
+(check equalish?
+       (syntax-case #'(a b c) ()
+         [(x ...) (datum (x ...))])
+       (list #'a #'b #'c))
+
+(struct ast:bind (var rhs) #:prefab)
+
+(define-syntax-class binding
+  (pattern [var:id rhs:expr]
+           #:attr ast (ast:bind #'var #'rhs)))
+
+(check equalish?
+       (syntax-parse #'([x 1] [y 2])
+         [(b:binding ...) (datum (b ...))])
+       (list #'[x 1] #'[y 2]))
+
+(check equalish?
+       (syntax-parse #'([x 1] [y 2])
+         [(b:binding ...) (datum ((b.var b.rhs) ...))])
+       (list (list #'x #'1) (list #'y #'2)))
+
+(check equalish?
+       (syntax-parse #'([x 1] [y 2])
+         [(b:binding ...) (datum (b.ast ...))])
+       (list (ast:bind #'x #'1) (ast:bind #'y #'2)))
+
+(check equalish?
+       (syntax-parse #'([x 1] [y 2])
+         [(b:binding ...) (datum ((~@ b.var b.rhs) ...))])
+       (list #'x #'1 #'y #'2))
+
+(check equalish?
+       (syntax-parse #'([x 1] [y 2])
+         [(b:binding ...) (datum ((~@ . b) ...))])
+       (list #'x #'1 #'y #'2))
+
+(define-syntax-class obinding
+  (pattern [var:id (~optional (rhs:expr ...))]
+           #:attr ast (ast:bind #'var (datum (~? (rhs ...) #f)))))
+
+(check equalish?
+       (syntax-parse #'([x (1)] [y])
+         [(b:obinding ...) (datum ([b.var (~? (b.rhs ...))] ...))])
+       (list (list #'x (list #'1)) (list #'y)))
+
+(check equalish?
+       (syntax-parse #'([x (1)] [y])
+         [(b:obinding ...) (datum (b.ast ...))])
+       (list (ast:bind #'x (list #'1)) (ast:bind #'y #f)))
+
+;; ------------------------------------------------------------
+;; The strange corner cases...
+
+(require racket/list racket/promise)
+
+;; The following are two consequences of the decision to make (datum a)
+;; equivalent to (attribute a), where a is an attribute. Thus if a is "absent"
+;; (has the value #f), (datum a) returns #f rather than signaling an
+;; error. Likewise, if the value of a is a promise, it just returns the promise.
+
+;; 1: ~? catches attempts to iterate over absent attrs, but not uses of absent
+;; attrs. Maybe add some sort of annotation to get other behavior?
+
+(check-equal? (syntax-parse #'(m)
+                [(_ (~optional x:id)) (datum (~? x default))])
+              #f)
+
+(check-equal? (syntax-parse #'(m)
+                [(_ (~optional (x:id ...))) (datum (~? (x ...) default))])
+              'default)
+
+;; 2: Promises are forced only when necessary for iterating over lists.
+
+(define-syntax-class nrange #:attributes ([r 0] [k 1])
+  (pattern n:nat
+           ;; Note: these attribute declarations are identical except for depth.
+           #:attr [r 0] (delay (range (syntax-e #'n)))
+           #:attr [k 1] (delay (range (syntax-e #'n)))))
+
+;; This returns a list of numbers:
+(check-equal? (syntax-parse #'(m 10) [(_ n:nrange) (datum (n.k ...))])
+              (range 10))
+
+;; But this returns a promise:
+(check-pred promise?
+            (syntax-parse #'(m 10) [(_ n:nrange) (datum n.r)]))

--- a/racket/collects/racket/private/template.rkt
+++ b/racket/collects/racket/private/template.rkt
@@ -364,7 +364,7 @@
     (define (lookup id depth0)
       (define (make-pvar var check pvar-depth)
         (define (make-ref var)
-          (cond [check `(t-check-var (,check ,var 0 #t (quote-syntax ,id)))]
+          (cond [check `(t-check-var (,check ,var 0 ,stx? (quote-syntax ,id)))]
                 [else `(t-var ,var)]))
         (define (make-src-ref var id)
           (cond [check `(#%expression (,check ,var 1 #f (quote-syntax ,id)))]
@@ -386,7 +386,7 @@
                         (dotsframe-add! (car depth) iter src (make-src-ref src id))
                         iter))]))))
       (let ([v (syntax-local-value id (lambda () #f))])
-        (cond [(and stx? (syntax-pattern-variable? v))
+        (cond [(syntax-pattern-variable? v)
                (define pvar-depth (syntax-mapping-depth v))
                (define attr
                  (let ([attr (syntax-local-value (syntax-mapping-valvar v) (lambda () #f))])

--- a/racket/collects/racket/private/template.rkt
+++ b/racket/collects/racket/private/template.rkt
@@ -387,6 +387,7 @@
                         iter))]))))
       (let ([v (syntax-local-value id (lambda () #f))])
         (cond [(syntax-pattern-variable? v)
+               ;; syntax variables allowed in both syntax and datum templates
                (define pvar-depth (syntax-mapping-depth v))
                (define attr
                  (let ([attr (syntax-local-value (syntax-mapping-valvar v) (lambda () #f))])
@@ -394,10 +395,15 @@
                (define var (if attr (attribute-mapping-var attr) (syntax-mapping-valvar v)))
                (define check (and attr (attribute-mapping-check attr)))
                (make-pvar var check pvar-depth)]
-              [(and (not stx?) (s-exp-pattern-variable? v))
-               (define pvar-depth (s-exp-mapping-depth v))
-               (define var (s-exp-mapping-valvar v))
-               (make-pvar var #f pvar-depth)]
+              [(s-exp-pattern-variable? v)
+               (cond [stx?
+                      ;; datum variable in syntax template is error
+                      (wrong-syntax id "datum variable not allowed in syntax template")]
+                     [else
+                      ;; datum variable in datum template
+                      (define pvar-depth (s-exp-mapping-depth v))
+                      (define var (s-exp-mapping-valvar v))
+                      (make-pvar var #f pvar-depth)])]
               [else
                ;; id is a constant; check that for all x s.t. id = x.y, x is not an attribute
                (for-each

--- a/racket/collects/syntax/parse/private/residual.rkt
+++ b/racket/collects/syntax/parse/private/residual.rkt
@@ -110,12 +110,12 @@
               (sub1 n)))))
 
 ;; check-attr-value : Any d:Nat b:Boolean Syntax/#f -> (Listof^d (if b Syntax Any))
-(define (check-attr-value v0 depth0 base? ctx)
+(define (check-attr-value v0 depth0 stx? ctx)
   (define (bad kind v)
     (raise-syntax-error #f (format "attribute contains non-~s value\n  value: ~e" kind v) ctx))
   (define (depthloop depth v)
     (if (zero? depth)
-        (if base? (baseloop v) v)
+        (baseloop v)
         (let listloop ([v v] [root? #t])
           (cond [(null? v) null]
                 [(pair? v) (let ([new-car (depthloop (sub1 depth) (car v))]
@@ -126,8 +126,9 @@
                 [(and root? (eq? v #f)) (begin (signal-absent-pvar) (bad 'list v))]
                 [else (bad 'list v)]))))
   (define (baseloop v)
-    (cond [(syntax? v) v]
-          [(promise? v) (baseloop (force v))]
+    (cond [(promise? v) (baseloop (force v))]
+          [(not stx?) v]
+          [(syntax? v) v]
           [(eq? v #f) (begin (signal-absent-pvar) (bad 'syntax v))]
           [else (bad 'syntax v)]))
   (depthloop depth0 v0))


### PR DESCRIPTION
This PR changes `datum` from `syntax/datum` to cooperate with syntax variables and syntax/parse attributes in addition to datum variables bound with datum-case. This has two nice consequences:

1. If x is a depth-1 syntax variable, then `(datum (x ...))` is equivalent to `(syntax->list #'(x ...))`. Moreover, if y is also a depth-1 syntax variable, then `(datum ((x y) ...))` is equivalent to `(map syntax->list (syntax->list #'((x y) ...)))`, and so on. That is, `datum` retains existing syntax objects in syntax variable bindings, but it never creates additional syntax.

2. If a is a depth-1 attribute with non-syntax values---say, an `ast` attribute that contains structures parsed from the syntax---then the list of values can be obtained with `(datum (a ...))`, which makes the list-ness apparent, unlike `(attribute a)`.

See the new test file for more examples.
