### PR TITLE
Fix contract-out for struct

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1838,7 +1838,7 @@ earlier fields.}}
   (code:line)
   (code:line #:unprotected-submodule submodule-name)]
  [contract-out-item
-  (struct id/super ((id contract-expr) ...)
+  (struct id/ignored ((id contract-expr) ...)
     struct-option)
   (rename orig-id id contract-expr)
   (id contract-expr)
@@ -1847,8 +1847,8 @@ earlier fields.}}
   (code:line #:∀ poly-variables)
   (code:line #:forall poly-variables)]
  [poly-variables id (id ...)]
- [id/super id
-           (id super-id)]
+ [id/ignored id
+             (id ignored-id)]
  [struct-option (code:line)
                 #:omit-constructor])]{
 
@@ -1876,13 +1876,8 @@ first variable (the internal name) with the name specified by the
 second variable (the external name).
 
 The @racket[struct] form of @racket[contract-out]
-provides a structure-type definition, and each field has a contract
-that dictates the contents of the fields. The structure-type
-definition must appear before the @racket[provide] clause within the
-enclosing module. If the structure type has a parent, the second
-@racket[struct] form (above) must be used, with the first name
-referring to the structure type to export and the second name
-referring to the parent structure type. Unlike a @racket[struct]
+provides a structure-type definition @racket[id], and each field has a contract
+that dictates the contents of the fields. Unlike a @racket[struct]
 definition, however, all of the fields (and their contracts) must be
 listed. The contract on the fields that the sub-struct shares with its
 parent are only used in the contract for the sub-struct's constructor, and
@@ -1890,7 +1885,10 @@ the selector or mutators for the super-struct are not provided. The
 exported structure-type name always doubles as a constructor, even if
 the original structure-type name does not act as a constructor.
 If the @racket[#:omit-constructor] option is present, the constructor
-is not provided.
+is not provided. The second form of @racket[id/ignored], which has both
+@racket[id] and @racket[ignored-id], is deprecated and allowed
+in the grammar only for backward compatability, where @racket[ignored-id] is ignored.
+The first form should be used instead.
 
 Note that if the struct is created with @racket[serializable-struct]
 or @racket[define-serializable-struct], @racket[contract-out] does not
@@ -1918,7 +1916,8 @@ is bound to vectors of two elements, the exported identifier and a
 syntax object for the expression that produces the contract controlling
 the export.
 
-@history[#:changed "7.3.0.3" @list{Added @racket[#:unprotected-submodule].}]
+@history[#:changed "7.3.0.3" @list{Added @racket[#:unprotected-submodule].}
+         #:changed "7.7.0.9" @list{Deprecated @racket[ignored-id].}]
 }
 
 @defform[(recontract-out id ...)]{

--- a/pkgs/racket-test/tests/racket/contract/contract-out.rkt
+++ b/pkgs/racket-test/tests/racket/contract/contract-out.rkt
@@ -1296,21 +1296,22 @@
                (require 'provide/contract70-b racket/contract/base)
                (void stream stream? stream-x stream-y set-stream-y!)))))
 
-  (contract-error-test
+  (test/spec-passed/result
    'provide/contract-struct-out
    #'(begin
-       (eval '(module pos racket/base
+       (eval '(module test-ignore-super-position racket/base
                 (require racket/contract)
                 (provide
                  (contract-out
-                  [struct (b not-a) ()])
+                  [struct (b not-a) ()]))
 
-                 (struct a ())
-                 (struct b a ())))))
-   (λ (x)
-     (and (exn:fail:syntax? x)
-          (regexp-match #rx"^contract-out: expected a struct name"
-                        (exn-message x)))))
+                (struct a ())
+                (struct b a ())))
+       (eval '(require 'test-ignore-super-position))
+       (eval '(b? (b))))
+   #t)
+
+
 
   (contract-error-test
    'contract-error-test8
@@ -1788,5 +1789,76 @@
               [x (>/c 5)]))
             (define x 6)))))
    (list '(>/c 5)))
-  
+
+  (test/spec-passed/result
+   'struct-field-name-computed-correctly
+   '(begin
+      (eval '(module first racket
+               (provide (contract-out (struct foo ([x any/c])))
+                        (contract-out (struct (bar foo) ([x any/c]))))
+               (struct foo (x))
+               (struct bar foo ())))
+      (eval '(module second racket
+               (require 'first)
+               (provide (contract-out (struct foo ([x any/c])))
+                        (contract-out (struct (bar foo) ([x any/c]))))))
+      (eval '(module third racket
+               (require 'second)
+               (provide (contract-out (struct foo ([x any/c])))
+                        (contract-out (struct (bar foo) ([x any/c]))))))
+      (eval '(require 'third))
+      (eval '(foo-x (bar 1))))
+   1)
+
+  (test/spec-passed/result
+   'provide/contract-struct-out-id-generation
+   '(begin
+      (eval '(module provide/contract-struct-out-id-generation racket
+               (struct foo (x))
+               (struct bar foo (x))
+               (provide (contract-out (struct foo ([x any/c]))
+                                      (struct (bar foo) ([x any/c] [x any/c]))))))
+      (eval '(require 'provide/contract-struct-out-id-generation))
+      (eval '(let ([val (bar 1 2)])
+               (list (foo-x val) (bar-x val)))))
+   (list 1 2))
+
+  (contract-error-test
+   'provide/contract-struct-out-omit-constructor
+   #'(begin
+       (eval '(module provide/contract-struct-out-omit-constructor racket/base
+                (require racket/contract)
+                (provide
+                 (contract-out
+                  [struct a () #:omit-constructor #:omit-constructor]))
+
+                (struct a ()))))
+   (λ (x)
+     (and (exn:fail:syntax? x)
+          (regexp-match #rx"malformed struct option" (exn-message x)))))
+
+  (test/spec-passed/result
+   'provide/contract-struct-out-super-struct-omitted
+   '(begin
+      (eval '(module provide/contract-struct-out-super-struct-omitted racket
+               (struct foo (x))
+               (struct bar foo (y))
+               (provide (contract-out (struct bar ([x any/c] [y any/c]))))))
+      (eval '(require 'provide/contract-struct-out-super-struct-omitted))
+      (eval '(let ([val (bar 1 2)])
+               (bar-y val))))
+   2)
+
+  (test/spec-passed/result
+   'provide/contract-struct-out-static-field-name
+   '(begin
+      (eval '(module provide/contract-struct-out-static-field-name racket
+               (struct foo (x))
+               (provide (contract-out (struct foo ([x any/c]))))))
+      (eval '(require 'provide/contract-struct-out-static-field-name
+                      (for-syntax racket/struct-info racket/base)))
+      (eval '(define-syntax (extract-field-names stx)
+               #`'#,(struct-field-info-list (syntax-local-value #'foo))))
+      (eval '(extract-field-names)))
+   (list 'x))
   )

--- a/racket/collects/racket/contract/private/helpers.rkt
+++ b/racket/collects/racket/contract/private/helpers.rkt
@@ -21,7 +21,7 @@
 (define (update-loc stx loc)
   (datum->syntax stx (syntax-e stx) loc))
 
-;; lookup-struct-info : syntax -> (union #f struct-info?)
+;; lookup-struct-info : syntax -> struct-info?
 (define (lookup-struct-info stx provide-stx)
   (define id (syntax-case stx ()
                [(a b) (syntax a)]


### PR DESCRIPTION
- A part of contract-out's code generation for struct assumes that
there's no parent struct and uses the provided struct name for
everything. This causes duplicate definitions when there are duplicate
field names where one is in a child struct and another is
in a parent struct. This PR fixes the problem.
- Disallow multiple #:omit-constructor
- Deprecate super-id. This information is unnecessary since we can
extract it from static struct information already. Attempting to
check that super-id is well-formed is error-prone due to how
the super struct type could be contracted which shields us from
detecting that they are indeed the super type.
- Utilize static struct field name information, and provide
the information when exporting a struct.

This PR is largely based on #732.

Fixes #3266
Fixes #3269 
Fixes #3271 
Fixes #3272