### PR TITLE
Fix typos

### DIFF
--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax-input.txt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax-input.txt
@@ -330,7 +330,7 @@
 ;;;   (define top-wrap '((top)))
 ;;;   (define top-marked?
 ;;;     (lambda (w) (memq 'top (wrap-marks w))))
-;;; On ther other hand, we don't do this consistently; we define make-wrap,
+;;; On the other hand, we don't do this consistently; we define make-wrap,
 ;;; wrap-marks, and wrap-subst simply as
 ;;;   (define make-wrap cons)
 ;;;   (define wrap-marks car)

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/redrawing-ala-drracket.rkt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/redrawing-ala-drracket.rkt
@@ -59,7 +59,7 @@ DrRacket redraws a full window's worth of text
 (queue-callback
  (λ ()
    (set! times '())
-   (set! s (make-semaphore)) ;; because earlier paints happend before we were ready
+   (set! s (make-semaphore)) ;; because earlier paints happened before we were ready
    (for ([i (in-range number-of-experiments)])
      (collect-garbage) (collect-garbage) (collect-garbage)
      (send ec refresh)

--- a/pkgs/racket-test-core/tests/racket/will.rktl
+++ b/pkgs/racket-test-core/tests/racket/will.rktl
@@ -430,7 +430,7 @@
                 (thread
                  (lambda ()
                    ;; Ideally, this loop retains only `loop`
-                   ;; and `sema`. If it retains everything refereneced
+                   ;; and `sema`. If it retains everything referenced
                    ;; or defined in the module, though, at least make
                    ;; sure it doesn't retain the whole namespace
                    (let loop () (sync sema) (loop)))))))

--- a/pkgs/racket-test/tests/pkg/tests-install.rkt
+++ b/pkgs/racket-test/tests/pkg/tests-install.rkt
@@ -115,7 +115,7 @@
     =stderr> #rx"unexpected checksum")
 
    (shelly-case
-    "remote/URL/http directory, non-existant file"
+    "remote/URL/http directory, non-existent file"
     $ "raco pkg install http://localhost:9997/pkg-test1.rar" =exit> 1)
    (shelly-case
     "remote/URL/http directory, no manifest fail"

--- a/racket/collects/compiler/private/cm-minimal.rkt
+++ b/racket/collects/compiler/private/cm-minimal.rkt
@@ -165,7 +165,7 @@
                                                                  ;; When taking a lock, we need to consistently
                                                                  ;; use the main destination (where we'll write)
                                                                  ;; and not find a ".zo" file that exists in an
-                                                                 ;; ealier root:
+                                                                 ;; earlier root:
                                                                  (list (car roots))
                                                                  roots)
                                                      ;; In cross-multi mode, we need to default to the

--- a/racket/collects/compiler/private/xform.rkt
+++ b/racket/collects/compiler/private/xform.rkt
@@ -234,7 +234,7 @@
 
         (define symbol-complex (trans (seqs L (arbno (alt L D)))))
 
-        ;; Accomodate things like 10_1 and 10.12.1 in `availability` attributes:
+        ;; Accommodate things like 10_1 and 10.12.1 in `availability` attributes:
         (define pseudo-symbol-complex (trans (alt*
                                               (seqs (arbno D) "_" (arbno D))
                                               (seqs (one+ D) "[.]" (one+ D) "[.]" (one+ D)))))

--- a/racket/collects/ffi/unsafe/objc.rkt
+++ b/racket/collects/ffi/unsafe/objc.rkt
@@ -119,7 +119,7 @@
                             p))]
          [empty-cache (lambda ()
                         ;; If you try things the hard way with Obj-C 2.0,
-                        ;;  you need to set up the cache. For ealier
+                        ;;  you need to set up the cache. For earlier
                         ;;  versions, you need to set the cache to #f.
                         #;
                         (let ([p (malloc 'raw 1 _objc_cache)])

--- a/racket/collects/file/ico.rkt
+++ b/racket/collects/file/ico.rkt
@@ -84,7 +84,7 @@
          (equal? (subbytes bstr 0 4) #"\211PNG"))
     'png]
    [else
-    ;; Asume BMP
+    ;; Assume BMP
     'bmp]))
 
 (define (ico-png-width i)

--- a/racket/collects/launcher/launcher.rkt
+++ b/racket/collects/launcher/launcher.rkt
@@ -576,7 +576,7 @@
               ;; for the executable and icon, but we don't want absolute
               ;; paths in an in-place build. So, the ".desktop" files
               ;; in an in-place build won't be usable directly, but they
-              ;; adn be patched up by `setup/unixstyle-install'.
+              ;; and be patched up by `setup/unixstyle-install'.
               (let ([p (simple-form-path (path->complete-path p))])
                 (if (or user?
                         (get-absolute-installation?))

--- a/racket/collects/planet/private/data.rkt
+++ b/racket/collects/planet/private/data.rkt
@@ -7,7 +7,7 @@
 ; defines common data used by the PLaneT system
 ; ==========================================================================================
 
-; exn:i/o:protocol: exception indicating that a protocol error occured
+; exn:i/o:protocol: exception indicating that a protocol error occurred
 (define-struct (exn:i/o:protocol exn:fail:network) ())
 
 ; FULL-PKG-SPEC : struct pkg-spec

--- a/racket/collects/racket/MzScheme_200.txt
+++ b/racket/collects/racket/MzScheme_200.txt
@@ -144,7 +144,7 @@ in several significant ways:
    work across module boundaries.
 
    The `struct' signature form for `unit/sig' introduces
-   expansion-time information into importing units that immitates that
+   expansion-time information into importing units that imitates that
    of a `define-struct' declaration. The information is currently
    limited, in that subtyping relations are not exposed and the actual
    structure type may have more fields than declared in the

--- a/racket/collects/racket/async-channel.rkt
+++ b/racket/collects/racket/async-channel.rkt
@@ -51,7 +51,7 @@
             ;; This thread is the part that makes the channel asynchronous.
             ;; It waits for a combination of gets and puts as appropriate.
             ;; Note that we start it with `thread/suspend-kill', and we
-            ;; resume the manager thread with the current thread everytime
+            ;; resume the manager thread with the current thread every time
             ;; we want to talk to the manager thread, which effectively
             ;; means that the manager thread is not bound by a custodian
             ;; that is weaker than any of its user's custodians (and thus,

--- a/racket/collects/racket/base/lang/reader.rkt
+++ b/racket/collects/racket/base/lang/reader.rkt
@@ -1,4 +1,4 @@
-;; This module is preserved only for backward compatiblity
+;; This module is preserved only for backward compatibility
 (module reader '#%kernel
   (#%require (submod racket/base reader))
   (#%provide (all-from (submod racket/base reader))))

--- a/racket/collects/racket/lang/reader.rkt
+++ b/racket/collects/racket/lang/reader.rkt
@@ -1,4 +1,4 @@
-;; This module is preserved only for backward compatiblity
+;; This module is preserved only for backward compatibility
 (module reader '#%kernel
   (#%require (submod racket reader))
   (#%provide (all-from (submod racket reader))))

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -122,7 +122,7 @@
             [parsed-ps (map parse ps)]
             [parsed-lp (rearm+parse #'lp)])
        ;; duplicates within *one* of the ps is fine, but duplicates
-       ;; *accross multiple* of the ps is an error, at least for now
+       ;; *across multiple* of the ps is an error, at least for now
        (check-list-no-order-duplicates (cons parsed-lp parsed-ps))
        (GSeq (cons (list parsed-lp)
                    (for/list ([p parsed-ps]) (list p)))
@@ -143,7 +143,7 @@
             ;; parsed versions of ps
             [parsed-ps (map rearm+parse ps)])
        ;; duplicates within *one* of the ps is fine, but duplicates
-       ;; *accross multiple* of the ps is an error, at least for now
+       ;; *across multiple* of the ps is an error, at least for now
        (check-list-no-order-duplicates parsed-ps)
        (GSeq (for/list ([p parsed-ps]) (list p))
              (map (lambda _ 1) ps)

--- a/racket/collects/setup/setup-core.rkt
+++ b/racket/collects/setup/setup-core.rkt
@@ -1749,7 +1749,7 @@
       (write-receipt-hash receipt-path ht2)))
 
   ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-  ;;       Foriegn Libraries and Man Pages         ;;
+  ;;       Foreign Libraries and Man Pages         ;;
   ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
   (define (make-copy/move-step what

--- a/racket/src/expander/common/make-match.rkt
+++ b/racket/src/expander/common/make-match.rkt
@@ -27,7 +27,7 @@
 ;;   
 ;;   (<m-id>)
 ;;
-;; to check whether the match suceeded (which makes sense only if a
+;; to check whether the match succeeded (which makes sense only if a
 ;; guard or `#:try` is included) or
 ;;
 ;;    (<m-id> '<pattern-id>)

--- a/racket/src/expander/compile/reserved-symbol.rkt
+++ b/racket/src/expander/compile/reserved-symbol.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 (require "built-in-symbol.rkt")
 
-;; Identifers used in the compiler's output; we make distinct names
+;; Identifiers used in the compiler's output; we make distinct names
 ;; for them once to avoid shadowing of other collisions
 (provide phase-shift-id
          dest-phase-id

--- a/racket/src/foreign/foreign.c
+++ b/racket/src/foreign/foreign.c
@@ -3716,7 +3716,7 @@ static Scheme_Object *ffi_do_call(int argc, Scheme_Object *argv[], Scheme_Object
   /* Use `data' to make sure it's kept alive (as far as the GC is concerned)
      until the foreign call returns: */
   if ((void*)data == (void*)scheme_true)
-    scheme_signal_error("dummy test suceeded!?");
+    scheme_signal_error("dummy test succeeded!?");
 
   if (save_errno != 0) save_errno_values(save_errno);
   ivals = NULL; /* no need now to hold on to this */

--- a/racket/src/foreign/foreign.rktc
+++ b/racket/src/foreign/foreign.rktc
@@ -2883,7 +2883,7 @@ static Scheme_Object *ffi_do_call(int argc, Scheme_Object *argv[], Scheme_Object
   /* Use `data' to make sure it's kept alive (as far as the GC is concerned)
      until the foreign call returns: */
   if ((void*)data == (void*)scheme_true)
-    scheme_signal_error("dummy test suceeded!?");
+    scheme_signal_error("dummy test succeeded!?");
 
   if (save_errno != 0) save_errno_values(save_errno);
   ivals = NULL; /* no need now to hold on to this */

--- a/racket/src/foreign/libffi/src/mips/o32.S
+++ b/racket/src/foreign/libffi/src/mips/o32.S
@@ -66,7 +66,7 @@ $LCFI3:
 	blt	bytes, v0, sixteen
 
 	ADDU	v0, bytes, 7	# make sure it is aligned 
-	and	v0, -8		# to an 8 byte boundry
+	and	v0, -8		# to an 8 byte boundary
 
 sixteen:
 	SUBU	$sp, v0		# move the stack pointer to reflect the

--- a/racket/src/mzcom/com_glue.c
+++ b/racket/src/mzcom/com_glue.c
@@ -545,7 +545,7 @@ static ULONG STDMETHODCALLTYPE classAddRef(IClassFactory *com_obj)
   // Since we never actually allocate/free an IClassFactory (ie, we
   // use just 1 static one), we don't need to maintain a separate
   // reference count for our IClassFactory. We'll just tell the caller
-  // that there's at least one of our IClassFactory objects in existance
+  // that there's at least one of our IClassFactory objects in existence
   return(1);
 }
 

--- a/racket/src/racket/gc/AmigaOS.c
+++ b/racket/src/racket/gc/AmigaOS.c
@@ -301,7 +301,7 @@ void GC_amiga_free_all_mem(void){
 	printf("GC_gcollect was called %d times to avoid returning NULL or start allocating with the MEMF_ANY flag.\n",numcollects);
 	printf("%d of them was a success. (the others had to use allocation from the OS.)\n",nullretries);
 	printf("\n");
-	printf("Succeded forcing %d gc-allocations (%d bytes) of chip-mem to be fast-mem.\n",succ,succ2);
+	printf("Succeeded forcing %d gc-allocations (%d bytes) of chip-mem to be fast-mem.\n",succ,succ2);
 	printf("Failed forcing %d gc-allocations (%d bytes) of chip-mem to be fast-mem.\n",nsucc,nsucc2);
 	printf("\n");
 	printf(

--- a/racket/src/racket/gc/ChangeLog
+++ b/racket/src/racket/gc/ChangeLog
@@ -117,7 +117,7 @@
 	
 	* mark.c (GC_push_next_marked): correct comment.
 	* Makefile.direct: document NO_PROC_STAT.
-	* include/private/gcconfig.h: Accomodate NO_PROC_STAT.
+	* include/private/gcconfig.h: Accommodate NO_PROC_STAT.
 
 2008-01-10  Hans Boehm <Hans.Boehm@hp.com>
 	
@@ -277,7 +277,7 @@
 	* dbg_mlc.c: Use random() on all glibc systems.
 	* mach_dep.c (GC_with_callee_saves_pushed): Don't use getcontext() on
 	HURD.  Add comment.
-	* pthread_stop_world.c (GC_suspend_handler, GC_stop_init): Accomodate
+	* pthread_stop_world.c (GC_suspend_handler, GC_stop_init): Accommodate
 	systems without SA_SIGINFO.
 
 2007-08-14  Hans Boehm <Hans.Boehm@hp.com> (partly really Henrik Theiling)
@@ -469,7 +469,7 @@
 2007-05-23  Hans Boehm <Hans.Boehm@hp.com> (Really mostly Romano Paolo Tenca)
 
 	* gc_dlopen.c, thread_local_alloc.c, threadlibs.c, win32_threads.c,
-	tests/test.c: Accomodate GC_WIN32_PTHREADS.
+	tests/test.c: Accommodate GC_WIN32_PTHREADS.
 	* include/gc.h: Don't include windows.h for GC_WIN32_PTHREADS.
 	* include/gc_config_macros.h: Define both PTHREADS and
 	GC_WIN32_THREADS.

--- a/racket/src/racket/gc/doc/README.ews4800
+++ b/racket/src/racket/gc/doc/README.ews4800
@@ -76,6 +76,6 @@ Hironori SAKAMOTO <hsaka@mth.biglobe.ne.jp>
 
 When using the new "configure; make" build process, please
 run configure with the --disable-shared option.  "Make check" does not
-yet pass with dynamic libraries.  Ther reasons for that are not yet
+yet pass with dynamic libraries.  Their reasons for that are not yet
 understood.  (HB, paraphrasing message from Hironori SAKAMOTO.)
 

--- a/racket/src/racket/gc/doc/porting.html
+++ b/racket/src/racket/gc/doc/porting.html
@@ -212,7 +212,7 @@ from are copied to the stack.  Typically this can be done portably,
 but on some platforms it may require assembly code, or just
 tweaking of conditional compilation tests.
 <P>
-For GC7, if your platform supports <TT>getcontext()</tt>, then definining
+For GC7, if your platform supports <TT>getcontext()</tt>, then defining
 the macro <TT>UNIX_LIKE</tt> for your OS in <TT>gcconfig.h</tt>
 (if it isn't defined there already) is likely to solve the problem.
 otherwise, if you are using gcc, <TT>_builtin_unwind_init()</tt>

--- a/racket/src/racket/gc/include/private/gc_priv.h
+++ b/racket/src/racket/gc/include/private/gc_priv.h
@@ -1025,7 +1025,7 @@ struct _GC_arrays {
 # endif
 # ifdef MSWINCE
     word _heap_lengths[MAX_HEAP_SECTS];
-    		/* Commited lengths of memory regions obtained from kernel. */
+    		/* Committed lengths of memory regions obtained from kernel. */
 # endif
   struct roots _static_roots[MAX_ROOT_SETS];
 # if !defined(MSWIN32) && !defined(MSWINCE)

--- a/racket/src/racket/gc/os_dep.c
+++ b/racket/src/racket/gc/os_dep.c
@@ -435,7 +435,7 @@ static ptr_t backing_store_base_from_proc(void)
     /* Some Linux distributions arrange to define __data_start.  Some	*/
     /* define data_start as a weak symbol.  The latter is technically	*/
     /* broken, since the user program may define data_start, in which	*/
-    /* case we lose.  Nonetheless, we try both, prefering __data_start.	*/
+    /* case we lose.  Nonetheless, we try both, preferring __data_start.	*/
     /* We assume gcc-compatible pragmas.	*/
 #   pragma weak __data_start
     extern int __data_start[];

--- a/racket/src/racket/gc2/README
+++ b/racket/src/racket/gc2/README
@@ -152,7 +152,7 @@ Racket allocates the following kinds of memory objects:
 
     void *GC_malloc_weak_box(void *p, void **secondary, int soffset);
 
-   If the `secondary' argument is not NULL, it points to an auxilliary
+   If the `secondary' argument is not NULL, it points to an auxiliary
    address that should be zeroed (by the collector) whenever `val' is
    zeroed. To allow zeroing in the interior of an allocated pointer,
    the zero-out address is determined by `secondary + soffset'. The

--- a/racket/src/racket/src/future.c
+++ b/racket/src/racket/src/future.c
@@ -2647,7 +2647,7 @@ void scheme_check_future_work()
       else {
         /* If ft is touching another future, then the other
            future may resume ft while we grab the continuation. 
-           Withold ft->can_continue_sema for now, so that we can
+           Withhold ft->can_continue_sema for now, so that we can
            capture the continuation, and then double-check 
            afterward whether the continuation wants a lwc: */
         can_continue_sema = ft->can_continue_sema;

--- a/racket/src/racket/src/lightning/arm/asm.h
+++ b/racket/src/racket/src/lightning/arm/asm.h
@@ -1298,7 +1298,7 @@ _arm_cc_vorsl(jit_state_t _jitp, int cc, int o, int r0, int r1, int i0)
 /* "oi" should be the result of encode_vfp_double */
 #define _VIMM(oi,r0)			arm_vodi(oi,r0)
 #define _VIMMQ(oi,r0)			arm_voqi(oi|ARM_V_Q,r0)
-/* index is multipled by four */
+/* index is multiplied by four */
 #define _CC_VLDRN_F32(cc,r0,r1,i0)	arm_cc_vldst(cc,ARM_VLDR,r0,r1,i0)
 #define _VLDRN_F32(r0,r1,i0)		_CC_VLDRN_F32(ARM_CC_AL,r0,r1,i0)
 #define _CC_VLDR_F32(cc,r0,r1,i0)	arm_cc_vldst(cc,ARM_VLDR|ARM_P,r0,r1,i0)

--- a/racket/src/racket/src/optimize.c
+++ b/racket/src/racket/src/optimize.c
@@ -10147,7 +10147,7 @@ static void optimize_uses_of_mutable_imply_early_alloc(Scheme_IR_Let_Value *at_i
   int i, j;
   Scheme_IR_Let_Value *irlv = at_irlv;
 
-  /* We we're reinterpreting a `letrec` as `let*`, and when it realy
+  /* We we're reinterpreting a `letrec` as `let*`, and when it really
      must be `let*` instead of `let`, and when a mutable variable is
      involved, then we need to tell the `resolve` pass that the
      mutable varaiable's value must be boxed immediately, instead of

--- a/racket/src/racket/src/port.c
+++ b/racket/src/racket/src/port.c
@@ -411,7 +411,7 @@ void scheme_init_port_places(void)
      custodian). */
 
   if (!stdin_refcount) {
-    /* Referece counts are needed for stdio and places; start
+    /* Reference counts are needed for stdio and places; start
        at 1 in main place, but then cancel initial count */
     stdin_refcount = malloc_refcount(1, 0);
     stdout_refcount = malloc_refcount(1, 0);


### PR DESCRIPTION
Should be non-semantic.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.