### PR TITLE
XDG Base Directory support

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/config.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/config.scrbl
@@ -161,8 +161,8 @@ directory}:
  @item{@indexed-racket['download-cache-dir] --- a path string used as
        the location for storing downloaded package archives. When not
        specified, packages are cached in a @filepath{download-cache}
-       directory in the user's add-on directory as reported by
-       @racket[(find-system-path 'addon-dir)].}
+       directory in the user's cache directory as reported by
+       @racket[(find-system-path 'cache-dir)].}
 
  @item{@indexed-racket['download-cache-max-files] and
        @indexed-racket['download-cache-max-bytes] --- real numbers that

--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -82,8 +82,9 @@ by @racket[kind], which must be one of the following:
  if it is defined, otherwise it is the current directory.}
 
  @item{@indexed-racket['init-dir] --- the directory containing the
- initialization file used by the Racket executable.
- It is the same as the @tech{user's home directory}.}
+ initialization file used by the Racket executable.  On Unix, it is
+ the same as the result returned for @racket['pref-dir]; on Mac OS and
+ Windows, it is the same as the @tech{user's home directory}.}
 
  @item{@indexed-racket['init-file] --- the file loaded at start-up by
  the Racket executable. The directory part of the
@@ -92,9 +93,9 @@ by @racket[kind], which must be one of the following:
 
   @itemize[
 
-  @item{@|AllUnix|: @indexed-file{.racketrc}}
+  @item{Unix and Windows: @indexed-file{racketrc.rktl}}
 
-  @item{Windows: @indexed-file{racketrc.rktl}}
+  @item{Mac OS: @indexed-file{.racketrc}}
 
   ]}
 

--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -52,8 +52,11 @@ by @racket[kind], which must be one of the following:
  the current executable is used as the home directory.}
 
  @item{@indexed-racket['pref-dir] --- the standard directory for
- storing the current user's preferences. On Unix, the directory is
- @filepath{.racket} in the @tech{user's home directory}.  On Windows,
+ storing the current user's preferences. On Unix, the directory is the
+ @filepath{racket} subdirectory of the path specified by
+ @indexed-envvar{XDG_CONFIG_HOME}, or @filepath{.config/racket} in the
+ @tech{user's home directory} if @envvar{XDG_CONFIG_HOME} is not set to
+ an absolute path. On Windows,
  it is @filepath{Racket} in the @tech{user's home directory} if
  determined by @envvar{PLTUSERHOME}, otherwise in the user's
  application-data folder as specified by the Windows registry; the
@@ -121,8 +124,11 @@ by @racket[kind], which must be one of the following:
  environment variable or flag is specified, or if the value is not a
  legal path name, then this directory defaults to
  @filepath{Library/Racket} in the @tech{user's home directory} on Mac
- OS and @racket['pref-dir] otherwise.  The directory might not
- exist.}
+ OS and @racket['pref-dir] on Windows. On Unix, it is the
+ @filepath{racket} subdirectory of the path specified by
+ @indexed-envvar{XDG_DATA_HOME}, or @filepath{.local/share/racket} in
+ the @tech{user's home directory} if @envvar{XDG_CONFIG_HOME} is not
+ set to an absolute path.  The directory might not exist.}
 
  @item{@indexed-racket['doc-dir] --- the standard directory for
  storing the current user's documents. On Unix, it's

--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -131,6 +131,14 @@ by @racket[kind], which must be one of the following:
  the @tech{user's home directory} if @envvar{XDG_CONFIG_HOME} is not
  set to an absolute path.  The directory might not exist.}
 
+ @item{@indexed-racket['cache-dir] --- a directory for storing
+ user-specific caches. On Unix, it is the @filepath{racket}
+ subdirectory of the path specified by @indexed-envvar{XDG_CACHE_HOME},
+ or @filepath{.cache/racket} in the @tech{user's home directory} if
+ @envvar{XDG_CACHE_HOME} is not set to an absolute path. On Mac OS and
+ Windows, it is the same as the result returned for @racket['addon-dir].
+ The directory might not exists.}
+
  @item{@indexed-racket['doc-dir] --- the standard directory for
  storing the current user's documents. On Unix, it's
  the @tech{user's home directory}.  On Windows, it is the @tech{user's

--- a/racket/collects/pkg/private/config.rkt
+++ b/racket/collects/pkg/private/config.rkt
@@ -69,7 +69,7 @@
              "https://planet-compats.racket-lang.org")]
       ['default-scope "user"]
       ['installation-name (version)]
-      ['download-cache-dir (build-path (find-system-path 'addon-dir)
+      ['download-cache-dir (build-path (find-system-path 'cache-dir)
                                        "download-cache")]
       ['download-cache-max-files 1024]
       ['download-cache-max-bytes (* 64 1024 1024)]

--- a/racket/src/io/host/rktio.rkt
+++ b/racket/src/io/host/rktio.rkt
@@ -89,3 +89,5 @@
 
 ;; Only in the main place:
 (void (rktio_do_install_os_signal_handler rktio))
+
+(void 1) ;; force recompile due to ../../rktio/rktio.rktl change

--- a/racket/src/io/path/system.rkt
+++ b/racket/src/io/path/system.rkt
@@ -47,6 +47,7 @@
       [(pref-file) (rktio-system-path who RKTIO_PATH_PREF_FILE)]
       [(addon-dir) (as-dir (or addon-dir
                                (rktio-system-path who RKTIO_PATH_ADDON_DIR)))]
+      [(cache-dir) (as-dir (rktio-system-path who RKTIO_PATH_CACHE_DIR))]
       [(home-dir) (as-dir (rktio-system-path who RKTIO_PATH_HOME_DIR))]
       [(desk-dir) (as-dir (rktio-system-path who RKTIO_PATH_DESK_DIR))]
       [(doc-dir) (as-dir (rktio-system-path who RKTIO_PATH_DOC_DIR))]
@@ -55,7 +56,7 @@
       [else (raise-argument-error who
                                   (string-append
                                    "(or/c 'home-dir 'pref-dir 'pref-file 'temp-dir\n"
-                                   "      'init-dir 'init-file 'addon-dir\n"
+                                   "      'init-dir 'init-file 'addon-dir 'cache-dir\n"
                                    "      'doc-dir 'desk-dir 'sys-dir 'exec-file 'run-file\n"
                                    "      'collects-dir 'config-dir 'orig-dir\n"
                                    "      'host-collects-dir 'host-config-dir)")

--- a/racket/src/racket/src/file.c
+++ b/racket/src/racket/src/file.c
@@ -122,7 +122,7 @@ READ_ONLY static Scheme_Object *doc_dir_symbol, *desk_dir_symbol;
 READ_ONLY static Scheme_Object *init_dir_symbol, *init_file_symbol, *sys_dir_symbol;
 READ_ONLY static Scheme_Object *exec_file_symbol, *run_file_symbol, *collects_dir_symbol;
 READ_ONLY static Scheme_Object *pref_file_symbol, *orig_dir_symbol, *addon_dir_symbol;
-READ_ONLY static Scheme_Object *config_dir_symbol;
+READ_ONLY static Scheme_Object *config_dir_symbol, *cache_dir_symbol;
 READ_ONLY static Scheme_Object *host_collects_dir_symbol, *host_config_dir_symbol;
 
 SHARED_OK static Scheme_Object *exec_cmd;
@@ -162,6 +162,7 @@ void scheme_init_file(Scheme_Startup_Env *env)
   REGISTER_SO(host_config_dir_symbol);
   REGISTER_SO(orig_dir_symbol);
   REGISTER_SO(addon_dir_symbol);
+  REGISTER_SO(cache_dir_symbol);
 
   REGISTER_SO(windows_symbol);
   REGISTER_SO(unix_symbol);
@@ -191,6 +192,7 @@ void scheme_init_file(Scheme_Startup_Env *env)
   host_config_dir_symbol = scheme_intern_symbol("host-config-dir");
   orig_dir_symbol = scheme_intern_symbol("orig-dir");
   addon_dir_symbol = scheme_intern_symbol("addon-dir");
+  cache_dir_symbol = scheme_intern_symbol("cache-dir");
 
   windows_symbol = scheme_intern_symbol("windows");
   unix_symbol = scheme_intern_symbol("unix");
@@ -4959,10 +4961,12 @@ find_system_path(int argc, Scheme_Object **argv)
   } else if (argv[0] == addon_dir_symbol) {
     if (addon_dir) return addon_dir;
     which = RKTIO_PATH_ADDON_DIR;
+  } else if (argv[0] == cache_dir_symbol) {
+    which = RKTIO_PATH_CACHE_DIR;
   } else {
     scheme_wrong_contract("find-system-path", 
                           "(or/c 'home-dir 'pref-dir 'pref-file 'temp-dir\n"
-                          "      'init-dir 'init-file 'addon-dir\n"
+                          "      'init-dir 'init-file 'addon-dir 'cache-dir\n"
                           "      'doc-dir 'desk-dir 'sys-dir 'exec-file 'run-file\n"
                           "      'collects-dir 'config-dir 'orig-dir\n"
                           "      'host-collects-dir 'host-config-dir)",

--- a/racket/src/rktio/rktio.h
+++ b/racket/src/rktio/rktio.h
@@ -948,7 +948,8 @@ enum {
   RKTIO_PATH_DESK_DIR,
   RKTIO_PATH_DOC_DIR,
   RKTIO_PATH_INIT_DIR,
-  RKTIO_PATH_INIT_FILE
+  RKTIO_PATH_INIT_FILE,
+  RKTIO_PATH_CACHE_DIR
 };
 
 RKTIO_EXTERN char *rktio_expand_user_tilde(rktio_t *rktio, rktio_const_string_t filename);

--- a/racket/src/rktio/rktio.rktl
+++ b/racket/src/rktio/rktio.rktl
@@ -84,6 +84,7 @@
 (define-constant RKTIO_PATH_DOC_DIR 7)
 (define-constant RKTIO_PATH_INIT_DIR 8)
 (define-constant RKTIO_PATH_INIT_FILE 9)
+(define-constant RKTIO_PATH_CACHE_DIR 10)
 (define-constant RKTIO_OS_SIGNAL_NONE -1)
 (define-constant RKTIO_OS_SIGNAL_INT 0)
 (define-constant RKTIO_OS_SIGNAL_TERM 1)

--- a/racket/src/rktio/rktio_fs.c
+++ b/racket/src/rktio/rktio_fs.c
@@ -1904,10 +1904,12 @@ char *rktio_system_path(rktio_t *rktio, int which)
     if ((which == RKTIO_PATH_PREF_DIR) 
         || (which == RKTIO_PATH_PREF_FILE)
         || (which == RKTIO_PATH_ADDON_DIR)
+        || (which == RKTIO_PATH_CACHE_DIR)
         || (which == RKTIO_PATH_INIT_DIR)
         || (which == RKTIO_PATH_INIT_FILE)) {
 #if defined(OS_X) && !defined(XONX)
-      if (which == RKTIO_PATH_ADDON_DIR)
+      if ((which == RKTIO_PATH_ADDON_DIR)
+          || (which == RKTIO_PATH_CACHE_DIR))
 	home_str = "~/Library/Racket/";
       else if ((which == RKTIO_PATH_INIT_DIR)
                || (which == RKTIO_PATH_INIT_FILE))
@@ -1919,6 +1921,10 @@ char *rktio_system_path(rktio_t *rktio, int which)
       if (which == RKTIO_PATH_ADDON_DIR) {
         home_str = "~/.local/share/racket/";
         envvar = "XDG_DATA_HOME";
+        suffix = "racket/";
+      } else if (which == RKTIO_PATH_CACHE_DIR) {
+        home_str = "~/.cache/racket/";
+        envvar = "XDG_CACHE_HOME";
         suffix = "racket/";
       } else {
         home_str = "~/.config/racket/";
@@ -1973,7 +1979,8 @@ char *rktio_system_path(rktio_t *rktio, int which)
     
     if ((which == RKTIO_PATH_PREF_DIR) || (which == RKTIO_PATH_INIT_DIR) 
 	|| (which == RKTIO_PATH_HOME_DIR) || (which == RKTIO_PATH_ADDON_DIR)
-	|| (which == RKTIO_PATH_DESK_DIR) || (which == RKTIO_PATH_DOC_DIR))
+	|| (which == RKTIO_PATH_DESK_DIR) || (which == RKTIO_PATH_DOC_DIR)
+        || (which == RKTIO_PATH_CACHE_DIR))
       return home;
 
     if (which == RKTIO_PATH_INIT_FILE) {
@@ -2036,6 +2043,7 @@ char *rktio_system_path(rktio_t *rktio, int which)
       int which_folder;
 
       if ((which == RKTIO_PATH_ADDON_DIR)
+          || (which == RKTIO_PATH_CACHE_DIR) /* maybe CSIDL_LOCAL_APPDATA instead? */
 	  || (which == RKTIO_PATH_PREF_DIR)
 	  || (which == RKTIO_PATH_PREF_FILE)) 
 	which_folder = CSIDL_APPDATA;
@@ -2129,6 +2137,7 @@ char *rktio_system_path(rktio_t *rktio, int which)
       return home;
 
     if ((which == RKTIO_PATH_ADDON_DIR)
+        || (which == RKTIO_PATH_CACHE_DIR)
 	|| (which == RKTIO_PATH_PREF_DIR)
 	|| (which == RKTIO_PATH_PREF_FILE)) {
       home = append_paths(home, "Racket", 1, 0);

--- a/racket/src/rktio/rktio_fs.c
+++ b/racket/src/rktio/rktio_fs.c
@@ -1903,10 +1903,15 @@ char *rktio_system_path(rktio_t *rktio, int which)
 
     if ((which == RKTIO_PATH_PREF_DIR) 
         || (which == RKTIO_PATH_PREF_FILE)
-        || (which == RKTIO_PATH_ADDON_DIR)) {
+        || (which == RKTIO_PATH_ADDON_DIR)
+        || (which == RKTIO_PATH_INIT_DIR)
+        || (which == RKTIO_PATH_INIT_FILE)) {
 #if defined(OS_X) && !defined(XONX)
       if (which == RKTIO_PATH_ADDON_DIR)
 	home_str = "~/Library/Racket/";
+      else if ((which == RKTIO_PATH_INIT_DIR)
+               || (which == RKTIO_PATH_INIT_FILE))
+        home_str = "~/";
       else
 	home_str = "~/Library/Preferences/";
 #elif USE_XDG_BASEDIR
@@ -1918,10 +1923,13 @@ char *rktio_system_path(rktio_t *rktio, int which)
       } else {
         home_str = "~/.config/racket/";
         envvar = "XDG_CONFIG_HOME";
-        if (which == RKTIO_PATH_PREF_DIR) {
+        if ((which == RKTIO_PATH_PREF_DIR)
+            || (which == RKTIO_PATH_INIT_DIR)) {
           suffix = "racket/";
-        } else { /* which == RKTIO_PATH_PREF_FILE */
+        } else if (which == RKTIO_PATH_PREF_FILE) {
           suffix = "racket/racket-prefs.rktd";
+        } else { /* (which == RKTIO_PATH_INIT_FILE) */
+          suffix = "racket/racketrc.rktl";
         }
       }
       xdg_dir = rktio_getenv(rktio, envvar);
@@ -1932,7 +1940,11 @@ char *rktio_system_path(rktio_t *rktio, int which)
         free(xdg_dir);
       }
 #else
-      home_str = "~/.racket/";
+      if ((which == RKTIO_PATH_INIT_DIR) || (which == RKTIO_INIT_FILE)) {
+        home_str = "~/";
+      } else { /* RKTIO_PATH_{ADDON_DIR,PREF_DIR,PREF_FILE} */
+        home_str = "~/.racket/";
+      }
 #endif 
     } else {
 #if defined(OS_X) && !defined(XONX)
@@ -1964,8 +1976,15 @@ char *rktio_system_path(rktio_t *rktio, int which)
 	|| (which == RKTIO_PATH_DESK_DIR) || (which == RKTIO_PATH_DOC_DIR))
       return home;
 
-    if (which == RKTIO_PATH_INIT_FILE)
+    if (which == RKTIO_PATH_INIT_FILE) {
+#if defined(OS_X) && !defined(XONX)
       return append_paths(home, ".racketrc", 1, 0);
+#elif USE_XDG_BASEDIR
+      return append_paths(home, "racketrc.rktl", 1, 0);
+#else
+      return append_paths(home, ".racketrc", 1, 0);
+#endif
+    }
     if (which == RKTIO_PATH_PREF_FILE) {
 #if defined(OS_X) && !defined(XONX)
       return append_paths(home, "org.racket-lang.prefs.rktd", 1, 0);


### PR DESCRIPTION
PR for discussion about changing Racket to follow the XDG Base Directory specification. See also #2740. 

Here's a summary of the changes to `find-system-path`:

    'pref-dir  = $XDG_CONFIG_HOME/racket or ~/.config/racket (was ~/.racket)
    'addon-dir = $XDG_DATA_HOME/racket or ~/.local/share/racket (was ~/.racket)
    'init-dir  = same as pref-dir (was ~/)
    'init-file = $XDG_CONFIG_HOME/racket/racketrc.rktl or ~/.config/racket/racketrc.rktl (was ~/.racketrc)

A new key is added:

    'cache-dir = $XDG_CACHE_HOME/racket or ~/.cache/racket

This directory is used as the default location for the "download-cache" directory. On Windows and Mac OS, `'cache-dir` currently returns the same path as `'addon-dir`.

These changes do not include any attempts at fallbacks or compatibility with the old `.racket` paths. One way of supporting both conventions would be symlink `~/.local/share/racket` and `~/.config/racket` (and `~/.cache/racket`, if you like) to an existing `~/.racket` directory.

Note: changes to rktio don't seem to automatically cause gracket to get recompiled, so I had to delete the racket/src/build directory and rebuilt before drracket saw the changes, for example.
