### PR TITLE
gracket/gc2 makefile

### DIFF
--- a/racket/src/bc/gracket/gc2/Makefile.in
+++ b/racket/src/bc/gracket/gc2/Makefile.in
@@ -64,7 +64,7 @@ XFORM_CPP_ARGS = -I$(srcdir)/../../gc2 $(NOGCINC) $(OPTIONS) @PREFLAGS@ $(XFORM_
 XFORM = $(XFORM_CMD) --cpp "$(CPP) $(XFORM_CPP_ARGS)" @XFORMFLAGS@ -o ++out
 XFORMDEP = $(srcdir)/../../gc2/xform-mod.rkt $(srcdir)/../../gc2/gc2.h
 
-GRACKETLDFLAGS = $(LDFLAGS) -L../../racket
+GRACKETLDFLAGS = $(LDFLAGS) -L../..
 
 DEF_COLLECTS_DIR = +D INITIAL_COLLECTS_DIRECTORY='"'"`cd $(srcdir)/../../../../collects; @PWD@`"'"'
 DEF_CONFIG_DIR = +D INITIAL_CONFIG_DIRECTORY='"'"`cd $(srcdir)/../../../..; @PWD@`/etc"'"'


### PR DESCRIPTION
Without this change, the below build comands with the latest snapshot from the Utah server fail for me.
This reflects the GRACKETLDFLAGS in the makefile one folder above. However I have no idea if this has wider implications...
```
mkdir build
cd build
..\configure --enable-bcdefault
make
```