### PR TITLE
Fix spelling typos

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ DEFAULT_SRC_CATALOG = https://pkgs.racket-lang.org
 PLT_SETUP_OPTIONS = 
 
 # Belongs in the "Configuration options" section, but here
-# to accomodate nmake:
+# to accommodate nmake:
 SRC_CATALOG = $(DEFAULT_SRC_CATALOG)
 
 CPUS = 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Quick Start
 -----------
 
 Pre-built versions of Racket for a variety of operating systems and
-architectures, as well as convienient source distributions are
+architectures, as well as convenient source distributions are
 available at
 
   [https://download.racket-lang.org](https://download.racket-lang.org)

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/common/index-template.html
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/common/index-template.html
@@ -51,7 +51,7 @@ every other benchmark&rsquo;s compile time.</font></p>
 </ul>
 These configurations are all &ldquo;safe mode,&rdquo; but they allow a
 compiler to assume that built-in Scheme functions are not redefined
-and that no top-level defintion is ever changed. Such assumptions
+and that no top-level definition is ever changed. Such assumptions
 correspond to putting the benchmark in an R6RS library.  We attempt to
 use the various implementations in a compentent way, but not in a
 sophisticated way. For example, we do not tweak inlining parameters or

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax-input.txt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax-input.txt
@@ -215,7 +215,7 @@
 ;;; implementation for this code to run.
 ;;;
 ;;; (voide)
-;;; returns the implementation's cannonical "unspecified value".  The
+;;; returns the implementation's canonical "unspecified value".  The
 ;;; following usually works:
 ;;;
 ;;; (define voide (lambda () (if #f #f))).
@@ -298,7 +298,7 @@
 
 ;;; When porting to a new Scheme implementation, you should define the
 ;;; procedures listed above, load the expanded version of psyntax.ss
-;;; (psyntax.pp, which should be available whereever you found
+;;; (psyntax.pp, which should be available wherever you found
 ;;; psyntax.ss), and register sc-expand as the current expander (how
 ;;; you do this depends upon your implementation of Scheme).  You may
 ;;; change the hooks and constructors defined toward the beginning of
@@ -1054,7 +1054,7 @@
 ;;; and pairs <<and preserve identity through `eval'>>
 
 ;;; indirect labels, which are implemented as pairs, are used to support
-;;; import aliasing for identifiers exported (explictly or implicitly) from
+;;; import aliasing for identifiers exported (explicitly or implicitly) from
 ;;; top-level modules.  chi-external creates an indirect label for each
 ;;; defined identifier, import causes the pair to be shared with aliases it
 ;;; establishes, and chi-top-module whacks the pair to hold the top-level

--- a/pkgs/racket-doc/scribblings/foreign/com-auto.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/com-auto.scrbl
@@ -17,7 +17,7 @@ interface.}
 @margin-note{The @racketmodname[ffi/com] library is based on the
 @deftech{MysterX} library by Paul Steckler. MysterX is included with
 Racket but deprecated, and it will be replaced in the next version
-with a partial compability library that redirects to this one.}
+with a partial compatibility library that redirects to this one.}
 
 @; ----------------------------------------
 

--- a/pkgs/racket-doc/scribblings/foreign/com-intf.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/com-intf.scrbl
@@ -59,8 +59,8 @@ information for a method along the lines of
 @racketmodname[ffi/unsafe/alloc].  If the @racket[maybe-alloc-spec] is
 @racket[#:release-with-function function-id], then
 @racket[function-id] is used to deallocate the result produced by the
-method, unless the result is explictly deallocated before it becomes
-unreachable; for exmaple, @racket[#:release-with-function Release] is
+method, unless the result is explicitly deallocated before it becomes
+unreachable; for example, @racket[#:release-with-function Release] is
 suitable for a method that returns a COM interface reference that must
 be eventually released.  The @racket[#:release-with-method method-id]
 form is similar, except that the deallocator is a method on the same

--- a/pkgs/racket-doc/scribblings/raco/test.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/test.scrbl
@@ -210,7 +210,7 @@ identifiers:
  @item{@racket[lock-name] --- a string that names a lock file that is
        used to serialize tests (i.e., tests that have the same lock
        name do not run concurrently). The lock file's location is
-       determined by the @envvar{PLTLOCKDIR} enviornment varible or
+       determined by the @envvar{PLTLOCKDIR} environment varible or
        defaults to @racket[(find-system-path 'temp-dir)]. The maximum
        time to wait on the lock file is determined by the
        @envvar{PLTLOCKTIME} environment variable or defaults to 4

--- a/pkgs/racket-doc/scribblings/raco/zo-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/zo-struct.scrbl
@@ -109,7 +109,7 @@ structures that are produced by @racket[zo-parse] and consumed by
  original source names for the definition. The @racket[source-names]
  table is used only for debugging.
 
- When a linklet is instantiated, variables correponding to the
+ When a linklet is instantiated, variables corresponding to the
  flattening of the lists @racket[importss], @racket[exports],
  @racket[internals], and @racket[lifts] are placed in an array (in
  that order) for access via @racket[toplevel] references. The initial

--- a/pkgs/racket-doc/syntax/scribblings/parse/stxclasses.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/stxclasses.scrbl
@@ -142,7 +142,7 @@ It is an error to use both @racket[#:commit] and
 
 Declares the literals and conventions that apply to the syntax class's
 variant patterns and their immediate @racket[#:with] clauses. Patterns
-occuring within subexpressions of the syntax class (for example, on
+occurring within subexpressions of the syntax class (for example, on
 the right-hand side of a @racket[#:fail-when] clause) are not
 affected.
 

--- a/pkgs/racket-test-core/tests/racket/chaperone.rktl
+++ b/pkgs/racket-test-core/tests/racket/chaperone.rktl
@@ -3441,7 +3441,7 @@
   (test #t impersonator? (impersonate-struct (b 1 2 3 4) set-a-y! void)))
 
 ;; ----------------------------------------
-;; Make sure `struct->vector` doesnt' have memory-management issues
+;; Make sure `struct->vector` doesn't have memory-management issues
 ;; with impersonated structs:
 
 (let ()

--- a/pkgs/racket-test-core/tests/racket/file.rktl
+++ b/pkgs/racket-test-core/tests/racket/file.rktl
@@ -2091,7 +2091,7 @@
                                                                    ;; Wait until the other end has read:
                                                                    (write-bytes-avail #"noise" (current-output-port))
                                                                    (close-output-port (current-output-port))
-                                                                   ;; Drain the OS-level input pipe, suceeding if we
+                                                                   ;; Drain the OS-level input pipe, succeeding if we
                                                                    ;; find a "!".
                                                                    (let loop ()
                                                                      (define b (read-byte (current-input-port)))

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -914,7 +914,7 @@
 (test-comp '(lambda (w) (cons))
            '(lambda (w) (cons) (k:random)))
 
-; test for unary aplications
+; test for unary applications
 (test-comp -1
            '(- 1))
 (test-comp '(lambda (f) (begin (f) -1))
@@ -1205,7 +1205,7 @@
               x)
            '3)
 
-;; The compiler doens't currently recognize the expansion of `quote-syntax`
+;; The compiler doesn't currently recognize the expansion of `quote-syntax`
 #;
 (test-comp '(if (lambda () 10)
                 'ok
@@ -2161,7 +2161,7 @@
               (void 10))
            '(module m racket/base))
 
-;; The compiler doens't currently recognize the expansion of `quote-syntax`
+;; The compiler doesn't currently recognize the expansion of `quote-syntax`
 #;
 (test-comp '(module m racket/base
               (void (quote-syntax unused!)))
@@ -4727,7 +4727,7 @@
 (err/rt-test (cwv-2-5-f (lambda () (values 1 2 3)) (lambda (y z) (+ y 2))) exn:fail:contract:arity?)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Transform call-with-values to direct aplication:
+;; Transform call-with-values to direct application:
 (test-comp '(lambda (f) (f 7))
            '(lambda (f) (call-with-values (lambda () 7) (lambda (x) (f x)))))
 (test-comp '(lambda () (car 7))
@@ -5254,7 +5254,7 @@
                    list)))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; Originally: make sure compiler isn't too agressive for the
+;; Originally: make sure compiler isn't too aggressive for the
 ;; validator in terms of typed arguments:
 
 (let ([m '(module m racket/base

--- a/pkgs/racket-test-core/tests/racket/serialize.rktl
+++ b/pkgs/racket-test-core/tests/racket/serialize.rktl
@@ -23,7 +23,7 @@
 (serializable-struct d/auto b/auto ([v #:auto #:mutable]) #:inspector insp)
 
 (define (same? v1 v2)
-  ;; This is not quite the same as `equal?', becuase it knows
+  ;; This is not quite the same as `equal?', because it knows
   ;; about the structure types a, b, etc.
   (define ht (make-hasheq))
   (let loop ([v1 v1][v2 v2])

--- a/pkgs/racket-test-core/tests/racket/string.rktl
+++ b/pkgs/racket-test-core/tests/racket/string.rktl
@@ -547,7 +547,7 @@
   (test #f string-contains? "" "racket")
   (test #f string-contains? "racket" "a..e")
   (test #t string-contains? "ra..et" "a..e")
-  ; string-contains? sometimes uses diferent code paths for short and long string,
+  ; string-contains? sometimes uses different code paths for short and long string,
   ; so add some long test too.
   (test #t string-contains? "racket012345678901234567890123456789012345678901234567890123456789racket"
                             "racket012345678901234567890123456789012345678901234567890123456789racket")

--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -1823,7 +1823,7 @@
                                   (q)))))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; check that the compiler is not too agressive with `letrec' -> `let*'
+;; check that the compiler is not too aggressive with `letrec' -> `let*'
 
 (test "<undefined>\nready\n"
       get-output-string

--- a/pkgs/racket-test/tests/racket/contract/make-contract.rkt
+++ b/pkgs/racket-test/tests/racket/contract/make-contract.rkt
@@ -210,7 +210,7 @@
                                          val
                                          "bad")))))
          #:name (λ (x) 'the-name)
-         ;; make a very aproximate first-order check
+         ;; make a very approximate first-order check
          #:first-order (λ (c) (λ (x) #t))
          #:stronger (λ (x y) #f)))
       
@@ -240,7 +240,7 @@
                                             "bad")])))))
          #:list-contract? (λ (c) #t)
          #:name (λ (x) 'the-name)
