### PR TITLE
RacketCS skips loading <init-lib> when given -v flag while Racket does load <init-lib>

### DIFF
--- a/racket/src/cs/main.sps
+++ b/racket/src/cs/main.sps
@@ -430,7 +430,6 @@
               (flags-loop (cdr args) (see saw 'non-config))]
              [("-v" "--version") 
               (set! version? #t)
-              (no-init! saw)
               (flags-loop (cdr args) (see saw 'non-config))]
              [("-c" "--no-compiled")
               (set! compiled-file-paths '())


### PR DESCRIPTION
Just to report a difference: Racket CS skips loading `init-lib` if given the `-v` flag while Racket does load `init-lib` unless given `-t`, `-l`, `-p` or `-u`. It's no big deal and I don't know if the current behavior is the preferred one or not.

```
$ racket -ve- '(quote ok)'
$ racketcs -ve- '(quote ok)'
#%top-interaction: unbound identifier
```

Racket: <https://github.com/racket/racket/blob/9db9991df619ac26f5384c67318063459d8dcde5/racket/src/racket/cmdline.inc#L1048-L1050>
RacketCS: <https://github.com/racket/racket/blob/9db9991df619ac26f5384c67318063459d8dcde5/racket/src/cs/main.sps#L431-L434>