### PR TITLE
Fix typo in quote example from section 2.4.1

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/truth.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/truth.scrbl
@@ -86,7 +86,7 @@ prints:
 
 @interaction[
 (eval:alts (@#,racket[quote] ("red" "green" "blue")) '("red" "green" "blue"))
-(eval:alts (@#,racket[quote] ((1) (2 3) (4))) '((1) (2 4) (4)))
+(eval:alts (@#,racket[quote] ((1) (2 3) (4))) '((1) (2 3) (4)))
 (eval:alts (@#,racket[quote] ()) '())
 ]
 


### PR DESCRIPTION
The first `4` in the output should be `3` to match what's in the input.