### PR TITLE
net/uri-codec: fix contracts for ->alist and alist-> fns

### DIFF
--- a/pkgs/net-doc/net/scribblings/uri-codec.scrbl
+++ b/pkgs/net-doc/net/scribblings/uri-codec.scrbl
@@ -12,10 +12,10 @@
 provides utilities for encoding and decoding strings using the URI
 encoding rules given in RFC 2396 @cite["RFC2396"], and to encode and
 decode name/value pairs using the
-@tt{application/x-www-form-urlencoded} mimetype given the in HTML 4.0
+@tt{application/x-www-form-urlencoded} mimetype given in the HTML 4.0
 specification.  There are minor differences between the two encodings.}
 
-The URI encoding uses allows a few characters to be represented as-is:
+The URI encoding allows a few characters to be represented as-is:
 @litchar{a} through @litchar{z}, @litchar{A} through @litchar{Z},
 @litchar{0}-@litchar{9}, @litchar{-}, @litchar{_}, @litchar{.},
 @litchar{!}, @litchar{~}, @litchar{*}, @litchar{'}, @litchar{(} and
@@ -120,7 +120,7 @@ Decode a string encoded using the
 @tt{application/x-www-form-urlencoded} encoding rules.}
 
 
-@defproc[(alist->form-urlencoded [alist (listof (cons/c symbol? string?))])
+@defproc[(alist->form-urlencoded [alist (listof (cons/c symbol? (or/c false/c string?)))])
          string?]{
 
 Encode an association list using the
@@ -131,7 +131,7 @@ separator used in the result.}
 
 
 @defproc[(form-urlencoded->alist [str string])
-         (listof (cons/c symbol? string?))]{
+         (listof (cons/c symbol? (or/c false/c string?)))]{
 
 Decode a string encoded using the
 @tt{application/x-www-form-urlencoded} encoding rules into an

--- a/pkgs/net-test/tests/net/uri-codec.rkt
+++ b/pkgs/net-test/tests/net/uri-codec.rkt
@@ -18,6 +18,12 @@
             "\u645\u627\u646\u6cc\u2f\u62d\u642\u648\u642\u2d\u628\u634\u631\u2d"
             "\u645\u6cc\u62f\u6cc\u627\u2f\u31\u32\u35\u34\u36\u2d")
 
+        (alist->form-urlencoded '([a . #f])) => "a"
+        (form-urlencoded->alist "a") => '([a . #f])
+
+        (alist->form-urlencoded '([a . ""])) => "a="
+        (form-urlencoded->alist "a=") => '([a . ""])
+
         (alist->form-urlencoded '([a . "hel+lo \u7238"]))
         => "a=hel%2Blo+%E7%88%B8"
         (form-urlencoded->alist


### PR DESCRIPTION
The behavior was already correct, but the contracts in the
documentation did not reflect it.