### PR TITLE
setup: Don’t count main docs as user docs when tidying

### DIFF
--- a/pkgs/racket-index/setup/scribble.rkt
+++ b/pkgs/racket-index/setup/scribble.rkt
@@ -412,23 +412,22 @@
                (not latex-dest)
                infos)
       (log-setup-info "tidying database")
-      (define files (make-hash))
       (define tidy-docs (if tidy?
                             docs
                             (map info-doc infos)))
-      (define (get-files! main?)
+      (define (get-files main?)
+        (define files (make-hash))
         (for ([doc (in-list tidy-docs)]
               #:when (eq? main? (main-doc? doc)))
           (hash-set! files (sxref-path latex-dest doc "in.sxref") #t)
           (for ([c (in-range (add1 (doc-out-count doc)))])
-            (hash-set! files (sxref-path latex-dest doc (format "out~a.sxref" c)) #t))))
+            (hash-set! files (sxref-path latex-dest doc (format "out~a.sxref" c)) #t)))
+        files)
       (unless avoid-main?
-        (get-files! #t)
-        (doc-db-clean-files main-db files))
+        (doc-db-clean-files main-db (get-files #t)))
       (when (and (file-exists? user-db)
                  (not (equal? main-db user-db)))
-        (get-files! #f)
-        (doc-db-clean-files user-db files))))
+        (doc-db-clean-files user-db (get-files #f)))))
 
   (define (make-loop first? iter)
     (let ([infos (filter-not info-failed? infos)]


### PR DESCRIPTION
Disclaimer: I am not certain this fix is right, as I don’t actually understand how most of this code works.

Context: I have been getting spurious duplicate tag warnings when running `raco setup` for well over a year now, which were confusingly complaining about duplicate tags coming from the same document. Since they didn’t seem to be causing any problems, and it wasn’t clear what was causing them, I didn’t do anything about it. But today I decided enough was enough, and I looked into where they were coming from.

I discovered I had a bunch of entries in my user doc db (for version `development`) that looked like this:

```
(dep ((lib "setup/plt-installer.rkt") run-single-installer))
(index-entry (def ((lib "setup/plt-installer.rkt") run-installer)))
(mod-path "setup/plt-installer")
(part ("(lib setup/plt-installer.scrbl)" "top"))
(index-entry (mod-path "setup/plt-installer"))
(index-entry (part ("(lib setup/plt-installer.scrbl)" "gui-unpacking")))
(def ((lib "setup/plt-installer.rkt") run-single-installer))
(def ((lib "setup/plt-installer.rkt") on-installer-run))
```

This was consistent with the warnings I was getting, which were about `setup/plt-installer.scrbl`. However, this didn’t make any sense to me, as I have exactly zero packages installed in user scope. Maybe I did at one point in the distant past, but I definitely don’t anymore.

I don’t think those entries should be there, but due to the way the currenty tidying code is written, main docs aren’t pruned from the user doc db. I am not sure why the code is written that way, but it doesn’t seem intentional, as the main docs would not be included in the hash table if `--avoid-main` were specified, which suggests it’s okay to prune those entries from the user db.

This PR therefore just builds two hash tables instead of reusing the same one twice. Happily, this made my duplicate tag warnings go away.