### PR TITLE
[doc] remove gen:name's contract

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/define-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/define-struct.scrbl
@@ -31,14 +31,12 @@
                               (code:line #:constructor-name constructor-id)
                               (code:line #:extra-constructor-name constructor-id)
                               (code:line #:reflection-name symbol-expr)
-                              (code:line #:methods gen:name method-defs)
+                              (code:line #:methods gen:name-id method-defs)
                               #:omit-define-syntaxes
                               #:omit-define-values]
                [field-option #:mutable
                              #:auto]
-               [method-defs (definition ...)])
-               #:contracts
-               ([gen:name identifier?])]{
+               [method-defs (definition ...)])]{
 
 Creates a new @techlink{structure type} (or uses a pre-existing
 structure type if @racket[#:prefab] is specified), and binds
@@ -224,10 +222,10 @@ name, as do the various procedures that are bound by @racket[struct].
   (eval:error (circle-radius "bad"))
 ]
 
-If @racket[#:methods gen:name method-defs] is provided, then
-@racket[gen:name] must be a transformer binding for the static
+If @racket[#:methods gen:name-id method-defs] is provided, then
+@racket[gen:name-id] must be a transformer binding for the static
 information about a generic interface produced by @racket[define-generics].
-The @racket[method-defs] define the methods of the @racket[gen:name]
+The @racket[method-defs] define the methods of the @racket[gen:name-id]
 interface. A @racket[define/generic] form or auxiliary definitions
 and expressions may also appear in @racket[method-defs].
 


### PR DESCRIPTION
`gen:name` is not an identifier value, so it should not have a contract.