### PR TITLE
Prevent assignment to `for` bindings

### DIFF
--- a/pkgs/racket-test-core/tests/racket/file.rktl
+++ b/pkgs/racket-test-core/tests/racket/file.rktl
@@ -2279,7 +2279,8 @@
           (parameterize ([current-directory tmp-dir])
             (for/hash ([f (in-directory)])
               (let ([real-f f])
-                (set! f 'trying-to-break-in-directory)
+                ;; FIXME: add test that this would be an error:
+                ;; (set! f 'trying-to-break-in-directory)
                 (values real-f #t)))))
     (define (mk) (in-directory))
     (test ht

--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -642,7 +642,8 @@
       (for*/lists (lst) ([x '()])
         (define-syntax (m stx) #'0)
         m))
-
+#|
+;; FIXME: test that this is an error
 (test '(bad 1)
       'for/lists-weird-set!
       (for/lists (acc)
@@ -650,6 +651,7 @@
         (unless (zero? v)
           (set! acc '(bad)))
         v))
+|#
 
 ;; for should discard any results and return void
 (test (void) 'for-0-values (for ([x '(1 2 3)] [y '(a b c)]) (values)))


### PR DESCRIPTION
This is an attempt at resolving https://github.com/racket/racket/issues/3378 by making it a syntax error to attempt to `set!` any of the identifiers bound by `for`-like forms. All of the existing tests pass (except those added in 8ca4977 that test the behavior I'm trying to change), but this needs more tests and, if it works out, a corresponding change to the documentation from 8ca4977. It may also need some more `syntax-protect`s.
