### PR TITLE
implement dict/c in racket/dict/contract

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/dicts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/dicts.scrbl
@@ -1,8 +1,8 @@
 #lang scribble/doc
-@(require "mz.rkt" (for-label racket/generic))
+@(require "mz.rkt" (for-label racket/generic racket/dict/contract))
 
 @(define dict-eval (make-base-eval))
-@examples[#:hidden #:eval dict-eval (require racket/dict racket/generic racket/contract)]
+@examples[#:hidden #:eval dict-eval (require racket/dict racket/generic racket/contract racket/dict/contract)]
 
 @title[#:tag "dicts"]{Dictionaries}
 
@@ -1013,5 +1013,86 @@ See also @racket[define-custom-hash-types].
 
 
 }
+
+@section{Dictionary Contracts with Wrapping}
+
+@note-lib-only[racket/dict/contract]
+
+@defproc[(dict/c
+          [key/c chaperone-contract?]
+          [value/c contract?]
+          [iter/c contract? any/c]
+          [#:immutable immutable (or/c #t #f 'dont-care) 'dont-care]
+          [#:flat? flat? boolean? #f])
+         contract?]{
+Produces a contract that recognizes @tech{dictionary}s with
+keys and values as specified by the @racket[key/c] and
+@racket[value/c] arguments. The iteration positions for
+@racket[dict-iterate-first] etc. are constrained by the
+@racket[iter/c] argument.
+
+When a non-flat @racket[dict/c] contract is applied to a
+dict, the resulting dict is usually not @racket[equal?] to
+the input.
+
+@examples[
+#:eval dict-eval
+(define/contract good-dict
+  (dict/c integer? boolean? #:immutable #t)
+  '((1 . #t) (2 . #f) (3 . #t)))
+(eval:error
+ (define/contract bad-dict
+   (dict/c integer? boolean? #:immutable #t)
+   '((1 . "elephant") (2 . "monkey") (3 . "manatee"))))]
+
+@itemlist[
+ @item{
+  If the @racket[flat?] argument is @racket[#t], then the
+  resulting contract is a @tech{flat contract}, and the
+  @racket[key/c] and @racket[value/c] arguments must also be
+  @tech{flat contracts}.
+
+  @examples[#:eval dict-eval
+            (flat-contract? (dict/c integer? boolean?))
+            (flat-contract? (dict/c integer? boolean? #:flat? #t))
+            (eval:error (dict/c integer? (-> integer? integer?) #:flat? #t))]
+ 
+  Such @tech{flat contracts} will be unsound if applied to
+  mutable dicts, as they will not check future mutations.
+ }
+ @item{
+  If the @racket[immutable] argument is @racket[#t] and the
+  @racket[key/c], @racket[value/c], and @racket[iter/c]
+  arguments are @tech{flat contract}s, the result will be a
+  @racket[flat-contract?].
+
+  @examples[#:eval dict-eval
+            (flat-contract? (dict/c integer? boolean? #:immutable #t))]
+ }
+ @item{
+  Otherwise the result cannot be a flat contract and
+  @racket[dict/c] produces an impersonator contract which is
+  not a chaperone contract. While the @racket[key/c] must be
+  a chaperone contract, so non-flat @racket[dict/c]
+  contracts cannot be nested as keys for other
+  @racket[dict/c] contracts.
+
+  On both mutable and immutable @tech{dictionary}s when the
+  contract isn't flat, the contract produces a new wrapper
+  dictionary. The wrapper guards calls to @tech{dictionary}
+  methods such as @racket[dict-ref] and @racket[dict-set].
+  On immutable dicts, this means the contract applies even
+  to new keys and values added by @racket[dict-set] after
+  the contract has been applied.
+
+  @examples[
+  #:eval dict-eval
+  (define/contract guarded-dict
+    (dict/c integer? boolean?)
+    '((1 . #t) (2 . #f) (3 . #t)))
+  (eval:error
+   (dict-set guarded-dict 1 "dolphin"))]
+ }
+]}
 
 @close-eval[dict-eval]

--- a/pkgs/racket-test/tests/racket/contract/dict.rkt
+++ b/pkgs/racket-test/tests/racket/contract/dict.rkt
@@ -1,0 +1,299 @@
+#lang racket/base
+(require racket/dict
+         "test-util.rkt")
+
+(define (make-basic-dict-contract-namespace)
+  (define n
+    (make-basic-contract-namespace 'racket/dict 'racket/dict/contract))
+  (parameterize ([current-namespace n])
+    (eval
+     `(begin
+        (struct immutable-dict [hash]
+          #:methods gen:dict
+          [(define (dict-ref self k [d (λ () (error "key not found" k))])
+             (hash-ref (immutable-dict-hash self) k d))
+           (define (dict-set self k v)
+             (immutable-dict (hash-set (immutable-dict-hash self) k v)))
+           (define (dict-remove self k)
+             (immutable-dict (hash-remove (immutable-dict-hash self) k)))
+           (define (dict-count self)
+             (hash-count (immutable-dict-hash self)))
+           (define (dict-iterate-first self)
+             (hash-iterate-first (immutable-dict-hash self)))
+           (define (dict-iterate-next self p)
+             (hash-iterate-next (immutable-dict-hash self) p))
+           (define (dict-iterate-key self p)
+             (hash-iterate-key (immutable-dict-hash self) p))
+           (define (dict-iterate-value self p)
+             (hash-iterate-value (immutable-dict-hash self) p))])
+
+        (struct mutable-dict [hash]
+          #:methods gen:dict
+          [(define (dict-ref self k [d (λ () (error "key not found" k))])
+             (hash-ref (mutable-dict-hash self) k d))
+           (define (dict-set! self k v)
+             (hash-set! (mutable-dict-hash self) k v))
+           (define (dict-remove! self k)
+             (hash-remove! (mutable-dict-hash self) k))
+           (define (dict-count self)
+             (hash-count (mutable-dict-hash self)))
+           (define (dict-iterate-first self)
+             (hash-iterate-first (mutable-dict-hash self)))
+           (define (dict-iterate-next self p)
+             (hash-iterate-next (mutable-dict-hash self) p))
+           (define (dict-iterate-key self p)
+             (hash-iterate-key (mutable-dict-hash self) p))
+           (define (dict-iterate-value self p)
+             (hash-iterate-value (mutable-dict-hash self) p))])
+
+        (define (write-dict d out)
+          (cond [(dict-can-functional-set? d) (write-string "(idict" out)]
+                [(dict-mutable? d) (write-string "(mdict" out)])
+          (for ([(k v) (in-dict d)])
+            (fprintf out " ~v ~v" k v))
+          (write-string ")" out)
+          (void))
+
+        (define (make-mdict [l '()]) (mutable-dict (make-hash l)))
+        (define (make-idict [l '()]) (immutable-dict (make-immutable-hash l)))
+        (define (idict . kvs) (immutable-dict (apply hash kvs))))))
+  n)
+
+(parameterize ([current-contract-namespace (make-basic-dict-contract-namespace)])
+  (test/spec-passed
+   'dict/c1
+   '(contract (dict/c symbol? boolean?)
+              (make-mdict)
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'dict/c1b
+   '(contract (dict/c symbol? boolean? #:flat? #t)
+              (make-mdict)
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'dict/c1c
+   '(let ([h (contract (dict/c symbol? boolean?)
+                       (make-mdict)
+                       'pos
+                       'neg)])
+      (dict-set! h 'x #t)
+      (dict-ref h 'x)))
+
+  (test/neg-blame
+   'dict/c1d
+   '(let ([h (contract (dict/c symbol? boolean?)
+                       (make-mdict)
+                       'pos
+                       'neg)])
+      (dict-set! h 3 #t)))
+
+  (test/neg-blame
+   'dict/c1e
+   '(let ([h (contract (dict/c symbol? boolean?)
+                       (make-mdict)
+                       'pos
+                       'neg)])
+      (dict-set! h 'x 3)))
+
+  (test/neg-blame
+   'dict/c1f
+   '(let ([h (contract (dict/c symbol? boolean?)
+                       (make-mdict)
+                       'pos
+                       'neg)])
+      (dict-ref h 3)))
+
+  (test/spec-passed
+   'dict/c2
+   '(contract (dict/c symbol? boolean?)
+              (let ([h (make-mdict)])
+                (dict-set! h 'x #t)
+                h)
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'dict/c3
+   '(write-dict (contract (dict/c symbol? boolean?)
+                          (let ([h (make-mdict)])
+                            (dict-set! h 'x 'x)
+                            h)
+                          'pos
+                          'neg)
+                (open-output-string)))
+
+  ;; no io, so failure undetected
+  (test/spec-passed
+   'dict/c3b
+   '(contract (dict/c symbol? boolean?)
+              (let ([h (make-mdict)])
+                (dict-set! h 'x 'x)
+                h)
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'dict/c4
+   '(write-dict (contract (dict/c symbol? boolean?)
+                          (let ([h (make-mdict)])
+                            (dict-set! h #t #f)
+                            h)
+                          'pos
+                          'neg)
+                (open-output-string)))
+
+  ;; no io, so failure undetected
+  (test/spec-passed
+   'dict/c4b
+   '(contract (dict/c symbol? boolean?)
+              (let ([h (make-mdict)])
+                (dict-set! h #t #f)
+                h)
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'dict/c5
+   '(contract (dict/c symbol? boolean? #:immutable #t)
+              (let ([h (make-mdict)])
+                (dict-set! h 'x #f)
+                h)
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'dict/c6
+   '(contract (dict/c symbol? boolean? #:immutable #t)
+              (make-idict '((x . #f)))
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'dict/c7
+   '(contract (dict/c symbol? boolean? #:immutable #f)
+              (let ([h (make-mdict)])
+                (dict-set! h 'x #f)
+                h)
+              'pos
+              'neg))
+
+  (test/pos-blame
+   'dict/c8
+   '(contract (dict/c symbol? boolean? #:immutable #f)
+              (make-idict '((x . #f)))
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'dict/c9
+   '(contract (dict/c symbol? boolean? #:immutable 'dont-care)
+              (make-idict '((x . #f)))
+              'pos
+              'neg))
+
+  (test/spec-passed
+   'dict/c10
+   '(contract (dict/c symbol? boolean? #:immutable 'dont-care)
+              (let ([h (make-mdict)])
+                (dict-set! h 'x #f)
+                h)
+              'pos
+              'neg))
+
+  (test/spec-passed/result
+   'dict/c11
+   '(dict-ref (contract (dict/c symbol? number? #:immutable #t)
+                        (make-idict '((x . 1)))
+                        'pos
+                        'neg)
+              'x)
+   1)
+
+  (test/spec-passed/result
+   'dict/c12
+   '(dict-ref (contract (dict/c symbol? number?)
+                        (let ([ht (make-mdict)])
+                          (dict-set! ht 'x 1)
+                          ht)
+                        'pos
+                        'neg)
+              'x)
+   1)
+
+  (test/neg-blame
+   'dict/c13c
+   '(let ([h (contract (dict/c (hash/c number? number?) number?)
+                       (make-mdict)
+                       'pos
+                       'neg)])
+      (dict-set! h (make-hash '((2 . 3))) 2)
+      (dict-set! h (make-hash '((3 . #t))) 3)
+      (for ([(k v) (in-dict h)])
+        (dict-ref k v))))
+
+  (test/neg-blame ; unlike the hash case, this should fail and blame 'neg
+   'dict/c14
+   '(let ()
+      (define h (idict 1 #f))
+      (dict-set (contract (dict/c integer? boolean?) h 'pos 'neg)
+                1 "x")))
+
+  (test/spec-passed/result
+   'dict/c15
+   '(let ()
+      (define h (contract (dict/c any/c any/c) (idict 1 #f) 'pos 'neg))
+      (impersonator-of? (contract (dict/c integer? boolean?) h 'pos 'neg)
+                        h))
+   #t)
+
+  (test/neg-blame ; unlike the hash case, this should fail and blame 'neg
+   'dict/c16
+   '(let ()
+      (define h (hash 1 #f))
+      (define c-h
+        (chaperone-hash
+         h
+         (λ (h k) (values k (λ (h k v) v)))
+         (λ (h k v) (values k v))
+         (λ (h k) k)
+         (λ (h k) k)))
+      (dict-set (contract (dict/c integer? boolean?) c-h 'pos 'neg)
+                1 "x")))
+
+  (test/spec-passed/result
+   'dict/c17
+   '(let ()
+      (define h (hash 1 #f))
+      (define c-h
+        (contract (dict/c any/c any/c) h 'pos 'neg))
+      (impersonator-of? (contract (dict/c integer? boolean?) c-h 'pos 'neg)
+                        c-h))
+   #t)
+
+  (test/no-error
+   '(let ([v (chaperone-hash (make-immutable-hash (list (cons 1 2)))
+                             (λ (hash k) (values k (λ (h k v) v)))
+                             (λ (hash k v) (values k v))
+                             (λ (hash k) k)
+                             (λ (hash k) k))])
+      (contract (dict/c any/c any/c) v 'pos 'neg)))
+
+  (test/no-error
+   '(let ([v (chaperone-hash (make-immutable-hasheq (list (cons 1 2)))
+                             (λ (hash k) (values k (λ (h k v) v)))
+                             (λ (hash k v) (values k v))
+                             (λ (hash k) k)
+                             (λ (hash k) k))])
+      (contract (dict/c any/c any/c) v 'pos 'neg)))
+
+  (test/no-error
+   '(let ([v (chaperone-hash (make-immutable-hasheqv (list (cons 1 2)))
+                             (λ (hash k) (values k (λ (h k v) v)))
+                             (λ (hash k v) (values k v))
+                             (λ (hash k) k)
+                             (λ (hash k) k))])
+      (contract (dict/c any/c any/c) v 'pos 'neg))))

--- a/racket/collects/racket/dict/contract.rkt
+++ b/racket/collects/racket/dict/contract.rkt
@@ -1,0 +1,501 @@
+#lang racket/base
+
+(provide dict/c)
+
+(require racket/contract
+         racket/dict
+         racket/match
+         racket/list
+         (for-syntax racket/base
+                     racket/list
+                     racket/syntax
+                     syntax/stx))
+
+;; ---------------------------------------------------------
+
+;; dict/c :
+;;   ChaperoneContract
+;;   Contract
+;;   [Contract]
+;;   [#:immutable (U Bool 'dont-care)]
+;;   [#:flat? Bool]
+;;   ->
+;;   Contract
+;; The iter contract is only checked if it's not flat
+(define (dict/c dom rng
+                [iter any/c]
+                #:immutable [immutable 'dont-care]
+                #:flat? [flat? #f])
+  (unless (member immutable '(#t #f dont-care))
+    (raise-argument-error 'dict/c
+                          "(or/c #t #f 'dont-care) for the #:immutable argument"
+                          immutable))
+  (define dom-ctc (if flat?
+                      (coerce-flat-contract 'dict/c dom)
+                      (coerce-chaperone-contract 'dict/c dom)))
+  (define rng-ctc (if flat?
+                      (coerce-flat-contract 'dict/c rng)
+                      (coerce-contract 'dict/c rng)))
+  (define iter-ctc (if flat?
+                       any/c
+                       (coerce-contract 'dict/c iter)))
+  (cond
+    [(or flat?
+         (and (eq? immutable #t)
+              (flat-contract? dom-ctc)
+              (flat-contract? rng-ctc)
+              (flat-contract? iter-ctc)))
+     (flat-dict/c dom-ctc rng-ctc any/c immutable)]
+    [else
+     (impersonator-dict/c dom-ctc rng-ctc iter-ctc immutable)]))
+
+;; immutable-dict? : Any -> Bool
+(define (immutable-dict? d)
+  (and (dict? d)
+       (dict-implements? d 'dict-set 'dict-remove)
+       (not (or (dict-implements? d 'dict-set!)
+                (dict-implements? d 'dict-remove!)))))
+
+;; mutable-dict? : Any -> Bool
+(define (mutable-dict? d)
+  (and (dict? d)
+       (dict-implements? d 'dict-set! 'dict-remove!)
+       (not (or (dict-implements? d 'dict-set)
+                (dict-implements? d 'dict-remove)))))
+
+;; dict-key-chaperone-allowed? : Any -> Bool
+;; Returns true if `d` can work with chaperones on keys.
+;; Hashes based on `equal?` can, but not on `eq?` or `eqv?`
+(define (dict-key-chaperone-allowed? d)
+  (cond [(hash? d) (hash-equal? d)]
+        [else #t]))
+
+;; ---------------------------------------------------------
+
+;; ... --> boolean
+;;  returns #t when it called raise-blame-error, #f otherwise
+(define (check-dict/c dom-ctc immutable flat? val blame neg-party) 
+  (cond
+    [(dict? val)
+     (cond
+       [(and (not flat?)
+             (not (flat-contract? dom-ctc))
+             (not (dict-key-chaperone-allowed? val)))
+        (raise-blame-error
+         blame val #:missing-party neg-party
+         '(expected
+           "equal?-based dict due to higher-order domain contract"
+           given:
+           "~e")
+         val)
+        #t]
+       [else
+        (case immutable
+          [(#t) 
+           (cond
+             [(immutable-dict? val) 
+              #f]
+             [else
+              (raise-blame-error 
+               blame val #:missing-party neg-party
+               '(expected "an immutable dict" given: "~e") val)
+              #t])]
+          [(#f)
+           (cond
+             [(mutable-dict? val)
+              #f]
+             [else
+              (raise-blame-error 
+               blame val #:missing-party neg-party
+               '(expected "a mutable dict" given: "~e") val)
+              #t])]
+          [(dont-care) #f])])]
+    [else 
+     (raise-blame-error blame val #:missing-party neg-party
+                        '(expected "a dict" given: "~e") val)
+     #t]))
+
+(define (dict/c-first-order ctc)
+  (define dom-ctc (base-dict/c-dom ctc))
+  (define rng-ctc (base-dict/c-rng ctc))
+  (define immutable (base-dict/c-immutable ctc))
+  (define flat? (flat-dict/c? ctc))
+  (λ (val)
+    (and (dict? val)
+         (or flat?
+             (flat-contract? dom-ctc)
+             (dict-key-chaperone-allowed? val))
+         (case immutable
+           [(#t) (immutable-dict? val)]
+           [(#f) (mutable-dict? val)]
+           [else #t])
+         (for/and ([(k v) (in-dict val)])
+           (and (contract-first-order-passes? dom-ctc k)
+                (contract-first-order-passes? rng-ctc v))))))
+
+(define (dict/c-name ctc)
+  (apply 
+   build-compound-type-name
+   'dict/c (base-dict/c-dom ctc) (base-dict/c-rng ctc)
+   (append
+    (if (or (flat-dict/c? ctc) (equal? (base-dict/c-iter ctc) any/c))
+        '()
+        (list (base-dict/c-iter ctc)))
+    (if (and (flat-dict/c? ctc)
+             (not (eq? (base-dict/c-immutable ctc) #t)))
+        (list '#:flat? #t)
+        '())
+    (case (base-dict/c-immutable ctc)
+      [(dont-care) '()]
+      [(#t)
+       (list '#:immutable #t)]
+      [(#f)
+       (list '#:immutable #f)]))))
+
+(struct base-dict/c [dom rng iter immutable])
+
+(define (dict/c-stronger this that)
+  (define this-dom (base-dict/c-dom this))
+  (define this-rng (base-dict/c-rng this))
+  (define this-iter (base-dict/c-iter this))
+  (define this-immutable (base-dict/c-immutable this))
+  (cond
+    [(base-dict/c? that)
+     (define that-dom (base-dict/c-dom that))
+     (define that-rng (base-dict/c-rng that))
+     (define that-iter (base-dict/c-iter that))
+     (define that-immutable (base-dict/c-immutable that))
+     (cond
+       [(and (equal? this-immutable #t)
+             (equal? that-immutable #t))
+        (and (contract-stronger? this-dom that-dom)
+             (contract-stronger? this-rng that-rng)
+             (contract-stronger? this-iter that-iter))]
+       [(or (equal? that-immutable 'dont-care)
+            (equal? this-immutable that-immutable))
+        (and (contract-equivalent? this-dom that-dom)
+             (contract-equivalent? this-rng that-rng)
+             (contract-equivalent? this-iter that-iter))]
+       [else #f])]
+    [else #f]))
+
+(define (dict/c-equivalent this that)
+  (cond
+    [(base-dict/c? that)
+     (define this-dom (base-dict/c-dom this))
+     (define this-rng (base-dict/c-rng this))
+     (define this-iter (base-dict/c-iter this))
+     (define this-immutable (base-dict/c-immutable this))
+     (define that-dom (base-dict/c-dom that))
+     (define that-rng (base-dict/c-rng that))
+     (define that-iter (base-dict/c-iter that))
+     (define that-immutable (base-dict/c-immutable that))
+     (and (equal? this-immutable that-immutable)
+          (contract-equivalent? this-dom that-dom)
+          (contract-equivalent? this-rng that-rng)
+          (contract-equivalent? this-iter that-iter))]
+    [else #f]))
+
+;; Will periodically generate empty dicts and dicts with multiple elements
+;; Only generates hashes, ignores iter
+(define (dict/c-generate ctc)
+  (define this-dom (base-dict/c-dom ctc))
+  (define this-rng (base-dict/c-rng ctc))
+  (define this-immutable (base-dict/c-immutable ctc))
+  (define hsh (hash/c this-dom this-rng #:immutable this-immutable))
+  (λ (fuel)
+    (contract-random-generate/choose hsh fuel)))
+
+(struct flat-dict/c base-dict/c []
+  #:omit-define-syntaxes
+  #:property prop:custom-write custom-write-property-proc
+  #:property prop:flat-contract
+  (build-flat-contract-property
+   #:name dict/c-name
+   #:first-order dict/c-first-order
+   #:generate dict/c-generate
+   #:stronger dict/c-stronger
+   #:equivalent dict/c-equivalent
+   #:late-neg-projection
+   (λ (ctc)
+     (define dom-ctc (base-dict/c-dom ctc))
+     (define immutable (base-dict/c-immutable ctc))
+     (define flat? (flat-dict/c? ctc))
+     (λ (blame)
+       (define dom-proj ((get/build-late-neg-projection (base-dict/c-dom ctc))
+                         (blame-add-key-context blame #f)))
+       (define rng-proj ((get/build-late-neg-projection (base-dict/c-rng ctc))
+                         (blame-add-value-context blame #f)))
+       (λ (val neg-party)
+         (cond
+           [(check-dict/c dom-ctc immutable flat? val blame neg-party)
+            val]
+           [else
+            (for ([(k v) (in-dict val)])
+              (dom-proj k neg-party)
+              (rng-proj v neg-party))
+            val]))))))
+
+(define ho-projection
+  (λ (ctc)
+    (define immutable (base-dict/c-immutable ctc))
+    (define dom-ctc (base-dict/c-dom ctc))
+    (define rng-ctc (base-dict/c-rng ctc))
+    (define iter-ctc (base-dict/c-iter ctc))
+    (define flat? (flat-dict/c? ctc))
+    (λ (blame)
+      (λ (val neg-party)
+        (cond
+          [(check-dict/c dom-ctc immutable flat? val blame neg-party)
+           val]
+          [else
+           (handle-the-dict val
+                            neg-party
+                            dom-ctc
+                            rng-ctc
+                            iter-ctc
+                            blame)])))))
+
+(define (blame-add-key-context blame swap?)
+  (blame-add-context blame "the keys of" #:swap? swap?))
+(define (blame-add-value-context blame swap?)
+  (blame-add-context blame "the values of" #:swap? swap?))
+
+(define (handle-the-dict val
+                         neg-party
+                         dom-ctc
+                         rng-ctc
+                         iter-ctc
+                         blame)
+  (define blame+neg-party (blame-replace-negative blame neg-party))
+  (wrap/add-layer (layer blame+neg-party dom-ctc rng-ctc iter-ctc) val))
+
+(struct impersonator-dict/c base-dict/c ()
+  #:omit-define-syntaxes
+  #:property prop:custom-write custom-write-property-proc
+  #:property prop:contract
+  (build-contract-property
+   #:name dict/c-name
+   #:first-order dict/c-first-order
+   #:stronger dict/c-stronger
+   #:equivalent dict/c-equivalent
+   #:late-neg-projection ho-projection))
+
+;; ---------------------------------------------------------
+
+;; A Dict/Contract is a (dict/contract [Listof Layer] Dict)
+;; meant as a parent struct for the actual wrappers for dicts
+;; immutable, mutable, and ?mutable
+;; A Layer is a (layer Blame ChaperoneCtc Ctc Ctc)
+;; inputs go through layers in the list order
+;; outputs go through layers in reverse order
+(struct dict/contract [layers dict])
+(struct layer [blame key/c value/c iter/c])
+
+;; Definig all the methods based on the roles of the inputs and outputs.
+;; Self is the Dict/Contract instance
+;; Key must be checked with key/c
+;; Value must be checked with value/c
+;; Iter must be checked with iter/c
+;; Default must use the escape-continuation
+
+(begin-for-syntax
+  ;; A Role is a one of:
+  ;;  - 'self
+  ;;  - (role (U Identifier #f) (U Identifier #f) Boolean)
+  ;; if escape is false:
+  ;;   wrap-in is an id for a function [[Listof Layer] X -> X]
+  ;;   wrap-out is an id for a function [[Listof Layer] X -> X]
+  ;; if escape is true:
+  ;;   wrap-in is for a function [[Listof Layer] EscapeContinuation X -> X]
+  ;;   wrap-out is for a function [[Listof Layer] EscapeContinuation X -> X]
+  ;; a #f for wrap-in means the role shouldn't be used for inputs
+  ;; a #f for wrap-out means the role shouldn't be used for outputs
+  (struct role [wrap-in wrap-out escape])
+  (define (role/self? r) (or (eq? r 'self) (role? r)))
+  (define (role-escape? r) (and (not (eq? r 'self)) (role-escape r)))
+  (define (lookup-role/record id) (syntax-local-value/record id role/self?)))
+
+(define-syntax define-dict-op-role
+  (λ (stx)
+    (syntax-case stx []
+      [(_ id #:self) #'(define-syntax id 'self)]
+      [(_ id #:in in) #'(define-syntax id (role (quote-syntax in) #f #f))]
+      [(_ id #:in in #:escape) #'(define-syntax id (role (quote-syntax in) #f #t))]
+      [(_ id #:out out) #'(define-syntax id (role #f (quote-syntax out) #f))]
+      [(_ id #:in in #:out out)
+       #'(define-syntax id (role (quote-syntax in) (quote-syntax out) #f))])))
+
+(define-dict-op-role Self #:self)
+(define-dict-op-role Dict #:in dict-in #:out dict-out)
+(define-dict-op-role Key #:in key-in #:out key-out)
+(define-dict-op-role Value #:in value-in #:out value-out)
+(define-dict-op-role Iter #:in iter-in)
+(define-dict-op-role MaybeIter #:out maybe-iter-out)
+(define-dict-op-role Default #:in default-in #:escape)
+(define-dict-op-role Void #:out void-out)
+(define-dict-op-role Nat #:out nat-out)
+
+(define-syntax-rule (define-dict-ops clause ...)
+  (begin (define-dict-op . clause) ...))
+
+(define-syntax define-dict-op
+  (λ (stx)
+    (syntax-case stx []
+      [(_ id op #:: in ... #:-> out)
+       (with-disappeared-uses
+         (define-values [mand opt]
+           (splitf-at (syntax->list #'(in ...)) identifier?))
+         (define mand-roles (map lookup-role/record mand))
+         (define opt-roles (map (compose lookup-role/record stx-car) opt))
+         (define out-role (lookup-role/record #'out))
+         (define mand-tmps (generate-temporaries mand))
+         (define opt-tmps (generate-temporaries opt))
+         (define self-tmp (list-ref mand-tmps (index-of mand-roles 'self)))
+         (define layers-tmp (generate-temporary 'layers))
+         ;; escape-index : (U #f Nat)
+         ;; The first case index where an escape is needed, if at all
+         (define escape-index
+           (cond [(or (ormap role-escape? mand-roles) (role-escape? out-role)) 0]
+                 [(index-where opt-roles role-escape?) => add1]
+                 [else #f]))
+         (define escape-tmp (and escape-index (generate-temporary 'escape)))
+         (define (in-expr role expr)
+           (cond [(eq? role 'self) #`(dict/contract-dict #,expr)]
+                 [(role-escape? role)
+                  #`(#,(role-wrap-in role) #,layers-tmp #,escape-tmp #,expr)]
+                 [else #`(#,(role-wrap-in role) #,layers-tmp #,expr)]))
+         (define (out-expr expr)
+           (cond [(role-escape? out-role)
+                  #`(#,(role-wrap-out out-role) #,layers-tmp #,escape-tmp #,expr)]
+                 [else #`(#,(role-wrap-out out-role) #,layers-tmp #,expr)]))
+         (define mand-exprs (map in-expr mand-roles mand-tmps))
+         (define opt-exprs (map in-expr opt-roles opt-tmps))
+         (define lam-cases
+           (for/list ([i (in-range (add1 (length opt-roles)))])
+             #`[(#,@mand-tmps #,@(take opt-tmps i))
+                (let ([#,layers-tmp (dict/contract-layers #,self-tmp)])
+                  #,(if (and escape-index (<= escape-index i))
+                        #`(let/ec #,escape-tmp
+                            #,(out-expr #`(op #,@mand-exprs #,@(take opt-exprs i))))
+                        (out-expr #`(op #,@mand-exprs #,@(take opt-exprs i)))))]))
+         #`(define id (case-lambda #,@lam-cases)))])))
+
+(define-dict-ops
+  [dref dict-ref #:: Self Key [Default] #:-> Value]
+  [dset! dict-set! #:: Self Key Value #:-> Void]
+  [dset dict-set #:: Self Key Value #:-> Dict]
+  [dremove! dict-remove! #:: Self Key #:-> Void]
+  [dremove dict-remove #:: Self Key #:-> Dict]
+  [dcount dict-count #:: Self #:-> Nat]
+  [diterate-first dict-iterate-first #:: Self #:-> MaybeIter]
+  [diterate-next dict-iterate-next #:: Self Iter #:-> MaybeIter]
+  [diterate-key dict-iterate-key #:: Self Iter #:-> Key]
+  [diterate-value dict-iterate-value #:: Self Iter #:-> Value])
+
+;; a wrapper for immutable dicts
+(struct immutable-dict/contract dict/contract []
+  #:property prop:dict
+  (vector-immutable dref #f dset #f dremove dcount
+                    diterate-first diterate-next diterate-key diterate-value)
+  #:methods gen:equal+hash
+  [;; immutable can use equal
+   (define (equal-proc self other rec)
+     (rec (dict/contract-dict self) (dict/contract-dict other)))
+   (define (hash-proc self rec)
+     (rec (dict/contract-dict self)))
+   (define (hash2-proc self rec)
+     (rec (dict/contract-dict self)))])
+
+;; a wrapper for mutable dicts
+(struct mutable-dict/contract dict/contract []
+  #:property prop:dict
+  (vector-immutable dref dset! #f dremove! #f dcount
+                    diterate-first diterate-next diterate-key diterate-value)
+  #:methods gen:equal+hash
+  [;; mutable uses eq
+   (define (equal-proc self other rec)
+     (eq? (dict/contract-dict self) (dict/contract-dict other)))
+   (define (hash-proc self rec)
+     (eq-hash-code (dict/contract-dict self)))
+   (define (hash2-proc self rec)
+     (eq-hash-code (dict/contract-dict self)))])
+
+;; a wrapper for dicts of unknown mutability
+(struct ?mutable-dict/contract dict/contract []
+  #:property prop:dict
+  (vector-immutable dref dset! dset dremove! dremove dcount
+                    diterate-first diterate-next diterate-key diterate-value)
+  #:methods gen:equal+hash
+  [;; potentially mutable uses eq
+   (define (equal-proc self other rec)
+     (eq? (dict/contract-dict self) (dict/contract-dict other)))
+   (define (hash-proc self rec)
+     (eq-hash-code (dict/contract-dict self)))
+   (define (hash2-proc self rec)
+     (eq-hash-code (dict/contract-dict self)))])
+
+;; wrap/add-layer : Layer Dict -> Dict/Contract
+(define (wrap/add-layer l1 d1)
+  (match d1
+    [(immutable-dict/contract ls2 d2) (immutable-dict/contract (cons l1 ls2) d2)]
+    [(mutable-dict/contract ls2 d2)   (mutable-dict/contract (cons l1 ls2) d2)]
+    [(?mutable-dict/contract ls2 d2)  (?mutable-dict/contract (cons l1 ls2) d2)]
+    [_                                (wrap/all-layers (list l1) d1)]))
+
+;; wrap/all-layers : [Listof Layer] Dict -> Dict/Contract
+(define (wrap/all-layers ls d)
+  (cond [(immutable-dict? d) (immutable-dict/contract ls d)]
+        [(mutable-dict? d)   (mutable-dict/contract ls d)]
+        [else                (?mutable-dict/contract ls d)]))
+
+;; ---------------------------------------------------------
+
+(define (dict-out ls d) (wrap/all-layers ls d))
+
+;; inputs go through layers in the list order, so first layer
+(define (default-in ls escape default)
+  (cond [(empty? ls) default]
+        [else
+         (define d
+           (project-in (layer-blame (first ls)) failure-result/c default))
+         (cond [(procedure? d) (λ () (escape (d)))]
+               [else (λ () (escape d))])]))
+;; outputs go through layers reverse order, so last layer
+(define (void-out ls v)
+  (cond [(empty? ls) v]
+        [else (project-out (layer-blame (last ls)) void? v)]))
+(define (nat-out ls n)
+  (cond [(empty? ls) n]
+        [else (project-out (layer-blame (last ls)) natural-number/c n)]))
+
+(define (key-in ls k) (layers-in ls layer-key/c k))
+(define (key-out ls k) (layers-out ls layer-key/c k))
+
+(define (value-in ls v) (layers-in ls layer-value/c v))
+(define (value-out ls v) (layers-out ls layer-value/c v))
+
+(define (iter-in ls i) (layers-in ls layer-iter/c i))
+(define (maybe-iter-out ls i) (and i (layers-out ls layer-iter/c i)))
+
+;; layers-in : [Listof Layer] [Layer -> Contract] Any -> Any
+;; inputs go through layers in the list order
+(define (layers-in ls l->c v)
+  (for/fold ([v v]) ([l (in-list ls)])
+    (project-in (layer-blame l) (l->c l) v)))
+
+;; layers-out : [Listof Layer] [Layer -> Contract] Any -> Any
+;; outputs go through layers reverse order
+(define (layers-out ls l->c v)
+  (for/fold ([v v]) ([l (in-list (reverse ls))])
+    (project-out (layer-blame l) (l->c l) v)))
+
+;; project-in : Blame Contract Any -> Any
+(define (project-in blame ctc v)
+  (((contract-projection ctc) (blame-swap blame)) v))
+
+;; project-out : Blame Contract Any -> Any
+(define (project-out blame ctc v)
+  (((contract-projection ctc) blame) v))
+
+;; ---------------------------------------------------------


### PR DESCRIPTION
This pull request adds a `dict/c` contract combinator to a new module `racket/dict/contract`. `(dict/c key/c value/c)` is similar to a generic dictionary version of `(hash/c key/c value/c)`.