### PR TITLE
class-internal: avoid wrapping "immediate" opt/kw defaults

### DIFF
--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -12,6 +12,7 @@
          racket/unsafe/undefined
          "class-undef.rkt"
          (for-syntax racket/stxparam
+                     racket/private/immediate-default
                      syntax/kerncase
                      syntax/stx
                      syntax/name
@@ -528,7 +529,7 @@
                                              [(pair? vars)
                                               (syntax-case (car vars) ()
                                                 [(id expr)
-                                                 (identifier? #'id)
+                                                 (and (identifier? #'id) (not (immediate-default? #'expr)))
                                                  ;; optional argument; need to wrap arg expression
                                                  (cons
                                                   (with-syntax ([expr (syntax/loc #'expr


### PR DESCRIPTION
When expanding a method definition, do not wrap the default expression
 for optional and keyword args if it matches `immediate-default?`

#### Benefits

1. Fully-expanded code can avoid an unsafe-undefined runtime check

2. Fixes an unsoundness in Typed Racket (which independently checks `immediate-default?`)

[[ I don't think the TR unsoundness is a danger for any programs, but it's blocking my dissertation work and the TR optimizer. There may be other reasons why the optimizer can't run on methods, though. ]]

- - -

#### Example

This change affects some methods with optional and/or keyword arguments.

First, here's a program that is unaffected because the default is a field (expression):

```
#lang racket

(define c1%
  (class object%
    (super-new)
    (field (my-num 2))
    (define/public (f [x my-num])
      (+ x x))))
```

The core lambda in the expansion of `f` checks for `unsafe-undefined` and evaluates the default expression:

```
(let-values (((|f method in c1%|)
              (lambda (self137815 x14)
               (let-values (((self1378) self137815))
                (let-values (((x)
                              (if (#%app eq? x14 unsafe-undefined)
                                (let-values ()
                                 (let-values ()
                                  (begin 
                                   '(declare-field-use my-num)
                                   (let-values (((obj) self1378))
                                    (#%app my-num2 obj)))))
                                x14)))
                 (let-values ()
                  (let-values ()
                   (let-values ()
                    (#%app + x x)))))))))
  (case-lambda
   ((self1378) (#%app |f method in c1%| self1378 unsafe-undefined))
   ((self1378 x14) (#%app |f method in c1%| self1378 x14))))
```

Second, here's a program that **is** affected.

```
#lang racket

(define c1%
  (class object%
    (super-new)
    (define/public (f [x 42])
      (+ x x))))
```

On master right now, the expansion looks like the example above.

With this PR, there's no `unsafe-undefined` check because the outer `case-lambda` can use the default value:

```
(let-values (((|f method in c1%|)
              (lambda (self137812 x11)
               (let-values (((self1378) self137812))
                (let-values (((x) (if '#f '42 x11)))
                 (let-values ()
                  (let-values ()
                   (let-values ()
                    (#%app + x x)))))))))
  (case-lambda
   ((self1378) (#%app |f method in c1%| self1378 '42))
   ((self1378 x11) (#%app |f method in c1%| self1378 x11))))))
```