### PR TITLE
Add option --enable-werror

### DIFF
--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -37,6 +37,7 @@ jobs:
       run: >
         ./configure 
         --prefix=$GITHUB_WORKSPACE/../racketcgc
+        --enable-werror
         $RACKET_EXTRA_CONFIGURE_ARGS 
         --enable-cgcdefault 
         --enable-jit 
@@ -51,7 +52,7 @@ jobs:
       working-directory: ./racket/src
       run: |
         export cpus=$(grep -c ^processor /proc/cpuinfo)
-        make CFLAGS="-Werror -O2" -l $cpus -j $((cpus+1))
+        make -l $cpus -j $((cpus+1))
     - name: Installing
       working-directory: ./racket/src
       run: make -j  $((cpus+1)) install
@@ -122,7 +123,8 @@ jobs:
         CC: ${{ matrix.cc }}
       run: >
         ./configure
-        --prefix=$GITHUB_WORKSPACE/../racket3m 
+        --prefix=$GITHUB_WORKSPACE/../racket3m
+        --enable-werror
         $RACKET_EXTRA_CONFIGURE_ARGS 
         --enable-racket=$GITHUB_WORKSPACE/../racketcgc/bin/racket 
         --enable-foreign 
@@ -136,10 +138,10 @@ jobs:
       working-directory: ./racket/src
       run: |
         export cpus=$(grep -c ^processor /proc/cpuinfo)
-        make CFLAGS="-Werror -O2" -l $cpus -j $((cpus+1))
+        make -l $cpus -j $((cpus+1))
     - name: Installing
       working-directory: ./racket/src
-      run: make -j  $((cpus+1)) install
+      run: make -j $((cpus+1)) install
     # We build on Linux with clang and gcc and on MacOS with clang only.
     # However, it makes little sense to test both builds on Linux so we tarball the 
     # gcc build only. Therefore this condition ensure we only perform the tarball

--- a/racket/src/cfg-racket
+++ b/racket/src/cfg-racket
@@ -844,6 +844,7 @@ enable_gcov
 enable_noopt
 enable_ubsan
 enable_jitframe
+enable_werror
 enable_crossany
 '
       ac_precious_vars='build_alias
@@ -1508,6 +1509,7 @@ Optional Features:
   --enable-noopt          drop -O C flags (useful for low-level debugging)
   --enable-ubsan          compile with -fsanitize=undefined
   --enable-jitframe       x86_64: use frame pointer for internal calls
+  --enable-werror         compile sources with warnings as errors
   --enable-crossany       Record own cross target as machine-independent
 
 Some influential environment variables:
@@ -2906,6 +2908,12 @@ fi
 # Check whether --enable-jitframe was given.
 if test "${enable_jitframe+set}" = set; then :
   enableval=$enable_jitframe;
+fi
+
+
+# Check whether --enable-werror was given.
+if test "${enable_werror+set}" = set; then :
+  enableval=$enable_werror;
 fi
 
 
@@ -7019,6 +7027,11 @@ else
   PLAIN_CC='$(CC)'
   FOREIGN_CONVENIENCE=""
   FOREIGN_OBJSLIB="\$(FOREIGN_OBJS)"
+fi
+
+# Last but not least, if Werror was requested, add it now
+if test "${enable_werror}" = "yes"; then
+  CFLAGS="-Werror ${CFLAGS}"
 fi
 
 ############## final output ################

--- a/racket/src/racket/configure.ac
+++ b/racket/src/racket/configure.ac
@@ -81,6 +81,8 @@ AC_ARG_ENABLE(noopt,   [  --enable-noopt          drop -O C flags (useful for lo
 m4_include(../ac/ubsan_arg.m4)
 AC_ARG_ENABLE(jitframe,[  --enable-jitframe       x86_64: use frame pointer for internal calls])
 
+AC_ARG_ENABLE(werror,  [  --enable-werror         compile sources with warnings as errors])  
+
 m4_include(../ac/crossany_arg.m4)
 
 ###### Some flags imply other flags #######
@@ -1433,6 +1435,11 @@ else
   PLAIN_CC='$(CC)'
   FOREIGN_CONVENIENCE=""
   FOREIGN_OBJSLIB="\$(FOREIGN_OBJS)"
+fi
+
+# Last but not least, if Werror was requested, add it now
+if test "${enable_werror}" = "yes"; then
+  CFLAGS="-Werror ${CFLAGS}"
 fi
 
 ############## final output ################

--- a/racket/src/racket/src/jitcommon.c
+++ b/racket/src/racket/src/jitcommon.c
@@ -255,6 +255,8 @@ static int common0(mz_jit_state *jitter, void *_data)
   (void)mz_finish_lwe(ts_scheme_unbound_global, ref);
   CHECK_LIMIT();
 
+  (void)ref; /* avoids set but not used error from gcc */
+
   return 1;
 }
 

--- a/racket/src/racket/src/jitcommon.c
+++ b/racket/src/racket/src/jitcommon.c
@@ -190,7 +190,7 @@ static Scheme_Object **ts_scheme_on_demand(Scheme_Object **rs) XFORM_SKIP_PROC
 static int common0(mz_jit_state *jitter, void *_data)
 {
   int in;
-  GC_CAN_IGNORE jit_insn *ref;
+  GC_CAN_IGNORE jit_insn *ref USED_ONLY_FOR_FUTURES;
 
   /* *** check_arity_code *** */
   /* Called as a function: */
@@ -254,8 +254,6 @@ static int common0(mz_jit_state *jitter, void *_data)
   jit_pusharg_p(JIT_R2);
   (void)mz_finish_lwe(ts_scheme_unbound_global, ref);
   CHECK_LIMIT();
-
-  (void)ref; /* avoids set but not used error from gcc */
 
   return 1;
 }


### PR DESCRIPTION
This adds an option `--enable-werror` to configure so that `-Werror` is added to `CFLAGS` without overwriting any default flags in place. This `--enable-werror` follows the practice by other free software.

I have also changed the CI workflow to make use of this.