### PR TITLE
Fix mutator listing in struct-auto-info. Closes #3501.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/struct.rktl
+++ b/pkgs/racket-test-core/tests/racket/struct.rktl
@@ -1478,6 +1478,15 @@
 ;; ----------------------------------------
 
 (let ()
+  (struct bar (a [b #:mutable] [c #:mutable] [d #:auto] [e #:auto] [f #:auto #:mutable]))
+  (define-syntax (get-bar-auto-field-accessors+mutators stx)
+    #`'#,(struct-auto-info-lists (syntax-local-value #'bar)))
+  (define (get-bar-auto-field-accessors+mutators*) (get-bar-auto-field-accessors+mutators))
+  (test '((bar-d bar-e bar-f) (set-bar-f!)) get-bar-auto-field-accessors+mutators*))
+
+;; ----------------------------------------
+
+(let ()
   (struct exn:foo exn () #:constructor-name make-exn:foo)
   (test "foo" exn-message (make-exn:foo "foo" (current-continuation-marks))))
 

--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -593,15 +593,18 @@
                              0
                              fld-size))
                    
-                   (define-values (sets field-to-mutator-directives)
+                   (define-values (sets field-to-mutator-directives sets-auto-count)
                      (let loop ([fields fields])
                        (cond
-                         [(null? fields) (values null null)]
+                         [(null? fields) (values null null 0)]
                          [(not (or mutable? (field-mutable? (car fields))))
                           (loop (cdr fields))]
                          [else
-                          (define-values (other-sets other-directives)
+                          (define-values (other-sets other-directives count)
                             (loop (cdr fields)))
+                          (define count* (if (field-auto? (car fields))
+                                             (+ count 1)
+                                             count))
                           (define this-set
                             (build-name id ; (field-id (car fields))
                                         "set-"
@@ -613,7 +616,8 @@
                                   (cons (field-to-selector/mutator-directive (car fields)
                                                                              this-set
                                                                              #f)
-                                        other-directives))])))
+                                        other-directives)
+                                  count*)])))
                    
                    (define all-directives
                      (append 
@@ -746,7 +750,7 @@
                                                                           (map protect (car super-autos))
                                                                           null))
                                                              (list #,@(map protect
-                                                                           (list-tail sets (max 0 (- (length sets) auto-count))))
+                                                                           (list-tail sets (max 0 (- (length sets) sets-auto-count))))
                                                                    #,@(if super-autos
                                                                           (map protect (cadr super-autos))
                                                                           null))))


### PR DESCRIPTION
Closes #3501.