### PR TITLE
pattern-expanders should not arm output patterns

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/for.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/for.scrbl
@@ -152,7 +152,7 @@ element.
               #:contracts ([length-expr exact-nonnegative-integer?])]{
 
 Iterates like @racket[for/list], but results are accumulated into
-a vector instead of a list. 
+a vector instead of a list.
 
 If the optional @racket[#:length] clause is specified, the result of
 @racket[length-expr] determines the length of the result vector.  In
@@ -520,7 +520,7 @@ nested.
 
 @deftogether[(
 @defform[(for*/list (for-clause ...) body-or-break ... body)]
-@defform[(for*/lists (id ... maybe-result) (for-clause ...) 
+@defform[(for*/lists (id ... maybe-result) (for-clause ...)
            body-or-break ... body)]
 @defform[(for*/vector maybe-length (for-clause ...) body-or-break ... body)]
 @defform[(for*/hash (for-clause ...) body-or-break ... body)]
@@ -685,7 +685,7 @@ The result can be either @racket[#f], to indicate that the forms
 should not be treated specially (perhaps because the number of bound
 identifiers is inconsistent with the @racket[(id . _rest)] form), or a
 new @racket[_for-clause] to replace the given one. The new clause might
-use @racket[:do-in]. To protect identifiers in the result of 
+use @racket[:do-in]. To protect identifiers in the result of
 @racket[clause-transform-expr], use @racket[for-clause-syntax-protect]
 instead of @racket[syntax-protect].
 
@@ -716,7 +716,16 @@ instead of @racket[syntax-protect].
 (for/list ([d (in-digits 1138)]) d)
 
 (map in-digits (list 137 216))
-]}
+]
+
+Sequence syntax transformer procedures should not arm their
+output clauses with syntax @tech{dye packs}, though they
+may arm expressions embedded within the clauses. Because of
+this, avoid using forms like @racket[syntax-rules] for
+@racket[clause-transform-expr], and only call
+@racket[syntax-protect] or @racket[syntax-arm] on
+expressions within clauses, not on clauses themselves.
+}
 
 @defform[(:do-in ([(outer-id ...) outer-expr] ...)
                  outer-check

--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -72,7 +72,7 @@ means specifically @tech{@Spattern}.
                 [H-pattern
                  pvar-id:splicing-syntax-class-id
                  (@#,ref[~var h] id splicing-syntax-class-id maybe-role)
-                 (@#,ref[~var h] id (splicing-syntax-class-id arg ...) 
+                 (@#,ref[~var h] id (splicing-syntax-class-id arg ...)
                                  maybe-role)
                  (~seq . L-pattern)
                  (@#,ref[~and h] proper-H/A-pattern ...+)
@@ -579,7 +579,7 @@ key and whose sequence of fields, when considered as a list, match the
 ]
 }
 
-@specsubform[#&@#,svar[S-pattern]]{ 
+@specsubform[#&@#,svar[S-pattern]]{
 
 Matches a term that is a box whose contents matches the inner
 @tech{@Spattern}.
@@ -1155,13 +1155,24 @@ Returns a @tech{pattern expander} that uses @racket[proc] to transform the patte
      (syntax-case stx ()
        [(~maybe pat ...)
         #'(~optional (~seq pat ...))]))))
-]}
+]
+
+@tech{Pattern expander} transformer procedures should not
+arm their output patterns with syntax
+@tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{dye packs},
+though they may arm expressions embedded within the
+patterns. Because of this, avoid using forms like
+@racket[syntax-rules] and @racket[syntax-id-rules]
+for @tech{pattern expanders}, and only call
+@racket[syntax-protect] or @racket[syntax-arm] on
+expressions within patterns, not on patterns themselves.
+}
 
 @defthing[prop:pattern-expander (struct-type-property/c (-> pattern-expander? (-> syntax? syntax?)))]{
 
 A @tech[#:doc '(lib "scribblings/reference/reference.scrbl")]{structure type property} to
 identify structure types that act as @tech{pattern expanders} like the
-ones created by @racket[pattern-expander]. 
+ones created by @racket[pattern-expander].
 
 @racketblock[
 (begin-for-syntax


### PR DESCRIPTION
Closes #2199 by documenting the fact that pattern expanders shouldn't use `syntax-arm` or `syntax-protect` on their results (and so shouldn't use `syntax-rules` either). Does the same for sequence syntax / for-clause transformers.