### PR TITLE
Disable implicit for-clause optimization with syntax property.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/for.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/for.scrbl
@@ -91,6 +91,14 @@ unreachable, and if the @racket[for] body can no longer reference an
 constructor supports additional sequences that behave like lists and
 streams in this way.
 
+If a @racket[seq-expr] is a quoted literal list, vector, exact integer,
+string, byte string, immutable hash, or expands to such a literal,
+then it may be treated as if a sequence transformer such as
+@racket[in-list] was used, unless the @racket[seq-expr] has a true
+value for the @indexed-racket['for:no-implicit-optimization] syntax
+property; in most cases this improves performance.
+@history[#:changed "7.8.0.11" @elem{Added support for implicit optimization.}]}
+
 @examples[
 (for ([i '(1 2 3)]
       [j "abc"]

--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -385,6 +385,7 @@
                           'feature-profile:generic-sequence #t))))
                   (make-rearm)))))]
           [[(id ...) rhs]
+           (not (syntax-property #'rhs 'for:no-implicit-optimization))
            (with-syntax ([expanded-rhs (syntax-disarm (local-expand #'rhs 'expression (list #'quote)) orig-insp)])
              (syntax-case #'expanded-rhs (quote)
                [(quote e)
@@ -418,6 +419,8 @@
                                               (make-rearm)))]
                     [else (eloop #f #'expanded-rhs)]))]
                [_ (eloop #f #'expanded-rhs)]))]
+          ;; when for:no-implicit-optimization is true
+          [[(id ...) rhs] (eloop #f #'rhs)]
           [_
            (raise-syntax-error #f
                                "bad sequence binding clause" orig-stx clause)]))))


### PR DESCRIPTION
Related to #3396.

cc @sorawee