### PR TITLE
match: eliminate field refs due to _ in constructor patterns

### DIFF
--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -342,6 +342,30 @@
         [(struct tree (a (struct tree (b  _ _)) _)) (list a b)]
         [_ 'no])))
 
+   (comp
+    'ok
+    (let ()
+      (define-struct st ([x #:mutable])
+        #:transparent)
+      (define a (st 1))
+      (define b (impersonate-struct a st-x (lambda (_self _x)
+                                             (error "must not impersonate"))))
+      (match b
+        [(st _) 'ok])))
+
+   (comp
+    'ok
+    (let ()
+      (define impersonated? #f)
+      (define-struct st ([x #:mutable])
+        #:transparent)
+      (define a (st 1))
+      (define b (impersonate-struct a st-x (lambda (_self x)
+                                             (set! impersonated? #t)
+                                             x)))
+      (match b
+        [(st x) (if impersonated? 'ok 'fail)])))
+
    (comp 1
          (match #&1
            [(box a) a]

--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -345,13 +345,15 @@
    (comp
     'ok
     (let ()
+      (define impersonated? #f)
       (define-struct st ([x #:mutable])
         #:transparent)
       (define a (st 1))
-      (define b (impersonate-struct a st-x (lambda (_self _x)
-                                             (error "must not impersonate"))))
+      (define b (impersonate-struct a st-x (lambda (_self x)
+                                             (set! impersonated? #t)
+                                             x)))
       (match b
-        [(st _) 'ok])))
+        [(st _) (if impersonated? 'fail 'ok)])))
 
    (comp
     'ok
@@ -365,6 +367,32 @@
                                              x)))
       (match b
         [(st x) (if impersonated? 'ok 'fail)])))
+
+   (comp
+    'ok
+    (let ()
+      (define impersonated? #f)
+      (define v (vector 1 2 3))
+      (define b (impersonate-vector v
+                                    (lambda (self idx _)
+                                      (set! impersonated? #t)
+                                      (vector-ref self idx))
+                                    vector-set!))
+      (match b
+        [(vector _ _ _) (if impersonated? 'fail 'ok)])))
+
+   (comp
+    'ok
+    (let ()
+      (define impersonated? #f)
+      (define v (vector 1 2 3))
+      (define b (impersonate-vector v
+                                    (lambda (self idx _)
+                                      (set! impersonated? #t)
+                                      (vector-ref self idx))
+                                    vector-set!))
+      (match b
+        [(vector a _ _) (if impersonated? 'ok 'fail)])))
 
    (comp 1
          (match #&1

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -149,8 +149,9 @@
        (for/first ([tmp (in-list (hash-keys todo))] #:when (free-identifier=? tmp stx))
          (hash-remove! todo tmp)
          (hash-set! seen tmp #t))]
-      [(list? (syntax-e stx))
-       (for-each loop (syntax-e stx))]))
+      [(syntax->list stx)
+       => (lambda (stxs)
+            (for-each loop stxs))]))
   (for/lists (tmps accs)
              ([tmp (in-list (syntax-e tmps))]
               [acc (in-list (syntax-e accs))]

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -41,12 +41,7 @@
   (map (lambda (p) (f (car p) (cdr p))) ht-l))
 
 (define (and* . vs)
-  (let loop ([r  #t]
-             [vs vs])
-    (cond
-      [(not r) r]
-      [(null? vs) r]
-      [else (loop (and r (car vs)) (cdr vs))])))
+  (andmap values vs))
 
 ;; Produce a bool for every column in a set of rows, where #t means
 ;; that every pat in that column is a Dummy.

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -138,10 +138,16 @@
 ;; present in `body'.
 (define (remove-unused-tmps tmps accs body)
   (define seen (make-hasheq))
+  (define todo (make-hasheq
+                (for/list ([tmp (in-list (syntax-e tmps))])
+                  (cons tmp #t))))
   (let loop ([stx body])
     (cond
+      ;; stop the search early if all the tmps have already been found
+      [(hash-empty? todo)]
       [(identifier? stx)
-       (for/first ([tmp (in-list (syntax-e tmps))] #:when (free-identifier=? tmp stx))
+       (for/first ([tmp (in-list (hash-keys todo))] #:when (free-identifier=? tmp stx))
+         (hash-remove! todo tmp)
          (hash-set! seen tmp #t))]
       [(list? (syntax-e stx))
        (for-each loop (syntax-e stx))]))

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -289,12 +289,14 @@
        (error 'compile-one "App block with multiple rows: ~a" block))
      (let* ([row (car block)]
             [pats (Row-pats row)]
-            [app-pats (App-ps first)])
+            [app-pats (App-ps first)]
+            [app-expr (App-expr first)])
        (with-syntax ([(t ...) (generate-temporaries app-pats)])
          #`(let-values ([(t ...)
-                         #,(if (procedure? (App-expr first))
-                             ((App-expr first) x)
-                             #`(#,(App-expr first) #,x))])
+                         #,(if (procedure? app-expr)
+                               (app-expr x)
+                               (quasisyntax/loc app-expr
+                                 (#,app-expr #,x)))])
              #,(compile* (append (syntax->list #'(t ...)) xs)
                          (list (make-Row (append app-pats (cdr pats))
                                          (Row-rhs row)

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -45,7 +45,11 @@
 ;; escaping to esc
 (define (gen-clause k rows x xs esc)
   (define-syntax-rule (constant-pat predicate-stx)
-    (with-syntax ([rhs (compile* (cons x xs)
+    (with-syntax ([lhs (if (procedure? predicate-stx)
+                           (predicate-stx x)
+                           (quasisyntax/loc predicate-stx
+                             (#,predicate-stx #,x)))]
+                  [rhs (compile* (cons x xs)
                                  (map (lambda (row)
                                         (define-values (p ps)
                                           (Row-split-pats row))
@@ -55,9 +59,7 @@
                                                   (Row-vars-seen row)))
                                       rows)
                                  esc)])
-      (if (procedure? predicate-stx)
-          #`[#,(predicate-stx x) rhs]
-          #`[(#,predicate-stx #,x) rhs])))
+      #'[lhs rhs]))
   (define (compile-con-pat accs pred pat-acc)
     (with-syntax* ([(tmps ...) (generate-temporaries accs)]
                    [(accs ...) accs]


### PR DESCRIPTION
Related to #3487.  This makes `_` in constructor patterns behave the same way as it does in simple patterns, where the binding is [already being elided](https://github.com/racket/racket/blob/128174594e06d789db736f5ef355055333fa02f3/racket/collects/racket/match/compiler.rkt#L167-L170).

Should the binding in `(st b)` from my example also be removed? I feel like it'd be surprising for something like that to potentially have a side-effect, but don't feel strongly about that case, especially since the docs for match explicitly state that a binding is created.