### PR TITLE
RacketCS: preserve immutability when encoding structs as chez records

### DIFF
--- a/racket/src/cs/rumble/struct.ss
+++ b/racket/src/cs/rumble/struct.ss
@@ -501,21 +501,15 @@
                                                parent-rtd*
                                                prefab-uid #f #f
                                                (+ init-count auto-count)
-					       (if (eq? insp 'prefab)
-						   (sub1 (general-arithmetic-shift 1 (+ init-count auto-count)))
-						   (let loop ([i 0] [mask 0])
-						     (cond
-						      [(fx= i init-count)
-						       (let loop ([i 0] [mask mask])
-							 (cond
-							  [(fx= i auto-count) mask]
-							  [else
-							   (loop (fx+ i 1)
-								 (bitwise-ior mask (arithmetic-shift 1 (fx+ i init-count))))]))]
-						      [(#%memq i immutables) (loop (fx+ i 1) mask)]
-						      [else
-						       (loop (fx+ i 1)
-							     (bitwise-ior mask (arithmetic-shift 1 i)))]))))]
+                                               (let ([mask (sub1 (general-arithmetic-shift 1 (+ init-count auto-count)))])
+                                                 (if (eq? insp 'prefab)
+                                                     mask
+                                                     (let loop ([imms immutables] [mask mask])
+                                                       (cond
+                                                        [(null? imms) mask]
+                                                        [else
+                                                         (let ([m (bitwise-not (arithmetic-shift 1 (car imms)))])
+                                                           (loop (cdr imms) (bitwise-and mask m)))])))))]
             [parent-auto*-count (get-field-info-auto*-count parent-fi)]
             [parent-init*-count (get-field-info-init*-count parent-fi)]
             [parent-total*-count (get-field-info-total*-count parent-fi)]

