### PR TITLE
add reference to macro debugger and syntax/parse

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/macros.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/macros.scrbl
@@ -19,6 +19,15 @@ This chapter provides an introduction to Racket macros, but see
 @hyperlink["http://www.greghendershott.com/fear-of-macros/"]{@italic{Fear of
 Macros}} for an introduction from a different perspective.
 
+Racket includes addional support for macro development: 
+A @hyperlink["https://docs.racket-lang.org/macro-debugger/index.html"]{@italic{macro 
+debugger}} to make it easier for experienced programmers
+to debug their macros and for novices to study their behavior, 
+and of macros. And the @hyperlink["https://docs.racket-lang.org/syntax/index.html"]{@italic{syntax/parse 
+library}} for writing macros and specifying syntax that
+automatically validates macro uses and reports syntax
+errors.
+
 @local-table-of-contents[]
 
 @;------------------------------------------------------------------------


### PR DESCRIPTION
In response to https://www.reddit.com/r/Racket/comments/ie8rlf/when_creating_macros_is_syntaxparse_preferred_to/?utm_source=share&utm_medium=web2x&context=3