-         ;; make a very aproximate first-order check
+         ;; make a very approximate first-order check
          #:first-order (λ (c) (λ (x) #t))
          #:stronger (λ (x y) #f)))
       (list-contract? (odd-length-list-of-integers)))

--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -271,7 +271,7 @@
                                    any/c
                                    number?)))))
 
-;; in this test, the and/c shoudl generate a dynamic
+;; in this test, the and/c should generate a dynamic
 ;; failure, which should trigger the 'cons/c' failing
 ;; it shouldn't make a pair of a strange value and #t
 (check-not-exn

--- a/racket/collects/net/git-checkout.rkt
+++ b/racket/collects/net/git-checkout.rkt
@@ -177,7 +177,7 @@
                                                 (retry-loop #f #f #f)))))))
                  (maybe-save-objects objs "objs")
 
-                 ;; Convert deltas into full objects withing `tmp`:
+                 ;; Convert deltas into full objects within `tmp`:
                  (rewrite-deltas objs tmp status)]))
              
              (maybe-save-objects obj-ids "all-objs")
@@ -397,7 +397,7 @@
   (values ref-commit want-commits))
 
 ;; ----------------------------------------
-;; A "pkt" is the basic unit of communiation in many parts
+;; A "pkt" is the basic unit of communication in many parts
 ;; of the git protocol. The first four bytes specify the
 ;; length of the package (including those bytes).
 

