### PR TITLE
Add sequence conversion functions for built-in collection types

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change only when
 ;; "racket_version.h" changes:
-(define version "7.9.0.9")
+(define version "7.9.0.10")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/reference/bytes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/bytes.scrbl
@@ -159,22 +159,29 @@ string.
 @mz-examples[(bytes-append #"Apple" #"Banana")]}
 
 
-@defproc[(bytes->list [bstr bytes?]) (listof byte?)]{ Returns a new
- list of bytes corresponding to the content of @racket[bstr]. That is,
- the length of the list is @racket[(bytes-length bstr)], and the
- sequence of bytes in @racket[bstr] is the same sequence in the
- result list.
+@defproc[(bytes->list [bstr bytes?]) (listof byte?)]{
+ Returns a new list of bytes corresponding to the content of @racket[bstr]. That is, the length of the
+ list is @racket[(bytes-length bstr)], and the sequence of bytes in @racket[bstr] is the same sequence
+ in the result list.
 
-@mz-examples[(bytes->list #"Apple")]}
+ Prefer using @racket[sequence->list], which accepts all kinds of sequences.
+
+ @mz-examples[(bytes->list #"Apple")]
+
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->bytes].}]}
 
 
-@defproc[(list->bytes [lst (listof byte?)]) bytes?]{ Returns a new
- mutable byte string whose content is the list of bytes in @racket[lst].
- That is, the length of the byte string is @racket[(length lst)], and
- the sequence of bytes in @racket[lst] is the same sequence in
- the result byte string.
+@defproc[(list->bytes [lst (listof byte?)]) bytes?]{
+ Returns a new mutable byte string whose content is the list of bytes in @racket[lst]. That is, the
+ length of the byte string is @racket[(length lst)], and the sequence of bytes in @racket[lst] is the
+ same sequence in the resulting byte string.
 
-@mz-examples[(list->bytes (list 65 112 112 108 101))]}
+ Prefer using @racket[sequence->bytes], which accepts all kinds of sequences and returns immutable
+ byte strings.
+
+ @mz-examples[(list->bytes (list 65 112 112 108 101))]
+
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->bytes].}]}
 
 @defproc[(make-shared-bytes [k exact-nonnegative-integer?] [b byte? 0])
 bytes?]{ Returns a new mutable byte string of length @racket[k] where each
@@ -677,5 +684,29 @@ each pair of bytes in @racket[strs].
 @mz-examples[#:eval string-eval
  (bytes-join '(#"one" #"two" #"three" #"four") #" potato ")
 ]}
+
+
+@defproc[(sequence->bytes [byte-sequence (sequence/c byte?)]) (and/c bytes? immutable?)]{
+
+ Copies @racket[byte-sequence] into an immutable byte string. This function makes an effort to avoid
+ unnecessary copying: if given an immutable byte string, the byte string is returned unchanged. For
+ some types of sequences, fast type-specific conversion functions are used rather than going through
+ the generic sequence interface. No guarantees about specific fast paths are provided, but users may
+ generally assume that there is no performance benefit to using a specialized byte string-copying
+ function such as @racket[list->bytes] or @racket[bytes->immutable-bytes] instead of using
+ @racket[sequence->bytes].
+
+ Note that @racket[sequence->bytes] does @bold{not} accept @tech{strings}. A string is a sequence of
+ characters, not a sequence of bytes. To convert strings into byte strings, use
+ @racket[string->bytes/utf-8] or a similar function.
+
+ @(mz-examples
+   #:eval string-eval
+   (sequence->bytes (list 104 101 108 108 111))
+   (sequence->bytes (vector 116 111 97 115 116))
+   (sequence->bytes #"banana"))
+
+ @history[#:added "7.9.0.10"]
+}
 
 @close-eval[string-eval]

--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -109,6 +109,27 @@ replaced by a later element that is @racket[equal?] or @racket[eqv?] but not
 
 }
 
+@defproc[(sequence->set [sequence (sequence/c any/c)]) set?]{
+ Converts @racket[sequence] into an immutable @tech{hash set}. The returned set uses @racket[equal?]
+ to compare elements. Duplicate elements in the sequence are ignored. The sequence must produce
+ elements one at a time; attempting to convert a multivalued sequence such as a @tech{hash table}
+ raises a contract error.
+
+ This function makes an effort to avoid unnecessary copying: if given an immutable hash set, the set
+ is returned unchanged. For some types of sequences, fast type-specific conversion functions are used
+ rather than going through the generic sequence interface. No guarantees about specific fast paths are
+ provided, but users may generally assume that there is no performance benefit to using a specialized
+ set-copying function such as @racket[list->set] instead of using @racket[sequence->set].
+
+ @(examples
+   #:eval set-eval
+   (sequence->set (list 1 2 3))
+   (sequence->set (set 1 2 3))
+   (sequence->set "hello"))
+ 
+ @history[#:added "7.9.0.10"]
+}
+
 @deftogether[(
 @defproc[(list->set [lst list?]) (and/c generic-set? set-equal? set?)]
 @defproc[(list->seteqv [lst list?]) (and/c generic-set? set-eqv? set?)]
@@ -705,6 +726,9 @@ Produces a list containing the elements of @racket[st].
 
 Supported for any @racket[st] that @supp{supports} @racket[set->stream].
 
+Prefer using @racket[sequence->list], which accepts all kinds of sequences.
+
+@history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->list].}]
 }
 
 @defproc[(set-map [st generic-set?]

--- a/pkgs/racket-doc/scribblings/reference/strings.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/strings.scrbl
@@ -53,9 +53,14 @@ whose positions are initialized with the given @racket[char]s.
 
 
 @defproc[(string->immutable-string [str string?]) (and/c string? immutable?)]{
-Returns an immutable string with the same content as
- @racket[str], returning @racket[str] itself if @racket[str] is
- immutable.}
+ Returns an immutable string with the same content as @racket[str], returning @racket[str] itself if
+ @racket[str] is immutable.
+
+ Prefer using @racket[sequence->string], which accepts all kinds of sequences and returns immutable
+ strings. When given mutable strings, @racket[sequence->string] is just as fast as
+ @racket[string->immutable-string].
+ 
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->string].}]}
 
 
 @defproc[(string-length [str string?]) exact-nonnegative-integer?]{
@@ -166,22 +171,31 @@ string.
 @history[#:added "7.5.0.14"]}
 
 
-@defproc[(string->list [str string?]) (listof char?)]{ Returns a new
- list of characters corresponding to the content of @racket[str]. That is,
- the length of the list is @racket[(string-length str)], and the
- sequence of characters in @racket[str] is the same sequence in the
- result list.
+@defproc[(string->list [str string?]) (listof char?)]{
 
-@mz-examples[(string->list "Apple")]}
+ Returns a new list of characters corresponding to the content of @racket[str]. That is, the length of
+ the list is @racket[(string-length str)], and the sequence of characters in @racket[str] is the same
+ sequence in the result list.
+
+ Prefer using @racket[sequence->list], which accepts all kinds of sequences.
+
+ @mz-examples[(string->list "Apple")]
+
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->list].}]}
 
 
-@defproc[(list->string [lst (listof char?)]) string?]{ Returns a new
- mutable string whose content is the list of characters in @racket[lst].
- That is, the length of the string is @racket[(length lst)], and
- the sequence of characters in @racket[lst] is the same sequence in
- the result string.
+@defproc[(list->string [lst (listof char?)]) string?]{
 
-@mz-examples[(list->string (list #\A #\p #\p #\l #\e))]}
+ Returns a new mutable string whose content is the list of characters in @racket[lst]. That is, the
+ length of the string is @racket[(length lst)], and the sequence of characters in @racket[lst] is the
+ same sequence in the result string.
+
+ Prefer using @racket[sequence->string], which accepts all kinds of sequences and returns immutable
+ strings.
+
+ @mz-examples[(list->string (list #\A #\p #\p #\l #\e))]
+
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->string].}]}
 
 
 @defproc[(build-string [n exact-nonnegative-integer?]
@@ -575,6 +589,28 @@ the second argument, respectively.
 @history[#:added "6.3"]{}
 }
 
+@defproc[(sequence->string [chars (sequence/c char?)]) (and/c string? immutable?)]{
+
+ Copies @racket[chars] into an immutable string. This function makes an effort to avoid unnecessary
+ copying: if given an immutable string, the string is returned unchanged. For some types of sequences,
+ fast type-specific conversion functions are used rather than going through the generic sequence
+ interface. No guarantees about specific fast paths are provided, but users may generally assume that
+ there is no performance benefit to using a specialized string-copying function such as
+ @racket[list->string] or @racket[string->immutable-string] instead of using
+ @racket[sequence->string].
+
+ Note that @racket[sequence->string] does @bold{not} accept @tech{byte strings}. A byte string is a
+ sequence of bytes, not a sequence of characters. To convert byte strings into strings, use
+ @racket[bytes->string/utf-8] or a similar function.
+
+ @(mz-examples
+   #:eval string-eval
+   (sequence->string (list #\a #\p #\p #\l #\e))
+   (sequence->string (vector #\r #\e #\d))
+   (sequence->string "hello"))
+
+ @history[#:added "7.9.0.10"]
+}
 
 @; ----------------------------------------
 @include-section["format.scrbl"]

--- a/pkgs/racket-doc/scribblings/reference/vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/vectors.scrbl
@@ -111,27 +111,42 @@ Compare and set operation for vectors. See @racket[box-cas!].
 
 @defproc[(vector->list [vec vector?]) list?]{
 
-Returns a list with the same length and elements as @racket[vec].
+ Returns a list with the same length and elements as @racket[vec].
 
-This function takes time proportional to the size of @racket[vec].}
+ This function takes time proportional to the size of @racket[vec].
+
+ Prefer using @racket[sequence->list], which accepts all kinds of sequences.
+
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->vector].}]}
 
 
 @defproc[(list->vector [lst list?]) vector?]{
 
-Returns a mutable vector with the same length and elements as
-@racket[lst].
-
-This function takes time proportional to the length of @racket[lst].}
+ Returns a mutable vector with the same length and elements as
+ @racket[lst].
+ 
+ This function takes time proportional to the length of @racket[lst].
+ 
+ Prefer using @racket[sequence->vector], which accepts all kinds of sequences and returns immutable
+ vectors.
+ 
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->vector].}]}
 
 
 @defproc[(vector->immutable-vector [vec vector?])
          (and/c vector? immutable?)]{
 
-Returns an immutable vector with the same length and elements as @racket[vec].
-If @racket[vec] is itself immutable, then it is returned as the result.
+ Returns an immutable vector with the same length and elements as @racket[vec].
+ If @racket[vec] is itself immutable, then it is returned as the result.
 
-This function takes time proportional to the size of @racket[vec] when
-@racket[vec] is mutable.}
+ This function takes time proportional to the size of @racket[vec] when
+ @racket[vec] is mutable.
+
+ Prefer using @racket[sequence->vector], which accepts all kinds of sequences and returns immutable
+ vectors. When given mutable vectors, @racket[sequence->vector] is just as fast as
+ @racket[vector->immutable-vector].
+ 
+ @history[#:changed "7.9.0.10" @elem{Soft deprecated in favor of @racket[sequence->vector].}]}
 
 
 @defproc[(vector-fill! [vec (and/c vector? (not/c immutable?))]
@@ -474,5 +489,24 @@ v2]
 @history[#:added "6.6.0.5"]{}
 }
 
+@defproc[(sequence->vector [sequence (sequence/c any/c)]) (and/c vector? immutable?)]{
+
+ Copies @racket[sequence] into an immutable vector. This function makes an effort to avoid unnecessary
+ copying: if given an immutable vector, the vector is returned unchanged. For some types of sequences,
+ fast type-specific conversion functions are used rather than going through the generic sequence
+ interface. No guarantees about specific fast paths are provided, but users may generally assume that
+ there is no performance benefit to using a specialized vector-copying function such as
+ @racket[list->vector] or @racket[vector->immutable-vector] instead of using
+ @racket[sequence->vector].
+
+ @(mz-examples
+   #:eval vec-eval
+   (sequence->vector (list 1 2 3))
+   (sequence->vector (vector 1 2 3))
+   (sequence->vector "hello")
+   (sequence->vector (in-range 5)))
+
+ @history[#:added "7.9.0.10"]
+}
 
 @close-eval[vec-eval]

--- a/racket/collects/racket/bytes.rkt
+++ b/racket/collects/racket/bytes.rkt
@@ -1,6 +1,9 @@
 #lang racket/base
 
-(provide bytes-append* bytes-join)
+(provide bytes-append* bytes-join
+         sequence->bytes)
+
+(require racket/sequence)
 
 (define bytes-append*
   (case-lambda [(strs) (apply bytes-append strs)] ; optimize common case
@@ -16,3 +19,20 @@
         [(null? strs) #""]
         [(null? (cdr strs)) (car strs)]
         [else (apply bytes-append (add-between strs sep))]))
+
+(define (sequence->bytes sequence)
+  (unless (sequence? sequence)
+    (raise-argument-error 'sequence->bytes "(sequence/c byte?)" sequence))
+  ;; This is a common enough case that we should give a better error message for it.
+  (when (string? sequence)
+    (raise-arguments-error
+     'sequence->bytes
+     "strings are sequences of characters, not bytes;
+ use string->bytes/utf-8 or a similar function instead"
+     "expected" (unquoted-printing-string "(sequence/c byte?)")
+     "given" sequence))
+  ;; TODO(jackfirth): Is there a way to reduce the number of copies we create here?
+  (cond
+    [(bytes? sequence) (bytes->immutable-bytes sequence)]
+    [(list? sequence) (bytes->immutable-bytes (list->bytes sequence))]
+    [else (bytes->immutable-bytes (list->bytes (sequence->list sequence)))]))

--- a/racket/collects/racket/private/set-types.rkt
+++ b/racket/collects/racket/private/set-types.rkt
@@ -13,6 +13,7 @@
 (provide set seteq seteqv
          weak-set weak-seteq weak-seteqv
          mutable-set mutable-seteq mutable-seteqv
+         sequence->set
          list->set list->seteq list->seteqv
          list->weak-set list->weak-seteq list->weak-seteqv
          list->mutable-set list->mutable-seteq list->mutable-seteqv
@@ -1105,3 +1106,10 @@
   (mutable-fors #'make-hasheq))
 (define-syntaxes (for/mutable-seteqv for*/mutable-seteqv)
   (mutable-fors #'make-hasheqv))
+
+(define (sequence->set sequence)
+  (unless (sequence? sequence)
+    (raise-argument-error 'sequence->set "(sequence/c any/c)" sequence))
+  (cond
+    [(list? sequence) (list->set sequence)]
+    [else (for/set ([element sequence]) element)]))

--- a/racket/collects/racket/set.rkt
+++ b/racket/collects/racket/set.rkt
@@ -29,6 +29,7 @@
          set seteq seteqv
          weak-set weak-seteq weak-seteqv
          mutable-set mutable-seteq mutable-seteqv
+         sequence->set
          list->set list->seteq list->seteqv
          list->weak-set list->weak-seteq list->weak-seteqv
          list->mutable-set list->mutable-seteq list->mutable-seteqv

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -7,7 +7,9 @@
          vector-filter vector-filter-not
          vector-count vector-argmin vector-argmax
          vector-member vector-memq vector-memv
-         vector-sort vector-sort!)
+         vector-sort vector-sort!
+         sequence->vector)
+
 (require racket/unsafe/ops
          (for-syntax racket/base)
          (rename-in (except-in "private/sort.rkt" sort)
@@ -296,3 +298,12 @@
     (if getkey
         (raw-vector-sort! vec less? start end getkey cache-keys?)
         (raw-vector-sort! vec less? start end))))
+
+(define (sequence->vector sequence)
+  (unless (sequence? sequence)
+    (raise-argument-error 'sequence->vector "(sequence/c any/c)" sequence))
+  ;; TODO(jackfirth): Is there a way to reduce the number of copies we create here?
+  (cond
+    [(vector? sequence) (vector->immutable-vector sequence)]
+    [(list? sequence) (vector->immutable-vector (list->vector sequence))]
+    [else (vector->immutable-vector (for/vector ([element sequence]) element))]))

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 7
 #define MZSCHEME_VERSION_Y 9
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 9
+#define MZSCHEME_VERSION_W 10
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
This pull request adds the following functions:

- `sequence->bytes` added to `racket/bytes`
- `sequence->string` added to `racket/string`
- `sequence->vector` added to `racket/vector`
- `sequence->set` added to `racket/set`

Each of these functions is equivalent to the corresponding list-specific version, such as `list->vector`, except they accept arbitrary single-element sequences instead of lists.  The functions include two important optimizations: fast paths for specific kinds of sequences and a fast path for already-converted inputs.

The functions are meant to serve as drop-in replacements for their monomorphic equivalents, with the exception that they always produce immutable values instead of mutable ones. To simplify the APIs of these collection types, all other forms of converting between these collections are soft-deprecated in favor of the unified sequence conversion APIs.

This change is backwards compatible, but it does represent a shift from some of the current Racket API design choices. I think it's a good shift worth making in standard Racket, but I'm open to discussing alternatives.

This pull request is missing tests because I'm not sure where to add them. Pointers to the appropriate test files would be appreciated.