### PR TITLE
Add future tests to CI

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -32,6 +32,7 @@ jobs:
         raco test -l tests/match/main
         raco test -l tests/zo-path
         raco test -c tests/xml
+        raco test -c tests/future
         raco test -l tests/db/all-tests
         raco test -c tests/stxparse
         raco test -c tests/syntax
@@ -71,5 +72,6 @@ jobs:
         call racket\raco.exe test -l tests/match/main
         call racket\raco.exe test -l tests/zo-path
         call racket\raco.exe test -c tests/xml
+        call racket\raco.exe test -c tests/future
         call racket\raco.exe test -l tests/db/all-tests
         racket\raco.exe test -c tests/stxparse

--- a/.github/workflows/ci-push.yml
+++ b/.github/workflows/ci-push.yml
@@ -308,6 +308,8 @@ jobs:
         run: raco test -l tests/zo-path
       - name: Run tests/xml
         run: raco test -c tests/xml
+      - name: Run tests/future
+        run: raco test -c tests/future
       - name: Run tests/stxparse
         run: raco test -c tests/stxparse
       - name: Install db tests dependency
@@ -381,6 +383,8 @@ jobs:
         run: raco test -l tests/zo-path
       - name: Run tests/xml
         run: raco test -c tests/xml
+      - name: Run tests/future
+        run: raco test -c tests/future
       - name: Run tests/stxparse
         run: raco test -c tests/stxparse
       - name: Install db tests dependency
@@ -446,6 +450,8 @@ jobs:
         run: raco test -l tests/zo-path
       - name: Run tests/xml
         run: raco test -c tests/xml
+      - name: Run tests/future
+        run: raco test -c tests/future
       - name: Run tests/stxparse
         run: raco test -c tests/stxparse
       - name: Install db tests dependency

--- a/.github/workflows/ci-ubsan.yml
+++ b/.github/workflows/ci-ubsan.yml
@@ -74,6 +74,9 @@ jobs:
     - name: Run tests/xml
       continue-on-error: true
       run: raco test -c tests/xml | tee logs/xml.log
+    - name: Run tests/future
+      continue-on-error: true
+      run: raco test -c tests/future
     - name: Run tests/stxparse
       continue-on-error: true
       run: raco test -c tests/stxparse | tee logs/stxparse.log
@@ -164,6 +167,9 @@ jobs:
     - name: Run tests/xml
       continue-on-error: true
       run: raco test -c tests/xml | tee logs/xml.log
+    - name: Run tests/future
+      continue-on-error: true
+      run: raco test -c tests/future
     - name: Run tests/stxparse
       continue-on-error: true
       run: raco test -c tests/stxparse | tee logs/stxparse.log

--- a/pkgs/racket-test/tests/future/vector-limit.rkt
+++ b/pkgs/racket-test/tests/future/vector-limit.rkt
@@ -38,7 +38,8 @@
     (error "didn't get out-of-memory or shutdown as expected"))
   (printf "ok at ~a\n" size))
 
-(try #x10000)
-(try #x100000)
-(try #x1000000)
-(try #x10000000)
+(unless (eq? (system-type 'gc) 'cgc)
+  (try #x10000)
+  (try #x100000)
+  (try #x1000000)
+  (try #x10000000))


### PR DESCRIPTION
After @mflatt work on futures for CGC (https://github.com/racket/racket/commit/761c577479852938086b7a83946fc03ef5cd1f84),  here's a second attempt at enabling tests.