### PR TITLE
fix syntax-local-eval when intdef argument given

### DIFF
--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -233,14 +233,19 @@
 
 (define (syntax-local-eval stx [intdefs '()])
   (let* ([name (generate-temporary)]
-         [intdef (syntax-local-make-definition-context)])
+         [intdef (syntax-local-make-definition-context)]
+         [all-intdefs (if (list? intdefs)
+                        (cons intdef intdefs)
+                        (list intdef intdefs))])
     (syntax-local-bind-syntaxes (list name)
                                 #`(call-with-values (lambda () #,stx) list)
                                 intdef
                                 intdefs)
     (apply values
-           (syntax-local-value (internal-definition-context-introduce intdef name)
-                               #f intdef))))
+           (syntax-local-value (for/fold ([name name]) ([intdef all-intdefs])
+                                 (internal-definition-context-introduce intdef name 'add))
+                               #f
+                               intdef))))
 
 (define-syntax (with-syntax* stx)
   (syntax-case stx ()


### PR DESCRIPTION
The implementation of `syntax-local-eval` is broken: it always produces an unbound identifier error when given definition contexts in the `intdef-ctxs` argument.

The implementation assumes that `syntax-local-bind-syntaxes` does not apply the scopes from its `extra-intdef-ctxs` argument to the bound identifiers. That assumption seems reasonable based on the documentation, but is apparently incorrect.

I'm not sure what the correct behavior of `syntax-local-bind-syntaxes` should be, but it's certainly easier to fix `syntax-local-eval` as this PR does.