--- a/racket/src/cs/schemified/io.scm
+++ b/racket/src/cs/schemified/io.scm
@@ -3700,7 +3700,7 @@
                         (|#%app| rktio_free h_0)
                         (loop_0 #t))))))))))
          (loop_0 #f))))))
-(define struct:exts (make-record-type-descriptor* 'exts #f #f #f #f 2 3))
+(define struct:exts (make-record-type-descriptor* 'exts #f #f #f #f 2 0))
 (define effect_2383
   (struct-type-install-properties!
    struct:exts
@@ -3992,7 +3992,7 @@
       (wrap-evt (|#%app| (input-port-evt-ref p_0) p_0) (lambda (v_0) p_0))
       (wrap-evt (|#%app| (output-port-evt-ref p_0) p_0) (lambda (v_0) p_0)))))
 (define struct:core-port
-  (make-record-type-descriptor* 'core-port #f #f #f #f 7 127))
+  (make-record-type-descriptor* 'core-port #f #f #f #f 7 124))
 (define effect_2716
   (struct-type-install-properties!
    struct:core-port
@@ -4061,7 +4061,7 @@
     (register-struct-field-mutator! set-core-port-count! struct:core-port 6)
     (void)))
 (define struct:core-port-methods.1
-  (make-record-type-descriptor* 'core-port-methods #f #f #f #f 5 31))
+  (make-record-type-descriptor* 'core-port-methods #f #f #f #f 5 0))
 (define effect_2750
   (struct-type-install-properties!
    struct:core-port-methods.1
@@ -4474,7 +4474,7 @@
    #f
    #f
    6
-   63))
+   0))
 (define effect_3216
   (struct-type-install-properties!
    struct:core-input-port-methods.1
@@ -4861,7 +4861,7 @@
    #f
    #f
    4
-   15))
+   0))
 (define effect_2581
   (struct-type-install-properties!
    struct:core-output-port-methods.1
@@ -5046,7 +5046,7 @@
                (values #f (replace-evt v_0 self-evt_0))
                (values (list v_0) #f)))))))))
 (define struct:write-evt
-  (make-record-type-descriptor* 'write-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'write-evt #f #f #f #f 1 0))
 (define effect_2681
   (struct-type-install-properties!
    struct:write-evt
@@ -5117,7 +5117,7 @@
    #f
    #f))
 (define struct:utf-8-state
-  (make-record-type-descriptor* 'utf-8-state #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'utf-8-state #f #f #f #f 3 0))
 (define effect_2417
   (struct-type-install-properties!
    struct:utf-8-state
@@ -7270,7 +7270,7 @@
           (set-core-port-offset! in_0 (+ amt_0 old-offset_0))
           (void))))))
 (define struct:commit-manager
-  (make-record-type-descriptor* 'commit-manager #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'commit-manager #f #f #f #f 3 0))
 (define effect_3024
   (struct-type-install-properties!
    struct:commit-manager
@@ -7371,7 +7371,7 @@
      2)
     (void)))
 (define struct:commit-request
-  (make-record-type-descriptor* 'commit-request #f #f #f #f 5 31))
+  (make-record-type-descriptor* 'commit-request #f #f #f #f 5 0))
 (define effect_2327
   (struct-type-install-properties!
    struct:commit-request
@@ -7514,7 +7514,7 @@
      4)
     (void)))
 (define struct:commit-response
-  (make-record-type-descriptor* 'commit-response #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'commit-response #f #f #f #f 2 0))
 (define effect_2424
   (struct-type-install-properties!
    struct:commit-response
@@ -8088,7 +8088,7 @@
              (begin (temp3.1$3 d_0) (temp4.1$2 d_0))
              (unsafe-end-atomic))))))))
 (define struct:pipe-data
-  (make-record-type-descriptor* 'pipe-data #f #f #f #f 16 65535))
+  (make-record-type-descriptor* 'pipe-data #f #f #f #f 16 65534))
 (define effect_3136
   (struct-type-install-properties!
    struct:pipe-data
@@ -9419,7 +9419,7 @@
       ((limit_0 input-name25_0) (make-pipe_0 limit_0 input-name25_0 'pipe))
       ((limit24_0) (make-pipe_0 limit24_0 'pipe 'pipe))))))
 (define struct:pipe-write-poller
-  (make-record-type-descriptor* 'pipe-write-poller #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'pipe-write-poller #f #f #f #f 1 0))
 (define effect_2371
   (struct-type-install-properties!
    struct:pipe-write-poller
@@ -9506,7 +9506,7 @@
      0)
     (void)))
 (define struct:pipe-read-poller
-  (make-record-type-descriptor* 'pipe-read-poller #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'pipe-read-poller #f #f #f #f 1 0))
 (define effect_2394
   (struct-type-install-properties!
    struct:pipe-read-poller
@@ -9720,7 +9720,7 @@
    #f
    #f
    1
-   1))
+   0))
 (define effect_2651
   (struct-type-install-properties!
    struct:peek-via-read-input-port-methods.1
@@ -10517,7 +10517,7 @@
    #f
    #f
    2
-   3))
+   0))
 (define effect_2334
   (struct-type-install-properties!
    struct:fd-input-port-methods.1
@@ -10961,7 +10961,7 @@
    #f
    #f
    2
-   3))
+   0))
 (define effect_2413
   (struct-type-install-properties!
    struct:fd-output-port-methods.1
@@ -11586,7 +11586,7 @@
                      (format-rktio-message 'file-position r_0 base-msg_0)))
                 (|#%app| exn:fail app_0 (current-continuation-marks)))))))
         (void)))))
-(define struct:fd-evt (make-record-type-descriptor* 'fd-evt #f #f #f #f 3 7))
+(define struct:fd-evt (make-record-type-descriptor* 'fd-evt #f #f #f #f 3 4))
 (define effect_2590
   (struct-type-install-properties!
    struct:fd-evt
@@ -11731,7 +11731,7 @@
     (register-struct-field-mutator! set-fd-evt-closed! struct:fd-evt 2)
     (void)))
 (define struct:rktio-fd-flushed-evt
-  (make-record-type-descriptor* 'rktio-fd-flushed-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'rktio-fd-flushed-evt #f #f #f #f 1 0))
 (define effect_2959
   (struct-type-install-properties!
    struct:rktio-fd-flushed-evt
@@ -12546,7 +12546,7 @@
                                 (loop_0 (fx+ i_0 1)))))))))))
                  (loop_0 pos_0))))))))))
 (define struct:progress-evt
-  (make-record-type-descriptor* 'progress-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'progress-evt #f #f #f #f 2 0))
 (define effect_2604
   (struct-type-install-properties!
    struct:progress-evt
@@ -15864,7 +15864,7 @@
         (unsafe-bytes-set! out-bstr_0 j_0 lo_0)
         (unsafe-bytes-set! out-bstr_0 (+ j_0 1) hi_0)))))
 (define struct:utf-8-converter
-  (make-record-type-descriptor* 'utf-8-converter #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'utf-8-converter #f #f #f #f 2 0))
 (define effect_2723
   (struct-type-install-properties!
    struct:utf-8-converter
@@ -18171,7 +18171,7 @@
        (bytes->string/locale_0 in-bstr_0 err-char_0 start6_0 unsafe-undefined))
       ((in-bstr_0 err-char5_0)
        (bytes->string/locale_0 in-bstr_0 err-char5_0 0 unsafe-undefined))))))
-(define struct:path (make-record-type-descriptor* 'path #f #f #f #f 2 3))
+(define struct:path (make-record-type-descriptor* 'path #f #f #f #f 2 0))
 (define effect_2407
   (struct-type-install-properties!
    struct:path
@@ -19901,7 +19901,7 @@
    #f
    #f
    2
-   3))
+   0))
 (define effect_2372
   (struct-type-install-properties!
    struct:bytes-output-port-methods.1
@@ -21728,7 +21728,7 @@
     (lambda (v_0 fuel_0 mode_0 print-graph?_0 config_0)
       (quick-no-graph?_0 config_0 mode_0 print-graph?_0 v_0 fuel_0))))
 (define struct:as-constructor
-  (make-record-type-descriptor* 'as-constructor #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'as-constructor #f #f #f #f 1 0))
 (define effect_2971
   (struct-type-install-properties!
    struct:as-constructor
@@ -25008,7 +25008,7 @@
             (just-separators-after? s_0 2)
             #f))))))
 (define struct:starting-point
-  (make-record-type-descriptor* 'starting-point #f #f #f #f 7 127))
+  (make-record-type-descriptor* 'starting-point #f #f #f #f 7 0))
 (define effect_2720
   (struct-type-install-properties!
    struct:starting-point
@@ -27109,7 +27109,7 @@
 (define listen-port-number?
   (lambda (v_0) (if (fixnum? v_0) (<= 0 v_0 65535) #f)))
 (define struct:security-guard
-  (make-record-type-descriptor* 'security-guard #f #f #f #f 4 15))
+  (make-record-type-descriptor* 'security-guard #f #f #f #f 4 0))
 (define effect_2690
   (struct-type-install-properties!
    struct:security-guard
@@ -33362,7 +33362,7 @@
 (define adjust-path
   (lambda (p_0) (if (is-path? p_0) (relative-to-user-directory p_0) p_0)))
 (define struct:logger
-  (make-record-type-descriptor* 'logger #f #f #f #f 11 2047))
+  (make-record-type-descriptor* 'logger #f #f #f #f 11 376))
 (define effect_2192
   (struct-type-install-properties!
    struct:logger
@@ -33904,7 +33904,7 @@
     (register-struct-field-mutator! set-queue-start! struct:queue 0)
     (register-struct-field-mutator! set-queue-end! struct:queue 1)
     (void)))
-(define struct:node (make-record-type-descriptor* 'node #f #f #f #f 3 7))
+(define struct:node (make-record-type-descriptor* 'node #f #f #f #f 3 6))
 (define effect_2547
   (struct-type-install-properties!
    struct:node
@@ -33971,7 +33971,7 @@
         (let ((app_0 (node-next n_0))) (set-node-prev! app_0 (node-prev n_0)))
         (set-queue-end! q_0 (node-prev n_0))))))
 (define struct:log-receiver
-  (make-record-type-descriptor* 'log-receiver #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'log-receiver #f #f #f #f 1 0))
 (define effect_2708
   (struct-type-install-properties!
    struct:log-receiver
@@ -34038,7 +34038,7 @@
    #f
    #f
    3
-   7))
+   0))
 (define effect_2757
   (struct-type-install-properties!
    struct:queue-log-receiver
@@ -34232,7 +34232,7 @@
    #f
    #f
    2
-   3))
+   0))
 (define effect_2592
   (struct-type-install-properties!
    struct:stdio-log-receiver
@@ -34391,7 +34391,7 @@
    #f
    #f
    2
-   3))
+   0))
 (define effect_2241
   (struct-type-install-properties!
    struct:syslog-log-receiver
@@ -35914,7 +35914,7 @@
                 (let ((bstr_0 (make-bytes sz_0)))
                   (begin (|#%app| final_0 p_0 bstr_0) bstr_0))))))))))
 (define struct:subprocess
-  (make-record-type-descriptor* 'subprocess #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'subprocess #f #f #f #f 3 3))
 (define effect_2272
   (struct-type-install-properties!
    struct:subprocess
@@ -37220,7 +37220,7 @@
              (begin (set-tcp-output-port-abandon?! cp_0 #t) (close-port p_0))
              (void))))))))
 (define struct:rktio-evt
-  (make-record-type-descriptor* 'rktio-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'rktio-evt #f #f #f #f 2 0))
 (define effect_3001
   (struct-type-install-properties!
    struct:rktio-evt
@@ -37838,7 +37838,7 @@
           (set-connect-progress-trying-fd! conn-prog_0 #f))
         (void)))))
 (define struct:tcp-listener
-  (make-record-type-descriptor* 'tcp-listener #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'tcp-listener #f #f #f #f 3 0))
 (define effect_2611
   (struct-type-install-properties!
    struct:tcp-listener
@@ -38236,7 +38236,7 @@
            (raise-argument-error 'tcp-accept-evt "tcp-listener?" listener_0))
          (accept-evt6.1 listener_0))))))
 (define struct:accept-evt
-  (make-record-type-descriptor* 'tcp-accept-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'tcp-accept-evt #f #f #f #f 1 0))
 (define effect_2325
   (struct-type-install-properties!
    struct:accept-evt
@@ -39614,7 +39614,7 @@
             wait?53_0
             who59_0)))))))
 (define struct:udp-sending-evt
-  (make-record-type-descriptor* 'udp-send-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'udp-send-evt #f #f #f #f 2 0))
 (define effect_2358
   (struct-type-install-properties!
    struct:udp-sending-evt
@@ -40036,7 +40036,7 @@
 (define cell.1$2 (unsafe-make-place-local #vu8()))
 (define cell.2 (unsafe-make-place-local ""))
 (define struct:udp-receiving-evt
-  (make-record-type-descriptor* 'udp-receive-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'udp-receive-evt #f #f #f #f 2 0))
 (define effect_2355
   (struct-type-install-properties!
    struct:udp-receiving-evt

--- a/racket/src/cs/schemified/regexp.scm
+++ b/racket/src/cs/schemified/regexp.scm
@@ -931,7 +931,7 @@
 (define rx:line-end 'line-end)
 (define rx:word-boundary 'word-boundary)
 (define rx:not-word-boundary 'not-word-boundary)
-(define struct:rx:alts (make-record-type-descriptor* 'rx:alts #f #f #f #f 2 3))
+(define struct:rx:alts (make-record-type-descriptor* 'rx:alts #f #f #f #f 2 0))
 (define effect_2665
   (struct-type-install-properties!
    struct:rx:alts
@@ -987,7 +987,7 @@
     (register-struct-field-accessor! rx:alts-rx_2761 struct:rx:alts 1)
     (void)))
 (define struct:rx:sequence
-  (make-record-type-descriptor* 'rx:sequence #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'rx:sequence #f #f #f #f 2 0))
 (define effect_2137
   (struct-type-install-properties!
    struct:rx:sequence
@@ -1061,7 +1061,7 @@
      1)
     (void)))
 (define struct:rx:group
-  (make-record-type-descriptor* 'rx:group #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'rx:group #f #f #f #f 2 0))
 (define effect_2340
   (struct-type-install-properties!
    struct:rx:group
@@ -1129,7 +1129,7 @@
     (register-struct-field-accessor! rx:group-number struct:rx:group 1)
     (void)))
 (define struct:rx:repeat
-  (make-record-type-descriptor* 'rx:repeat #f #f #f #f 4 15))
+  (make-record-type-descriptor* 'rx:repeat #f #f #f #f 4 0))
 (define effect_2551
   (struct-type-install-properties!
    struct:rx:repeat
@@ -1232,7 +1232,7 @@
     (register-struct-field-accessor! rx:repeat-non-greedy? struct:rx:repeat 3)
     (void)))
 (define struct:rx:maybe
-  (make-record-type-descriptor* 'rx:maybe #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'rx:maybe #f #f #f #f 2 0))
 (define effect_2619
   (struct-type-install-properties!
    struct:rx:maybe
@@ -1300,7 +1300,7 @@
     (register-struct-field-accessor! rx:maybe-non-greedy? struct:rx:maybe 1)
     (void)))
 (define struct:rx:conditional
-  (make-record-type-descriptor* 'rx:conditional #f #f #f #f 6 63))
+  (make-record-type-descriptor* 'rx:conditional #f #f #f #f 6 0))
 (define effect_2459
   (struct-type-install-properties!
    struct:rx:conditional
@@ -1459,7 +1459,7 @@
      5)
     (void)))
 (define struct:rx:lookahead
-  (make-record-type-descriptor* 'rx:lookahead #f #f #f #f 4 15))
+  (make-record-type-descriptor* 'rx:lookahead #f #f #f #f 4 0))
 (define effect_2324
   (struct-type-install-properties!
    struct:rx:lookahead
@@ -1567,7 +1567,7 @@
     (register-struct-field-accessor! rx:lookahead-num-n struct:rx:lookahead 3)
     (void)))
 (define struct:rx:lookbehind
-  (make-record-type-descriptor* 'rx:lookbehind #f #f #f #f 6 63))
+  (make-record-type-descriptor* 'rx:lookbehind #f #f #f #f 6 12))
 (define effect_2263
   (struct-type-install-properties!
    struct:rx:lookbehind
@@ -1764,7 +1764,7 @@
      struct:rx:lookbehind
      3)
     (void)))
-(define struct:rx:cut (make-record-type-descriptor* 'rx:cut #f #f #f #f 4 15))
+(define struct:rx:cut (make-record-type-descriptor* 'rx:cut #f #f #f #f 4 0))
 (define effect_2942
   (struct-type-install-properties!
    struct:rx:cut
@@ -1859,7 +1859,7 @@
     (register-struct-field-accessor! rx:cut-needs-backtrack? struct:rx:cut 3)
     (void)))
 (define struct:rx:reference
-  (make-record-type-descriptor* 'rx:reference #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'rx:reference #f #f #f #f 2 0))
 (define effect_2344
   (struct-type-install-properties!
    struct:rx:reference
@@ -1935,7 +1935,7 @@
      1)
     (void)))
 (define struct:rx:range
-  (make-record-type-descriptor* 'rx:range #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'rx:range #f #f #f #f 1 0))
 (define effect_2702
   (struct-type-install-properties!
    struct:rx:range
@@ -1986,7 +1986,7 @@
     (register-struct-field-accessor! rx:range-range struct:rx:range 0)
     (void)))
 (define struct:rx:unicode-categories
-  (make-record-type-descriptor* 'rx:unicode-categories #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'rx:unicode-categories #f #f #f #f 2 0))
 (define effect_2129
   (struct-type-install-properties!
    struct:rx:unicode-categories
@@ -2270,7 +2270,7 @@
      (let ((or-part_0 (needs-backtrack? pces1_0)))
        (if or-part_0 or-part_0 (needs-backtrack? pces2_0))))))
 (define struct:parse-config
-  (make-record-type-descriptor* 'parse-config #f #f #f #f 7 127))
+  (make-record-type-descriptor* 'parse-config #f #f #f #f 7 0))
 (define effect_2566
   (struct-type-install-properties!
    struct:parse-config
@@ -4926,7 +4926,7 @@
                                       #f)))))))))))))))))))
 (define union (lambda (a_0 b_0) (if a_0 (if b_0 (range-union a_0 b_0) #f) #f)))
 (define struct:lazy-bytes
-  (make-record-type-descriptor* 'lazy-bytes #f #f #f #f 13 8191))
+  (make-record-type-descriptor* 'lazy-bytes #f #f #f #f 13 3075))
 (define effect_2272
   (struct-type-install-properties!
    struct:lazy-bytes
@@ -7578,7 +7578,7 @@
             (range-matcher* (compile-range (rx:range-range rx_0)) max_0)
             #f))))))
 (define struct:rx:regexp
-  (make-record-type-descriptor* 'regexp #f #f #f #f 10 1023))
+  (make-record-type-descriptor* 'regexp #f #f #f #f 10 0))
 (define effect_2503
   (struct-type-install-properties!
    struct:rx:regexp

--- a/racket/src/cs/schemified/schemify.scm
+++ b/racket/src/cs/schemified/schemify.scm
@@ -16397,31 +16397,34 @@
                                     (let ((n_0
                                            (struct-type-info-immediate-field-count
                                             sti_0)))
-                                      (let ((c1_0
-                                             (struct-type-info-non-prefab-immutables
-                                              sti_0)))
-                                        (if c1_0
-                                          (letrec*
-                                           ((loop_0
-                                             (|#%name|
-                                              loop
-                                              (lambda (i_0 mask_0)
-                                                (begin
-                                                  (if (= i_0 n_0)
-                                                    mask_0
-                                                    (if (memq i_0 c1_0)
-                                                      (loop_0 (+ i_0 1) mask_0)
-                                                      (let ((app_4 (+ i_0 1)))
-                                                        (loop_0
-                                                         app_4
-                                                         (bitwise-ior
-                                                          mask_0
-                                                          (arithmetic-shift
-                                                           1
-                                                           i_0)))))))))))
-                                           (loop_0 0 0))
-                                          (sub1
-                                           (arithmetic-shift 1 n_0)))))))))))))
+                                      (let ((mask_0
+                                             (sub1 (arithmetic-shift 1 n_0))))
+                                        (let ((c1_0
+                                               (struct-type-info-non-prefab-immutables
+                                                sti_0)))
+                                          (if c1_0
+                                            (letrec*
+                                             ((loop_0
+                                               (|#%name|
+                                                loop
+                                                (lambda (imms_0 mask_1)
+                                                  (begin
+                                                    (if (null? imms_0)
+                                                      mask_1
+                                                      (let ((m_0
+                                                             (bitwise-not
+                                                              (arithmetic-shift
+                                                               1
+                                                               (car imms_0)))))
+                                                        (let ((app_4
+                                                               (cdr imms_0)))
+                                                          (loop_0
+                                                           app_4
+                                                           (bitwise-and
+                                                            mask_1
+                                                            m_0))))))))))
+                                             (loop_0 c1_0 mask_0))
+                                            mask_0))))))))))))
                      (list*
                       'begin
                       app_0

--- a/racket/src/cs/schemified/schemify.scm
+++ b/racket/src/cs/schemified/schemify.scm
@@ -4378,7 +4378,7 @@
          (let ((app_0
                 (if (string? prefix_0) prefix_0 (symbol->string prefix_0))))
            (string-append app_0 (number->string (unbox b_0)))))))))
-(define struct:import (make-record-type-descriptor* 'import #f #f #f #f 4 15))
+(define struct:import (make-record-type-descriptor* 'import #f #f #f #f 4 0))
 (define effect_2897
   (struct-type-install-properties!
    struct:import
@@ -4467,7 +4467,7 @@
     (register-struct-field-accessor! import-ext-id struct:import 3)
     (void)))
 (define struct:import-group
-  (make-record-type-descriptor* 'import-group #f #f #f #f 6 63))
+  (make-record-type-descriptor* 'import-group #f #f #f #f 6 60))
 (define effect_2514
   (struct-type-install-properties!
    struct:import-group
@@ -4868,7 +4868,7 @@
             (|#%app| inc-index!_0)
             (|#%app| add-group!_0 grp_0)
             grp_0))))))
-(define struct:export (make-record-type-descriptor* 'export #f #f #f #f 2 3))
+(define struct:export (make-record-type-descriptor* 'export #f #f #f #f 2 0))
 (define effect_2166
   (struct-type-install-properties!
    struct:export
@@ -4929,7 +4929,7 @@
     (register-struct-field-accessor! export-ext-id struct:export 1)
     (void)))
 (define struct:too-early
-  (make-record-type-descriptor* 'too-early #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'too-early #f #f #f #f 2 0))
 (define effect_2681
   (struct-type-install-properties!
    struct:too-early
@@ -7034,18 +7034,18 @@
       ((k_0 im_0) k_0)
       (args (raise-binding-result-arity-error 2 args))))))
 (define struct:struct-type-info
-  (make-record-type-descriptor* 'struct-type-info #f #f #f #f 9 511))
-(define effect_2978
+  (make-record-type-descriptor* 'struct-type-info #f #f #f #f 10 0))
+(define effect_3042
   (struct-type-install-properties!
    struct:struct-type-info
    'struct-type-info
-   9
+   10
    0
    #f
    null
    (current-inspector)
    #f
-   '(0 1 2 3 4 5 6 7 8)
+   '(0 1 2 3 4 5 6 7 8 9)
    #f
    'struct-type-info))
 (define struct-type-info1.1
@@ -7189,41 +7189,59 @@
          s
          'struct-type-info
          'prefab-immutables))))))
-(define struct-type-info-constructor-name-expr_2507
+(define struct-type-info-non-prefab-immutables_2507
+  (|#%name|
+   struct-type-info-non-prefab-immutables
+   (record-accessor struct:struct-type-info 7)))
+(define struct-type-info-non-prefab-immutables
+  (|#%name|
+   struct-type-info-non-prefab-immutables
+   (lambda (s)
+     (if (struct-type-info?_2591 s)
+       (struct-type-info-non-prefab-immutables_2507 s)
+       ($value
+        (impersonate-ref
+         struct-type-info-non-prefab-immutables_2507
+         struct:struct-type-info
+         7
+         s
+         'struct-type-info
+         'non-prefab-immutables))))))
+(define struct-type-info-constructor-name-expr_2796
   (|#%name|
    struct-type-info-constructor-name-expr
-   (record-accessor struct:struct-type-info 7)))
+   (record-accessor struct:struct-type-info 8)))
 (define struct-type-info-constructor-name-expr
   (|#%name|
    struct-type-info-constructor-name-expr
    (lambda (s)
      (if (struct-type-info?_2591 s)
-       (struct-type-info-constructor-name-expr_2507 s)
+       (struct-type-info-constructor-name-expr_2796 s)
        ($value
         (impersonate-ref
-         struct-type-info-constructor-name-expr_2507
+         struct-type-info-constructor-name-expr_2796
          struct:struct-type-info
-         7
+         8
          s
          'struct-type-info
          'constructor-name-expr))))))
-(define struct-type-info-rest_2796
-  (|#%name| struct-type-info-rest (record-accessor struct:struct-type-info 8)))
+(define struct-type-info-rest_2430
+  (|#%name| struct-type-info-rest (record-accessor struct:struct-type-info 9)))
 (define struct-type-info-rest
   (|#%name|
    struct-type-info-rest
    (lambda (s)
      (if (struct-type-info?_2591 s)
-       (struct-type-info-rest_2796 s)
+       (struct-type-info-rest_2430 s)
        ($value
         (impersonate-ref
-         struct-type-info-rest_2796
+         struct-type-info-rest_2430
          struct:struct-type-info
-         8
+         9
          s
          'struct-type-info
          'rest))))))
-(define effect_2648
+(define effect_1914
   (begin
     (register-struct-constructor! struct-type-info1.1)
     (register-struct-predicate! struct-type-info?)
@@ -7256,13 +7274,17 @@
      struct:struct-type-info
      6)
     (register-struct-field-accessor!
-     struct-type-info-constructor-name-expr
+     struct-type-info-non-prefab-immutables
      struct:struct-type-info
      7)
     (register-struct-field-accessor!
-     struct-type-info-rest
+     struct-type-info-constructor-name-expr
      struct:struct-type-info
      8)
+    (register-struct-field-accessor!
+     struct-type-info-rest
+     struct:struct-type-info
+     9)
     (void)))
 (define struct-type-info-rest-properties-list-pos 0)
 (define make-struct-type-info
@@ -8002,53 +8024,225 @@
                                       (if (> (length rest_0) 5)
                                         (list-ref rest_0 5)
                                         #f)))
-                                 (if prefab-imms_1
-                                   (let ((app_0
-                                          (+
-                                           fields_0
-                                           (if u-parent_0
-                                             (known-struct-type-field-count
-                                              parent-sti_0)
-                                             0))))
-                                     (let ((app_1
-                                            (if (let ((or-part_0
-                                                       (not u-parent_0)))
-                                                  (if or-part_0
-                                                    or-part_0
-                                                    (known-struct-type-pure-constructor?
-                                                     parent-sti_0)))
+                                 (let ((non-prefab-imms_0
+                                        (if (eq? prefab-imms_1 'non-prefab)
+                                          (if (begin-unsafe
+                                               (let ((app_0 (unwrap '())))
+                                                 (eq? app_0 (unwrap rest_0))))
+                                            '()
+                                            (if (let ((p_0 (unwrap rest_0)))
+                                                  (if (pair? p_0)
+                                                    (let ((a_0 (cdr p_0)))
+                                                      (begin-unsafe
+                                                       (let ((app_0
+                                                              (unwrap '())))
+                                                         (eq?
+                                                          app_0
+                                                          (unwrap a_0)))))
+                                                    #f))
+                                              '()
+                                              (if (let ((p_0 (unwrap rest_0)))
+                                                    (if (pair? p_0)
+                                                      (let ((a_0 (cdr p_0)))
+                                                        (let ((p_1
+                                                               (unwrap a_0)))
+                                                          (if (pair? p_1)
+                                                            (let ((a_1
+                                                                   (cdr p_1)))
+                                                              (begin-unsafe
+                                                               (let ((app_0
+                                                                      (unwrap
+                                                                       '())))
+                                                                 (eq?
+                                                                  app_0
+                                                                  (unwrap
+                                                                   a_1)))))
+                                                            #f)))
+                                                      #f))
+                                                '()
+                                                (if (let ((p_0
+                                                           (unwrap rest_0)))
+                                                      (if (pair? p_0)
+                                                        (let ((a_0 (cdr p_0)))
+                                                          (let ((p_1
+                                                                 (unwrap a_0)))
+                                                            (if (pair? p_1)
+                                                              (let ((a_1
+                                                                     (cdr
+                                                                      p_1)))
+                                                                (let ((p_2
+                                                                       (unwrap
+                                                                        a_1)))
+                                                                  (if (pair?
+                                                                       p_2)
+                                                                    (let ((a_2
+                                                                           (cdr
+                                                                            p_2)))
+                                                                      (begin-unsafe
+                                                                       (let ((app_0
+                                                                              (unwrap
+                                                                               '())))
+                                                                         (eq?
+                                                                          app_0
+                                                                          (unwrap
+                                                                           a_2)))))
+                                                                    #f)))
+                                                              #f)))
+                                                        #f))
+                                                  '()
+                                                  (if (let ((p_0
+                                                             (unwrap rest_0)))
+                                                        (if (pair? p_0)
+                                                          (let ((a_0
+                                                                 (cdr p_0)))
+                                                            (let ((p_1
+                                                                   (unwrap
+                                                                    a_0)))
+                                                              (if (pair? p_1)
+                                                                (let ((a_1
+                                                                       (cdr
+                                                                        p_1)))
+                                                                  (let ((p_2
+                                                                         (unwrap
+                                                                          a_1)))
+                                                                    (if (pair?
+                                                                         p_2)
+                                                                      (let ((a_2
+                                                                             (cdr
+                                                                              p_2)))
+                                                                        (let ((p_3
+                                                                               (unwrap
+                                                                                a_2)))
+                                                                          (if (pair?
+                                                                               p_3)
+                                                                            (if (let ((a_3
+                                                                                       (car
+                                                                                        p_3)))
+                                                                                  (let ((p_4
+                                                                                         (unwrap
+                                                                                          a_3)))
+                                                                                    (if (pair?
+                                                                                         p_4)
+                                                                                      (if (let ((a_4
+                                                                                                 (car
+                                                                                                  p_4)))
+                                                                                            (begin-unsafe
+                                                                                             (let ((app_0
+                                                                                                    (unwrap
+                                                                                                     'quote)))
+                                                                                               (eq?
+                                                                                                app_0
+                                                                                                (unwrap
+                                                                                                 a_4)))))
+                                                                                        (let ((a_4
+                                                                                               (cdr
+                                                                                                p_4)))
+                                                                                          (let ((p_5
+                                                                                                 (unwrap
+                                                                                                  a_4)))
+                                                                                            (if (pair?
+                                                                                                 p_5)
+                                                                                              (let ((a_5
+                                                                                                     (cdr
+                                                                                                      p_5)))
+                                                                                                (begin-unsafe
+                                                                                                 (let ((app_0
+                                                                                                        (unwrap
+                                                                                                         '())))
+                                                                                                   (eq?
+                                                                                                    app_0
+                                                                                                    (unwrap
+                                                                                                     a_5)))))
+                                                                                              #f)))
+                                                                                        #f)
+                                                                                      #f)))
+                                                                              #t
+                                                                              #f)
+                                                                            #f)))
+                                                                      #f)))
+                                                                #f)))
+                                                          #f))
+                                                    (let ((immutables_0
+                                                           (let ((d_0
+                                                                  (cdr
+                                                                   (unwrap
+                                                                    rest_0))))
+                                                             (let ((d_1
+                                                                    (cdr
+                                                                     (unwrap
+                                                                      d_0))))
+                                                               (let ((d_2
+                                                                      (cdr
+                                                                       (unwrap
+                                                                        d_1))))
+                                                                 (let ((a_0
+                                                                        (car
+                                                                         (unwrap
+                                                                          d_2))))
+                                                                   (let ((d_3
+                                                                          (cdr
+                                                                           (unwrap
+                                                                            a_0))))
+                                                                     (let ((a_1
+                                                                            (car
+                                                                             (unwrap
+                                                                              d_3))))
+                                                                       a_1))))))))
+                                                      immutables_0)
+                                                    #f)))))
+                                          #f)))
+                                   (if (if (eq? prefab-imms_1 'non-prefab)
+                                         non-prefab-imms_0
+                                         prefab-imms_1)
+                                     (let ((app_0
+                                            (+
+                                             fields_0
+                                             (if u-parent_0
+                                               (known-struct-type-field-count
+                                                parent-sti_0)
+                                               0))))
+                                       (let ((app_1
                                               (if (let ((or-part_0
-                                                         (<
-                                                          (length rest_0)
-                                                          5)))
+                                                         (not u-parent_0)))
                                                     (if or-part_0
                                                       or-part_0
-                                                      (not
-                                                       (unwrap
-                                                        (list-ref rest_0 4)))))
-                                                (not
-                                                 (includes-property?_0
-                                                  rest_0
-                                                  'prop:chaperone-unsafe-undefined))
-                                                #f)
-                                              #f)))
-                                       (let ((app_2
-                                              (includes-property?_0
-                                               rest_0
-                                               'prop:authentic)))
-                                         (struct-type-info1.1
-                                          name_0
-                                          parent_0
-                                          fields_0
-                                          app_0
-                                          app_1
-                                          app_2
-                                          (if (eq? prefab-imms_1 'non-prefab)
-                                            #f
-                                            prefab-imms_1)
-                                          constructor-name-expr_0
-                                          rest_0))))
-                                   #f)))))
+                                                      (known-struct-type-pure-constructor?
+                                                       parent-sti_0)))
+                                                (if (let ((or-part_0
+                                                           (<
+                                                            (length rest_0)
+                                                            5)))
+                                                      (if or-part_0
+                                                        or-part_0
+                                                        (not
+                                                         (unwrap
+                                                          (list-ref
+                                                           rest_0
+                                                           4)))))
+                                                  (not
+                                                   (includes-property?_0
+                                                    rest_0
+                                                    'prop:chaperone-unsafe-undefined))
+                                                  #f)
+                                                #f)))
+                                         (let ((app_2
+                                                (includes-property?_0
+                                                 rest_0
+                                                 'prop:authentic)))
+                                           (struct-type-info1.1
+                                            name_0
+                                            parent_0
+                                            fields_0
+                                            app_0
+                                            app_1
+                                            app_2
+                                            (if (eq? prefab-imms_1 'non-prefab)
+                                              #f
+                                              prefab-imms_1)
+                                            non-prefab-imms_0
+                                            constructor-name-expr_0
+                                            rest_0))))
+                                     #f))))))
                          #f)
                        #f)
                      #f)))))
@@ -16203,7 +16397,31 @@
                                     (let ((n_0
                                            (struct-type-info-immediate-field-count
                                             sti_0)))
-                                      (sub1 (arithmetic-shift 1 n_0)))))))))))
+                                      (let ((c1_0
+                                             (struct-type-info-non-prefab-immutables
+                                              sti_0)))
+                                        (if c1_0
+                                          (letrec*
+                                           ((loop_0
+                                             (|#%name|
+                                              loop
+                                              (lambda (i_0 mask_0)
+                                                (begin
+                                                  (if (= i_0 n_0)
+                                                    mask_0
+                                                    (if (memq i_0 c1_0)
+                                                      (loop_0 (+ i_0 1) mask_0)
+                                                      (let ((app_4 (+ i_0 1)))
+                                                        (loop_0
+                                                         app_4
+                                                         (bitwise-ior
+                                                          mask_0
+                                                          (arithmetic-shift
+                                                           1
+                                                           i_0)))))))))))
+                                           (loop_0 0 0))
+                                          (sub1
+                                           (arithmetic-shift 1 n_0)))))))))))))
                      (list*
                       'begin
                       app_0
@@ -30592,7 +30810,7 @@
        wcm-state_0
        v_0))))
 (define struct:liftable
-  (make-record-type-descriptor* 'liftable #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'liftable #f #f #f #f 3 6))
 (define effect_2347
   (struct-type-install-properties!
    struct:liftable
@@ -39664,7 +39882,7 @@
           (lift-in_0 find-loops_0 leave-loops-intact?_0 v_0))
          v_0)))))
 (define struct:convert-mode
-  (make-record-type-descriptor* 'convert-mode #f #f #f #f 4 15))
+  (make-record-type-descriptor* 'convert-mode #f #f #f #f 4 0))
 (define effect_2645
   (struct-type-install-properties!
    struct:convert-mode
@@ -48892,7 +49110,7 @@
                           #t
                           (if (extflonum? q_0) #t #f))))))))))))))
 (define struct:to-unfasl
-  (make-record-type-descriptor* 'to-unfasl #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'to-unfasl #f #f #f #f 3 0))
 (define effect_3053
   (struct-type-install-properties!
    struct:to-unfasl
@@ -49043,7 +49261,7 @@
      'write
      "cannot marshal value that is embedded in compiled code\n  value: ~v"
      v_0)))
-(define struct:node (make-record-type-descriptor* 'node #f #f #f #f 5 31))
+(define struct:node (make-record-type-descriptor* 'node #f #f #f #f 5 0))
 (define effect_2498
   (struct-type-install-properties!
    struct:node
@@ -49373,7 +49591,7 @@
                          (stack-set stack_1 pos_1 (car vals_1))))))))))))
          (loop_0 pos_0 vals_0 count_0 stack_0))))))
 (define struct:stack-info
-  (make-record-type-descriptor* 'stack-info #f #f #f #f 5 31))
+  (make-record-type-descriptor* 'stack-info #f #f #f #f 5 28))
 (define effect_2396
   (struct-type-install-properties!
    struct:stack-info
@@ -49758,7 +49976,7 @@
   (lambda (stk-i_0 stack-depth_0)
     (set-stack-info-non-tail-call-later?! stk-i_0 #t)))
 (define struct:indirect
-  (make-record-type-descriptor* 'indirect #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'indirect #f #f #f #f 2 0))
 (define effect_2066
   (struct-type-install-properties!
    struct:indirect
@@ -49825,7 +50043,7 @@
     (register-struct-field-accessor! indirect-pos struct:indirect 0)
     (register-struct-field-accessor! indirect-element struct:indirect 1)
     (void)))
-(define struct:boxed (make-record-type-descriptor* 'boxed #f #f #f #f 1 1))
+(define struct:boxed (make-record-type-descriptor* 'boxed #f #f #f #f 1 0))
 (define effect_2559
   (struct-type-install-properties!
    struct:boxed

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -1075,7 +1075,7 @@
     (register-struct-field-mutator! set-queue-start! struct:queue 0)
     (register-struct-field-mutator! set-queue-end! struct:queue 1)
     (void)))
-(define struct:node$2 (make-record-type-descriptor* 'node #f #f #f #f 3 7))
+(define struct:node$2 (make-record-type-descriptor* 'node #f #f #f #f 3 6))
 (define effect_2809
   (struct-type-install-properties!
    struct:node$2
@@ -1311,7 +1311,7 @@
   (hash-ref (primitive-table '|#%engine|) 'continuation-current-primitive #f))
 (define host:prop:unsafe-authentic-override
   (hash-ref (primitive-table '|#%engine|) 'prop:unsafe-authentic-override #f))
-(define struct:node$1 (make-record-type-descriptor* 'node #f #f #f #f 5 31))
+(define struct:node$1 (make-record-type-descriptor* 'node #f #f #f #f 5 0))
 (define effect_2451
   (struct-type-install-properties!
    struct:node$1
@@ -2081,7 +2081,7 @@
              "(or/c evt? (procedure-arity-includes/c 1) exact-nonnegative-integer?)"
              v_0))))))))
 (define struct:selector-prop-evt-value
-  (make-record-type-descriptor* 'selector-prop-evt-value #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'selector-prop-evt-value #f #f #f #f 1 0))
 (define effect_2090
   (struct-type-install-properties!
    struct:selector-prop-evt-value
@@ -2130,7 +2130,7 @@
      (begin
        (let ((or-part_0 (primary-evt? v_0)))
          (if or-part_0 or-part_0 (secondary-evt? v_0)))))))
-(define struct:poller (make-record-type-descriptor* 'poller #f #f #f #f 1 1))
+(define struct:poller (make-record-type-descriptor* 'poller #f #f #f #f 1 0))
 (define effect_2384
   (struct-type-install-properties!
    struct:poller
@@ -2158,7 +2158,7 @@
     (register-struct-field-accessor! poller-proc struct:poller 0)
     (void)))
 (define struct:poll-ctx
-  (make-record-type-descriptor* 'poll-ctx #f #f #f #f 4 15))
+  (make-record-type-descriptor* 'poll-ctx #f #f #f #f 4 8))
 (define effect_3060
   (struct-type-install-properties!
    struct:poll-ctx
@@ -2318,7 +2318,7 @@
     (register-struct-predicate! async-evt?)
     (void)))
 (define the-async-evt (async-evt6.1))
-(define struct:wrap-evt (make-record-type-descriptor* 'evt #f #f #f #f 2 3))
+(define struct:wrap-evt (make-record-type-descriptor* 'evt #f #f #f #f 2 0))
 (define effect_2319
   (struct-type-install-properties!
    struct:wrap-evt
@@ -2420,7 +2420,7 @@
     (register-struct-predicate! handle-evt?$1)
     (void)))
 (define struct:control-state-evt
-  (make-record-type-descriptor* 'control-state-evt #f #f #f #f 5 31))
+  (make-record-type-descriptor* 'control-state-evt #f #f #f #f 5 0))
 (define effect_2665
   (struct-type-install-properties!
    struct:control-state-evt
@@ -2570,7 +2570,7 @@
      4)
     (void)))
 (define struct:poll-guard-evt
-  (make-record-type-descriptor* 'evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'evt #f #f #f #f 1 0))
 (define effect_2393
   (struct-type-install-properties!
    struct:poll-guard-evt
@@ -2629,7 +2629,7 @@
      struct:poll-guard-evt
      0)
     (void)))
-(define struct:choice-evt (make-record-type-descriptor* 'evt #f #f #f #f 1 1))
+(define struct:choice-evt (make-record-type-descriptor* 'evt #f #f #f #f 1 0))
 (define effect_2512
   (struct-type-install-properties!
    struct:choice-evt
@@ -2714,7 +2714,7 @@
             (|#%app| (poller-proc v_1) evt_0 poll-ctx_0)
             (if (1/evt? v_1) (values #f v_1) (values #f the-never-evt))))))))
 (define struct:delayed-poll
-  (make-record-type-descriptor* 'delayed-poll #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'delayed-poll #f #f #f #f 1 0))
 (define effect_3144
   (struct-type-install-properties!
    struct:delayed-poll
@@ -2744,7 +2744,7 @@
     (register-struct-field-accessor! delayed-poll-resume struct:delayed-poll 0)
     (void)))
 (define struct:poller-evt
-  (make-record-type-descriptor* 'poller-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'poller-evt #f #f #f #f 1 0))
 (define effect_2558
   (struct-type-install-properties!
    struct:poller-evt
@@ -2799,7 +2799,7 @@
  (prop:waiter waiter? waiter-ref)
  (make-struct-type-property 'waiter))
 (define struct:waiter-methods
-  (make-record-type-descriptor* 'waiter-methods #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'waiter-methods #f #f #f #f 2 0))
 (define effect_3162
   (struct-type-install-properties!
    struct:waiter-methods
@@ -2849,7 +2849,7 @@
   (lambda (w_0 interrupt-cb_0)
     (|#%app| (waiter-methods-suspend (waiter-ref w_0)) w_0 interrupt-cb_0)))
 (define struct:select-waiter
-  (make-record-type-descriptor* 'select-waiter #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'select-waiter #f #f #f #f 1 0))
 (define effect_2458
   (struct-type-install-properties!
    struct:select-waiter
@@ -2911,7 +2911,7 @@
     (register-struct-field-accessor! select-waiter-proc struct:select-waiter 0)
     (void)))
 (define struct:custodian
-  (make-record-type-descriptor* 'custodian #f #f #f #f 13 8191))
+  (make-record-type-descriptor* 'custodian #f #f #f #f 13 8188))
 (define effect_2364
   (struct-type-install-properties!
    struct:custodian
@@ -3132,7 +3132,7 @@
  (prop:place-message place-message? place-message-ref)
  (make-struct-type-property 'place-message))
 (define struct:message-ized
-  (make-record-type-descriptor* 'message-ized #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'message-ized #f #f #f #f 1 0))
 (define effect_2650
   (struct-type-install-properties!
    struct:message-ized
@@ -4280,7 +4280,7 @@
                                  v_0)))))))))))))
     (lambda (v_0) (let ((graph_0 (box #f))) (loop_0 graph_0 v_0)))))
 (define struct:place
-  (make-record-type-descriptor* 'place #f #f #f #f 19 524287))
+  (make-record-type-descriptor* 'place #f #f #f #f 19 491440))
 (define effect_3017
   (struct-type-install-properties!
    struct:place
@@ -4521,7 +4521,7 @@
     (void)))
 (define count-field-pos 2)
 (define struct:semaphore-peek-evt
-  (make-record-type-descriptor* 'semaphore-peek-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'semaphore-peek-evt #f #f #f #f 1 0))
 (define effect_2819
   (struct-type-install-properties!
    struct:semaphore-peek-evt
@@ -4862,7 +4862,7 @@
 (define child-node (lambda (child_0) child_0))
 (define node-child (lambda (n_0) n_0))
 (define struct:thread-group
-  (make-record-type-descriptor* 'thread-group struct:node #f #f #f 4 15))
+  (make-record-type-descriptor* 'thread-group struct:node #f #f #f 4 14))
 (define effect_2111
   (struct-type-install-properties!
    struct:thread-group
@@ -5195,7 +5195,7 @@
   (lambda (sched-info_0) (set-schedule-info-did-work?! sched-info_0 #t)))
 (define reference-sink
   (lambda (v_0) (ephemeron-value (make-ephemeron #f (void)) (void) v_0)))
-(define struct:plumber (make-record-type-descriptor* 'plumber #f #f #f #f 2 3))
+(define struct:plumber (make-record-type-descriptor* 'plumber #f #f #f #f 2 0))
 (define effect_2525
   (struct-type-install-properties!
    struct:plumber
@@ -5243,7 +5243,7 @@
        v_0))
    'current-plumber))
 (define struct:plumber-flush-handle
-  (make-record-type-descriptor* 'plumber-flush-handle #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'plumber-flush-handle #f #f #f #f 2 0))
 (define effect_2524
   (struct-type-install-properties!
    struct:plumber-flush-handle
@@ -5479,7 +5479,7 @@
      exit
      (case-lambda (() (begin (exit_0 #t))) ((v1_0) (exit_0 v1_0))))))
 (define struct:custodian-box
-  (make-record-type-descriptor* 'custodian-box #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'custodian-box #f #f #f #f 2 1))
 (define effect_3118
   (struct-type-install-properties!
    struct:custodian-box
@@ -5523,7 +5523,7 @@
      0)
     (void)))
 (define struct:willed-callback
-  (make-record-type-descriptor* 'willed-callback #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'willed-callback #f #f #f #f 2 0))
 (define effect_2810
   (struct-type-install-properties!
    struct:willed-callback
@@ -6916,7 +6916,7 @@
               (void)))))))
      (loop_0 mref_0))))
 (define struct:thread
-  (make-record-type-descriptor* 'thread struct:node #f #f #f 24 16777215))
+  (make-record-type-descriptor* 'thread struct:node #f #f #f 24 16777082))
 (define effect_3120
   (struct-type-install-properties!
    struct:thread
@@ -7492,7 +7492,7 @@
            (raise-argument-error 'thread-wait "thread?" t_0))
          (1/semaphore-wait (|#%app| get-thread-dead-sema t_0)))))))
 (define struct:dead-evt
-  (make-record-type-descriptor* 'thread-dead-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'thread-dead-evt #f #f #f #f 1 0))
 (define effect_2381
   (struct-type-install-properties!
    struct:dead-evt
@@ -7823,7 +7823,7 @@
                       (loop_0 app_0 (cons (car crs_0) accum_0))))))))))))
      (loop_0 (thread-custodian-references t_0) null))))
 (define struct:transitive-resume
-  (make-record-type-descriptor* 'transitive-resume #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'transitive-resume #f #f #f #f 2 0))
 (define effect_2586
   (struct-type-install-properties!
    struct:transitive-resume
@@ -7956,7 +7956,7 @@
           (|#%app| interrupt-callback_0))
         (void)))))
 (define struct:suspend-resume-evt
-  (make-record-type-descriptor* 'suspend-resume-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'suspend-resume-evt #f #f #f #f 2 2))
 (define effect_2576
   (struct-type-install-properties!
    struct:suspend-resume-evt
@@ -8658,7 +8658,7 @@
                 #f))))
        (begin-unsafe (set! thread-engine-for-roots thread-engine_0))))
     (void)))
-(define struct:channel (make-record-type-descriptor* 'channel #f #f #f #f 2 3))
+(define struct:channel (make-record-type-descriptor* 'channel #f #f #f #f 2 0))
 (define effect_1902
   (struct-type-install-properties!
    struct:channel
@@ -8730,7 +8730,7 @@
     (register-struct-field-accessor! channel-put-queue struct:channel 1)
     (void)))
 (define struct:channel-put-evt*
-  (make-record-type-descriptor* 'channel-put-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'channel-put-evt #f #f #f #f 2 0))
 (define effect_2960
   (struct-type-install-properties!
    struct:channel-put-evt*
@@ -8826,7 +8826,7 @@
    #f
    #f
    1
-   1))
+   0))
 (define effect_3243
   (struct-type-install-properties!
    struct:channel-select-waiter
@@ -11116,7 +11116,7 @@
          (start-atomic)
          (begin0 (retry_0 s_0 timeout-at_0) (end-atomic)))))))
 (define struct:replacing-evt
-  (make-record-type-descriptor* 'evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'evt #f #f #f #f 1 0))
 (define effect_2056
   (struct-type-install-properties!
    struct:replacing-evt
@@ -11178,7 +11178,7 @@
      0)
     (void)))
 (define struct:nested-sync-evt
-  (make-record-type-descriptor* 'evt #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'evt #f #f #f #f 3 0))
 (define effect_2232
   (struct-type-install-properties!
    struct:nested-sync-evt
@@ -11473,7 +11473,7 @@
 (define TICKS 100000)
 (define set-schedule-quantum! (lambda (n_0) (set! TICKS n_0)))
 (define struct:future*
-  (make-record-type-descriptor* 'future #f #f #f #f 10 1023))
+  (make-record-type-descriptor* 'future #f #f #f #f 10 1016))
 (define effect_2884
   (struct-type-install-properties!
    struct:future*
@@ -11906,7 +11906,7 @@
 (define 1/futures-enabled?
   (|#%name| futures-enabled? (lambda () (begin (|#%app| threaded?)))))
 (define struct:future-evt
-  (make-record-type-descriptor* 'future-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'future-evt #f #f #f #f 1 0))
 (define effect_2234
   (struct-type-install-properties!
    struct:future-evt
@@ -12349,7 +12349,7 @@
 (define pthread-count 1)
 (define set-processor-count! (lambda (n_0) (set! pthread-count n_0)))
 (define struct:scheduler
-  (make-record-type-descriptor* 'scheduler #f #f #f #f 6 63))
+  (make-record-type-descriptor* 'scheduler #f #f #f #f 6 7))
 (define effect_2611
   (struct-type-install-properties!
    struct:scheduler
@@ -12407,7 +12407,7 @@
      struct:scheduler
      2)
     (void)))
-(define struct:worker (make-record-type-descriptor* 'worker #f #f #f #f 5 31))
+(define struct:worker (make-record-type-descriptor* 'worker #f #f #f #f 5 26))
 (define effect_2322
   (struct-type-install-properties!
    struct:worker
@@ -13275,7 +13275,7 @@
 (define set-check-place-activity!
   (lambda (proc_0) (set! check-place-activity proc_0)))
 (define struct:alarm-evt
-  (make-record-type-descriptor* 'alarm-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'alarm-evt #f #f #f #f 1 0))
 (define effect_2693
   (struct-type-install-properties!
    struct:alarm-evt
@@ -13842,7 +13842,7 @@
       ((s_0 proc_0 try-fail12_0 . args_0)
        (call-with-semaphore/enable-break_0 s_0 proc_0 try-fail12_0 args_0))))))
 (define struct:will-executor
-  (make-record-type-descriptor* 'will-executor #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'will-executor #f #f #f #f 2 0))
 (define effect_2934
   (struct-type-install-properties!
    struct:will-executor
@@ -14884,7 +14884,7 @@
                         (loop_0)))))))))))
        (loop_0)))))
 (define struct:place-done-evt
-  (make-record-type-descriptor* 'place-dead-evt #f #f #f #f 2 3))
+  (make-record-type-descriptor* 'place-dead-evt #f #f #f #f 2 0))
 (define effect_3079
   (struct-type-install-properties!
    struct:place-done-evt
@@ -14993,7 +14993,7 @@
            (raise-argument-error 'place-dead-evt "place?" p_0))
          (place-done-evt3.1 p_0 #f))))))
 (define struct:message-queue
-  (make-record-type-descriptor* 'message-queue #f #f #f #f 6 63))
+  (make-record-type-descriptor* 'message-queue #f #f #f #f 6 22))
 (define effect_2821
   (struct-type-install-properties!
    struct:message-queue
@@ -15181,7 +15181,7 @@
                     (|#%app| host:mutex-release lock_0)
                     (|#%app| success-k_0 (car q_0))))))))))))
 (define struct:pchannel
-  (make-record-type-descriptor* 'place-channel #f #f #f #f 6 63))
+  (make-record-type-descriptor* 'place-channel #f #f #f #f 6 0))
 (define effect_2691
   (struct-type-install-properties!
    struct:pchannel
@@ -15486,7 +15486,7 @@
       (lambda () (ensure-wakeup-handle!))))
     (void)))
 (define struct:fsemaphore
-  (make-record-type-descriptor* 'fsemaphore #f #f #f #f 4 15))
+  (make-record-type-descriptor* 'fsemaphore #f #f #f #f 4 13))
 (define effect_2870
   (struct-type-install-properties!
    struct:fsemaphore
@@ -15540,7 +15540,7 @@
      3)
     (void)))
 (define struct:fsemaphore-box-evt
-  (make-record-type-descriptor* 'fsemaphore-box-evt #f #f #f #f 1 1))
+  (make-record-type-descriptor* 'fsemaphore-box-evt #f #f #f #f 1 0))
 (define effect_2505
   (struct-type-install-properties!
    struct:fsemaphore-box-evt
@@ -15744,7 +15744,7 @@
           (lambda () (begin (start-atomic) (|#%app| proc_0))))
          (void))))))
 (define struct:os-semaphore
-  (make-record-type-descriptor* 'os-semaphore #f #f #f #f 3 7))
+  (make-record-type-descriptor* 'os-semaphore #f #f #f #f 3 1))
 (define effect_2794
   (struct-type-install-properties!
    struct:os-semaphore

--- a/racket/src/schemify/struct-convert.rkt
+++ b/racket/src/schemify/struct-convert.rkt
@@ -69,20 +69,20 @@
                                                            #f
                                                            #f
                                                            ,(struct-type-info-immediate-field-count sti)
-                                                           ,(let ([n (struct-type-info-immediate-field-count sti)])
+                                                           ,(let* ([n (struct-type-info-immediate-field-count sti)]
+                                                                   [mask (sub1 (arithmetic-shift 1 n))])
                                                               (cond
                                                                 [(struct-type-info-non-prefab-immutables sti)
                                                                  =>
                                                                  (lambda (immutables)
-                                                                   (let loop ([i 0] [mask 0])
+                                                                   (let loop ([imms immutables] [mask mask])
                                                                      (cond
-                                                                       [(= i n) mask]
-                                                                       [(memq i immutables) (loop (+ i 1) mask)]
-                                                                       [else
-                                                                        (loop (+ i 1)
-                                                                              (bitwise-ior mask (arithmetic-shift 1 i)))])))]
+                                                                      [(null? imms) mask]
+                                                                      [else
+                                                                       (let ([m (bitwise-not (arithmetic-shift 1 (car imms)))])
+                                                                         (loop (cdr imms) (bitwise-and mask m)))])))]
                                                                 [else
-                                                                 (sub1 (arithmetic-shift 1 n))]))))
+                                                                 mask]))))
            ,@(if (null? (struct-type-info-rest sti))
                  null
                  `((define ,(deterministic-gensym "effect")

--- a/racket/src/schemify/struct-convert.rkt
+++ b/racket/src/schemify/struct-convert.rkt
@@ -69,9 +69,20 @@
                                                            #f
                                                            #f
                                                            ,(struct-type-info-immediate-field-count sti)
-                                                           ;; Reporting all as mutable, for now:
                                                            ,(let ([n (struct-type-info-immediate-field-count sti)])
-                                                              (sub1 (arithmetic-shift 1 n)))))
+                                                              (cond
+                                                                [(struct-type-info-non-prefab-immutables sti)
+                                                                 =>
+                                                                 (lambda (immutables)
+                                                                   (let loop ([i 0] [mask 0])
+                                                                     (cond
+                                                                       [(= i n) mask]
+                                                                       [(memq i immutables) (loop (+ i 1) mask)]
+                                                                       [else
+                                                                        (loop (+ i 1)
+                                                                              (bitwise-ior mask (arithmetic-shift 1 i)))])))]
+                                                                [else
+                                                                 (sub1 (arithmetic-shift 1 n))]))))
            ,@(if (null? (struct-type-info-rest sti))
                  null
                  `((define ,(deterministic-gensym "effect")

--- a/racket/src/schemify/struct-type-info.rkt
+++ b/racket/src/schemify/struct-type-info.rkt
@@ -18,6 +18,7 @@
                                pure-constructor?
                                authentic?
                                prefab-immutables ; #f or immutable expression to be quoted
+                               non-prefab-immutables ; #f or immutable expression to be quoted
                                constructor-name-expr  ; an expression
                                rest)) ; argument expressions after auto-field value
 (define struct-type-info-rest-properties-list-pos 0)
@@ -61,7 +62,18 @@
                        [`,_ #f])))
               (define constructor-name-expr (and ((length rest) . > . 5)
                                                  (list-ref rest 5)))
-              (and prefab-imms
+              (define non-prefab-imms
+                (and (eq? prefab-imms 'non-prefab)
+                     (match rest
+                       [`() '()]
+                       [`(,_) '()]
+                       [`(,_ ,_) '()]
+                       [`(,_ ,_ ,_) '()]
+                       [`(,_ ,_ ,_ ',immutables . ,_) immutables]
+                       [`,_ #f])))
+              (and (if (eq? prefab-imms 'non-prefab)
+                       non-prefab-imms
+                       prefab-imms)
                    (struct-type-info name
                                      parent
                                      fields
@@ -78,6 +90,7 @@
                                      (if (eq? prefab-imms 'non-prefab)
                                          #f
                                          prefab-imms)
+                                     non-prefab-imms
                                      constructor-name-expr
                                      rest)))))]
     [`(let-values () ,body)


### PR DESCRIPTION
This enables more optimizations in cp0.
For example:
```racket
(let ()
  (struct A (a b))
  (define x (A 1 2))
  (+ (A-a x) (A-b x)))
```
Without this change, cp0 outputs
```scheme
...
(let ([x_7 (#3%$record struct:A_1 1 2)])
  (let ([app_16 (#3%$object-ref 'scheme-object x_7 9)])
    (#2%+
     app_16
     (#3%$object-ref 'scheme-object x_7 17))))
```
while with these changes it just outputs `3`.