### PR TITLE
Fix variable replacement

### DIFF
--- a/racket/src/ChezScheme/c/Mf-arm32le
+++ b/racket/src/ChezScheme/c/Mf-arm32le
@@ -16,7 +16,7 @@
 m ?= arm32le
 Cpu ?= ARMV6
 
-mdclib = -lm -ldl ${ncursesLib} {$threadLibs} -lrt
+mdclib = -lm -ldl ${ncursesLib} ${threadLibs} -lrt
 C = ${CC} ${CPPFLAGS} ${warningFlags} ${optFlags} ${CFLAGS}
 o = o
 mdsrc ?= arm32le.c


### PR DESCRIPTION
By using `{$threadLibs}` it meant we ended up with a command line with `{hreadLibs}`, which breaks the arm32le build.