### PR TITLE
fix doc typo

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/types.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/types.scrbl
@@ -1735,7 +1735,7 @@ a-union-val
 ]}
 
 
-@defproc[(union-ptr [u array?]) cpointer?]{
+@defproc[(union-ptr [u union?]) cpointer?]{
 
 Extracts the pointer for a union's storage.
 


### PR DESCRIPTION
```racket
#lang racket

(require ffi/unsafe)

(define u (cast 42 _int (_union _int _float)))

(union? u)
;; => #t

(array? u)
;; => #f

(union-ptr u)
;; => #<cpointer>
```