### PR TITLE
Switch /replacement and /our-replacement names

### DIFF
--- a/racket/collects/racket/random.rkt
+++ b/racket/collects/racket/random.rkt
@@ -21,7 +21,7 @@
 
 (define (random-ref seq [prng (current-pseudo-random-generator)])
   (define samples
-    (random-sample/out-replacement seq 1 prng))
+    (random-sample/replacement seq 1 prng))
   (unless samples
     (raise-argument-error 'random-ref "non-empty sequence" seq))
   (vector-ref samples 0))
@@ -36,7 +36,7 @@
    [(zero? n) '()]
    [(not replacement?)
     (define samples
-      (random-sample/replacement seq n prng))
+      (random-sample/out-replacement seq n prng))
     ;; did we get enough?
     (unless (for/and ([s (in-vector samples)])
               (not (eq? s not-there)))
@@ -46,14 +46,14 @@
     (vector->list samples)]
    [else
     (define samples
-      (random-sample/out-replacement seq n prng))
+      (random-sample/replacement seq n prng))
     (unless samples
       (raise-argument-error 'random-sample
                             "non-empty sequence for n>0"
                             0 seq n prng))
     (vector->list samples)]))
 
-(define (random-sample/replacement seq n prng)
+(define (random-sample/out-replacement seq n prng)
   ;; Based on: http://rosettacode.org/wiki/Knuth's_algorithm_S#Racket
   (define samples (make-vector n not-there))
   (for ([elt seq]
@@ -64,7 +64,7 @@
            (vector-set! samples (random n prng) elt)]))
   samples)
 
-(define (random-sample/out-replacement seq n prng)
+(define (random-sample/replacement seq n prng)
   ;; similar to above, except each sample is independent
   (define samples #f)
   (for ([elt seq]


### PR DESCRIPTION
The call to `random-sample/replacement` gets called when `(not
replacement?)` holds, while `random-sample/out-replacement` gets called
otherwise.

This is probably because the algorithm for the without replacement case
actually replaces parts of the sample, but that is different from the
meaning of a sample with and without replacement, which means with
possible duplicates or without.

Important note: I don't know how to run tests on my local fork, so I didn't test this.