### PR TITLE
Add syntax tests for other configurations.

### DIFF
--- a/.github/workflows/ci-push-arm_linux.yml
+++ b/.github/workflows/ci-push-arm_linux.yml
@@ -273,6 +273,8 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax
 
   test-cs:
     container:
@@ -343,3 +345,5 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax

--- a/.github/workflows/ci-push-x86_linux.yml
+++ b/.github/workflows/ci-push-x86_linux.yml
@@ -345,6 +345,8 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax
 
   test-cs:
     runs-on: ubuntu-18.04
@@ -409,6 +411,8 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax
   slack:
     runs-on: ubuntu-latest
     needs: [test-cgc, test-3m, test-cs]

--- a/.github/workflows/ci-push_macos.yml
+++ b/.github/workflows/ci-push_macos.yml
@@ -239,6 +239,8 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax
 
   test-3m:
     strategy:
@@ -304,6 +306,8 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax
           
   test-cs:
     runs-on: macos-latest
@@ -364,3 +368,5 @@ jobs:
         run: raco pkg install --auto db-test
       - name: Run db tests
         run: raco test -l tests/db/all-tests
+      - name: Run syntax tests
+        run: raco test -c tests/syntax

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -65,3 +65,4 @@ jobs:
         call racket\raco.exe test -c tests/future
         call racket\raco.exe test -l tests/db/all-tests
         racket\raco.exe test -c tests/stxparse
+        call racket\raco.exe test -c tests/syntax


### PR DESCRIPTION
The pull request racket#3078 adds syntax tests for x86_linux test-cgc, but not for other configurations.

This commit adds syntax tests for the others. If that's is not desired, please feel free to close this issue.