### PR TITLE
pkg: improve CI template for new packages

### DIFF
--- a/racket/collects/pkg/private/new.rkt
+++ b/racket/collects/pkg/private/new.rkt
@@ -136,21 +136,23 @@ jobs:
     name: "Build on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        racket-version: ["7.9", "current"]
-        racket-variant: ["regular", "CS"]
+        racket-version: ["stable", "current"]
+        racket-variant: ["BC", "CS"]
     steps:
       - uses: actions/checkout@v2
-      - uses: Bogdanp/setup-racket@v0.10
+      - uses: Bogdanp/setup-racket@v0.12
         with:
           architecture: x64
           distribution: full
           variant: ${{ matrix.racket-variant }}
           version: ${{ matrix.racket-version }}
-      - run: |
-          raco pkg install --auto --name <<name>>
-          raco test -x -p <<name>>
+      - name: Installing <<name>> and its dependencies
+        run: raco pkg install --no-docs --auto --name <<name>>
+      - name: Compiling <<name>> and building its docs
+        run: raco setup --check-pkg-deps --unused-pkg-deps <<name>>
+      - name: Testing <<name>>
+        run: raco test -x -p <<name>>
 
 EOS
 )))


### PR DESCRIPTION
Related to #1500.

This improves the following aspects of the CI config:

* The config now tracks the current stable version of Racket so
package authors don't have to remember to upgrade the config on new
releases.  This is a double-edged sword, because it makes it easy to
use features of new Racket version and potentially break
backwards-compatibility by accident.  Running CI against a set of
static Racket versions doesn't have this problem since any such change
would end up failing.  Maybe a better change here would be to
interpolate the current `(version)` into the CI file instead.

* The job is now set to fail on the first error it encounters on the
assumption that most packages fail due to internal issues and not due
to mismatches between Racket versions.  The intent with this change is
to use fewer resources overall when possible.  Additionally, the
packages' dependencies are now validated during the setup step.

* Lastly, the install step now avoids building documentation for
dependencies, which can shave off significant amounts of time.

cc @sorawee @jackfirth 