### PR TITLE
Use new URL for GitHub tarballs.

### DIFF
--- a/racket/collects/pkg/private/stage.rkt
+++ b/racket/collects/pkg/private/stage.rkt
@@ -340,7 +340,7 @@
           (define new-url
             (url "https" #f "github.com" #f #t
                  (map (λ (x) (path/param x empty))
-                      (list user repo "tarball" checksum))
+                      (list user repo "legacy.tar.gz" checksum))
                  empty
                  #f))
           (define tmp.tgz


### PR DESCRIPTION
GitHub switched URLs for tarballs, redirecting to the new one with
a 302. However, old versions of Racket don't follow redirects in
`raco pkg install`, so they broke (before 6.3). Using the new URL
should work for everyone.

Reported by @greghendershott.