### PR TITLE
Fix some typos in expander comments

### DIFF
--- a/racket/src/expander/common/struct-star.rkt
+++ b/racket/src/expander/common/struct-star.rkt
@@ -9,8 +9,8 @@
 ;; The `struct*` form is like `struct`, but a field can be have a `*`
 ;; before it or not: the fields without `*` are moved into a nested
 ;; structure (and cannot be mutable), and the ones with `*` are kept
-;; immediate. This distinction is useful is `struct*-copy` is used
-;; often to asjust some fields and not others in a relatively larger
+;; immediate. This distinction is useful if `struct*-copy` is used
+;; often to adjust some fields and not others in a relatively larger
 ;; struct.
 
 ;; Example:

--- a/racket/src/expander/expand/reference-record.rkt
+++ b/racket/src/expander/expand/reference-record.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 (require "../common/set.rkt")
 
-;; A reference record keeps tarck of which bindings in a frame are
+;; A reference record keeps track of which bindings in a frame are
 ;; being referenced and which have been already bound so that a
 ;; reference doesn't count as a forward reference. This information
 ;; is needed for expanding internal definitions to break them into

--- a/racket/src/expander/syntax/binding-table.rkt
+++ b/racket/src/expander/syntax/binding-table.rkt
@@ -112,7 +112,7 @@
     ;; that are just to extend the set of nominal imports. We keep those
     ;; separate --- and don't serialize them --- because they interfere
     ;; with bulk representations of binding and they're used only to
-    ;; commuincate to `provide`.
+    ;; communicate to `provide`.
     (define new-syms/serialize
       (cond
        [just-for-nominal? (table-with-bulk-bindings-syms/serialize bt)]

--- a/racket/src/expander/syntax/fallback.rkt
+++ b/racket/src/expander/syntax/fallback.rkt
@@ -9,7 +9,7 @@
          fallback->list)
 
 ;; When a syntax object is expanded in namespace A and then
-;; re-expanded in namespace B, then the scopes of B are added to rhe
+;; re-expanded in namespace B, then the scopes of B are added to the
 ;; syntax object, but a failed binding search will fall back to the
 ;; scope set that doesn't include the additional scope for B. This
 ;; fallback makes it easier to work across namespaces (including

--- a/racket/src/expander/syntax/local-binding.rkt
+++ b/racket/src/expander/syntax/local-binding.rkt
@@ -17,7 +17,7 @@
 
 ;; Represent a local binding with a key, where the value of
 ;; the key is kept in a separate environment. That indirection
-;; ensures that a fuly expanded program doesn't reference
+;; ensures that a fully expanded program doesn't reference
 ;; compile-time values from local bindings, but it records that
 ;; the binding was local. The `frame-id` field is used to
 ;; trigger use-site scopes as needed


### PR DESCRIPTION
Found while familiarizing myself with the expander code.