### PR TITLE
extensions.scrbl fix confusing typo in example

### DIFF
--- a/pkgs/racket-doc/scribblings/inside/extensions.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/extensions.scrbl
@@ -210,7 +210,7 @@ To create an extension that behaves as a module, return a symbol from
 @cpp{scheme_reload} declare a module using @cpp{scheme_primitive_module}.
 
 For example, the following extension implements a module named
-@racket[hello] that exports a binding @racket[greeting]:
+@racket[hi] that exports a binding @racket[greeting]:
 
 @verbatim[#:indent 2]{
   #include "escheme.h"


### PR DESCRIPTION
The module is named `hi` but the text said that it was named `hello`
which is quite confusing since `"hello"` is actually the string that
is bound to `greeting`.