### PR TITLE
Doc: more illustrative example for the filter-map function

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -1243,7 +1243,7 @@ because @racket[filter-map] avoids
 building the intermediate list.
 
 @mz-examples[#:eval list-eval
-  (filter-map (lambda (x) (and (positive? x) x)) '(1 2 3 -2 8))]}
+  (filter-map (lambda (x) (and (negative? x) (abs x))) '(1 2 -3 -4 8))]}
 
 
 @defproc[(count [proc procedure?] [lst list?] ...+)


### PR DESCRIPTION
The current example could as well be written using `filter`. This patch makes the example complicated a little bit to illustrate how `filter-map` could be used (differently than `filter`).