### PR TITLE
win32: add Power Shell script to set env vars

### DIFF
--- a/racket/src/worksp/README.txt
+++ b/racket/src/worksp/README.txt
@@ -21,6 +21,10 @@ tries to find Visual Studio and run its "vcvarsall.bat". Provide an
 argument such as "x86" (32-bit mode) or "x86_amd64" (64-bit mode) to
 select the build mode.
 
+When using Power Shell, use the "msvcprep.ps1" script instead of
+"msvcprep.bat".  Running the latter from PS will appear to work, but
+will not actually change any environment variables.
+
 After you have Visual Studio command-line tools set up, then you can
 build either the traditional Racket implementation or Racket-on-Chez
 (or both).

--- a/racket/src/worksp/README.txt
+++ b/racket/src/worksp/README.txt
@@ -21,9 +21,9 @@ tries to find Visual Studio and run its "vcvarsall.bat". Provide an
 argument such as "x86" (32-bit mode) or "x86_amd64" (64-bit mode) to
 select the build mode.
 
-When using Power Shell, use the "msvcprep.ps1" script instead of
-"msvcprep.bat".  Running the latter from PS will appear to work, but
-will not actually change any environment variables.
+When using PowerShell, run the "msvcprep.ps1" script instead of
+"msvcprep.bat".  Running the latter from PowerShell will appear to
+work, but will not actually change any environment variables.
 
 After you have Visual Studio command-line tools set up, then you can
 build either the traditional Racket implementation or Racket-on-Chez

--- a/racket/src/worksp/msvcprep.ps1
+++ b/racket/src/worksp/msvcprep.ps1
@@ -1,0 +1,30 @@
+<#
+.SYNOPSIS
+    A variant of msvcprep.bat for Power Shell users.
+
+.DESCRIPTION
+    Runs Visual Studio's vcvarsall.bat script to set the necessary
+    environment variables for a given target platform.
+
+.EXAMPLE
+    Set variables for x86.
+    PS C:\>racket\src\worksp\msvcprep.ps1 x86
+
+.EXAMPLE
+    Set variables for x86_64
+    PS C:\>racket\src\worksp\msvcprep.ps1 x86_amd64
+
+.NOTES
+    Adapted from this StackOverflow answer:
+    * https://stackoverflow.com/a/2124759/144981
+#>
+
+$command = $PSScriptRoot + "\msvcprep.bat " + $Args[0] + " & set"
+cmd /c $command |
+  ForEach {
+      if ($_ -match "=") {
+          $v = $_.split("=")
+          Set-Item -Force -Path "ENV:\$($v[0])"  -Value "$($v[1])"
+      }
+  }
+Write-Host "Visual Studio variables set." -ForegroundColor Yellow

--- a/racket/src/worksp/msvcprep.ps1
+++ b/racket/src/worksp/msvcprep.ps1
@@ -19,12 +19,12 @@
     * https://stackoverflow.com/a/2124759/144981
 #>
 
-$command = $PSScriptRoot + "\msvcprep.bat " + $Args[0] + " & set"
+$command = "echo off & " + $PSScriptRoot + "\msvcprep.bat " + $Args[0] + " & set"
 cmd /c $command |
   ForEach {
       if ($_ -match "=") {
-          $v = $_.split("=")
-          Set-Item -Force -Path "ENV:\$($v[0])"  -Value "$($v[1])"
+          $v = $_.split("=", 2)
+          Set-Item -Force -Path "ENV:\$($v[0])" -Value "$($v[1])"
       }
   }
 Write-Host "Visual Studio variables set." -ForegroundColor Yellow

--- a/racket/src/worksp/msvcprep.ps1
+++ b/racket/src/worksp/msvcprep.ps1
@@ -1,6 +1,6 @@
 <#
 .SYNOPSIS
-    A variant of msvcprep.bat for Power Shell users.
+    A variant of msvcprep.bat for PowerShell users.
 
 .DESCRIPTION
     Runs Visual Studio's vcvarsall.bat script to set the necessary


### PR DESCRIPTION
I noticed yesterday that running `msvcprep.bat` from within Power Shell doesn't modify any environment variables. This doesn't seem to be because of any sort of problem with `msvcprep.bat` itself. The added PS script runs `msvcprep.bat` in a sub shell then reads the environment variables line by line and sets them in the current shell. 

Cherry-picked from #3281. 