### PR TITLE
pkg: deduplicate dependency list for install command

### DIFF
--- a/racket/collects/pkg/private/install.rkt
+++ b/racket/collects/pkg/private/install.rkt
@@ -191,6 +191,7 @@
       (when clean?
         (delete-directory/files pkg-dir)))
     (define (show-dependencies deps update? auto?)
+      (define unique-deps (remove-duplicates deps))
       (unless quiet?
         (printf/flush "The following~a packages are listed as dependencies of ~a~a:~a\n"
                       (if update? " out-of-date" " uninstalled")
@@ -201,8 +202,8 @@
                                   (if update? "updated" "installed"))
                           "")
                       (if update?
-                          (format-deps deps)
-                          (format-list deps)))))
+                          (format-deps unique-deps)
+                          (format-list unique-deps)))))
     (define simultaneous-installs
       (for/hash ([i (in-list infos)])
         (values (install-info-name i) (install-info-directory i))))


### PR DESCRIPTION
Without this change, installing a package that depends on a missing package for both runtime and build lists that package twice. For example:

```racket
#lang info

(define deps '("blah"))
(define build-deps '("blah"))
```

```
$ raco pkg install --name test
Linking current directory as a package
The following uninstalled packages are listed as dependencies of test:                                       
   blah                               
   blah                                                                                                      
Would you like to install these dependencies? [Y/n/a/c/?]
```

After this change:

```
Linking current directory as a package                                                                       
The following uninstalled packages are listed as dependencies of test:
   blah                                 
Would you like to install these dependencies? [Y/n/a/c/?]
```