### PR TITLE
Fix typos in guide

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/distributed.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/distributed.scrbl
@@ -51,7 +51,7 @@ symbol.
 The code for the tuple-server place exists in the file
 @filepath{tuple.rkt}.  The @filepath{tuple.rkt} file contains the use of
 @racket[define-named-remote-server] form, which defines a RPC server
-suitiable for invocation by @racket[supervise-place-at].
+suitable for invocation by @racket[supervise-place-at].
 
 
 

--- a/pkgs/racket-doc/scribblings/guide/for.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/for.scrbl
@@ -193,7 +193,7 @@ mutually nested, instead of in parallel, even with @racket[for].
   (printf "~a Chapter ~a. ~a\n" book i chapter))
 ]
 
-An @racket[#:unless] clause is analogus to a @racket[#:when] clause, but
+An @racket[#:unless] clause is analogous to a @racket[#:when] clause, but
 the @racket[_body]s evaluate only when the @racket[_boolean-expr]
 produces a false value.
 

--- a/pkgs/racket-doc/scribblings/guide/places.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/places.scrbl
@@ -55,7 +55,7 @@ then calls @racket[any-double?] on the list and binds the result to
 In DrRacket, after saving and running the above program, evaluate
 @racket[(main)] in the interactions window to create the new
 place. @margin-note*{When using @tech{places} inside DrRacket, the
-module containg place code must be saved to a file before it will
+module containing place code must be saved to a file before it will
 execute.}  Alternatively, save the program as @filepath{double.rkt}
 and run from a command line with
 

--- a/pkgs/racket-doc/scribblings/guide/proc-macros.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/proc-macros.scrbl
@@ -36,7 +36,7 @@ lexical-binding information with each part of the form. The
 source-location information is used when reporting syntax errors (for
 example), and the lexical-binding information allows the macro system
 to maintain lexical scope. To accommodate this extra information, the
-represention of the expression @racket[(+ 1 2)] is not merely
+representation of the expression @racket[(+ 1 2)] is not merely
 @racket['(+ 1 2)], but a packaging of @racket['(+ 1 2)] into a syntax
 object.
 
@@ -330,7 +330,7 @@ turned partially inside-out.
 As sets of macros get more complicated, you might want to write
 your own helper functions, like
 @racket[generate-temporaries]. For example, to provide good
-syntax error messsages, @racket[swap], @racket[rotate], and
+syntax error messages, @racket[swap], @racket[rotate], and
 @racket[define-cbr] all should check that certain sub-forms in
 the source form are identifiers. We could use a
 @racket[check-ids] function to perform this checking everywhere:

--- a/pkgs/racket-doc/scribblings/guide/running.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/running.scrbl
@@ -30,7 +30,7 @@ runs in @seclink["start-interactive-mode"]{interactive mode},
 @subsection[#:tag "start-interactive-mode"]{Interactive Mode}
 
 When @exec{racket} is run with no command-line arguments (other than
-confguration options, like @Flag{j}), then it starts a @tech{REPL}
+configuration options, like @Flag{j}), then it starts a @tech{REPL}
 with a @litchar{> } prompt:
 
 @verbatim[#:indent 2]{

--- a/racket/collects/racket/HISTORY.txt
+++ b/racket/collects/racket/HISTORY.txt
@@ -1788,7 +1788,7 @@ Changed initial setting of current-library-collection-paths
 Unit definitions and embedded definitions are not allowed
  to shadow syntax or macro names; this restriction resolves
  all potential ambiguity resulting from shadowing syntax
-Changed display for symbols containg special characters:
+Changed display for symbols containing special characters:
  the special characters are not escaped (or bar-quoted)
 Changed write to use the value of (read-accept-bar-quote)
  for printing symbols containing special characters; if

--- a/racket/src/racket/gc/thread_local_alloc.c
+++ b/racket/src/racket/gc/thread_local_alloc.c
@@ -235,7 +235,7 @@ extern int GC_gcj_kind;
 /* fundamental issue is that we may end up marking a free list, which	*/
 /* has freelist links instead of "vtable" pointers.  That is usually	*/
 /* OK, since the next object on the free list will be cleared, and	*/
-/* will thus be interpreted as containg a zero descriptor.  That's fine	*/
+/* will thus be interpreted as containing a zero descriptor.  That's fine	*/
 /* if the object has not yet been initialized.  But there are		*/
 /* interesting potential races.						*/
 /* In the case of incremental collection, this seems hopeless, since	*/


### PR DESCRIPTION
Fix a few typos in the docs in the guide