### PR TITLE
Do not run ARM tests on PR

### DIFF
--- a/.github/workflows/ci-pr-arm_fastbuild.yml
+++ b/.github/workflows/ci-pr-arm_fastbuild.yml
@@ -1,0 +1,40 @@
+name: ARM Linux Fast Build
+
+on: [pull_request]
+
+jobs:
+  build-racket3m:
+    container:
+      image: racket/racket-ci:latest
+                
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM64]
+
+    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+    - name: Build Racket 3m
+      run: make CPUS=$(nproc) PKGS="" bc-in-place
+
+  build-racketcs:
+    container:
+      image: racket/racket-ci:latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: [ARM64]
+
+    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+    - name: Build Racket CS
+      run: make CPUS=$(nproc) PKGS="" cs-in-place

--- a/.github/workflows/ci-push-arm_linux.yml
+++ b/.github/workflows/ci-push-arm_linux.yml
@@ -1,6 +1,6 @@
 name: CI Linux ARM
 
-on: [push, pull_request]
+on: [push]
 
 jobs:
 

--- a/.github/workflows/ubsan-arm.yml
+++ b/.github/workflows/ubsan-arm.yml
@@ -1,6 +1,8 @@
 name: Test with UBSan on ARM
 
-on: [push, pull_request]
+on:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
 


### PR DESCRIPTION
Due to the speed and volume of available ARM HW reduce tests on
ARM during PRs and leave them for push-only. Run ubsan only on a
daily basis.