### PR TITLE
Rename define-simple-macro to define-syntax-parse-rule

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
@@ -39,7 +39,7 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 (fn2 a #:b 'c)
 ]
 
-@history[#:added "7.9.0.3"]
+@history[#:added "7.9.0.22"]
 }
 
 @defform[(define-syntax-parser macro-id parse-option ... clause ...+)]{

--- a/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/define.scrbl
@@ -12,7 +12,7 @@
 
 @defmodule[syntax/parse/define]
 
-@defform[(define-simple-macro (macro-id . pattern) pattern-directive ...
+@defform[(define-syntax-parse-rule (macro-id . pattern) pattern-directive ...
            template)]{
 
 Defines a macro named @racket[macro-id]; equivalent to the following:
@@ -26,11 +26,11 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 
 @(the-eval '(require syntax/parse/define))
 @examples[#:eval the-eval
-(define-simple-macro (fn x:id rhs:expr) (lambda (x) rhs))
+(define-syntax-parse-rule (fn x:id rhs:expr) (lambda (x) rhs))
 ((fn x x) 17)
 (fn 1 2)
 
-(define-simple-macro (fn2 x y rhs)
+(define-syntax-parse-rule (fn2 x y rhs)
   #:declare x id
   #:declare y id
   #:declare rhs expr
@@ -39,12 +39,7 @@ Defines a macro named @racket[macro-id]; equivalent to the following:
 (fn2 a #:b 'c)
 ]
 
-@history[#:changed "6.12.0.3" @elem{Changed pattern head to @racket[(~var macro-id id)] from
-                                    @racket[macro-id], allowing tilde-prefixed identifiers or
-                                    identifiers containing colons to be used as @racket[macro-id]
-                                    without producing a syntax error.}
-         #:changed "6.90.0.29" @elem{Changed to always use the @racket[#:track-literals]
-                                     @racket[syntax-parse] option.}]
+@history[#:added "7.9.0.3"]
 }
 
 @defform[(define-syntax-parser macro-id parse-option ... clause ...+)]{
@@ -67,5 +62,19 @@ Defines a macro named @racket[macro-id]; equivalent to:
 (fn3 1 2)
 (fn3 a #:b 'c)
 ]}
+
+@defform[(define-simple-macro (macro-id . pattern) pattern-directive ...
+           template)]{
+@deprecated[#:what "macro" @racket[define-syntax-parse-rule]]
+
+Re-exports @racket[define-syntax-parse-rule] for backward-compatibility.
+
+@history[#:changed "6.12.0.3" @elem{Changed pattern head to @racket[(~var macro-id id)] from
+                                    @racket[macro-id], allowing tilde-prefixed identifiers or
+                                    identifiers containing colons to be used as @racket[macro-id]
+                                    without producing a syntax error.}
+         #:changed "6.90.0.29" @elem{Changed to always use the @racket[#:track-literals]
+                                     @racket[syntax-parse] option.}]
+}
 
 @(close-eval the-eval)

--- a/racket/collects/syntax/parse/define.rkt
+++ b/racket/collects/syntax/parse/define.rkt
@@ -2,19 +2,20 @@
 (require (for-syntax racket/base
                      syntax/parse
                      "private/sc.rkt"))
-(provide define-simple-macro
+(provide define-syntax-parse-rule
          define-syntax-parser
+         (rename-out [define-syntax-parse-rule define-simple-macro])
          (for-syntax (all-from-out syntax/parse)))
 
-(define-syntax (define-simple-macro stx)
+(define-syntax (define-syntax-parse-rule stx)
   (syntax-parse stx
-    [(define-simple-macro (macro:id . pattern) . body)
+    [(_ (macro:id . pattern) . body)
      #`(define-syntax macro
          (syntax-parser/template
           #,((make-syntax-introducer) stx)
           [((~var macro id) . pattern) . body]))]))
 
-(define-simple-macro (define-syntax-parser macro:id option-or-clause ...)
+(define-syntax-parse-rule (define-syntax-parser macro:id option-or-clause ...)
   (define-syntax macro
     (syntax-parser option-or-clause ...)))
 


### PR DESCRIPTION
This PR is based on @lexi-lambda's #1310.
It resolves the conflicts in the mentioned PR and
adjusts the version so that it's up-to-date.

Closes #1310