### PR TITLE
use gcc build-in functions to perform unsafe fixnum arithmetic

### DIFF
--- a/.github/workflows/ci-ubsan.yml
+++ b/.github/workflows/ci-ubsan.yml
@@ -84,7 +84,9 @@ jobs:
       continue-on-error: true
       run: raco test -l tests/db/all-tests | tee logs/db-all-tests.log
     - name: Gather runtime errors
-      run: grep 'runtime error' logs/*.log > runtime-errors_git${{ github.sha }}.log
+      run: |
+        grep 'runtime error' logs/*.log > runtime-errors_git${{ github.sha }}.log || true
+        test ! -s runtime-errors_git${{ github.sha }}.log
     - uses: actions/upload-artifact@v2
       with:
         name: runtime-errors_git${{ github.sha }}

--- a/racket/src/bc/src/numarith.c
+++ b/racket/src/bc/src/numarith.c
@@ -1246,13 +1246,13 @@ static Scheme_Object *fx_abs(int argc, Scheme_Object *argv[])
 #define UNSAFE_DIV(r, x, y) r = x / y
 #define UNSAFE_REM(r, x, y) r = x % y
 #if (__GNUC__ >= 5) || defined(__clang__)
-  #define UNSAFE_PLUS(r, x, y) __builtin_add_overflow(x, y, &r)
+  #define UNSAFE_PLUS(r, x, y)  __builtin_add_overflow(x, y, &r)
   #define UNSAFE_MINUS(r, x, y) __builtin_sub_overflow(x, y, &r)
-  #define UNSAFE_MULT(r, x, y) __builtin_mul_overflow(x, y, &r)
+  #define UNSAFE_MULT(r, x, y)  __builtin_mul_overflow(x, y, &r)
 #else
-  #define UNSAFE_PLUS(x, y, r) r = x + y
-  #define UNSAFE_MINUS(x, y, r) r = x - y
-  #define UNSAFE_MULT(x, y, r) r = x * y
+  #define UNSAFE_PLUS(r, x, y)  r = x + y
+  #define UNSAFE_MINUS(r, x, y) r = x - y
+  #define UNSAFE_MULT(r, x, y)  r = x * y
 #endif
 
 UNSAFE_FX(unsafe_fx_plus, UNSAFE_PLUS, fx_plus, scheme_make_integer(0), )

--- a/racket/src/bc/src/numarith.c
+++ b/racket/src/bc/src/numarith.c
@@ -1228,11 +1228,14 @@ static Scheme_Object *fx_abs(int argc, Scheme_Object *argv[])
   return o;
 }
 
-#if !defined(__GNUC__) && !defined(__clang__)
-#  define __attribute__(x)
+#if __GNUC__ >= 8 || __clang_major__ >= 4
+# define NO_SANITIZE_SIGNED_INTEGER_OVERFLOW \
+  __attribute__((no_sanitize("signed-integer-overflow")))
+#else
+# define NO_SANITIZE_SIGNED_INTEGER_OVERFLOW
 #endif
 #define UNSAFE_FX(name, op, fold, zero_args, PRE_CHECK)                 \
- __attribute__((no_sanitize("signed-integer-overflow")))                \
+ NO_SANITIZE_SIGNED_INTEGER_OVERFLOW                                    \
  static Scheme_Object *name(int argc, Scheme_Object *argv[]) \
  {                                                           \
    intptr_t v;                                                          \

--- a/racket/src/bc/src/numarith.c
+++ b/racket/src/bc/src/numarith.c
@@ -1246,13 +1246,18 @@ static Scheme_Object *fx_abs(int argc, Scheme_Object *argv[])
 #define UNSAFE_DIV(r, x, y) r = x / y
 #define UNSAFE_REM(r, x, y) r = x % y
 #if (__GNUC__ >= 5) || defined(__clang__)
-  #define UNSAFE_PLUS(r, x, y)  __builtin_add_overflow(x, y, &r)
-  #define UNSAFE_MINUS(r, x, y) __builtin_sub_overflow(x, y, &r)
-  #define UNSAFE_MULT(r, x, y)  __builtin_mul_overflow(x, y, &r)
+/*
+ * using __builtin functions to avoid overflow runtime error
+ * when compiled with --enable-ubsan
+ * https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html
+ */
+# define UNSAFE_PLUS(r, x, y)  __builtin_add_overflow(x, y, &r)
+# define UNSAFE_MINUS(r, x, y) __builtin_sub_overflow(x, y, &r)
+# define UNSAFE_MULT(r, x, y)  __builtin_mul_overflow(x, y, &r)
 #else
-  #define UNSAFE_PLUS(r, x, y)  r = x + y
-  #define UNSAFE_MINUS(r, x, y) r = x - y
-  #define UNSAFE_MULT(r, x, y)  r = x * y
+# define UNSAFE_PLUS(r, x, y)  r = x + y
+# define UNSAFE_MINUS(r, x, y) r = x - y
+# define UNSAFE_MULT(r, x, y)  r = x * y
 #endif
 
 UNSAFE_FX(unsafe_fx_plus, UNSAFE_PLUS, fx_plus, scheme_make_integer(0), )


### PR DESCRIPTION
and eliminate overflow errors from fixnum test when racket bc compiled with
--enable-ubsan(issue #2314)

gcc document: https://gcc.gnu.org/onlinedocs/gcc/Integer-Overflow-Builtins.html