### PR TITLE
raco-pkg: show full path instead of broken front page

### DIFF
--- a/racket/collects/pkg/private/catalog.rkt
+++ b/racket/collects/pkg/private/catalog.rkt
@@ -136,10 +136,12 @@
     (or (add-to-cache
          pkg cache
          (for/or ([i (in-list (pkg-catalogs))])
-           (define (consulting-catalog suffix)
+           (define (consulting-catalog suffix #:url [url #f])
              (if download-printf
-                 (download-printf "Resolv~a ~s via ~a\n" suffix pkg (url->string i))
-                 (log-pkg-debug "consult~a catalog ~a" suffix (url->string i))))
+                 (download-printf "Resolv~a ~s via ~a\n"
+                                  suffix pkg (url->string (or url i)))
+                 (log-pkg-debug "consult~a catalog ~a"
+                                suffix (url->string (or url i)))))
            (source->absolute-source
             i
             (select-info-version
@@ -147,9 +149,9 @@
               i
               ;; Server:
               (lambda (i)
-                (consulting-catalog "ing")
                 (define addr (add-version-query
                               (combine-url/relative i (format "pkg/~a" pkg))))
+                (consulting-catalog "ing" #:url addr)
                 (log-pkg-debug "resolving via ~a" (url->string addr))
                 (read-from-server
                  'package-catalog-lookup


### PR DESCRIPTION
`raco pkg` currently shows a message like:

Resolving "pollen" via https://download.racket-lang.org/releases/7.9/catalog/

However, this URL is not meant to be visited, giving 404 to visitors,
causing them to think that the package server is down, even though
that might not actually be the case.

The problem is exacerbated by the now-fixed #3499, but
I have seen this problem even before the 7.9 release (at least 5 times),
so it seems worth fixing.

In general, we should not show 404 URLs to users, anyway.

Note that I didn't change the local database and local directory cases
because I don't know how to best display the information.
However, since they are local, users at least won't (incorrectly) think that
the server is down.