### PR TITLE
Add ARM32 version of PR fast build workflow

### DIFF
--- a/.github/workflows/PR_ARM32-fastbuild.yml
+++ b/.github/workflows/PR_ARM32-fastbuild.yml
@@ -1,0 +1,24 @@
+name: ARM32 Linux Fast Build
+
+on: [pull_request]
+
+jobs:
+  build-racket3m:
+    runs-on: [self-hosted, Linux, ARM]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+    - name: Build Racket 3m
+      run: make CPUS=$(nproc) PKGS="" bc-in-place
+
+  build-racketcs:
+    runs-on: [self-hosted, Linux, ARM]
+
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: 100
+    - name: Build Racket CS
+      run: make CPUS=$(nproc) PKGS="" cs-in-place

--- a/.github/workflows/PR_ARM64-fastbuild.yml
+++ b/.github/workflows/PR_ARM64-fastbuild.yml
@@ -1,4 +1,4 @@
-name: ARM Linux Fast Build
+name: ARM64 Linux Fast Build
 
 on: [pull_request]
 
@@ -7,12 +7,7 @@ jobs:
     container:
       image: racket/racket-ci:latest
                 
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ARM64]
-
-    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    runs-on: [self-hosted, Linux, ARM64]
 
     steps:
     - uses: actions/checkout@v2
@@ -25,12 +20,7 @@ jobs:
     container:
       image: racket/racket-ci:latest
 
-    strategy:
-      fail-fast: false
-      matrix:
-        arch: [ARM64]
-
-    runs-on: [self-hosted, Linux, '${{ matrix.arch }}']
+    runs-on: [self-hosted, Linux, ARM64]
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Unfortunately, due to bug https://github.com/moby/moby/issues/41217,
ARM and ARM64 versions cannot share the same jobs through a matrix
setting.