### PR TITLE
Fixes #2219: correct the contract for rem

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/contracts/examples/3.rkt
+++ b/pkgs/racket-doc/scribblings/guide/contracts/examples/3.rkt
@@ -71,7 +71,7 @@
   [rem         (->d ([d dictionary?]
                      [k (and/c symbol? (lambda (k) (has? d k)))])
                     ()
-                    [result (and/c dictionary? not-has?)]
+                    [result (and/c dictionary? (lambda (d) ((not-has? d) k)))]
                     #:post-cond
                     (= (count d) (+ (count result) 1)))]))
 ;; end of interface


### PR DESCRIPTION
I didn't use the suggested fix by either @Syntacticlosure or @mfelleisen
because there's another usage of `not-has?` which is correct already, so
changing `not-has?` would break it.