### PR TITLE
Fix compiler warning in 32bits due to size mismatch in ptr cast

### DIFF
--- a/racket/src/ChezScheme/c/gcwrapper.c
+++ b/racket/src/ChezScheme/c/gcwrapper.c
@@ -14,6 +14,8 @@
  * limitations under the License.
  */
 
+#include <stdint.h>
+
 #include "system.h"
 #include "popcount.h"
 
@@ -576,7 +578,7 @@ static void check_pointer(ptr *pp, IBOOL address_is_meaningful, ptr base, uptr s
       }
 
       if (address_is_meaningful) {
-        seginfo *ppsi = MaybeSegInfo(ptr_get_segment(pp));
+        seginfo *ppsi = MaybeSegInfo(ptr_get_segment((uintptr_t)pp));
         if ((ppsi != NULL)
             && (ppsi->generation > psi->generation)
             /* space_data includes stacks, which are always swept */
@@ -854,7 +856,7 @@ void S_check_heap(aftergc, mcg) IBOOL aftergc; IGEN mcg; {
                     pp1 = TO_VOIDP((ptr)((uptr)TO_PTR(pp1) + size_object(p)));
                   } else {
                     /* skip past unmarked */
-                    pp1 = TO_VOIDP((ptr)((uptr)pp1 + byte_alignment));
+                    pp1 = TO_VOIDP((ptr)((uintptr_t)pp1 + byte_alignment));
                   }
                 } else {
                   if (*pp1 == forward_marker)

--- a/racket/src/ChezScheme/c/gcwrapper.c
+++ b/racket/src/ChezScheme/c/gcwrapper.c
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#include <stdint.h>
-
 #include "system.h"
 #include "popcount.h"
 
@@ -578,7 +576,7 @@ static void check_pointer(ptr *pp, IBOOL address_is_meaningful, ptr base, uptr s
       }
 
       if (address_is_meaningful) {
-        seginfo *ppsi = MaybeSegInfo(ptr_get_segment((uintptr_t)pp));
+        seginfo *ppsi = MaybeSegInfo(ptr_get_segment(TO_PTR(pp)));
         if ((ppsi != NULL)
             && (ppsi->generation > psi->generation)
             /* space_data includes stacks, which are always swept */
@@ -856,7 +854,7 @@ void S_check_heap(aftergc, mcg) IBOOL aftergc; IGEN mcg; {
                     pp1 = TO_VOIDP((ptr)((uptr)TO_PTR(pp1) + size_object(p)));
                   } else {
                     /* skip past unmarked */
-                    pp1 = TO_VOIDP((ptr)((uintptr_t)pp1 + byte_alignment));
+                    pp1 = TO_VOIDP((ptr)((uptr)TO_PTR(pp1) + byte_alignment));
                   }
                 } else {
                   if (*pp1 == forward_marker)


### PR DESCRIPTION
Casting a ptr to an integer of a different size causes a warning -
this is only noticeable on 32bits. Fix this by casting the ptr first
to uintptr_t.