### PR TITLE
Fail when ubsan finds failures

### DIFF
--- a/.github/workflows/ci-ubsan.yml
+++ b/.github/workflows/ci-ubsan.yml
@@ -171,8 +171,11 @@ jobs:
       continue-on-error: true
       run: raco test -l tests/db/all-tests | tee logs/db-all-tests.log
     - name: Gather runtime errors
-      run: grep 'runtime error' logs/*.log > runtime-errors_git${{ github.sha }}.log
+      run: |
+        grep 'runtime error' logs/*.log > runtime-errors_git${{ github.sha }}.log || true
+        test ! -s runtime-errors_git${{ github.sha }}.log
     - uses: actions/upload-artifact@v2
+      if: failure()
       with:
         name: runtime-errors-cs_git${{ github.sha }}
         path: runtime-errors_git${{ github.sha }}.log


### PR DESCRIPTION
This is enabled for CS since ChezScheme has no ubsan warnings since: https://github.com/racket/ChezScheme/commit/65e05772a1ee14d73c368f311e837b00af771a23