### PR TITLE
Add generalized common-prefix procedures

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -1113,6 +1113,24 @@ combined with the from-right functionality of @racket[take-right],
 @history[#:added "6.3"]{}
 }
 
+@deftogether[(
+  @defproc[(take-common-prefix* [lst (listof list?)]
+                                [same? (any/c any/c . -> . any/c) equal?])
+           list?]
+  @defproc[(drop-common-prefix* [lst (listof list?)]
+                                [same? (any/c any/c . -> . any/c) equal?])
+           (listof list?)]
+  @defproc[(split-common-prefix* [lst (listof list?)]
+                                 [same? (any/c any/c . -> . any/c) equal?])
+           (values list? (listof list?))]
+)]{
+
+  Like @racket[take-common-prefix], @racket[drop-common-prefix], and
+  @racket[split-common-prefix], but operating on arbitrarily-sized lists of
+  lists @racket[lst].
+
+@history[#:added "7.6"]{}
+}
 
 @defproc[(add-between [lst list?] [v any/c]
                       [#:before-first before-first list? '()]

--- a/pkgs/racket-test-core/tests/racket/list.rktl
+++ b/pkgs/racket-test-core/tests/racket/list.rktl
@@ -677,6 +677,23 @@
 (err/rt-test (split*-list '() '() #f))
 (err/rt-test (take-common-prefix 1 1))
 
+(test '(a b) take-common-prefix* '((a b c d) (a b x y z) (a b 1 2 3)))
+(test '() take-common-prefix* '((1 a b c) (a b c d) (a b 1 2 3)))
+(test '(1 2) take-common-prefix* '((1 2) (1 2) (1 2)))
+(test '(1 2) take-common-prefix* '((1 2 3 4) (1 2 4 3)) =)
+(test '((c d) (x y z) (1 2 3)) drop-common-prefix* '((a b c d) (a b x y z) (a b 1 2 3)))
+(define (split*-list* ls)
+  (define-values (prefix tails)
+    (split-common-prefix* ls))
+  (list prefix tails))
+(test '((a b) ((c d) (x y z) (1 2 3))) split*-list* '((a b c d) (a b x y z) (a b 1 2 3)))
+(err/rt-test (take-common-prefix* '() #f))
+(err/rt-test (take-common-prefix* '(1)))
+(err/rt-test (take-common-prefix* 1))
+(err/rt-test (drop-common-prefix* '() #f))
+(err/rt-test (split-common-prefix* '() #f))
+
+
 ;; ---------- remf / remf* ----------
 
 (test '() remf positive? '())

--- a/racket/collects/racket/list.rkt
+++ b/racket/collects/racket/list.rkt
@@ -36,6 +36,10 @@
          take-common-prefix
          drop-common-prefix
 
+         split-common-prefix*
+         take-common-prefix*
+         drop-common-prefix*
+
          append*
          flatten
          add-between
@@ -317,6 +321,60 @@
   (let-values ([(prefix atail btail)
                 (internal-split-common-prefix as bs same? #f 'drop-common-prefix)])
     (values atail btail)))
+
+; ==================================================================================================
+; internal-split-common-prefix*: listof list? procedure? boolean? symbol? -> list? listof list?
+; --------------------------------------------------------------------------------------------------
+; Returns the longest common prefix of lists in ls together with the tails of lists in ls with the
+; prefix removed. Drives generalized split-/take-/drop-common-prefix procedures.
+; ==================================================================================================
+(define (internal-split-common-prefix* ls same? keep-prefix? name)
+  (unless (list? ls)
+    (raise-argument-error name "listof list?" ls))
+  (let check ([ls ls])
+    (unless (null? ls)
+      (if (list? (car ls))
+          (check (cdr ls))
+          (error name "non-list found in list: ~a in ~a" (car ls) ls))))
+  (unless (and (procedure? same?)
+               (procedure-arity-includes? same? 2))
+    (raise-argument-error name "(any/c any/c . -> . any/c)" same?))
+  (if (null? ls)
+      (values '() '())
+      (let loop ([ls ls] [prefix '()])
+        (if (and (andmap pair? ls)
+                 (andmap (lambda (v) (same? (caar ls) v)) (map car ls)))
+            (loop (map cdr ls)
+                  (and keep-prefix?
+                       (append prefix (list (caar ls)))))
+            (values prefix ls)))))
+
+; ==================================================================================================
+; split-common-prefix*: listof list? -> list? listof list?
+; --------------------------------------------------------------------------------------------------
+; Returns the longest common prefix of lists in ls together
+; with the tails of lists in ls with the prefix removed.
+; ==================================================================================================
+(define (split-common-prefix* ls [same? equal?])
+  (internal-split-common-prefix* ls same? #t 'split-common-prefix*))
+
+; ==================================================================================================
+; take-common-prefix*: listof list? -> list?
+; --------------------------------------------------------------------------------------------------
+; Returns the longest common prefix of lists in ls.
+; ==================================================================================================
+(define (take-common-prefix* ls [same? equal?])
+  (let-values ([(prefix ls) (internal-split-common-prefix* ls same? #t 'take-common-prefix*)])
+    prefix))
+
+; ==================================================================================================
+; drop-common-prefix*: listof list? -> listof list?
+; --------------------------------------------------------------------------------------------------
+; Returns the tails of lists in ls with the longest common prefix removed
+; ==================================================================================================
+(define (drop-common-prefix* ls [same? equal?])
+  (let-values ([(prefix ls) (internal-split-common-prefix* ls same? #f 'drop-common-prefix*)])
+    ls))
 
 (define append*
   (case-lambda [(ls) (apply append ls)] ; optimize common case


### PR DESCRIPTION
Adds `split-common-prefix*`, `take-common-prefix*`, and `drop-common-prefix*`, which behave like the unstarred procedures but operate on an arbitrarily-sized list of lists, rather than only two lists. Where `split-common-prefix` and `drop-common-prefix` return the tails of the two argument lists, the corresponding new procedures return a list containing the tails of the lists in the passed list.

This update generalizes the behaviours of the original common-prefix procedures but leaves them untouched, retaining backwards-compatibility.