### PR TITLE
Changes required to compile Racket with C99+exts

### DIFF
--- a/pkgs/racket-build-guide/contribute.scrbl
+++ b/pkgs/racket-build-guide/contribute.scrbl
@@ -182,6 +182,13 @@ make that process faster by keeping a few guidelines in mind:
        will only be detected by a full @exec{raco setup}.
        @italic{Really:} run @exec{raco setup}.}
 
+ @item{For changes to the C code, ensure your code follows the C99 standard.
+
+       On *nix systems, extensions that are part of the @exec{_DEFAULT_SOURCE}
+       pre-processor flag are also allowed. See the
+       @hyperlink[https://www.gnu.org/software/libc/manual/html_node/Feature-Test-Macros.html#index-_005fDEFAULT_005fSOURCE]{glibc}
+       manual for more details.}
+
 ]
 
 @; ------------------------------------------------------------

--- a/racket/src/bc/src/future.c
+++ b/racket/src/bc/src/future.c
@@ -864,11 +864,11 @@ void scheme_future_block_until_gc()
 #  endif
       int _eax, _ebx, _ecx, _edx, op = 0;
       /* we can't always use EBX, so save and restore it: */
-      asm (MZ_PUSH_EBX "\n\t"
-           "cpuid \n\t" 
-           "movl %%ebx, %1 \n\t"
-           MZ_POP_EBX
-           : "=a" (_eax), "=r" (_ebx), "=c" (_ecx), "=d" (_edx) : "a" (op));
+      __asm__ (MZ_PUSH_EBX "\n\t"
+               "cpuid \n\t"
+               "movl %%ebx, %1 \n\t"
+               MZ_POP_EBX
+               : "=a" (_eax), "=r" (_ebx), "=c" (_ecx), "=d" (_edx) : "a" (op));
     }
 #  undef MZ_PUSH_EBX
 #  undef MZ_POP_EBX

--- a/racket/src/bc/src/number.c
+++ b/racket/src/bc/src/number.c
@@ -265,14 +265,14 @@ READ_ONLY Scheme_Object *scheme_zerol, *scheme_nzerol, *scheme_long_pi,
 XFORM_NONGCING static void to_double_prec(void)
 {
   int _dblprec = 0x27F;
-  asm ("fldcw %0" : : "m" (_dblprec));
+  __asm__ ("fldcw %0" : : "m" (_dblprec));
 }
 #endif
 #if defined(ASM_DBLPREC_CONTROL_87) || defined(ASM_EXTPREC_CONTROL_87)
 XFORM_NONGCING static void to_extended_prec(void)
 {
   int _extprec = 0x37F;
-  asm ("fldcw %0" : : "m" (_extprec));
+  __asm__ ("fldcw %0" : : "m" (_extprec));
 }
 #endif
 

--- a/racket/src/rktio/rktio_fs.c
+++ b/racket/src/rktio/rktio_fs.c
@@ -12,6 +12,7 @@
 # include <pwd.h>
 # include <grp.h>
 # include <dirent.h>
+# include <sys/time.h>
 #endif
 #ifdef RKTIO_SYSTEM_WINDOWS
 # include <shlobj.h>


### PR DESCRIPTION
With these changes RacketCS and RacketBC can be compiled with:
     `-std=c99 -D_DEFAULT_SOURCE`