### PR TITLE
Update fixnums documentation to suggest require'ing only fixnum-relat…

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/fixnums.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/fixnums.scrbl
@@ -25,7 +25,9 @@ code where the @racket[require] of @racketmodname[racket/fixnum] is
 replaced with
 
 @racketblock[(require (filtered-in
-                       (λ (name) (regexp-replace #rx"unsafe-" name ""))
+                       (λ (name)
+                         (and (regexp-match #rx"^unsafe-fx" name)
+                              (regexp-replace #rx"unsafe-" name "")))
                        racket/unsafe/ops))]
 
 to drop in unsafe versions of the library. Alternately, when


### PR DESCRIPTION
…ed parts of racket/unsafe/ops and not the rest of unsafe ops.

It should prevent users from require'ing unsafe versions of for example vector-* operations which may lead to crashes in different parts of the code which do not need to use fx* operations at all.