### PR TITLE
Use locale.h if not xlocale.h header

### DIFF
--- a/racket/src/rktio/rktio_private.h
+++ b/racket/src/rktio/rktio_private.h
@@ -14,6 +14,8 @@
 #ifdef RKTIO_USE_XLOCALE
 # ifdef RKTIO_USE_XLOCALE_HEADER
 #  include <xlocale.h>
+# else
+#  include <locale.h>
 # endif
 #endif
 


### PR DESCRIPTION
Otherwise we have a missing definition for locale_t when
RKTIO_USE_XLOCALE but !RKTIO_USE_XLOCALE_HEADER.