### PR TITLE
Use CPUS instead of -j on top level makefile

### DIFF
--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -32,7 +32,7 @@ jobs:
         DISTRO_BUILD_SITE_DEST: "${{ runner.temp }}/site-dest/"
       run: |
         export cpus=$(grep -c ^processor /proc/cpuinfo)
-        make snapshot-site PLAIN_RACKET=/usr/bin/racket CONFIG=".github/workflows/site-small.rkt" -j $((cpus+1))
+        make snapshot-site PLAIN_RACKET=/usr/bin/racket CONFIG=".github/workflows/site-small.rkt" CPUS=$((cpus+1))
 
     - name: S3 Sync
       env:


### PR DESCRIPTION
AFAIU -j will only work on a make file level but is not propagated to
raco.