### PR TITLE
net/http-client: add support of deflate content encoding

### DIFF
--- a/pkgs/net-doc/net/scribblings/http-client.scrbl
+++ b/pkgs/net-doc/net/scribblings/http-client.scrbl
@@ -98,7 +98,7 @@ configured to @tech{auto-reconnect}.
                           [#:method method (or/c bytes? string? symbol?) #"GET"]
                           [#:close? close? boolean? #f]
                           [#:headers headers (listof (or/c bytes? string?)) empty]
-                          [#:content-decode decodes (listof symbol?) '(gzip)]
+                          [#:content-decode decodes (listof symbol?) '(gzip deflate)]
                           [#:data data (or/c false/c bytes? string? data-procedure/c) #f])
          void?]{
 
@@ -120,7 +120,7 @@ are accepted is automatically added.
 
 If @racket[close?] is @racket[#t] and @racket[headers] does not
 contain a @litchar{Connection} header, then a @litchar{Connection:
-close} header will be added.
+close} header will be added (currently, @racket['gzip] and @racket['deflate] are supported).
 
 This function does not support requests that expect
 @litchar{100 (Continue)} responses.
@@ -128,7 +128,7 @@ This function does not support requests that expect
 }
 
 @defproc[(http-conn-recv! [hc http-conn-liveable?]
-                          [#:content-decode decodes (listof symbol?) '(gzip)]
+                          [#:content-decode decodes (listof symbol?) '(gzip deflate)]
                           [#:method method (or/c bytes? string? symbol?) #"GET"]
                           [#:close? close? boolean? #f])
          (values bytes? (listof bytes?) input-port?)]{
@@ -154,7 +154,7 @@ to do so.
                               [#:method method (or/c bytes? string? symbol?) #"GET"]
                               [#:headers headers (listof (or/c bytes? string?)) empty]
                               [#:data data (or/c false/c bytes? string? data-procedure/c) #f]
-                              [#:content-decode decodes (listof symbol?) '(gzip)]
+                              [#:content-decode decodes (listof symbol?) '(gzip deflate)]
                               [#:close? close? boolean? #f])
          (values bytes? (listof bytes?) input-port?)]{
 
@@ -169,7 +169,7 @@ Calls @racket[http-conn-send!] and @racket[http-conn-recv!] in sequence.
                         [#:method method (or/c bytes? string? symbol?) #"GET"]
                         [#:headers headers (listof (or/c bytes? string?)) empty]
                         [#:data data (or/c false/c bytes? string? data-procedure/c) #f]
-                        [#:content-decode decodes (listof symbol?) '(gzip)])
+                        [#:content-decode decodes (listof symbol?) '(gzip deflate)])
          (values bytes? (listof bytes?) input-port?)]{
 
 Calls @racket[http-conn-send!] and @racket[http-conn-recv!] in

--- a/pkgs/net-doc/net/scribblings/http-client.scrbl
+++ b/pkgs/net-doc/net/scribblings/http-client.scrbl
@@ -125,7 +125,7 @@ close} header will be added (currently, @racket['gzip] and @racket['deflate] are
 This function does not support requests that expect
 @litchar{100 (Continue)} responses.
 
-@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
+@history[#:changed "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 @defproc[(http-conn-recv! [hc http-conn-liveable?]
@@ -147,8 +147,8 @@ following the response parsing. If @racket[close?] is @racket[#f],
 then the connection is only closed if the server instructs the client
 to do so.
 
-@history[#:changed "6.1.1.6" @elem{Added the @racket[#:method] argument.}]
-@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
+@history[#:changed "6.1.1.6" @elem{Added the @racket[#:method] argument.}
+         #:changed "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 
@@ -163,7 +163,7 @@ to do so.
 
 Calls @racket[http-conn-send!] and @racket[http-conn-recv!] in sequence.
 
-@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
+@history[#:changed "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 @defproc[(http-sendrecv [host (or/c bytes? string?)] [uri (or/c bytes? string?)]
@@ -184,7 +184,7 @@ The HTTP connection is not returned, so it is always closed after one
 response, which is why there is no @racket[#:closed?] argument like
 @racket[http-conn-recv!].
 
-@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
+@history[#:changed "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 @defproc[(http-conn-CONNECT-tunnel [proxy-host (or/c bytes? string?)]

--- a/pkgs/net-doc/net/scribblings/http-client.scrbl
+++ b/pkgs/net-doc/net/scribblings/http-client.scrbl
@@ -125,6 +125,7 @@ close} header will be added (currently, @racket['gzip] and @racket['deflate] are
 This function does not support requests that expect
 @litchar{100 (Continue)} responses.
 
+@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 @defproc[(http-conn-recv! [hc http-conn-liveable?]
@@ -146,7 +147,9 @@ following the response parsing. If @racket[close?] is @racket[#f],
 then the connection is only closed if the server instructs the client
 to do so.
 
-@history[#:changed "6.1.1.6" @elem{Added the @racket[#:method] argument.}]}
+@history[#:changed "6.1.1.6" @elem{Added the @racket[#:method] argument.}]
+@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
+}
 
 
 @defproc[(http-conn-sendrecv! [hc http-conn-liveable?] [uri (or/c bytes? string?)]
@@ -160,6 +163,7 @@ to do so.
 
 Calls @racket[http-conn-send!] and @racket[http-conn-recv!] in sequence.
 
+@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 @defproc[(http-sendrecv [host (or/c bytes? string?)] [uri (or/c bytes? string?)]
@@ -180,6 +184,7 @@ The HTTP connection is not returned, so it is always closed after one
 response, which is why there is no @racket[#:closed?] argument like
 @racket[http-conn-recv!].
 
+@history[#:version "7.6.0.9" @elem{Added support for @racket['deflate] decoding.}]
 }
 
 @defproc[(http-conn-CONNECT-tunnel [proxy-host (or/c bytes? string?)]

--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -169,12 +169,10 @@
   (unless (regexp-member #rx"^(?i:User-Agent:) +.+$" headers-bs)
     (fprintf to "User-Agent: Racket/~a (net/http-client)\r\n" 
              (version)))
-  (unless (or (not (memq 'gzip decodes))
+  (unless (or (empty? decodes)
               (regexp-member #rx"^(?i:Accept-Encoding:) +.+$" headers-bs))
-    (fprintf to "Accept-Encoding: gzip\r\n"))
-  (unless (or (not (memq 'deflate decodes))
-              (regexp-member #rx"^(?i:Accept-Encoding:) +.+$" headers-bs))
-    (fprintf to "Accept-Encoding: deflate\r\n"))
+    (fprintf to "Accept-Encoding: ~s\r\n"
+             (string-join (map symbol->string decodes) ",")))
 
   (define body (->bytes data))
   (cond [(procedure? body)

--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -155,7 +155,7 @@
                          #:method [method-bss #"GET"]
                          #:close? [close? #f]
                          #:headers [headers-bs empty]
-                         #:content-decode [decodes '(gzip)]
+                         #:content-decode [decodes '(gzip deflate)]
                          #:data [data #f])
   (http-conn-enliven! hc)
   (match-define (http-conn host port port-usual? to from _
@@ -333,7 +333,7 @@
 
 (define (http-conn-recv! hc
                          #:method [method-bss #"GET"]
-                         #:content-decode [decodes '(gzip)]
+                         #:content-decode [decodes '(gzip deflate)]
                          #:close? [iclose? #f])
   (http-conn-enliven! hc)
   (define status (http-conn-status! hc))
@@ -398,7 +398,7 @@
                              #:method [method-bss #"GET"]
                              #:headers [headers-bs empty]
                              #:data [data #f]
-                             #:content-decode [decodes '(gzip)]
+                             #:content-decode [decodes '(gzip deflate)]
                              #:close? [close? #f])
   (http-conn-send! hc url-bs
                    #:version version-bs
@@ -419,7 +419,7 @@
                        #:method [method-bss #"GET"]
                        #:headers [headers-bs empty]
                        #:data [data #f]
-                       #:content-decode [decodes '(gzip)])
+                       #:content-decode [decodes '(gzip deflate)])
   (define hc (http-conn-open host-bs #:ssl? ssl? #:port port))
   (begin0 (http-conn-sendrecv! hc url-bs
                                #:version version-bs

--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -170,7 +170,7 @@
              (version)))
   (unless (or (empty? decodes)
               (regexp-member #rx"^(?i:Accept-Encoding:) +.+$" headers-bs))
-    (fprintf to "Accept-Encoding: ~s\r\n"
+    (fprintf to "Accept-Encoding: ~a\r\n"
              (string-join (map symbol->string decodes) ",")))
 
   (define body (->bytes data))


### PR DESCRIPTION
This commit allows net/http-client to request `deflate` encoded content and decode the response.