### PR TITLE
style: consistent figure style

### DIFF
--- a/pkgs/racket-doc/scribblings/style/textual.scrbl
+++ b/pkgs/racket-doc/scribblings/style/textual.scrbl
@@ -30,21 +30,24 @@ your code.
  (define (conversion f)
    (* 5/9 (- f 32)))
 ]
- @filebox[@tt{really bad}
- @codeblock{#lang racket
+ @racketmod[#:file
+ @tt{really bad}
+ racket
+
  (define (conversion f)
    (* 5/9 (- f 32)
      )
    )
- }]
+ ]
 ]
 
 You are allowed to place all closing parenthesis on a line by itself at the
 end of long sequences, be those definitions or pieces of data.
 
 @compare[
- @filebox[@tt{acceptable}
- @codeblock{#lang racket
+ @racketmod[#:file
+ @tt{acceptable}
+ racket
  (define modes
    '(edit
      help
@@ -53,9 +56,10 @@ end of long sequences, be those definitions or pieces of data.
      trace
      step
      ))
- }]
- @filebox[@tt{also acceptable}
- @codeblock{#lang racket
+ ]
+ @racketmod[#:file
+ @tt{also acceptable}
+ racket
  (define turn%
    (class object%
      (init-field state)
@@ -68,7 +72,7 @@ end of long sequences, be those definitions or pieces of data.
      (define/public (is-placable? place)
        (send state legal? place))
      ))
- }]
+ ]
 ]
  Doing so is most useful when you expect to add, delete, or swap items in
  such sequences.
@@ -383,12 +387,13 @@ space between the two, even if they’re separated by parentheses.
  (define (f x g)
    [(< x 3) (g (g 3))])
 ]
- @filebox[@tt{bad}
- @codeblock{#lang racket
+ @racketmod[#:file
+ @tt{bad}
+ racket
 
  (define(f x g)
    [(< x 3)(g(g 3))])
- }]
+ ]
 ]
 
 


### PR DESCRIPTION
Use a consistent style for the "good / bad" examples:

- start the code at the far left of each box
- keep a little space between the top of the box & the label

- - -

### Before, at the top of the page:
![parenthesis-before](https://user-images.githubusercontent.com/1731829/75484150-334e3d80-5976-11ea-9865-da3362c7cf75.png)

### After
![parenthesis-after](https://user-images.githubusercontent.com/1731829/75484293-7f997d80-5976-11ea-9ca0-c31b56d37f9a.png)

### Before, at the bottom:
![space-before](https://user-images.githubusercontent.com/1731829/75484316-87592200-5976-11ea-898b-871646615eec.png)

### After
![space-after](https://user-images.githubusercontent.com/1731829/75484321-8b853f80-5976-11ea-99d8-8962cb595bd5.png)

