### PR TITLE
Change return type of rktio_get_milliseconds to be unsigned

### DIFF
--- a/racket/src/racket/include/mzwin.def
+++ b/racket/src/racket/include/mzwin.def
@@ -105,6 +105,7 @@ EXPORTS
  scheme_warning
  scheme_raise
  scheme_log_level_p
+ scheme_log_level_topic_p
  scheme_log
  scheme_log_w_data
  scheme_log_message

--- a/racket/src/racket/include/mzwin3m.def
+++ b/racket/src/racket/include/mzwin3m.def
@@ -105,6 +105,7 @@ EXPORTS
  scheme_warning
  scheme_raise
  scheme_log_level_p
+ scheme_log_level_topic_p
  scheme_log
  scheme_log_w_data
  scheme_log_message

--- a/racket/src/racket/include/racket.exp
+++ b/racket/src/racket/include/racket.exp
@@ -102,6 +102,7 @@ scheme_raise_exn
 scheme_warning
 scheme_raise
 scheme_log_level_p
+scheme_log_level_topic_p
 scheme_log
 scheme_log_w_data
 scheme_log_message

--- a/racket/src/racket/include/racket3m.exp
+++ b/racket/src/racket/include/racket3m.exp
@@ -102,6 +102,7 @@ scheme_raise_exn
 scheme_warning
 scheme_raise
 scheme_log_level_p
+scheme_log_level_topic_p
 scheme_log
 scheme_log_w_data
 scheme_log_message

--- a/racket/src/racket/src/fun.c
+++ b/racket/src/racket/src/fun.c
@@ -9732,7 +9732,7 @@ static Scheme_Object *jump_to_alt_continuation()
 /*                                  time                                  */
 /*========================================================================*/
 
