### PR TITLE
Small fixes to enable LTO compilation

### DIFF
--- a/racket/src/ChezScheme/c/new-io.c
+++ b/racket/src/ChezScheme/c/new-io.c
@@ -78,7 +78,7 @@ static int is_valid_lz4_length(iptr count);
   do { body;                                            \
     if (ok) { flag = 0; }                               \
     else {                                              \
-      INT errnum;                                       \
+      INT errnum = 0;                                   \
       S_glzerror((fd),&errnum);                         \
       S_glzclearerr((fd));                              \
       if (errnum == Z_ERRNO) {                          \
@@ -117,7 +117,7 @@ static int is_valid_lz4_length(iptr count);
   do { body;                                            \
     if (ok) { flag = 0; }                               \
     else {                                              \
-      INT errnum;                                       \
+      INT errnum = 0;                                   \
       S_glzerror((fd),&errnum);                         \
       S_glzclearerr((fd));                              \
       if (errnum == Z_ERRNO) { flag = 1; }              \

--- a/racket/src/ChezScheme/c/new-io.c
+++ b/racket/src/ChezScheme/c/new-io.c
@@ -99,7 +99,7 @@ static int is_valid_lz4_length(iptr count);
   do { body;                                            \
     if (ok) { flag = 0; break; }                        \
     else {                                              \
-      INT errnum;                                       \
+      INT errnum = 0;                                   \
       S_glzerror((fd),&errnum);                         \
       S_glzclearerr((fd));                              \
       if (errnum == Z_ERRNO) {                          \

--- a/racket/src/cs/c/main.c
+++ b/racket/src/cs/c/main.c
@@ -53,7 +53,7 @@ static void scheme_set_dll_procs(scheme_dll_open_proc open,
 # define embedded_dll_close NULL
 #endif
 
-__attribute__((used))
+PRESERVE_IN_EXECUTABLE
 char *boot_file_data = "BooT FilE OffsetS:\0\0\0\0\0\0\0\0\0\0\0\0";
 static int boot_file_offset = 18;
 

--- a/racket/src/cs/c/main.c
+++ b/racket/src/cs/c/main.c
@@ -53,6 +53,7 @@ static void scheme_set_dll_procs(scheme_dll_open_proc open,
 # define embedded_dll_close NULL
 #endif
 
+__attribute__((used))
 char *boot_file_data = "BooT FilE OffsetS:\0\0\0\0\0\0\0\0\0\0\0\0";
 static int boot_file_offset = 18;
 


### PR DESCRIPTION
To do this in racket/src:
```
  ./configure CFLAGS="-O3 -march=native -flto"
              LDFLAGS="-O3 -march=native -flto"
              --prefix=...
```

One fix deals with variable `errnum` that might be used uninitialized.
The other is to ensure that `boot_file_data` is marked as used
otherwise, it is removed by LTO and ends up crashing build
in `embed-boot.rkt`.