### PR TITLE
Correct which racket is built for CS bootstrap

### DIFF
--- a/racket/src/worksp/README.txt
+++ b/racket/src/worksp/README.txt
@@ -47,7 +47,7 @@ Build the Racket-on-Chez implementation using
 
    build-cs.bat
 
-which builds "..\..\RacketCGC.exe" to bootstrap the build.
+which builds "..\..\Racket3m.exe" to bootstrap the build.
 
 To instead build using an existing Racket installation, use
 


### PR DESCRIPTION
From what I can read in `build-cs.bat`, it seems that it's `Racket3m.exe` that's built to bootstrap, not `RacketCGC.exe`.