### PR TITLE
Use AC_CHECK_MEMBERS to check for dirent name length flds

### DIFF
--- a/racket/src/rktio/configure
+++ b/racket/src/rktio/configure
@@ -4175,10 +4175,6 @@ if test "x$ac_cv_member_struct_dirent_d_namelen" = xyes; then :
 
 $as_echo "#define HAVE_DIRENT_NAMELEN 1" >>confdefs.h
 
-else
-
-$as_echo "#define HAVE_DIRENT_NAMELEN 0" >>confdefs.h
-
 fi
 
 ac_fn_c_check_member "$LINENO" "struct dirent" "d_namlen" "ac_cv_member_struct_dirent_d_namlen" "#include <dirent.h>
@@ -4186,10 +4182,6 @@ ac_fn_c_check_member "$LINENO" "struct dirent" "d_namlen" "ac_cv_member_struct_d
 if test "x$ac_cv_member_struct_dirent_d_namlen" = xyes; then :
 
 $as_echo "#define HAVE_DIRENT_NAMLEN 1" >>confdefs.h
-
-else
-
-$as_echo "#define HAVE_DIRENT_NAMLEN 0" >>confdefs.h
 
 fi
 
@@ -4595,6 +4587,9 @@ fi
 ############## final output ################
 
 CPPFLAGS="$CPPFLAGS $PREFLAGS"
+
+
+
 
 
 

--- a/racket/src/rktio/configure
+++ b/racket/src/rktio/configure
@@ -4167,7 +4167,8 @@ $as_echo "#define RKTIO_BIG_ENDIAN 1" >>confdefs.h
 fi
 
 # Struct dirent
-ac_fn_c_check_member "$LINENO" "struct dirent" "d_namelen" "ac_cv_member_struct_dirent_d_namelen" "$ac_includes_default"
+ac_fn_c_check_member "$LINENO" "struct dirent" "d_namelen" "ac_cv_member_struct_dirent_d_namelen" "#include <dirent.h>
+"
 if test "x$ac_cv_member_struct_dirent_d_namelen" = xyes; then :
 
 cat >>confdefs.h <<_ACEOF
@@ -4176,7 +4177,8 @@ _ACEOF
 
 
 fi
-ac_fn_c_check_member "$LINENO" "struct dirent" "d_namlen" "ac_cv_member_struct_dirent_d_namlen" "$ac_includes_default"
+ac_fn_c_check_member "$LINENO" "struct dirent" "d_namlen" "ac_cv_member_struct_dirent_d_namlen" "#include <dirent.h>
+"
 if test "x$ac_cv_member_struct_dirent_d_namlen" = xyes; then :
 
 cat >>confdefs.h <<_ACEOF

--- a/racket/src/rktio/configure
+++ b/racket/src/rktio/configure
@@ -1668,6 +1668,63 @@ $as_echo "$ac_res" >&6; }
 
 } # ac_fn_c_check_header_compile
 
