### PR TITLE
Explicit zero assign to avoid warning

### DIFF
--- a/racket/src/racket/src/hash.c
+++ b/racket/src/racket/src/hash.c
@@ -265,7 +265,7 @@ static Scheme_Object *do_hash(Scheme_Hash_Table *table, Scheme_Object *key, int 
 {
   Scheme_Object *tkey, *ekey, **keys;
   intptr_t hx, h2x;
-  hash_v_t h, h2, useme = 0;
+  hash_v_t h, h2 = 0, useme = 0;
   uintptr_t mask;
 
  rehash_key:


### PR DESCRIPTION
GCC 9.3 things that `h2` might reach line 385 uninitialized.
```
./hash.c:385:14: warning: 'h2' may be used uninitialized in this function [-Wmaybe-uninitialized]
  385 |       h = (h + h2) & mask;
      |           ~~~^~~~~
```