### PR TITLE
[CS] regexp-replace: handle #f submatches

### DIFF
--- a/pkgs/racket-test-core/tests/racket/rx.rktl
+++ b/pkgs/racket-test-core/tests/racket/rx.rktl
@@ -1836,5 +1836,20 @@
 (test #f 'optimized (regexp-match #px"a*(?<=bc)" (make-bytes 100024 (char->integer #\a))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Ensure that regexp-replace can handle sub-matches that are #f
+;; (https://github.com/racket/racket/issues/3032)
+;;
+(test "" regexp-replace "(x)?" "" (lambda a ""))
+(test "" regexp-replace "(x)?" "" "\\1")
+
+(test "x" regexp-replace "x(y)?(z)?" "x" "&\\1\\2")
+(test "xyy" regexp-replace "x(y)?(z)?" "xy" "&\\1\\2")
+
+(test "xyy[z]" regexp-replace "x(y)?(z)?" "xy" (lambda (x y z)
+                                                 (string-append x
+                                                                (or y "[y]")
+                                                                (or z "[z]"))))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (report-errs)

--- a/racket/src/regexp/replace/main.rkt
+++ b/racket/src/regexp/replace/main.rkt
@@ -80,7 +80,8 @@
    [(procedure? insert)
     (define a (apply insert
                      (for/list ([pos (in-list poss)])
-                       (subchytes in (car pos) (cdr pos)))))
+                       (and pos
+                            (subchytes in (car pos) (cdr pos))))))
     (unless (chytes? in a)
       (raise-result-error who (if (bytes? in) "bytes?" "string?") a))
     a]
@@ -92,7 +93,10 @@
       (cond
        [(n . < . count)
         (define pos (list-ref poss n))
-        (subchytes in (car pos) (cdr pos))]
+
+        (if pos
+            (subchytes in (car pos) (cdr pos))
+            (subchytes in 0 0))]
        [else (subchytes in 0 0)]))
   
     (define (cons-chytes since pos l)


### PR DESCRIPTION
A regexp can match while having sub-patterns that are not used in
the match. In regexp-replace, the "insert" argument can refer to
these unused sub-matches. If a function is given for the "insert"
argument, it will receive these unused submatches as #f values.
If a string or byte-string is given, then any reference to an
unused sub-match (by means of a back-reference) is treated as the
empty string or byte-string.

Fixes #3032.