### PR TITLE
Clarify that synchronizing on a semaphore decrements its counter

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/semaphores.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/semaphores.scrbl
@@ -19,7 +19,8 @@ thread is eventually unblocked.
 In addition to its use with semaphore-specific procedures, a semaphore
 can be used as a @tech{synchronizable event} (see @secref["sync"]).
 A semaphore is @tech{ready for synchronization} when
-@racket[semaphore-wait] would not block; @resultItself{semaphore}.
+@racket[semaphore-wait] would not block. Upon synchronization, the
+semaphore's counter is decremented, and @resultItself{semaphore}.
 
 @defproc[(semaphore? [v any/c]) boolean?]{
 


### PR DESCRIPTION
This behavior is mentioned in the `Events` section of the manual but not in the section that deals specifically with semaphores.