### PR TITLE
Ensure DEST exists before calling find

### DIFF
--- a/racket/src/cs/c/reset_boot.sh
+++ b/racket/src/cs/c/reset_boot.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-# Force all workare boot files back to links to immediate "boot"
+# Force all workarea boot files back to links to immediate "boot"
 
 MACH=$1
 SCHEME_WORKAREA=$2
@@ -10,7 +10,10 @@ ready_mach()
     INIT=$SCHEME_WORKAREA/boot/$MACH/$1
     RELINIT=../../../boot/$MACH/$1
     DEST=$SCHEME_WORKAREA/$MACH/boot/$MACH/$1
-    if [ "`/usr/bin/find "$INIT" -newer "$DEST"`" != "" ] ; then
+    if [ ! -f "$DEST" ]; then
+        mkdir -p `dirname $DEST`
+        ln -s "$RELINIT" "$DEST"
+    elif [ "`/usr/bin/find "$INIT" -newer "$DEST"`" != "" ] ; then
         rm "$DEST"
         ln -s "$RELINIT" "$DEST"
     fi


### PR DESCRIPTION
On raw racket clones when compiling with `--enable-racket` (i.e. no
pb), there are `find` warnings that DEST does not exist and
compilation still succeeds.

This change however, ensures that we do not have build warnings and
that the symlinks are properly created.