### PR TITLE
pkg-stage: ~return a list, not a set~ change contract

### DIFF
--- a/pkgs/racket-doc/pkg/scribblings/lib.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/lib.scrbl
@@ -186,7 +186,7 @@ is a directory within @racket[path]).
                     [#:in-place? in-place? boolean? #f]
                     [#:namespace namespace namespace? (make-base-namespace)]
                     [#:strip strip (or/c #f 'source 'binary 'binary-lib) #f]
-                    [#:force-strip? force-string? boolean? #f]
+                    [#:force-strip? force-strip? boolean? #f]
                     [#:use-cache? use-cache? boolean? #f]
                     [#:quiet? quiet? boolean? #t])
          (values string? path? (or/c #f string?) boolean? (listof module-path?))]{
@@ -262,7 +262,7 @@ is true, error messages may suggest specific command-line flags for
                            [#:use-trash? use-trash? boolean? #f]
                            [#:from-command-line? from-command-line? boolean? #f]
                            [#:strip strip (or/c #f 'source 'binary 'binary-lib) #f]
-                           [#:force-strip? force-string? boolean? #f]
+                           [#:force-strip? force-strip? boolean? #f]
                            [#:multi-clone-mode multi-clone-mode (or/c 'fail 'force 'convert 'ask) 'fail]
                            [#:pull-mode pull-mode (or/c 'ff-only 'try 'rebase) 'ff-only]
                            [#:link-dirs? link-dirs? boolean? #f]
@@ -319,7 +319,7 @@ The package lock must be held; see @racket[with-pkg-lock].
                           [#:use-trash? use-trash? boolean? #f]
                           [#:from-command-line? from-command-line? boolean? #f]
                           [#:strip strip (or/c #f 'source 'binary 'binary-lib) #f]
-                          [#:force-strip? force-string? boolean? #f]
+                          [#:force-strip? force-strip? boolean? #f]
                           [#:lookup-for-clone? lookup-for-clone? boolean? #f]
                           [#:multi-clone-mode multi-clone-mode (or/c 'fail 'force 'convert 'ask) 'fail]
                           [#:pull-mode pull-mode (or/c 'ff-only 'try 'rebase) 'ff-only]
@@ -438,7 +438,7 @@ The package lock must be held to allow reads; see
                            [#:quiet? quiet? boolean? #f]
                            [#:from-command-line? from-command-line? boolean? #f]
                            [#:strip strip (or/c #f 'source 'binary 'binary-lib) #f]
-                           [#:force-strip? force-string? boolean? #f]
+                           [#:force-strip? force-strip? boolean? #f]
                            [#:dry-run? dry-run? boolean? #f])
          (or/c 'skip
                #f

--- a/pkgs/racket-doc/pkg/scribblings/lib.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/lib.scrbl
@@ -3,6 +3,7 @@
           (for-label (except-in racket/base
                                 remove)
                      racket/contract/base
+                     (only-in racket/set set/c)
                      pkg
                      pkg/lib
                      (only-in pkg/db current-pkg-catalog-file)
@@ -189,7 +190,7 @@ is a directory within @racket[path]).
                     [#:force-strip? force-strip? boolean? #f]
                     [#:use-cache? use-cache? boolean? #f]
                     [#:quiet? quiet? boolean? #t])
-         (values string? path? (or/c #f string?) boolean? (listof module-path?))]{
+         (values string? path? (or/c #f string?) boolean? (set/c module-path?))]{
 
 Locates the implementation of the package specified by @racket[desc]
 and downloads and unpacks it to a temporary directory (as needed).

--- a/racket/collects/pkg/lib.rkt
+++ b/racket/collects/pkg/lib.rkt
@@ -1,5 +1,6 @@
 #lang racket/base
 (require racket/contract/base
+         (only-in racket/set set/c)
          net/url
          "path.rkt"
          "private/desc.rkt"
@@ -232,7 +233,7 @@
                           path?
                           (or/c #f string?)
                           boolean?
-                          (listof module-path?)))]
+                          (set/c module-path? #:cmp 'equal #:kind 'immutable)))]
   [pkg-config-catalogs
    (-> (listof string?))]
   [pkg-catalog-update-local


### PR DESCRIPTION
Change `pkg-stage` to call a different helper function that returns a list. Fixes #3029.

This fix puts lists inside all `install-info` structs.

Another simpler fix is to call `list->set` at the end of the `pkg-stage` function.