### PR TITLE
docs: add example for subprocess

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/subprocess.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/subprocess.scrbl
@@ -111,6 +111,19 @@ The @racket[subprocess] procedure returns four values:
 explicitly closed, usually with @racket[close-input-port] or
 @racket[close-output-port].
 
+Example:
+
+@racketblock[
+(define-values (k out in err)
+  (subprocess #f #f #f "/bin/ls" "-l"))
+(displayln (format "stdout:\n~a" (port->string out)))
+(displayln (format "stderr:\n~a" (port->string err)))
+(close-input-port out)
+(close-output-port in)
+(close-input-port err)
+(subprocess-wait k)
+]
+
 @margin-note{A @tech{file-stream port} for communicating with a
 subprocess is normally a pipe with a limited capacity. Beware of
 creating deadlock by serializing a write to a subprocess followed by a

--- a/pkgs/racket-doc/scribblings/reference/subprocess.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/subprocess.scrbl
@@ -111,19 +111,6 @@ The @racket[subprocess] procedure returns four values:
 explicitly closed, usually with @racket[close-input-port] or
 @racket[close-output-port].
 
-Example:
-
-@racketblock[
-(define-values (k out in err)
-  (subprocess #f #f #f "/bin/ls" "-l"))
-(displayln (format "stdout:\n~a" (port->string out)))
-(displayln (format "stderr:\n~a" (port->string err)))
-(close-input-port out)
-(close-output-port in)
-(close-input-port err)
-(subprocess-wait k)
-]
-
 @margin-note{A @tech{file-stream port} for communicating with a
 subprocess is normally a pipe with a limited capacity. Beware of
 creating deadlock by serializing a write to a subprocess followed by a
@@ -148,6 +135,19 @@ whether the subprocess itself is registered with the current
 A subprocess can be used as a @tech{synchronizable event} (see @secref["sync"]).
 A subprocess value is @tech{ready for synchronization} when
 @racket[subprocess-wait] would not block; @resultItself{subprocess value}.
+
+Example:
+
+@racketblock[
+(define-values (sp out in err)
+  (subprocess #f #f #f "/bin/ls" "-l"))
+(printf "stdout:\n~a" (port->string out))
+(printf "stderr:\n~a" (port->string err))
+(close-input-port out)
+(close-output-port in)
+(close-input-port err)
+(subprocess-wait sp)
+]
 
 @history[#:changed "6.11.0.1" @elem{Added the @racket[group] argument.}
          #:changed "7.4.0.5" @elem{Added waiting for a fifo without a reader


### PR DESCRIPTION
The example shows two import rules as noted in document:
1. The ports returned from `subprocess` must be closed explicitly.
2. Close ports before waiting the process to exit.

Closes #3395