### PR TITLE
Preserve undocumented `args` syntax class attribute.

### DIFF
--- a/racket/collects/syntax/parse/lib/function-header.rkt
+++ b/racket/collects/syntax/parse/lib/function-header.rkt
@@ -6,7 +6,7 @@
 (provide function-header formal formals)
 
 (define-syntax-class function-header
-  #:attributes (name params)
+  #:attributes (name params args)
   (pattern ((~or header:function-header name*:id) . args:formals)
            #:attr params #'((~@ . (~? header.params ())) . args.params)
            #:attr name   #'(~? header.name name*)))


### PR DESCRIPTION
PR #2678 unintentionally removed this attribute, but it was used
at least by "collections-lib" and "static-rename-lib".

cc @sorawee @lexi-lambda @jackfirth @rmculpepper