--- a/racket/collects/planet/private/planet-shared.rkt
+++ b/racket/collects/planet/private/planet-shared.rkt
@@ -798,7 +798,7 @@ Various common pieces of code that both the client and server need to access
         (λ () (do-installation))
         (λ () (close-output-port p))))]
     [else
-     ;; we didn't get the lock (and didn't alreayd have it); poll for the SUCCESS FILE
+     ;; we didn't get the lock (and didn't already have it); poll for the SUCCESS FILE
      (planet-log "waiting for someone else to finish installation in ~s" dir)
      (let loop ()
        (cond

--- a/racket/collects/racket/HISTORY.txt
+++ b/racket/collects/racket/HISTORY.txt
@@ -520,7 +520,7 @@ Changed eqv? so that inexacts are equivalent only when they
 Changed file-or-directory-permission to add 'bits mode
  and permission-setting mode
 Added special treatment of void as an 'inferred-name property
-Removed the "MrEd" compatability executable under Windows
+Removed the "MrEd" compatibility executable under Windows
  and Mac OS X, but the "mred" compatibility script remains
 racket/gui: added multi-column support to list-box%
 racket/gui: added scrollbar support to panel%, vertical-panel%,

--- a/racket/collects/racket/contract/region.rkt
+++ b/racket/collects/racket/contract/region.rkt
@@ -601,7 +601,7 @@
        ;; rewrite-define returns:
        ;; * The unused parts of id-info
        ;; * The definition, possibly rewritten to replace certain identifiers
-       ;;   along with any auxillary definitions that should be introduced
+       ;;   along with any auxiliary definitions that should be introduced
        ;;   (contract and external id defs)
        (define (rewrite-define head ids expr)
          (let ([id-pairs (map syntax->list (syntax->list #'id-info))])

--- a/racket/collects/racket/list.rkt
+++ b/racket/collects/racket/list.rkt
@@ -183,7 +183,7 @@
           (cons x (loop (cdr list)))
           '()))
       ;; could return `list' here, but make it behave like `take'
-      ;; exmaple: (takef '(a b c . d) symbol?) should be similar
+      ;; example: (takef '(a b c . d) symbol?) should be similar
       ;; to (take '(a b c . d) 3)
       '())))
 

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -273,7 +273,7 @@
   (unless (vector? vec)
     (raise-argument-error 'vector-sort "vector?" vec))
   
-  ;; calulate end if not provided
+  ;; calculate end if not provided
   (let ([end (or end (vector-length vec))])
     (perform-common-sort-arg-checks vector-sort vec less? start end getkey)
     (if getkey
@@ -290,7 +290,7 @@
                           "(and/c vector? (not/c immutable?))"
                           vec))
   
-  ;; calulate end if not provided
+  ;; calculate end if not provided
   (let ([end (or end (vector-length vec))])
     (perform-common-sort-arg-checks vector-sort! vec less? start end getkey)
     (if getkey

--- a/racket/collects/version/check.rkt
+++ b/racket/collects/version/check.rkt
@@ -87,7 +87,7 @@
 ;;   You have an old version, please upgrade to `version' you may consider also
 ;;   the alpha version
 ;; * `(error ,message [,additional-info])
-;;   An error occured, the third (optional) value can be shown as the system
+;;   An error occurred, the third (optional) value can be shown as the system
 ;;   error that happened or the value that caused an error.
 (provide check-version)
 (define (check-version)

--- a/racket/collects/xml/private/reader.rkt
+++ b/racket/collects/xml/private/reader.rkt
@@ -327,7 +327,7 @@
         (loop)))))
 
 ;; lex-pcdata : Input-port (-> Location) -> Pcdata
-;; deviation - disallow ]]> "for compatability" with SGML, sec 2.4 XML spec 
+;; deviation - disallow ]]> "for compatibility" with SGML, sec 2.4 XML spec 
 (define (lex-pcdata in pos)
   (let ([start (pos)]
         [data (let loop ()

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -372,7 +372,7 @@ Some less commonly needed `configure` flags for traditional Racket:
 
  * `--enable-bigendian`, if target platform is big-endian.
 
- * `--enable-cify` or `--disable-cify` if the JIT availablity on the
+ * `--enable-cify` or `--disable-cify` if the JIT availability on the
     target platform is different than the build platform; use
     `--enable-cify` if the JIT is not abailable on the target
     platform.

--- a/racket/src/cify/README.txt
+++ b/racket/src/cify/README.txt
@@ -14,7 +14,7 @@ Compilation by cify is UNSAFE. For example:
    is applied to an instance of the struct, and so on.
 
  * cify assumes that a variable is not referenced before its
-   defintion.
+   definition.
 
  * cify assumes that a function defined within the linklet is called
    within the linklet with the right number of arguments.

--- a/racket/src/cify/ref.rkt
+++ b/racket/src/cify/ref.rkt
@@ -18,7 +18,7 @@
 
          wrap-ref)
 
-;; Wrap each refernce to a local variable with a `ref` record, which
+;; Wrap each reference to a local variable with a `ref` record, which
 ;; provides an identity for tracking last references to implement
 ;; space safety.
 

--- a/racket/src/cs/bootstrap/README.txt
+++ b/racket/src/cs/bootstrap/README.txt
@@ -16,4 +16,4 @@ Chez Scheme.
 While the similation of Chez Scheme should be robust to common Chez
 Scheme changes, it does rely on details of the Chez Scheme
 implementation and source, So, the simulation will have to be updated
-to accomodate some Chez Scheme changes.
+to accommodate some Chez Scheme changes.

--- a/racket/src/cs/rumble/memory.ss
+++ b/racket/src/cs/rumble/memory.ss
@@ -423,7 +423,7 @@
        [else #'(foreign-procedure s ...)])]))
 
 ;; This is an inconvenient callback interface, certainly, but it
-;; accomodates a limitation of the traditional Racket implementation
+;; accommodates a limitation of the traditional Racket implementation
 (define (run-one-collect-callback v save sel)
   (let ([protocol (#%vector-ref v 0)]
         [proc (cpointer-address (#%vector-ref v 1))]

--- a/racket/src/expander/compile/serialize.rkt
+++ b/racket/src/expander/compile/serialize.rkt
@@ -41,7 +41,7 @@
 ;;    can refer to mutable values)
 ;;
 ;;  - a vector of "fill" descriptions to complete the construction of
-;;    mutable values (whcih can refer to mutable and shared values);
+;;    mutable values (which can refer to mutable and shared values);
 ;;    and
 ;;
 ;;  - a final value construction (which can refer to shared and

--- a/racket/src/expander/compile/write-linklet.rkt
+++ b/racket/src/expander/compile/write-linklet.rkt
@@ -44,7 +44,7 @@
   ;;   bundle count as 4-byte integer
   ;;   binary tree:
   ;;     bundle-name length as 4-byte integer
-  ;;     bundle name [encoding decribed below]
+  ;;     bundle name [encoding described below]
   ;;     bundle offset as 4-byte integer
   ;;     bundle size as 4-byte integer
   ;;     left-branch offset as 4-byte integer

--- a/racket/src/expander/expand/def-id.rkt
+++ b/racket/src/expander/expand/def-id.rkt
@@ -21,7 +21,7 @@
 ;; linklet-level symbol.
 
 ;; As a concession to top-level evaluation, reserve plain symbols for
-;; identifers that have only the module's scopes. That way, if a
+;; identifiers that have only the module's scopes. That way, if a
 ;; reference to an identifier is encountered before a definition, the
 ;; reference can still work in normal cases.
 

--- a/racket/src/expander/expand/main.rkt
+++ b/racket/src/expander/expand/main.rkt
@@ -177,7 +177,7 @@
          (cond
            [(transformer? t)
             (define fail-non-transformer
-              ;; Make sure a rename transformer eventualy leads to syntax
+              ;; Make sure a rename transformer eventually leads to syntax
               (and (rename-transformer? t)
                    (lambda ()
                      (raise-syntax-implicit-error s sym trigger-id ctx))))
@@ -359,8 +359,8 @@
 
 ;; Given a macro transformer `t`, apply it --- adding appropriate
 ;; scopes to represent the expansion step; the `insp-of-t` inspector
-;; is the inspector of the module that defines `t`, which gives it
-;; priviledge for `syntax-arm` and similar
+;; is the inspector of the module that defines `t`, which gives its
+;; privilege for `syntax-arm` and similar
 (define (apply-transformer t insp-of-t s id ctx binding
                            #:origin-id [origin-id #f])
   (performance-region

--- a/racket/src/expander/extract/underscore.rkt
+++ b/racket/src/expander/extract/underscore.rkt
@@ -8,7 +8,7 @@
 ;; for local variables, where the expander adds "_<num>" suffixes to
 ;; generate local-variable names, and the "<num>"s count up across all
 ;; symbols. Renumber with symbol-specific counting to reduce
-;; unneccessary changes to generated code. A relatively simple
+;; unnecessary changes to generated code. A relatively simple
 ;; strategy works because no primitive or exported name has a "_<num>"
 ;; suffix.
 

--- a/racket/src/expander/read/number.rkt
+++ b/racket/src/expander/read/number.rkt
@@ -14,7 +14,7 @@
 ;; The `string->number` parser is responsible for handling Racket's
 ;; elaborate number syntax (mostly inherited from Scheme). It relies
 ;; on a host-system `string->number` only for generating
-;; psuedo-extflonums when flonums aren't really supported. Otherwise,
+;; pseudo-extflonums when flonums aren't really supported. Otherwise,
 ;; the parser here performs all checking and arithmetic that the
 ;; reader needs.
 

--- a/racket/src/expander/syntax/fallback.rkt
+++ b/racket/src/expander/syntax/fallback.rkt
@@ -14,7 +14,7 @@
 ;; scope set that doesn't include the additional scope for B. This
 ;; fallback makes it easier to work across namespaces (including
 ;; moving from the top level to a module body or vice versa), and it
-;; accomodates existing Racket programs.
+;; accommodates existing Racket programs.
 ;;
 ;; A syntax object contains a fallback search list only if
 ;; `push-scope` has been used. The fallback chain is in the

--- a/racket/src/expander/syntax/scope.rkt
+++ b/racket/src/expander/syntax/scope.rkt
@@ -493,7 +493,7 @@
   (for/fold ([s s]) ([sc (in-list scs)])
     (flip-scope s sc)))
 
-;; Pushes a multi-scope to accomodate multiple top-level namespaces.
+;; Pushes a multi-scope to accommodate multiple top-level namespaces.
 ;; See "fallback.rkt".
 (define (push-scope s sms)
   (define-memo-lite (push smss/maybe-fallbacks)
@@ -519,7 +519,7 @@
                      scope-ops  ; scope -> (or/c 'add 'remove 'flip)
                      ;; mpi-shifts and inspectors are mostly
                      ;; implemented at the "binding.rkt" layer,
-                     ;; but we accomodate them here
+                     ;; but we accommodate them here
                      prev-mss   ; owner's mpi-shifts before adds
                      add-mpi-shifts ; #f or (mpi-shifts -> mpi-shifts)
                      inspector  ; #f or inspector

--- a/racket/src/foreign/libffi/ChangeLog
+++ b/racket/src/foreign/libffi/ChangeLog
@@ -310,7 +310,7 @@ Date:   Sat Mar 22 10:00:53 2014 -0700
     win32.S: Add handling for position-independent code on Darwin
     
     Newer versions of Darwin generate the necessary stub functions
-    automatically and just need a call instruction, but accomodating older
+    automatically and just need a call instruction, but accommodating older
     versions as well requires adding the stub.
 
 commit ef5890ebafb7cd2fbf9acf161edb55fe1382871c

--- a/racket/src/foreign/libffi/ChangeLog.libffi-3.1
+++ b/racket/src/foreign/libffi/ChangeLog.libffi-3.1
@@ -20,7 +20,7 @@
 	* Makefile.am: Compile in src/x86/win32.S on non-Windows x86-32.
 	* src/x86/ffitarget.h: Add FFI_STDCALL, FFI_THISCALL, and
 	FFI_FASTCALL on non-Windows x86-32.  Increase trampoline size to
-	accomodate these calling conventions, and unify some ifdeffery.
+	accommodate these calling conventions, and unify some ifdeffery.
 	* src/x86/ffi.c: Add support for FFI_STDCALL, FFI_THISCALL, and
 	FFI_FASTCALL on non-Windows x86-32 platforms; update ifdeffery.
 	* src/x86/win32.S: Support compiling on non-Windows x86-32
@@ -2844,7 +2844,7 @@
 
 2007-11-25  Andreas Tobler  <a.tobler@schweiz.org>
 
-	* src/closures.c: Move defintion of MAYBE_UNUSED from here to ...
+	* src/closures.c: Move definition of MAYBE_UNUSED from here to ...
 	* include/ffi_common.h: ... here.
 	Update copyright.
 

--- a/racket/src/foreign/libffi/ltmain.sh
+++ b/racket/src/foreign/libffi/ltmain.sh
@@ -1522,7 +1522,7 @@ func_run_hooks ()
 #    }
 #    func_add_hook func_validate_options my_option_validation
 #
-# You'll alse need to manually amend $usage_message to reflect the extra
+# You'll also need to manually amend $usage_message to reflect the extra
 # options you parse.  It's preferable to append if you can, so that
 # multiple option parsing hooks can be added safely.
 
@@ -1555,7 +1555,7 @@ func_options ()
 # All initialisations required before starting the option parse loop.
 # Note that when calling hook functions, we pass through the list of
 # positional parameters.  If a hook function modifies that list, and
-# needs to propogate that back to rest of this script, then the complete
+# needs to propagate that back to rest of this script, then the complete
 # modified list must be put in 'func_run_hooks_result' before
 # returning.
 func_hookable func_options_prep

--- a/racket/src/foreign/libffi/src/mips/n32.S
+++ b/racket/src/foreign/libffi/src/mips/n32.S
@@ -76,7 +76,7 @@ ffi_call_N32:
 
 	bigger:	
 	ADDU	t4, v0, 2 * FFI_SIZEOF_ARG -1	# make sure it is aligned 
-	and	v0, t4, -2 * FFI_SIZEOF_ARG		# to a proper boundry.
+	and	v0, t4, -2 * FFI_SIZEOF_ARG		# to a proper boundary.
 
 sixteen:
 	SUBU	$sp, $sp, v0	# move the stack pointer to reflect the

--- a/racket/src/io/port/commit-port.rkt
+++ b/racket/src/io/port/commit-port.rkt
@@ -40,7 +40,7 @@
         #t]
        [else
         ;; General case to support blocking and potentially multiple
-        ;; commiting threads:
+        ;; committing threads:
         (unless commit-manager
           (set! commit-manager (make-commit-manager)))
         (commit-manager-wait commit-manager progress-evt ext-evt finish)]))]

--- a/racket/src/io/unsafe/schedule.rkt
+++ b/racket/src/io/unsafe/schedule.rkt
@@ -26,7 +26,7 @@
                   (when vals
                     ;; The rule here is that we cancel any sleep so
                     ;; that the event will be polled again; we do not
-                    ;; select the event now. That rule accomodates
+                    ;; select the event now. That rule accommodates
                     ;; the old Racket scheduler.
                     (sandman-poll-ctx-merge-timeout poll-ctx (current-inexact-milliseconds)))
                   (values #f self)]

--- a/racket/src/lt/aclocal.m4
+++ b/racket/src/lt/aclocal.m4
@@ -1143,7 +1143,7 @@ if test -n "$_LT_AC_TAGVAR(hardcode_libdir_flag_spec, $1)" || \
    test -n "$_LT_AC_TAGVAR(runpath_var, $1)" || \
    test "X$_LT_AC_TAGVAR(hardcode_automatic, $1)" = "Xyes" ; then
 
-  # We can hardcode non-existant directories.
+  # We can hardcode non-existent directories.
   if test "$_LT_AC_TAGVAR(hardcode_direct, $1)" != no &&
      # If the only mechanism to avoid hardcoding is shlibpath_var, we
      # have to relink, otherwise we might link with an installed library

--- a/racket/src/mzcom/com_glue.c
+++ b/racket/src/mzcom/com_glue.c
@@ -438,7 +438,7 @@ static STDMETHODIMP GetConnectionPointContainer(IConnectionPoint *com_obj, IConn
 // app object from which we can request the app to give us its IMzObjEvents. All of
 // this convoluted stuff is a combination of poor pre-planning by Microsoft
 // programmers when they designed this stuff, as well as the colossal blunder of
-// designing COM to accomodate the limitations of early, primitive editions of
+// designing COM to accommodate the limitations of early, primitive editions of
 // Visual Basic.
 //
 // The second arg passed here is some app object whose QueryInterface function

--- a/racket/src/racket/gc/blacklst.c
+++ b/racket/src/racket/gc/blacklst.c
@@ -21,7 +21,7 @@
  * See the definition of page_hash_table in gc_private.h.
  * False hits from the stack(s) are much more dangerous than false hits
  * from elsewhere, since the former can pin a large object that spans the
- * block, eventhough it does not start on the dangerous block.
+ * block, even though it does not start on the dangerous block.
  */
  
 /*

--- a/racket/src/racket/gc/configure.in
+++ b/racket/src/racket/gc/configure.in
@@ -411,7 +411,7 @@ AC_DEFINE(ATOMIC_UNCOLLECTABLE)
 
 dnl This is something of a hack.  When cross-compiling we turn off
 dnl some functionality.  We also enable the "small" configuration.
-dnl These is only correct when targetting an embedded system.  FIXME.
+dnl These is only correct when targeting an embedded system.  FIXME.
 if test -n "${with_cross_host}"; then
    AC_DEFINE(NO_SIGSET)
    AC_DEFINE(NO_CLOCK)

--- a/racket/src/racket/gc/doc/README.DGUX386
+++ b/racket/src/racket/gc/doc/README.DGUX386
@@ -88,7 +88,7 @@ Note (HB):
 +    # that compilation of execitables will put them in correct order
 +    # in any case and sometimes are wrong when listed as deplibs (or missing some deplibs)
 +    # However when GNU ld and --whole-archive needs to be used we have the problem
-+    # that if the -fPIC *_s.a archive is linked through deplibs list we ommiting crucial
++    # that if the -fPIC *_s.a archive is linked through deplibs list we omitting crucial
 +    # .lo/.o files from the created shared lib. This I think is not the case here.
 +    archive_cmds='$CC -shared -h $soname -o $lib $libobjs $linkopts'
 +    thread_safe_flag_spec='-pthread'

--- a/racket/src/racket/gc/doc/README.changes
+++ b/racket/src/racket/gc/doc/README.changes
@@ -1875,7 +1875,7 @@ Since 6.2alpha6:
  - Fixed Makefile.direct for DARWIN.  (Thanks to Manuel Serrano.)
  - There was a race between GC_pthread_detach and thread exit that could
    result in a thread structure being deallocated by GC_pthread_detach
-   eventhough it was still needed by the thread exit code.  (Thanks to
+   even though it was still needed by the thread exit code.  (Thanks to
    Dick Porter for the small test case that allowed this to be debugged.)
  - Fixed version parsing for non-alpha versions in acinclude.m4 and
    version checking in version.h.
@@ -2550,7 +2550,7 @@ Since first gc7.0alpha8 version:
  - __GNUC__ was misspelled as __GNUC in thread_local_alloc.h.
    (Thanks to Peter Wang.)
  - Integrated various MacOSX patches and tried to reconcile them.
-   Thanks to Allan Hsu, several contributers at Apple, and probably
+   Thanks to Allan Hsu, several contributors at Apple, and probably
    others.
  - Added some casts to powerpc.h in libatomic_ops to silence warnings.
 

--- a/racket/src/racket/gc/doc/README.ews4800
+++ b/racket/src/racket/gc/doc/README.ews4800
@@ -20,7 +20,7 @@ GC on EWS4800
      AR = /usr/ccs64/bin/ar
 
 3. ELF file format
-   *** Caution: The following infomation is empirical. ***
+   *** Caution: The following information is empirical. ***
 
  32bit:
    ELF file has an unique format. (See a.out(4) and end(3C).)

--- a/racket/src/racket/gc/doc/gcdescr.html
+++ b/racket/src/racket/gc/doc/gcdescr.html
@@ -546,7 +546,7 @@ accomplished with <TT># define</tt>'s in <TT>gc.h</tt>
 (really <TT>gc_pthread_redirects.h</tt>), or optionally
 by using ld's function call wrapping mechanism under Linux.
 <P>
-Recent versions of the collector support several facilites to enhance
+Recent versions of the collector support several facilities to enhance
 the processor-scalability and thread performance of the collector.
 These are discussed in more detail <A HREF="scale.html">here</a>.
 We briefly outline the data approach to thread-local allocation in the

--- a/racket/src/racket/gc/dyn_load.c
+++ b/racket/src/racket/gc/dyn_load.c
@@ -959,7 +959,7 @@ void GC_register_dynamic_libraries()
       /* Get info about next shared library */
         status = shl_get(index, &shl_desc);
 
-      /* Check if this is the end of the list or if some error occured */
+      /* Check if this is the end of the list or if some error occurred */
         if (status != 0) {
 #	 ifdef GC_HPUX_THREADS
 	   /* I've seen errno values of 0.  The man page is not clear	*/

--- a/racket/src/racket/gc/include/gc.h
+++ b/racket/src/racket/gc/include/gc.h
@@ -151,7 +151,7 @@ GC_API int GC_use_entire_heap;
 		/* entire heap before collecting.  This was the only 	*/
 		/* option for GC versions < 5.0.  This sometimes	*/
 		/* results in more large block fragmentation, since	*/
-		/* very larg blocks will tend to get broken up		*/
+		/* very large blocks will tend to get broken up		*/
 		/* during each GC cycle.  It is likely to result in a	*/
 		/* larger working set, but lower collection		*/
 		/* frequencies, and hence fewer instructions executed	*/

--- a/racket/src/racket/gc/include/gc_mark.h
+++ b/racket/src/racket/gc/include/gc_mark.h
@@ -32,7 +32,7 @@
 /* A client supplied mark procedure.  Returns new mark stack pointer.	*/
 /* Primary effect should be to push new entries on the mark stack.	*/
 /* Mark stack pointer values are passed and returned explicitly.	*/
-/* Global variables decribing mark stack are not necessarily valid.	*/
+/* Global variables describing mark stack are not necessarily valid.	*/
 /* (This usually saves a few cycles by keeping things in registers.)	*/
 /* Assumed to scan about GC_PROC_BYTES on average.  If it needs to do	*/
 /* much more work than that, it should do it in smaller pieces by	*/

--- a/racket/src/racket/gc/include/private/gcconfig.h
+++ b/racket/src/racket/gc/include/private/gcconfig.h
@@ -418,7 +418,7 @@
 #   if defined(_MSC_VER) && defined(_M_IA64)
 #     define IA64
 #     define MSWIN32	/* Really win64, but we don't treat 64-bit 	*/
-			/* variants as a differnt platform.		*/
+			/* variants as a different platform.		*/
 #   endif
 # endif
 # if defined(__DJGPP__)
@@ -1188,7 +1188,7 @@
 #	  define PREFETCH(x) \
 	    __asm__ __volatile__ ("	prefetchnta	%0": : "m"(*(char *)(x)))
 	    /* Empirically prefetcht0 is much more effective at reducing	*/
-	    /* cache miss stalls for the targetted load instructions.  But it	*/
+	    /* cache miss stalls for the targeted load instructions.  But it	*/
 	    /* seems to interfere enough with other cache traffic that the net	*/
 	    /* result is worse than prefetchnta.				*/
 #         if 0 

--- a/racket/src/racket/gc/mark.c
+++ b/racket/src/racket/gc/mark.c
@@ -984,7 +984,7 @@ void GC_do_local_mark(mse *local_mark_stack, mse *local_top)
 	    /* Try to share the load, since the main stack is empty,	*/
 	    /* and helper threads are waiting for a refill.		*/
 	    /* The entries near the bottom of the stack are likely	*/
-	    /* to require more work.  Thus we return those, eventhough	*/
+	    /* to require more work.  Thus we return those, even though	*/
 	    /* it's harder.						*/
  	    mse * new_bottom = local_mark_stack
 				+ (local_top - local_mark_stack)/2;

--- a/racket/src/racket/gc/os_dep.c
+++ b/racket/src/racket/gc/os_dep.c
@@ -1737,7 +1737,7 @@ ptr_t GC_SysVGetDataStart(size_t max_page_size, ptr_t etext_addr)
     		      & ~((word)max_page_size - 1));
     word page_offset = (text_end & ((word)max_page_size - 1));
     volatile char * result = (char *)(next_page + page_offset);
-    /* Note that this isnt equivalent to just adding		*/
+    /* Note that this isn't equivalent to just adding		*/
     /* max_page_size to &etext if &etext is at a page boundary	*/
     
     GC_setup_temporary_fault_handler();
@@ -2379,7 +2379,7 @@ PCR_ERes GC_push_thread_stack(PCR_Th_T *t, PCR_Any dummy)
 }
 
 /* Push the contents of an old object. We treat this as stack	*/
-/* data only becasue that makes it robust against mark stack	*/
+/* data only because that makes it robust against mark stack	*/
 /* overflow.							*/
 PCR_ERes GC_push_old_obj(void *p, size_t size, PCR_Any data)
 {
@@ -3836,7 +3836,7 @@ static void *GC_mprotect_thread(void *arg)
 }
 
 /* All this SIGBUS code shouldn't be necessary. All protection faults should
-   be going throught the mach exception handler. However, it seems a SIGBUS is
+   be going through the mach exception handler. However, it seems a SIGBUS is
    occasionally sent for some unknown reason. Even more odd, it seems to be
    meaningless and safe to ignore. */
 #ifdef BROKEN_EXCEPTION_HANDLING

--- a/racket/src/racket/gc/pthread_support.c
+++ b/racket/src/racket/gc/pthread_support.c
@@ -129,7 +129,7 @@ unsigned long GC_lock_holder = NO_THREAD;
 #     define REAL_FUNC(f) GC_real_##f
       /* We define both GC_f and plain f to be the wrapped function.	*/
       /* In that way plain calls work, as do calls from files that	*/
-      /* included gc.h, wich redefined f to GC_f.			*/
+      /* included gc.h, which redefined f to GC_f.			*/
       /* FIXME: Needs work for DARWIN and True64 (OSF1) */
       typedef int (* GC_pthread_create_t)(pthread_t *, const pthread_attr_t *,
 		      		          void * (*)(void *), void *);

--- a/racket/src/racket/gc/threadlibs.c
+++ b/racket/src/racket/gc/threadlibs.c
@@ -57,7 +57,7 @@ int main()
 	printf("-pthread -lrt"); /* DOB: must be -pthread, not -lpthread */
 #   endif
     /* You need GCC 3.0.3 to build this one!           */  
-    /* DG/UX native gcc doesnt know what "-pthread" is */
+    /* DG/UX native gcc doesn't know what "-pthread" is */
 #   if defined(GC_DGUX386_THREADS)
         printf("-ldl -pthread\n");
 #   endif

--- a/racket/src/racket/gc/typd_mlc.c
+++ b/racket/src/racket/gc/typd_mlc.c
@@ -28,7 +28,7 @@
  * must trace the complex_descriptor.
  *
  * Note that descriptors inside objects may appear cleared, if we encounter a
- * false refrence to an object on a free list.  In the GC_descr case, this
+ * false reference to an object on a free list.  In the GC_descr case, this
  * is OK, since a 0 descriptor corresponds to examining no fields.
  * In the complex_descriptor case, we explicitly check for that case.
  *

--- a/racket/src/racket/gc2/block_cache.c
+++ b/racket/src/racket/gc2/block_cache.c
@@ -439,7 +439,7 @@ static void block_cache_protect_one_page(BlockCache* bc, void *p, size_t len, in
         GC_ASSERT(pos < (b->size >> LOG_APAGE_SIZE));
         GC_ASSERT(BD_MAP_GET_BIT(b->alloc_map, pos));
         /* Since a queued mprotect affects more pages than the client can be sure of,
-           we have to accomodate redundant requests. */
+           we have to accommodate redundant requests. */
         if (writeable) {
           if (BD_MAP_GET_BIT(b->protect_map, pos)) {
             BD_MAP_UNSET_BIT(b->protect_map, pos);

--- a/racket/src/racket/gc2/newgc.c
+++ b/racket/src/racket/gc2/newgc.c
@@ -5841,9 +5841,9 @@ static void garbage_collect(NewGC *gc, int force_full, int no_full,
                                    /* new memory use; gen0_phantom_count can be non-zero due to
                                       phantom-bytes record in generation 1/2: */
                                    gc->memory_in_use + gc->gen0_phantom_count,
-                                   /* original memory use, including adminstrative structures: */
+                                   /* original memory use, including administrative structures: */
                                    old_mem_allocated,
-                                   /* new memory use with adminstrative structures: */
+                                   /* new memory use with administrative structures: */
                                    mmu_memory_allocated(gc->mmu)+gc->phantom_count+gc->gen0_phantom_count,
                                    gc->child_gc_total);
     unpark_for_inform_callback(gc);

--- a/racket/src/racket/src/gmp/gmp.c
+++ b/racket/src/racket/src/gmp/gmp.c
@@ -3111,7 +3111,7 @@ mpn_sqrtrem (mp_ptr sp, mp_ptr rp, mp_srcptr np, mp_size_t nn)
   return rn;
 }
 
-/* mpn_bz_divrem_n and auxilliary routines. */
+/* mpn_bz_divrem_n and auxiliary routines. */
 
 /*
 [1] Fast Recursive Division, by Christoph Burnikel and Joachim Ziegler,

--- a/racket/src/racket/src/jitstate.c
+++ b/racket/src/racket/src/jitstate.c
@@ -67,7 +67,7 @@ int scheme_mz_retain_it(mz_jit_state *jitter, void *v)
 }
 
 void scheme_mz_load_retained(mz_jit_state *jitter, int rs, void *obj)
-/* obj is a pointer, but not necesarily tagged (in CGC) */
+/* obj is a pointer, but not necessarily tagged (in CGC) */
 {
   if (!SCHEME_INTP((Scheme_Object *)obj)
       && !SAME_OBJ((Scheme_Object *)obj, scheme_true)

--- a/racket/src/racket/src/letrec_check.c
+++ b/racket/src/racket/src/letrec_check.c
@@ -140,7 +140,7 @@ typedef struct Scheme_Deferred_Expr {
      only need to process it once */
   int done;
 
-  /* the expression that has been deferred -- usally a Scheme_Lambda,
+  /* the expression that has been deferred -- usually a Scheme_Lambda,
      but can be a Scheme_IR_Local for propagation */
   Scheme_Object *expr;
 

--- a/racket/src/racket/src/linklet.c
+++ b/racket/src/racket/src/linklet.c
@@ -1267,7 +1267,7 @@ Scheme_Object *scheme_linklet_run_finish(Scheme_Linklet* linklet, Scheme_Instanc
         /* Double-check that the definition-installing part of the
            continuation was not skipped. Otherwise, the compiler would
            not be able to assume that a variable reference that is
-           lexically later (incuding a reference to an imported
+           lexically later (including a reference to an imported
            variable) always references a defined variable. Putting the
            prompt around a definition's RHS might be a better
            approach, but that would change the language (so mabe next

--- a/racket/src/racket/src/resolve.c
+++ b/racket/src/racket/src/resolve.c
@@ -51,7 +51,7 @@ struct Resolve_Info
                            `instance_pos` in an
                            `Scheme_IR_Topelevel`). */
   int *toplevel_deltas; /* shifts for toplevels in the import range to
-                           accomodate removals */
+                           accommodate removals */
 
   Scheme_Hash_Table *toplevel_defns; /* for pruning unused definitions, if
                                         some definitions are unexported

--- a/racket/src/racket/src/thread.c
+++ b/racket/src/racket/src/thread.c
@@ -1456,8 +1456,8 @@ Scheme_Thread *scheme_do_close_managed(Scheme_Custodian *m, Scheme_Exit_Closer_F
   m->shut_down = 1;
 
   /* Need to kill children first, transitively, so find
-     last decendent. The family will be the global-list from
-     m to this last decendent, inclusive. */
+     last descendant. The family will be the global-list from
+     m to this last descendant, inclusive. */
   for (c = m; CUSTODIAN_FAM(c->children); ) {
     for (c = CUSTODIAN_FAM(c->children); CUSTODIAN_FAM(c->sibling); ) {
       c = CUSTODIAN_FAM(c->sibling);
@@ -4560,7 +4560,7 @@ void scheme_break_main_thread_at(void *p)
 }
 
 void scheme_break_main_thread()
-/* Calling this function from an arbitary
+/* Calling this function from an arbitrary
    thread is dangerous when therad locals are enabled. */
 {
   scheme_break_main_thread_at((void *)&delayed_break_ready);
@@ -4844,8 +4844,8 @@ void scheme_thread_block(float sleep_time)
   shrink_cust_box_array();
 
   /* Scheduling queries might involve callbacks through the FFI that put
-     the runtime system into `scheme_no_stack_overflow` mode. Immitate
-     the foriegn-call entry point with an extra check that we have enough
+     the runtime system into `scheme_no_stack_overflow` mode. Imitate
+     the foreign-call entry point with an extra check that we have enough
      stack to survive in foreign functions. */
   if (!scheme_no_stack_overflow && scheme_is_stack_too_shallow()) {
     p->sleep_end = sleep_time; /* an abuse of the `sleep_end` field to
@@ -8935,7 +8935,7 @@ static void run_gc_callbacks(int pre)
       for (j = 0; j < SCHEME_VEC_SIZE(acts); j++) {
         act = SCHEME_VEC_ELS(acts)[j];
         protocol = SCHEME_VEC_ELS(act)[0];
-        /* The set of suported protocols is arbitary, based on what we've needed
+        /* The set of suported protocols is arbitrary, based on what we've needed
            so far. */
         if (!strcmp(SCHEME_SYM_VAL(protocol), "int->void")) {
           gccb_Int_to_Void proc;

--- a/racket/src/racket/src/unwind/libunwind.c
+++ b/racket/src/racket/src/unwind/libunwind.c
@@ -855,7 +855,7 @@ parse_cie (unw_addr_space_t as, unw_accessors_t *a, unw_word_t addr,
   return 0;
 }
 
-/* Extract proc-info from the FDE starting at adress ADDR.
+/* Extract proc-info from the FDE starting at address ADDR.
    
    Pass BASE as zero for eh_frame behaviour, or a pointer to
    debug_frame base for debug_frame behaviour.  */

--- a/racket/src/regexp/match/interp.rkt
+++ b/racket/src/regexp/match/interp.rkt
@@ -5,7 +5,7 @@
 ;; Compilation produces a matcher function; see "match.rkt"
 (define (interp m      ; the compiled matcher function
                 s      ; input bytes or lazy-bytes
-                pos    ; starting seach position, can be > `start`, must be < `limit`
+                pos    ; starting search position, can be > `start`, must be < `limit`
                 start  ; input start in the sense of `^`; don't read before this
                 limit/end ; don't read past `limit`; `end` corresponds to `$` and can be < `limit`
                 state) ; vector where group position-pair matches are installed

--- a/racket/src/rktio/rktio.h
+++ b/racket/src/rktio/rktio.h
@@ -475,7 +475,7 @@ RKTIO_EXTERN_ERR(RKTIO_WRITE_ERROR)
 intptr_t rktio_udp_sendto(rktio_t *rktio, rktio_fd_t *rfd, RKTIO_NULLABLE rktio_addrinfo_t *addr,
                           const char *buffer, intptr_t len);
 /* Extends `rktio_write` to accept a destination `addr`, and binds `rfd` if it 
-   is not bound aready. The `addr` can be NULL if the socket is connected. */
+   is not bound already. The `addr` can be NULL if the socket is connected. */
 
 RKTIO_EXTERN_ERR(RKTIO_WRITE_ERROR)
 intptr_t rktio_udp_sendto_in(rktio_t *rktio, rktio_fd_t *rfd, RKTIO_NULLABLE rktio_addrinfo_t *addr,
@@ -541,7 +541,7 @@ RKTIO_EXTERN rktio_bool_t rktio_is_ok_envvar_name(rktio_t *rktio, rktio_const_st
 RKTIO_EXTERN rktio_bool_t rktio_are_envvar_names_case_insensitive(rktio_t *rktio);
 /* Checks whether environment variables are case-folded by the OS.
    That doesn't mean that clients need to case-fold names, but clients
-   may want to immitate the OS. */
+   may want to imitate the OS. */
 
 RKTIO_EXTERN char *rktio_getenv(rktio_t *rktio, rktio_const_string_t name);
 /* Gets an environment variable value, or reports
@@ -710,7 +710,7 @@ RKTIO_EXTERN void rktio_poll_set_add_eventmask(rktio_t *rktio, rktio_poll_set_t 
 RKTIO_EXTERN void rkio_reset_sleep_backoff(rktio_t *rktio);
 /* Call this function when using `rktio_poll_set_add_eventmask` and
    when matching events are not always consumed from the queue between
-   sleeps. To accomodate messages that are not consumed, the poll set
+   sleeps. To accommodate messages that are not consumed, the poll set
    will actually only sleep a short while at first, and then back off
    exponentially. Call this function when your program does useful
    work (instead of spinning on sleep) to reset the backoff

--- a/racket/src/rktio/rktio_convert.c
+++ b/racket/src/rktio/rktio_convert.c
@@ -143,7 +143,7 @@ static void init_iconv()
       iconv_errno = (errno_proc_t)GetProcAddress(m, "_errno");
     if (!iconv_errno) {
       /* The iconv.dll distributed with Racket links to msvcrt.dll.
-	 It's a slighly dangerous assumption that whatever iconv we
+	 It's a slightly dangerous assumption that whatever iconv we
 	 found also uses msvcrt.dll. */
       m = LoadLibraryW(L"msvcrt.dll");
       if (m) {

--- a/racket/src/rktio/rktio_fd.c
+++ b/racket/src/rktio/rktio_fd.c
@@ -1423,7 +1423,7 @@ intptr_t rktio_write(rktio_t *rktio, rktio_fd_t *rfd, const char *buffer, intptr
 	if (towrite)
 	  ok = WriteConsoleW((HANDLE)rfd->fd, w_buffer, towrite, &winwrote, NULL);
 	else {
-	  /* can happend if can_leftover is > 0 */
+	  /* can happen if can_leftover is > 0 */
 	  ok = 1;
 	  winwrote = 0;
 	}

--- a/racket/src/schemify/interpret.rkt
+++ b/racket/src/schemify/interpret.rkt
@@ -106,7 +106,7 @@
            (hash-set env arg (+ stack-depth i))))
        (define body-vars-index (+ num-args stack-depth))
        ;; Gather all the names that have `define`s, and build up the
-       ;; enviornment that has them consceptually pushed after the
+       ;; environment that has them consceptually pushed after the
        ;; import and export variables.
        (define-values (body-env num-body-vars)
          (for/fold ([env args-env] [num-body-vars 0]) ([e (in-wrap-list body)])

--- a/racket/src/schemify/intmap.rkt
+++ b/racket/src/schemify/intmap.rkt
@@ -4,7 +4,7 @@
 
 ;; Simplified version of Jon Zeppieri's intmap
 ;; implementation for Racket-on-Chez.
-;; This one always has fixnum keys, doens't have
+;; This one always has fixnum keys, doesn't have
 ;; to hash, doesn't have to deal with collisions,
 ;; and doesn't need a wrapper to distinguish
 ;; the type and record the comparison function.

--- a/racket/src/setup-go.rkt
+++ b/racket/src/setup-go.rkt
@@ -29,7 +29,7 @@
 ;; The point of going through `setup/main` is that the Racket module
 ;; gets compiled as needed, so that it doesn't have to be loaded from
 ;; source every time. At the same time `setup/main` detects when files
-;; need to be recompiled, either becuase the underlying Racket's
+;; need to be recompiled, either because the underlying Racket's
 ;; version changed or because a dependency changed.
 
 (provide go)

--- a/racket/src/start/MemoryModule.h
+++ b/racket/src/start/MemoryModule.h
@@ -139,7 +139,7 @@ BOOL MemoryDefaultFree(LPVOID, SIZE_T, DWORD, void *);
 
 /**
  * Default implementation of CustomLoadLibraryFunc that calls LoadLibraryA
- * internally to load an additional libary.
+ * internally to load an additional library.
  *
  * This is the default as used by MemoryLoadLibrary.
  */
@@ -155,7 +155,7 @@ FARPROC MemoryDefaultGetProcAddress(HCUSTOMMODULE, LPCSTR, void *);
 
 /**
  * Default implementation of CustomFreeLibraryFunc that calls FreeLibrary
- * internally to release an additional libary.
+ * internally to release an additional library.
  *
  * This is the default as used by MemoryLoadLibrary.
  */

--- a/racket/src/thread/custodian-object.rkt
+++ b/racket/src/thread/custodian-object.rkt
@@ -22,7 +22,7 @@
                    [gc-roots #:mutable]   ; weak references to charge to custodian; access without interrupts
                    [memory-limits #:mutable]   ; list of (cons limit cust)
                    [immediate-limit #:mutable] ; limit on immediate allocation
-                   [sync-futures? #:mutable]   ; whether a sync witht future threads is needed on shutdown
+                   [sync-futures? #:mutable]   ; whether a sync with future threads is needed on shutdown
                    [post-shutdown #:mutable])  ; callbacks to run in atomic mode after shutdown
   #:authentic)
 

--- a/racket/src/thread/custodian.rkt
+++ b/racket/src/thread/custodian.rkt
@@ -445,7 +445,7 @@
 (define compute-memory-sizes 0)
 
 (void (set-reachable-size-increments-callback!
-       ;; Called in an arbitary host thread, with interrupts off and all other threads suspended:
+       ;; Called in an arbitrary host thread, with interrupts off and all other threads suspended:
        (lambda (compute-size-increments)
          (unless (zero? compute-memory-sizes)
            (host:call-with-current-place-continuation

--- a/racket/src/thread/thread.rkt
+++ b/racket/src/thread/thread.rkt
@@ -444,7 +444,7 @@
 ;; Extends `do-thread-deschdule!` where `t` is always `(current-thread)`.
 ;; The `interrupt-callback` is called if the thread receives a break
 ;; signal, is killed, or is suspended; if the break signal is
-;; supressed or resumed, then `retry-callback` is called to try again
+;; suppressed or resumed, then `retry-callback` is called to try again
 ;; --- but `retry-callback` will only be used if `interrupt-callback`
 ;; was previously called, and neither is called if the thread is
 ;; "internal"-resumed normally instead of by a break signal of a


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos.