+# ac_fn_c_check_member LINENO AGGR MEMBER VAR INCLUDES
+# ----------------------------------------------------
+# Tries to find if the field MEMBER exists in type AGGR, after including
+# INCLUDES, setting cache variable VAR accordingly.
+ac_fn_c_check_member ()
+{
+  as_lineno=${as_lineno-"$1"} as_lineno_stack=as_lineno_stack=$as_lineno_stack
+  { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $2.$3" >&5
+$as_echo_n "checking for $2.$3... " >&6; }
+if eval \${$4+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$5
+int
+main ()
+{
+static $2 ac_aggr;
+if (ac_aggr.$3)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$4=yes"
+else
+  cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+/* end confdefs.h.  */
+$5
+int
+main ()
+{
+static $2 ac_aggr;
+if (sizeof ac_aggr.$3)
+return 0;
+  ;
+  return 0;
+}
+_ACEOF
+if ac_fn_c_try_compile "$LINENO"; then :
+  eval "$4=yes"
+else
+  eval "$4=no"
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+rm -f core conftest.err conftest.$ac_objext conftest.$ac_ext
+fi
+eval ac_res=\$$4
+	       { $as_echo "$as_me:${as_lineno-$LINENO}: result: $ac_res" >&5
+$as_echo "$ac_res" >&6; }
+  eval $as_lineno_stack; ${as_lineno_stack:+:} unset as_lineno
+
+} # ac_fn_c_check_member
+
 # ac_fn_c_check_header_mongrel LINENO HEADER VAR INCLUDES
 # -------------------------------------------------------
 # Tests whether HEADER exists, giving a warning if it cannot be compiled using
@@ -4108,6 +4165,27 @@ if test "${endianness}" = "big" ; then
 $as_echo "#define RKTIO_BIG_ENDIAN 1" >>confdefs.h
 
 fi
+
+# Struct dirent
+ac_fn_c_check_member "$LINENO" "struct dirent" "d_namelen" "ac_cv_member_struct_dirent_d_namelen" "$ac_includes_default"
+if test "x$ac_cv_member_struct_dirent_d_namelen" = xyes; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_STRUCT_DIRENT_D_NAMELEN 1
+_ACEOF
+
+
+fi
+ac_fn_c_check_member "$LINENO" "struct dirent" "d_namlen" "ac_cv_member_struct_dirent_d_namlen" "$ac_includes_default"
+if test "x$ac_cv_member_struct_dirent_d_namlen" = xyes; then :
+
+cat >>confdefs.h <<_ACEOF
+#define HAVE_STRUCT_DIRENT_D_NAMLEN 1
+_ACEOF
+
+
+fi
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for getaddrinfo" >&5
 $as_echo_n "checking for getaddrinfo... " >&6; }

--- a/racket/src/rktio/configure
+++ b/racket/src/rktio/configure
@@ -621,6 +621,8 @@ ac_includes_default="\
 
 ac_subst_vars='LTLIBOBJS
 LIBOBJS
+HAVE_DIRENT_NAMELEN
+HAVE_DIRENT_NAMLEN
 RKTIO_NO_ICONV
 HIDE_STANDALONE
 HIDE_NOT_STANDALONE
@@ -4171,20 +4173,23 @@ ac_fn_c_check_member "$LINENO" "struct dirent" "d_namelen" "ac_cv_member_struct_
 "
 if test "x$ac_cv_member_struct_dirent_d_namelen" = xyes; then :
 
-cat >>confdefs.h <<_ACEOF
-#define HAVE_STRUCT_DIRENT_D_NAMELEN 1
-_ACEOF
+$as_echo "#define HAVE_DIRENT_NAMELEN 1" >>confdefs.h
 
+else
+
+$as_echo "#define HAVE_DIRENT_NAMELEN 0" >>confdefs.h
 
 fi
+
 ac_fn_c_check_member "$LINENO" "struct dirent" "d_namlen" "ac_cv_member_struct_dirent_d_namlen" "#include <dirent.h>
 "
 if test "x$ac_cv_member_struct_dirent_d_namlen" = xyes; then :
 
-cat >>confdefs.h <<_ACEOF
-#define HAVE_STRUCT_DIRENT_D_NAMLEN 1
-_ACEOF
+$as_echo "#define HAVE_DIRENT_NAMLEN 1" >>confdefs.h
 
+else
+
+$as_echo "#define HAVE_DIRENT_NAMLEN 0" >>confdefs.h
 
 fi
 

--- a/racket/src/rktio/configure.ac
+++ b/racket/src/rktio/configure.ac
@@ -149,7 +149,7 @@ if test "${endianness}" = "big" ; then
 fi
 
 # Struct dirent
-AC_CHECK_MEMBERS([struct dirent.d_namelen, struct dirent.d_namlen])
+AC_CHECK_MEMBERS([struct dirent.d_namelen, struct dirent.d_namlen],,,[#include <dirent.h>])
 
 AC_MSG_CHECKING([for getaddrinfo])
 AC_TRY_LINK([#include <sys/types.h>

--- a/racket/src/rktio/configure.ac
+++ b/racket/src/rktio/configure.ac
@@ -148,6 +148,9 @@ if test "${endianness}" = "big" ; then
   AC_DEFINE(RKTIO_BIG_ENDIAN,1,[Big endian])
 fi
 
+# Struct dirent
+AC_CHECK_MEMBERS([struct dirent.d_namelen, struct dirent.d_namlen])
+
 AC_MSG_CHECKING([for getaddrinfo])
 AC_TRY_LINK([#include <sys/types.h>
 #include <sys/socket.h>

--- a/racket/src/rktio/configure.ac
+++ b/racket/src/rktio/configure.ac
@@ -149,7 +149,14 @@ if test "${endianness}" = "big" ; then
 fi
 
 # Struct dirent
-AC_CHECK_MEMBERS([struct dirent.d_namelen, struct dirent.d_namlen],,,[#include <dirent.h>])
+AC_CHECK_MEMBER([struct dirent.d_namelen],
+                [AC_DEFINE(HAVE_DIRENT_NAMELEN, 1, [struct dirent has field namelen])],
+		[AC_DEFINE(HAVE_DIRENT_NAMELEN, 0, [struct dirent has NOT field namelen])],
+		[#include <dirent.h>])
+AC_CHECK_MEMBER([struct dirent.d_namlen],
+                [AC_DEFINE(HAVE_DIRENT_NAMLEN, 1, [struct dirent has field namlen])],
+		[AC_DEFINE(HAVE_DIRENT_NAMLEN, 0, [struct dirent has NOT field namlen])],
+		[#include <dirent.h>])
 
 AC_MSG_CHECKING([for getaddrinfo])
 AC_TRY_LINK([#include <sys/types.h>
@@ -428,6 +435,9 @@ AC_SUBST(HIDE_NOT_STANDALONE)
 AC_SUBST(HIDE_STANDALONE)
 
 AC_SUBST(RKTIO_NO_ICONV)
+
+AC_SUBST(HAVE_DIRENT_NAMLEN)
+AC_SUBST(HAVE_DIRENT_NAMELEN)
 
 makefiles="Makefile"
 

--- a/racket/src/rktio/configure.ac
+++ b/racket/src/rktio/configure.ac
@@ -150,12 +150,10 @@ fi
 
 # Struct dirent
 AC_CHECK_MEMBER([struct dirent.d_namelen],
-                [AC_DEFINE(HAVE_DIRENT_NAMELEN, 1, [struct dirent has field namelen])],
-		[AC_DEFINE(HAVE_DIRENT_NAMELEN, 0, [struct dirent has NOT field namelen])],
+                [AC_DEFINE(HAVE_DIRENT_NAMELEN, 1, [struct dirent has field namelen])],,
 		[#include <dirent.h>])
 AC_CHECK_MEMBER([struct dirent.d_namlen],
-                [AC_DEFINE(HAVE_DIRENT_NAMLEN, 1, [struct dirent has field namlen])],
-		[AC_DEFINE(HAVE_DIRENT_NAMLEN, 0, [struct dirent has NOT field namlen])],
+                [AC_DEFINE(HAVE_DIRENT_NAMLEN, 1, [struct dirent has field namlen])],,
 		[#include <dirent.h>])
 
 AC_MSG_CHECKING([for getaddrinfo])

--- a/racket/src/rktio/rktio_config.h.in
+++ b/racket/src/rktio/rktio_config.h.in
@@ -60,3 +60,8 @@ typedef unsigned long long rktio_uint64_t;
 
 /* In case iconv is not available: */
 #undef RKTIO_NO_ICONV
+
+/* Fields of struct dirent */
+#undef HAVE_DIRENT_NAMLEN
+#undef HAVE_DIRENT_NAMELEN
+

--- a/racket/src/rktio/rktio_fs.c
+++ b/racket/src/rktio/rktio_fs.c
@@ -1487,12 +1487,13 @@ char *rktio_directory_list_step(rktio_t *rktio, rktio_directory_list_t *dl)
   while ((e = readdir(dl->dir))) {
     int nlen;
 
-# ifdef DIRENT_NO_NAMLEN
-    nlen = strlen(e->d_name);
-# elif defined(__QNX__) || defined(__QNXNTO__)
+# ifdef HAVE_DIRENT_NAMLEN
+    nlen = e->d_namlen;
+# elif HAVE_DIRENT_NAMELEN
+    /* Case for QNX - which seems to define d_namelen instead */
     nlen = e->d_namelen;
 # else
-    nlen = e->d_namlen;
+    nlen = strlen(e->d_name);
 # endif
 
 # if defined(RKTIO_SYSTEM_UNIX) || defined(RKTIO_SYSTEM_WINDOWS)

--- a/racket/src/rktio/rktio_platform.h
+++ b/racket/src/rktio/rktio_platform.h
@@ -7,7 +7,6 @@
 # include <errno.h>
 # ifdef ECHRNG
 /* Solaris */
-#  define DIRENT_NO_NAMLEN
 #  define NO_USLEEP
 #  define USE_ULIMIT
 #  define SOME_FDS_ARE_NOT_SELECTABLE
@@ -43,8 +42,6 @@
   /************** Linux ****************/
 
 #if defined(__linux__)
-
-# define DIRENT_NO_NAMLEN
 
 # define USE_TIMEZONE_VAR_W_DLS
 # define USE_TZNAME_VAR
@@ -91,8 +88,6 @@
 #if  (defined(mips) || defined(__mips)) \
      && !(defined(ultrix) || defined(__ultrix) || defined(__linux__) || defined(__OpenBSD__))
 
-# define DIRENT_NO_NAMLEN
-
 # define BSTRING_INCLUDE
 
 # define NO_USLEEP
@@ -105,8 +100,6 @@
   /************** Ultrix ****************/
 
 #if defined(ultrix) || defined(__ultrix)
-
-# define DIRENT_NO_NAMLEN
 
 # define NO_USLEEP
 
@@ -136,15 +129,6 @@
 
 #endif
 
-  /************** x86/SCO Unix with gcc ****************/
-  /* Contributed by Atanas Ivanov <nasko@noac.bg>      */
-
-#if defined(_M_XENIX) && defined(_M_SYSV)
-
-# define DIRENT_NO_NAMLEN
-
-#endif
-
   /****************** Windows with MSVC or MinGW *****************/
 
 #if (defined(__BORLANDC__) \
@@ -157,7 +141,6 @@
 #  define MKDIR_NO_MODE_FLAG
 # endif
 # if defined(__BORLANDC__)
-#  define DIRENT_NO_NAMLEN
 #  define MKDIR_NO_MODE_FLAG
 # endif
 
@@ -168,8 +151,6 @@
 #if defined(__CYGWIN32__)
 
 # define RKTIO_BINARY O_BINARY
-
-# define DIRENT_NO_NAMLEN
 
 # define SIGCHILD_DOESNT_INTERRUPT_SELECT
 
@@ -274,10 +255,6 @@
 
  /* NO_READDIR means that there is no opendir() and readdir() for
      implementing directory-list. */
-
- /* DIRENT_NO_NAMLEN specifies that dirent entries do not have a
-     d_namlen field; this is used only when NO_READDIR is not
-     specified. */
 
  /* MKDIR_NO_MODE_FLAG specifies that mkdir() takes only one argument,
      instead of a directory name and mode flags. */


### PR DESCRIPTION
This allows us to remote DIRENT_NO_NAMLEN, and simply slightly
rktio_platform.h.

Fix for problem seen while investigating #2906 