### PR TITLE
Fix typos, via a Levenshtein-style corrector

### DIFF
--- a/pkgs/compiler-test/tests/compiler/embed/embed-me35.rkt
+++ b/pkgs/compiler-test/tests/compiler/embed/embed-me35.rkt
@@ -9,7 +9,7 @@
   (unless (and (list? ps) (andmap path? ps))
     (error 'embed-me35 "no good: ~s" ps)))
 
-;; These directories are not available in a created distibution, but
+;; These directories are not available in a created distribution, but
 ;; they shouldn't crash:
 (check-path-or-false (find-apps-dir))
 (check-path-or-false (find-pkgs-dir))

--- a/pkgs/net-lib/net/cookie.rkt
+++ b/pkgs/net-lib/net/cookie.rkt
@@ -65,7 +65,7 @@
  cookie:add-path
  cookie:secure
  cookie:version
- ;; To actually return a cookie (string formated as a cookie):
+ ;; To actually return a cookie (string formatted as a cookie):
  print-cookie
  ;; To parse the Cookies header:
  get-cookie

--- a/pkgs/net-lib/net/mime-util.rkt
+++ b/pkgs/net-lib/net/mime-util.rkt
@@ -104,7 +104,7 @@
   (lambda (msg . args)
     (log-warning (apply format (cons msg args)))))
 
-;; Copies its input `in' to its ouput port if given, it uses
+;; Copies its input `in' to its output port if given, it uses
 ;; current-output-port if out is not provided.
 (define (cat in [out (current-output-port)])
   (let loop ([ln (read-line in)])

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/common/earley.sch
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/common/earley.sch
@@ -13,7 +13,7 @@
 ; defined is the grammar's goal.  Each rule is a possibly empty list of
 ; non-terminals.  Thus a rule has the form: (nt1 nt2...).  A non-terminal
 ; can be any scheme value.  Note that all grammar symbols are treated as
-; non-terminals.  This is fine though because the lexer will be outputing
+; non-terminals.  This is fine though because the lexer will be outputting
 ; non-terminals.
 ;
 ; The lexer defines what a token is and the mapping between tokens and

--- a/pkgs/racket-doc/scribblings/guide/contracts/examples/ho-version4.rkt
+++ b/pkgs/racket-doc/scribblings/guide/contracts/examples/ho-version4.rkt
@@ -45,7 +45,7 @@
   (with-handlers ([exn:fail:contract:blame? void])
     (printf "*** 1: ~s\n" (argmax car '())))
   ;; changed: 
-  ;; the functin violates -> real but the single element isn't checked
+  ;; the function violates -> real but the single element isn't checked
   (printf "2: ~s\n" (argmax car '((apples 3))))
   (printf "3: ~s\n" (argmax car '((3 apples) (3 oranges))))
   ;; --- copies from version 2 --- 

--- a/pkgs/racket-index/scribblings/main/private/make-search.rkt
+++ b/pkgs/racket-index/scribblings/main/private/make-search.rkt
@@ -71,7 +71,7 @@
   ;;   span-classes table holding a class name.
   ;; In addition, a "file:/main-doc.../path..." url is saved as ">path..."
   ;; This function does the url compacting.
-  (define main-url ; (make sure that it teminates with a slash)
+  (define main-url ; (make sure that it terminates with a slash)
     (if user-dir?
       (regexp-replace #rx"/*$" (url->string (path->url (find-doc-dir))) "/")
       "../"))

--- a/pkgs/racket-test-core/tests/racket/file.rktl
+++ b/pkgs/racket-test-core/tests/racket/file.rktl
@@ -1718,7 +1718,7 @@
   (do-once #f "localhost")
   (do-once #t "localhost")
   (with-handlers ([exn:fail:network:errno? (lambda (e)
-                                             ;; Catch forms of non-suport for IPv6:
+                                             ;; Catch forms of non-support for IPv6:
                                              ;;       EAFNOSUPPORT "Address family not supported by protocol"
                                              ;;    or getaddrinfo failure "no address associated with name"
                                              ;; In case IPv6 is supported by the OS but not for the loopback

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -321,7 +321,7 @@
 
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-; Use keys that are a multile of a power of 2 to
+; Use keys that are a multiple of a power of 2 to
 ; get "almost" collisions that force the hash table
 ; to use a deeper tree.
 

--- a/pkgs/racket-test-core/tests/racket/read.rktl
+++ b/pkgs/racket-test-core/tests/racket/read.rktl
@@ -1046,7 +1046,7 @@
   (test #\y read-char-or-special p)
   (test 3 file-position p))
 
-;; Reading somethign like a symbol should stop at a special
+;; Reading something like a symbol should stop at a special
 ;; without calling the special-producing procedure:
 (let* ([pos 0]
        [p (make-input-port

--- a/pkgs/racket-test/tests/racket/contract/list-contract.rkt
+++ b/pkgs/racket-test/tests/racket/contract/list-contract.rkt
@@ -9,7 +9,7 @@
   
   (test/spec-passed/result
    'list-contract-2
-   '(list-contract? (λ (a b c) a)) ;; somethign that's not coerceable to a contract
+   '(list-contract? (λ (a b c) a)) ;; something that's not coerceable to a contract
    #f)
   
   (test/spec-passed/result

--- a/racket/collects/file/gunzip.rkt
+++ b/racket/collects/file/gunzip.rkt
@@ -56,7 +56,7 @@
    codes are customized to the probabilities in the current block, and so
 <   can code it much better than the pre-determined fixed codes.
  
-   The Huffman codes themselves are decoded using a mutli-level table
+   The Huffman codes themselves are decoded using a multi-level table
    lookup, in order to maximize the speed of decoding plus the speed of
    building the decoding tables.  See the comments below that precede the
    lbits and dbits tuning parameters.

--- a/racket/collects/pkg/private/install.rkt
+++ b/racket/collects/pkg/private/install.rkt
@@ -1240,7 +1240,7 @@
                       null]
                      [else
                       ;; Flush cache of downloaded checksums, in case
-                      ;; there was a race between our checkig and updates on
+                      ;; there was a race between our checking and updates on
                       ;; the catalog server:
                       (clear-checksums-in-cache! update-cache)
                       (list (pkg-desc orig-pkg-source orig-pkg-type pkg-name #f auto?

--- a/racket/collects/racket/file.rkt
+++ b/racket/collects/racket/file.rkt
@@ -204,7 +204,7 @@
                                                (eqv? (car errno) 5) ; ERROR_ACCESS_DENIED
                                                ;; On Windows, if the target path refers to a file
                                                ;; that has been deleted but is still open
-                                               ;; somehere, then an access-denied error is reported
+                                               ;; somewhere, then an access-denied error is reported
                                                ;; instead of a file-exists error; there appears
                                                ;; to be no way to detect that it was really a
                                                ;; file-still-exists error. Try again for a while.

--- a/racket/collects/racket/private/serialize-structs.rkt
+++ b/racket/collects/racket/private/serialize-structs.rkt
@@ -2,7 +2,7 @@
   
   (#%declare #:cross-phase-persistent)
 
-  ;; Exports just the structre info, which is needed in
+  ;; Exports just the structure info, which is needed in
   ;;  "class.rkt" (which is, in turn, ultimately required by
   ;;  "serialize.rkt")
 

--- a/racket/src/cs/rumble/error.ss
+++ b/racket/src/cs/rumble/error.ss
@@ -524,7 +524,7 @@
 ;; For `instantiate-linklet` to help report which linklet is being run:
 (define linklet-instantiate-key '#{linklet o9xm0uula3d2mbq9wueixh79r-1})
 
-;; Convert a contination to a list of function-name and
+;; Convert a continuation to a list of function-name and
 ;; source information. Cache the result half-way up the
 ;; traversal, so that it's amortized constant time.
 (define-thread-local cached-traces (make-ephemeron-eq-hashtable))

--- a/racket/src/expander/expand/module.rkt
+++ b/racket/src/expander/expand/module.rkt
@@ -1079,7 +1079,7 @@
 ;; ----------------------------------------
 
 ;; Pass 3 of `module` expansion, which parses `provide` forms and
-;; matches them up with defintiions and requires
+;; matches them up with definitions and requires
 (define (resolve-provides expression-expanded-bodys
                           #:requires-and-provides requires+provides
                           #:declared-submodule-names declared-submodule-names

--- a/racket/src/expander/syntax/binding-table.rkt
+++ b/racket/src/expander/syntax/binding-table.rkt
@@ -243,7 +243,7 @@
 ;; Iterate through all non-bulk symbol+scope+binding combinations.
 ;; This iterator allocates; its intended for use in situations
 ;; that don't need a tight loop, which should generally be the
-;; case for somethign that's inspecting all bindings.
+;; case for something that's inspecting all bindings.
 (define-sequence-syntax in-full-non-bulk-binding-table
   (lambda () #'do-not-use-in-full-non-bulk-binding-table-as-an-expression)
   (lambda (stx)

--- a/racket/src/expander/syntax/binding.rkt
+++ b/racket/src/expander/syntax/binding.rkt
@@ -181,7 +181,7 @@
 
 ;; Use `resolve+shift` instead of `resolve` when the module of a
 ;; module binding is relevant or when `free-identifier=?` equivalences
-;; (as installed by a binding to a rename transfomer) are relevant;
+;; (as installed by a binding to a rename transformer) are relevant;
 ;; module path index shifts attached to `s` are taken into account in
 ;; the result
 (define (resolve+shift s phase

--- a/racket/src/foreign/libffi/ChangeLog.v1
+++ b/racket/src/foreign/libffi/ChangeLog.v1
@@ -304,7 +304,7 @@ Tue Oct  8 11:40:36 1996  Anthony Green  <green@rtl.cygnus.com>
 
 Mon Oct  7 10:58:12 1996  Anthony Green  <green@hoser.cygnus.com>
 
-	* ffi.h.in: The SGI assember is very picky about parens. Redefined
+	* ffi.h.in: The SGI assembler is very picky about parens. Redefined
  	some macros to avoid problems.
 
 	* ffi.h.in: Added FFI_DEFAULT_ABI definitions. Also added

--- a/racket/src/foreign/libffi/m4/ax_enable_builddir.m4
+++ b/racket/src/foreign/libffi/m4/ax_enable_builddir.m4
@@ -42,7 +42,7 @@
 #   into. Usually, the last one is the only one used. However, almost all
 #   targets have an additional "*-all" rule which makes the script to
 #   recurse into _all_ variants of the current HOST (!!) setting. The "-all"
-#   suffix can be overriden for the macro as well.
+#   suffix can be overridden for the macro as well.
 #
 #   a special rule is only given for things like "dist" that will copy the
 #   tarball from the builddir to the sourcedir (or $(PUB)) for reason of

--- a/racket/src/foreign/libffi/src/x86/ffi64.c
+++ b/racket/src/foreign/libffi/src/x86/ffi64.c
@@ -76,7 +76,7 @@ extern void ffi_call_unix64 (void *args, unsigned long bytes, unsigned flags,
    just gcc will use SF or DFmode move instead of DImode to avoid
    reformatting penalties.
 
-   Similary we play games with INTEGERSI_CLASS to use cheaper SImode moves
+   Similarly we play games with INTEGERSI_CLASS to use cheaper SImode moves
    whenever possible (upper half does contain padding).  */
 enum x86_64_reg_class
   {

--- a/racket/src/racket/Makefile.in
+++ b/racket/src/racket/Makefile.in
@@ -73,7 +73,7 @@ FOREIGN_OBJSLIB = @FOREIGN_OBJSLIB@
 #  having the file-open syscall open an ".exe" file for reading when
 #  (1) the given filename has no suffix, and (2) there's not a suffixless
 #  file present. However, Cygwin doesn't do that when opening a file for
-#  output, even when the output mode is 'update. So we need to explcitly
+#  output, even when the output mode is 'update. So we need to explicitly
 #  add EXE_SUFFIX in a few places.
 
 ################################################################################

--- a/racket/src/racket/gc/configure.host
+++ b/racket/src/racket/gc/configure.host
@@ -31,7 +31,7 @@ else
 	if test :$GCC: != :"yes": ; then
             gc_cflags="${gc_flags} +ESdbgasm"
 	fi
-        # :TODO: actaully we should check using Autoconf if
+        # :TODO: actually we should check using Autoconf if
         #     the compiler supports this option.
         ;;
     esac

--- a/racket/src/racket/gc/cord/cordbscs.c
+++ b/racket/src/racket/gc/cord/cordbscs.c
@@ -354,7 +354,7 @@ CORD CORD_substr_closure(CORD x, size_t i, size_t n, CORD_fn f)
 
 # define SUBSTR_LIMIT (10 * SHORT_LIMIT)
 	/* Substrings of function nodes and flat strings shorter than 	*/
-	/* this are flat strings.  Othewise we use a functional 	*/
+	/* this are flat strings.  Otherwise we use a functional 	*/
 	/* representation, which is significantly slower to access.	*/
 
 /* A version of CORD_substr that assumes i >= 0, n > 0, and i + n < length(x).*/

--- a/racket/src/racket/gc/doc/README.macros
+++ b/racket/src/racket/gc/doc/README.macros
@@ -14,7 +14,7 @@ In my opinion, it's still well worth it, for the same reason that we indent
 ordinary "if" statements.
 
 2) Whenever possible, tests are performed on the macros defined in gcconfig.h
-instead of directly testing patform-specific predefined macros.  This makes it
+instead of directly testing platform-specific predefined macros.  This makes it
 relatively easy to adapt to new compilers with a different set of predefined
 macros.  Currently these macros generally identify platforms instead of
 features.  In many cases, this is a mistake.

--- a/racket/src/racket/gc/os_dep.c
+++ b/racket/src/racket/gc/os_dep.c
@@ -1398,7 +1398,7 @@ void GC_register_data_segments(void)
     FILE * myexefile;
     struct exe_hdr hdrdos;	/* MSDOS header.	*/
     struct e32_exe hdr386;	/* Real header for my executable */
-    struct o32_obj seg;	/* Currrent segment */
+    struct o32_obj seg;	/* Current segment */
     int nsegs;
     
     

--- a/racket/src/racket/gc/pthread_support.c
+++ b/racket/src/racket/gc/pthread_support.c
@@ -1210,7 +1210,7 @@ WRAP_FUNC(pthread_create)(pthread_t *new_thread,
 }
 
 /* Spend a few cycles in a way that can't introduce contention with	*/
-/* othre threads.							*/
+/* other threads.							*/
 void GC_pause(void)
 {
     int i;

--- a/racket/src/racket/src/hamt_subset.inc
+++ b/racket/src/racket/src/hamt_subset.inc
@@ -42,7 +42,7 @@ HAMT_NONGCING static int HAMT_ELEMENT_OF(Scheme_Object *key1, Scheme_Object *val
 
 HAMT_NONGCING int HAMT_SUBSET_OF(Scheme_Hash_Tree *t1, Scheme_Hash_Tree *t2, int shift,
                                  int stype, void *eql_data)
-/* checks wheher `t1` is a subset of `t2`; `t1` and `t2` must be of the same kind */
+/* checks whether `t1` is a subset of `t2`; `t1` and `t2` must be of the same kind */
 {
   hash_tree_bitmap_t i;
   int pos1, pos2, index, popcount1, popcount2;

--- a/racket/src/racket/src/jitcall.c
+++ b/racket/src/racket/src/jitcall.c
@@ -1958,7 +1958,7 @@ int scheme_generate_app(Scheme_App_Rec *app, Scheme_Object **alt_rands, int num_
 #endif
 
     if (direct_self)
-      reorder_ok = 0; /* superceded by direct_self */
+      reorder_ok = 0; /* superseded by direct_self */
   }
 
   FOR_LOG(if (direct_native) { LOG_IT((" [direct]\n")); } )

--- a/racket/src/racket/src/read.c
+++ b/racket/src/racket/src/read.c
@@ -3315,7 +3315,7 @@ static Scheme_Object *read_compact(CPort *port, int use_stack)
         if (!v) {
           if (port->delay_info) {
             /* This is where we construct information for
-               loading the lamda form on demand. */
+               loading the lambda form on demand. */
             v = scheme_make_raw_pair(scheme_make_integer(l),
                                      (Scheme_Object *)port->delay_info);
           } else {

--- a/racket/src/schemify/Makefile
+++ b/racket/src/schemify/Makefile
@@ -4,7 +4,7 @@
 RACKET = ../../bin/racket
 RACO = $(RACKET) -N raco -l- raco
 
-# Ignoring functions from `#%read` works beause they won't appear in
+# Ignoring functions from `#%read` works because they won't appear in
 # the simplified expansion. Make annotation references direct to
 # improve performance. Declaring "collect.rkt" pure works around a
 # limitation of the flattener.

--- a/racket/src/schemify/infer-name.rkt
+++ b/racket/src/schemify/infer-name.rkt
@@ -48,7 +48,7 @@
                         "::"
                         (number->string pos)))]
        [else ; includes `(void? inferred-name)`
-        ;; We can't provide a source name, but explicity
+        ;; We can't provide a source name, but explicitly
         ;; suppress any other inferred name:
         (wrap-property-set (reannotate orig-s new-s)
                            'inferred-name

--- a/racket/src/start/README.txt
+++ b/racket/src/start/README.txt
@@ -1,4 +1,4 @@
-This directory constaint source programs and fragments for wrapper
+This directory constraint source programs and fragments for wrapper
 executables used to start/embed Racket. The programs and fragments are
 used both for the traditional Racket virtual machine and Racket on
 Chez Scheme.

--- a/racket/src/start/ustart.c
+++ b/racket/src/start/ustart.c
@@ -36,7 +36,7 @@
    and `end' are ignored if a ".rackcmdl" (starter) or ".rackprog"
    (embedding) section is found. The `start' value is set to match the
    section offset, and `decl_end', `prog_end', and `end' are correspondingly
-   adjusted. Using a seciton offset allows linking tools (such as
+   adjusted. Using a section offset allows linking tools (such as
    `strip') to move the data in the executable.
 */
 PRESERVE_IN_EXECUTABLE


### PR DESCRIPTION
Should be non-semantic.

Uses an improved version of the tool that found typos in https://github.com/racket/racket/pull/2969 .