### PR TITLE
flat-contract-with-explanation: fix internal error

### DIFF
--- a/racket/collects/racket/contract/private/misc.rkt
+++ b/racket/collects/racket/contract/private/misc.rkt
@@ -1282,6 +1282,7 @@
          [else
           (accept-or-reason (blame-add-missing-party b neg-party))
           (error 'flat-contract-with-explanation
-                 "expected that result of the first argument, when it"
-                 " is a procedure, to always escape when called"
-                 " (by calling raise-blame-error with the arguments it was given")])))))
+                 (string-append
+                   "expected that result of the first argument, when it"
+                   " is a procedure, to always escape when called"
+                   " (by calling raise-blame-error with the arguments it was given"))])))))


### PR DESCRIPTION
Previously, `error` would raise an `exn:fail` with the following message,
because it treated the first of the three strings as a format string
and the other two as its arguments:

> error: format string requires 0 arguments, given 2;
> arguments were:
> " is a procedure, to always escape when called"
> " (by calling raise-blame-error with the arguments it was given"`