### PR TITLE
generics: adjust generated error messages

### DIFF
--- a/racket/collects/racket/private/generic.rkt
+++ b/racket/collects/racket/private/generic.rkt
@@ -441,10 +441,10 @@
        (define/with-syntax (opt-name ...) opt)
        (define/with-syntax ((optkw-key optkw-val) ...) opt-kw)
        (define/with-syntax arg-labels/restargs ; labels for args
-         #'((symbol->string 'req-name) ... 
-            (string-append (symbol->string 'opt-name) " (optional)") ...
-            (string-append "#:" (keyword->string 'reqkw-key)) ...
-            (string-append "#:" (keyword->string 'optkw-key) " (optional)")  ...
+         #'((string-append (symbol->string 'req-name) " argument...") ... 
+            (string-append (symbol->string 'opt-name) " (optional) argument...") ...
+            (string-append "#:" (keyword->string 'reqkw-key) " argument...") ...
+            (string-append "#:" (keyword->string 'optkw-key) " (optional) argument...")  ...
             "rest args"))
        (define/with-syntax arg-labels ; drop restargs if none
          (if rest #'arg-labels/restargs (stx-drop-last #'arg-labels/restargs)))
@@ -462,12 +462,9 @@
          (apply append (stx-map list #'other-arg-labels #'other-args)))
        (define/with-syntax err-fmt-str
          (string-append "contract violation:\n"
-                        "expected: ~a\n"
-                        "given: ~v\n"
-                        (if (null? (syntax->list #'other-arg-labels))
-                            "argument position: ~a"
-                            (string-append "argument position: ~a\n"
-                                           "other arguments...:"))))
+                        "  expected: ~a\n"
+                        "  given: ~e\n"
+                        "  argument position: ~a"))
        (define/with-syntax contract-str
          (format "~s?" (syntax-e #'self-name)))
        (define/with-syntax self-i-stx self-i)


### PR DESCRIPTION
For #3478.

The error messages generated by `define-generic` currently do not follow the normal format. Besides using `~v` where `~e` should be used, the labelled error clauses are not indented by two spaces. And if extra arguments are provided, they are not really formatted right under an `other arguments...:` label.

The patch here adds indentation and changes the way that other arguments are reported in the message. For the other arguments, it preserves the argument names, but gives each a separate error clause with the argument name followed by `argument...`.

For example, with
```
#lang racket
(require racket/generic)

(define-generics something
  (both-something? something x))

(both-something? 1 2)
```

Before:
```
both-something?: contract violation:
expected: something?
given: 1
argument position: 1st
other arguments...:
  x: 2
  context...:
   ....
```

After:
```
both-something?: contract violation:
  expected: something?
  given: 1
  argument position: 1st
  x argument...: 2
  context...:
   ....
```

I'm not sure this is a good idea. for one thing, `define-generic` is still generating a lot of code just for errors. It's not clear to me that it's worth all that just to give names to arguments, and it might be better to just use `raise-argument-error`. But the original author of the `define-generic` error code was clearly interested in including this information for the error, so that's why I've tried to keep it while repairing the format.

As always with changing error messages, there's a danger that a test suite somewhere is relying on exactly the old message.