### PR TITLE
make char-numeric? docs more specific

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/chars.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/chars.scrbl
@@ -187,8 +187,8 @@ Returns @racket[#t] if @racket[char]'s Unicode general category is
 
 @defproc[(char-numeric? [char char?]) boolean?]{
 
-Returns @racket[#t] if @racket[char]'s Unicode general category is
-@UCat{Nd}, @UCat{Nl}, or @UCat{No}, @racket[#f] otherwise.}
+Returns @racket[#t] if @racket[char] has the Unicode ``Numeric_Value''
+property.}
 
 @defproc[(char-symbolic? [char char?]) boolean?]{
 

--- a/pkgs/racket-doc/scribblings/reference/chars.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/chars.scrbl
@@ -187,8 +187,8 @@ Returns @racket[#t] if @racket[char]'s Unicode general category is
 
 @defproc[(char-numeric? [char char?]) boolean?]{
 
-Returns @racket[#t] if @racket[char] has the Unicode ``Numeric''
-property.}
+Returns @racket[#t] if @racket[char]'s Unicode general category is
+@UCat{Nd}, @UCat{Nl}, or @UCat{No}, @racket[#f] otherwise.}
 
 @defproc[(char-symbolic? [char char?]) boolean?]{
 


### PR DESCRIPTION
It now matches the docs for other `char-X` functions.

I used the categories here: http://www.fileformat.info/info/unicode/category/index.htm