### PR TITLE
Load core-tests instead of mz-tests

### DIFF
--- a/pkgs/racket-test-core/tests/racket/expand.rktl
+++ b/pkgs/racket-test-core/tests/racket/expand.rktl
@@ -122,7 +122,7 @@
  'expand-load
  #f
  (lambda ()
-   (namespace-set-variable-value! 'expand-load "mz-tests.rktl")))
+   (namespace-set-variable-value! 'expand-load "core-tests.rktl")))
 
 (let ([orig (current-eval)])
   (dynamic-wind


### PR DESCRIPTION
`mz-tests.rktl` became `core-tests.rktl` in 29a0c44c98d5c8d3660e4bd10eb566c7ec6e46e2.