### PR TITLE
Cptypes: Add special case for zero?

### DIFF
--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -548,7 +548,8 @@
   (test-chain '((lambda (x) (eq? x 0)) fixnum? #;exact-integer? real? number?))
   (test-chain* '(fixnum? integer? real?))
   (test-chain* '(fixnum? exact? number?)) ; exact? may raise an error
-  (test-chain* '((lambda (x) (eq? x (expt 256 100))) real? number?)) ; bignum?
+  (test-chain* '(bignum? exact? number?)) ; exact? may raise an error
+  (test-chain* '((lambda (x) (eq? x (expt 256 100))) bignum? real? number?))
   (test-chain '((lambda (x) (eqv? 0.0 x)) flonum? real? number?))
   (test-chain '(gensym? symbol?))
   (test-chain '(not boolean?))

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -198,6 +198,18 @@
   (cptypes-equivalent-expansion?
     '(lambda (x) (vector-set! x 0 0) (#2%odd? x) 1)
     '(lambda (x) (vector-set! x 0 0) (#2%odd? x) 2))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (or (fixnum? x) (bignum? x)) (zero? x)))
+    '(lambda (x) (when (or (fixnum? x) (bignum? x)) (#3%eq? x 0))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (and (or (fixnum? x) (bignum? x)) (zero? x)) x))
+    '(lambda (x) (when (and (or (fixnum? x) (bignum? x)) (zero? x)) 0)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (fixnum? x) (zero? x)))
+    '(lambda (x) (when (fixnum? x) (#3%fxzero? x))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (and (fixnum? x) (zero? x)) x))
+    '(lambda (x) (when (and (fixnum? x) (zero? x)) 0)))
 )
 
 (mat cptypes-type-if

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -462,7 +462,7 @@ Notes:
                       (predicate-implies? y t)))
                '(char null-or-pair $record
                  gensym uninterned-symbol interned-symbol symbol
-                 fixnum exact-integer flonum real number
+                 fixnum bignum exact-integer flonum real number
                  boolean true ptr))] ; ensure they are order from more restrictive to less restrictive
         [else #f]))
 
@@ -573,6 +573,7 @@ Notes:
       [box? 'box]
       [$record? '$record]
       [fixnum? 'fixnum]
+      [bignum? 'bignum]
       [flonum? 'flonum]
       [real? 'real]
       [number? 'number]
@@ -619,6 +620,7 @@ Notes:
       [box 'box]
       [$record '$record]
       [fixnum 'fixnum]
+      [bignum 'bignum]
       [flonum 'flonum]
       [real 'real]
       [number 'number]
@@ -716,16 +718,20 @@ Notes:
                   [(null-or-pair) (or (eq? x 'pair)
                                       (check-constant-is? x null?))]
                   [(fixnum) (check-constant-is? x target-fixnum?)]
+                  [(bignum) (check-constant-is? x target-bignum?)]
                   [(exact-integer)
                    (or (eq? x 'fixnum)
+                       (eq? x 'bignum)
                        (check-constant-is? x (lambda (x) (and (integer? x)
                                                               (exact? x)))))]
                   [(flonum) (check-constant-is? x flonum?)]
                   [(real) (or (eq? x 'fixnum)
+                              (eq? x 'bignum)
                               (eq? x 'exact-integer)
                               (eq? x 'flonum)
                               (check-constant-is? x real?))]
                   [(number) (or (eq? x 'fixnum)
+                                (eq? x 'bignum)
                                 (eq? x 'exact-integer)
                                 (eq? x 'flonum)
                                 (eq? x 'real)

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -1073,6 +1073,40 @@ Notes:
                  [else
                   (values `(call ,preinfo ,pr ,n) ret ntypes #f #f)]))])
 
+      (define-specialize 2 zero?
+        [(n) (let ([r (get-type n)])
+               (cond
+                 [(predicate-implies? r 'bignum)
+                  (values (make-seq ctxt n false-rec)
+                          false-rec ntypes #f #f)]
+                 [(predicate-implies? r 'fixnum)
+                  (values `(call ,preinfo ,(lookup-primref 3 'fxzero?) ,n)
+                          ret
+                          ntypes
+                          (pred-env-add/ref ntypes n `(quote 0) plxc)
+                          #f)]
+                 [(predicate-implies? r 'exact-integer)
+                  (values `(call ,preinfo ,(lookup-primref 3 'eq?) ,n (quote 0))
+                          ret
+                          ntypes
+                          (pred-env-add/ref ntypes n `(quote 0) plxc)
+                          #f)]
+                 [(predicate-implies? r 'flonum)
+                  (values `(call ,preinfo ,(lookup-primref 3 'flzero?) ,n)
+                          ret
+                          ntypes
+                          #f ; TODO: Add a type for flzero
+                          #f)]
+                 [else
+                  (values `(call ,preinfo ,pr ,n) ret ntypes #f #f)]))])
+
+      (define-specialize 2 fxzero?
+        [(n) (values `(call ,preinfo ,pr ,n)
+                     ret
+                     ntypes
+                     (pred-env-add/ref ntypes n `(quote 0) plxc)
+                     #f)])
+
       (define-specialize 2 atan
         [(n) (let ([r (get-type n)])
                (cond

--- a/racket/src/ChezScheme/s/primdata.ss
+++ b/racket/src/ChezScheme/s/primdata.ss
@@ -45,7 +45,7 @@
   (fx=? [sig [(fixnum fixnum fixnum ...) -> (boolean)]] [flags pure cp02 safeongoodargs])    ; restricted to 2+ arguments
   (fx>? [sig [(fixnum fixnum fixnum ...) -> (boolean)]] [flags pure cp02 safeongoodargs])    ; restricted to 2+ arguments
   (fx>=? [sig [(fixnum fixnum fixnum ...) -> (boolean)]] [flags pure cp02 safeongoodargs])   ; restricted to 2+ arguments
-  (fxzero? [sig [(fixnum) -> (boolean)]] [flags pure cp02 safeongoodargs])
+  (fxzero? [sig [(fixnum) -> (boolean)]] [flags pure cp02 safeongoodargs cptypes2])
   (fxnegative? [sig [(fixnum) -> (boolean)]] [flags pure cp02 safeongoodargs])
   (fxpositive? [sig [(fixnum) -> (boolean)]] [flags pure cp02 safeongoodargs])
   (fxeven? [sig [(fixnum) -> (boolean)]] [flags pure cp02 safeongoodargs])
@@ -201,7 +201,7 @@
   ((r6rs: =) [sig [(number number number ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])   ; restricted to 2+ arguments
   ((r6rs: >) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])   ; restricted to 2+ arguments
   ((r6rs: >=) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])  ; restricted to 2+ arguments
-  (zero? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
+  (zero? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2 ieee r5rs])
   (positive? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
   (negative? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
   (odd? [sig [(integer) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])


### PR DESCRIPTION
Add a special case for `zero?` It has more subcases than I expected.
 
IIUC a call to `zero?` is expanded to a local check `(eq? x 0)` and (`fixnum? x)` and then a call to    

https://github.com/racket/racket/blob/master/racket/src/ChezScheme/s/5_3.ss#L2481-L2488

It would be nice to just inline this implementation of `zero?` and let cptypes remove as much as possible, but I guess a naive expansion of all the instances of this function and all the similar function would increase the size of the compiled code too much.