### PR TITLE
docs: for/stream: mention multiple values

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1192,10 +1192,12 @@ stream, but plain lists can be used as streams, and functions such as
   @racket[body] will not be evaluated until the resulting stream is forced. This
   allows @racket[for/stream] and @racket[for*/stream] to iterate over infinite
   sequences, unlike their finite counterparts.
-  
+
   Please note that these forms don't support returning multiple values on each
-  iteration, but third party packages exist that provide this functionality.
-  
+  iteration, but third-party packages exist that provide this functionality
+  (see @hyperlink[https://pkgs.racket-lang.org/package/stream-values]{stream-values}
+  for example).
+
   @examples[#:eval sequence-evaluator
     (for/stream ([i '(1 2 3)]) (* i i))
     (stream->list (for/stream ([i '(1 2 3)]) (* i i)))

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1192,7 +1192,10 @@ stream, but plain lists can be used as streams, and functions such as
   @racket[body] will not be evaluated until the resulting stream is forced. This
   allows @racket[for/stream] and @racket[for*/stream] to iterate over infinite
   sequences, unlike their finite counterparts.
-
+  
+  Please note that these forms don't support returning multiple values on each
+  iteration, but third party packages exist that provide this functionality.
+  
   @examples[#:eval sequence-evaluator
     (for/stream ([i '(1 2 3)]) (* i i))
     (stream->list (for/stream ([i '(1 2 3)]) (* i i)))

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1193,10 +1193,8 @@ stream, but plain lists can be used as streams, and functions such as
   allows @racket[for/stream] and @racket[for*/stream] to iterate over infinite
   sequences, unlike their finite counterparts.
 
-  Please note that these forms don't support returning multiple values on each
-  iteration, but third-party packages exist that provide this functionality
-  (see @hyperlink[https://pkgs.racket-lang.org/package/stream-values]{stream-values}
-  for example).
+  Please note that these forms don't support returning
+  @seclink["multiple-values" #:doc '(lib "scribblings/guide/guide.scrbl")]{multiple values}
 
   @examples[#:eval sequence-evaluator
     (for/stream ([i '(1 2 3)]) (* i i))

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1193,8 +1193,7 @@ stream, but plain lists can be used as streams, and functions such as
   allows @racket[for/stream] and @racket[for*/stream] to iterate over infinite
   sequences, unlike their finite counterparts.
 
-  Please note that these forms don't support returning
-  @seclink["multiple-values" #:doc '(lib "scribblings/guide/guide.scrbl")]{multiple values}
+  Please note that these forms do not support returning @tech{multiple values}.
 
   @examples[#:eval sequence-evaluator
     (for/stream ([i '(1 2 3)]) (* i i))


### PR DESCRIPTION
Resulting from [a discussion on racket-users mailing list](https://groups.google.com/forum/#!topic/racket-users/Cavti-N5u6o), a small improvement to the documentation of the `for/stream` form.

Before I am confident with this, I need a little advice:
1. Is there a general approach to (not?) recommending specific third-party packages in the main distribution documentation? I included a mention of the [stream-values](https://pkgs.racket-lang.org/package/stream-values) package directly, but what if someone comes up with a different package - the docs would then give preference to one package of many. Is that desirable?
2. I'm not sure the link to the package is the best way to do it - maybe I should link to the manual instead?
3. I would also add a link to the racket guide under the mention of "multiple values" - would [`@other-doc`](https://docs.racket-lang.org/scribble/base.html#%28def._%28%28lib._scribble%2Fbase..rkt%29._other-doc%29%29) be the correct way to do it?

Also, I'm building racket locally now to inspect the rendered docs and make sure there are no parsing errors.