-intptr_t scheme_get_milliseconds(void)
+uintptr_t scheme_get_milliseconds(void)
 /* this function can be called from any OS thread */
 {
   return rktio_get_milliseconds();
@@ -9856,10 +9856,11 @@ static Scheme_Object *seconds_to_date(int argc, Scheme_Object **argv)
 
 static Scheme_Object *time_apply(int argc, Scheme_Object *argv[])
 {
-  intptr_t start, end;
+  uintptr_t start, end;
   intptr_t cpustart, cpuend;
   intptr_t gcstart, gcend;
-  intptr_t dur, cpudur, gcdur;
+  uintptr_t dur;
+  intptr_t cpudur, gcdur;
   int i, num_rands;
   Scheme_Object *v, *p[4], **rand_vec, *rands, *r;
 

--- a/racket/src/racket/src/schemef.h
+++ b/racket/src/racket/src/schemef.h
@@ -1150,7 +1150,7 @@ MZ_EXTERN Scheme_Object *scheme_load_extension(const char *filename, Scheme_Env 
 MZ_EXTERN void scheme_register_extension_global(void *ptr, intptr_t size);
 
 MZ_EXTERN intptr_t scheme_get_seconds(void);
-XFORM_NONGCING MZ_EXTERN intptr_t scheme_get_milliseconds(void);
+XFORM_NONGCING MZ_EXTERN uintptr_t scheme_get_milliseconds(void);
 XFORM_NONGCING MZ_EXTERN double scheme_get_inexact_milliseconds(void);
 XFORM_NONGCING MZ_EXTERN intptr_t scheme_get_process_milliseconds(void);
 XFORM_NONGCING MZ_EXTERN intptr_t scheme_get_process_children_milliseconds(void);

--- a/racket/src/racket/src/schemex.h
+++ b/racket/src/racket/src/schemex.h
@@ -143,6 +143,7 @@ void (*scheme_raise_exn)(int exnid, ...);
 void (*scheme_warning)(char *msg, ...);
 void (*scheme_raise)(Scheme_Object *exn);
 int (*scheme_log_level_p)(Scheme_Logger *logger, int level);
+int (*scheme_log_level_topic_p)(Scheme_Logger *logger, int level, Scheme_Object *name);
 void (*scheme_log)(Scheme_Logger *logger, int level, int flags,
                           const char *msg, ...);
 void (*scheme_log_w_data)(Scheme_Logger *logger, int level, int flags,
@@ -938,7 +939,7 @@ Scheme_Object *(*scheme_load)(const char *file);
 Scheme_Object *(*scheme_load_extension)(const char *filename, Scheme_Env *env);
 void (*scheme_register_extension_global)(void *ptr, intptr_t size);
 intptr_t (*scheme_get_seconds)(void);
-intptr_t (*scheme_get_milliseconds)(void);
+uintptr_t (*scheme_get_milliseconds)(void);
 double (*scheme_get_inexact_milliseconds)(void);
 intptr_t (*scheme_get_process_milliseconds)(void);
 intptr_t (*scheme_get_process_children_milliseconds)(void);

--- a/racket/src/racket/src/schemex.inc
+++ b/racket/src/racket/src/schemex.inc
@@ -111,6 +111,7 @@
   scheme_extension_table->scheme_warning = scheme_warning;
   scheme_extension_table->scheme_raise = scheme_raise;
   scheme_extension_table->scheme_log_level_p = scheme_log_level_p;
+  scheme_extension_table->scheme_log_level_topic_p = scheme_log_level_topic_p;
   scheme_extension_table->scheme_log = scheme_log;
   scheme_extension_table->scheme_log_w_data = scheme_log_w_data;
   scheme_extension_table->scheme_log_message = scheme_log_message;

--- a/racket/src/racket/src/schemexm.h
+++ b/racket/src/racket/src/schemexm.h
@@ -111,6 +111,7 @@
 #define scheme_warning (scheme_extension_table->scheme_warning)
 #define scheme_raise (scheme_extension_table->scheme_raise)
 #define scheme_log_level_p (scheme_extension_table->scheme_log_level_p)
+#define scheme_log_level_topic_p (scheme_extension_table->scheme_log_level_topic_p)
 #define scheme_log (scheme_extension_table->scheme_log)
 #define scheme_log_w_data (scheme_extension_table->scheme_log_w_data)
 #define scheme_log_message (scheme_extension_table->scheme_log_message)

--- a/racket/src/rktio/rktio.h
+++ b/racket/src/rktio/rktio.h
@@ -1013,7 +1013,7 @@ typedef struct rktio_date_t {
   char *zone_name; /* can be NULL; otherwise, free it */
 } rktio_date_t;
 
-RKTIO_EXTERN_NOERR intptr_t rktio_get_milliseconds(void);
+RKTIO_EXTERN_NOERR uintptr_t rktio_get_milliseconds(void);
 RKTIO_EXTERN_NOERR double rktio_get_inexact_milliseconds(void);
 
 RKTIO_EXTERN_NOERR intptr_t rktio_get_process_milliseconds(rktio_t *rktio);

--- a/racket/src/rktio/rktio_time.c
+++ b/racket/src/rktio/rktio_time.c
@@ -81,7 +81,7 @@ rktio_int64_t get_hectonanoseconds_as_longlong()
 }
 #endif
 
-intptr_t rktio_get_milliseconds(void)
+uintptr_t rktio_get_milliseconds(void)
 /* this function can be called from any OS thread */
 {
 #ifdef RKTIO_SYSTEM_WINDOWS
@@ -89,7 +89,7 @@ intptr_t rktio_get_milliseconds(void)
 #else
   struct timeval now;
   gettimeofday(&now, NULL);
-  return now.tv_sec * 1000 + now.tv_usec / 1000;
+  return ((uintptr_t) now.tv_sec) * 1000 + ((uintptr_t) now.tv_usec) / 1000;
 #endif
 }
 


### PR DESCRIPTION
This fixes a major issue in arm 32bits, detected by ubsan, where
conversion of type to milliseconds results in overflow.

```
rktio_time.c:92:21: runtime error: signed integer overflow: 1584975753 * 1000 cannot be represented in type 'long int'
```