### PR TITLE
assemble-distribution: convert string relative bases to paths

### DIFF
--- a/racket/collects/compiler/distribute.rkt
+++ b/racket/collects/compiler/distribute.rkt
@@ -138,7 +138,8 @@
         (let ([relative->binary-relative
                (lambda (sub-dir type relative-dir)
                  (cond
-                  [relative-base relative-base]
+                  [relative-base
+                   (if (string? relative-base) (string->path relative-base) relative-base)]
                   [(not executables?)
                    (build-path dest-dir relative-dir)]
                   [sub-dir


### PR DESCRIPTION
Fixes an issue where the distribution assembler expects these to be `path?`s so `raco ctool` with a `--runtime-access` argument fails with a contract error due to a call to `path->bytes`.

I originally considered making this change in the ctool command in `cext-lib` instead, but then I noticed the documented contract for `assemble-distribution` is `(or/c #f path-string?)`.