### PR TITLE
Make get-pure-port redirection case-insensitive

### DIFF
--- a/racket/collects/net/url.rkt
+++ b/racket/collects/net/url.rkt
@@ -320,7 +320,7 @@
 
     (define new-url
       (ormap (λ (h)
-               (match (regexp-match #rx#"^Location: (.*)$" h)
+               (match (regexp-match #rx#"^(?i:Location): (.*)$" h)
                  [#f #f]
                  [(list _ m1b)
                   (define m1 (bytes->string/utf-8 m1b))


### PR DESCRIPTION
GitHub's CDN seems to have recently started returning the `Location` header for a redirect with a lowercase `l`, which breaks the redirect logic. The HTTP spec says that header names are case-insensitive, so we need to look for either version.