### PR TITLE
Ensure sorting is applied for in-directory

### DIFF
--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -2335,7 +2335,7 @@
     (if orig-dir
 	(dir-list (path->complete-path orig-dir init-dir)
 		  orig-dir null)
-	(directory-list init-dir)))
+	(sort (directory-list init-dir) path<?)))
 
   (define in-directory
     (case-lambda 


### PR DESCRIPTION
In initial-state, the call to dir-list will sort the results of directory-list. However, in initial-state, there is a different path that will call directory-list without sorting. This change makes these paths consistent.

Please imagine the following filesystem:

```
/var/tmp/test/1.txt
/var/tmp/test/2.txt
/var/tmp/test/3.txt
/var/tmp/test/4.txt
```

With this code:

```
> (current-directory "/var/tmp/test")
> (for/list ([f (in-directory)]) (displayln f))
```

Before the patch, I get:

```
4.txt
2.txt
1.txt
3.txt
```

After the patch, I get:

```
1.txt
2.txt
3.txt
4.txt
```

This change is proposed to make [(in-directory)](https://docs.racket-lang.org/reference/sequences.html?q=in-directory#%28def._%28%28lib._racket%2Fprivate%2Fbase..rkt%29._in-directory%29%29) results sorted as is stated in the docs.