### PR TITLE
Fix bug in Racket Guide (7.3.7 Notation).

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/contracts/general-function.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/contracts/general-function.scrbl
@@ -463,13 +463,13 @@ racket
 (define (f) (set! x (cons 'f x)))
 (provide
  (contract-out
-  [f (->i () [_ (begin (set! x (cons 'ctc x)) any/c)])]
+  [f (->i () [_ () (begin (set! x (cons 'ctc x)) any/c)])]
   [get-x (-> (listof symbol?))]))
 ]
 If you were to require this module, call @racket[f], then
 the result of @racket[get-x] would be @racket['(f ctc)]. In
 contrast, if the contract for @racket[f] were
-@racketblock[(->i () [res (begin (set! x (cons 'ctc x)) any/c)])]
+@racketblock[(->i () [res () (begin (set! x (cons 'ctc x)) any/c)])]
 (only changing the underscore to @racket[res]), then
 the result of @racket[get-x] would be @racket['(ctc f)].
 


### PR DESCRIPTION
```(begin (set! x (cons 'ctc x)) any/c)``` should be evaluated whenever ```(f)``` is called. If there isn't an arg list ```()```, it would only be evaluated 1 time.

https://github.com/racket/racket/issues/2711