### PR TITLE
Fix rationalize with +nan.0 tolerance

### DIFF
--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -2440,15 +2440,15 @@
 (err/rt-test (rationalize .3+0.0i 1/10))
 
 (define (test-rat-inf v)
-  (define zero (if (exact? v) 0 0.0))
-
   (test +inf.0 rationalize +inf.0 v)
   (test -inf.0 rationalize -inf.0 v)
   (test-nan.0 rationalize +nan.0 v)
 
-  (test zero rationalize v +inf.0)
-  (test zero rationalize v -inf.0)
+  (test 0.0 rationalize v +inf.0)
+  (test 0.0 rationalize v -inf.0)
   (test-nan.0 rationalize v +nan.0))
+
+(test-rat-inf 1/3)
 
 (let loop ([i 100])
   (unless (= i -100)

--- a/racket/collects/racket/private/misc.rkt
+++ b/racket/collects/racket/private/misc.rkt
@@ -68,12 +68,12 @@
                [lo (- x delta)]
                [hi (+ x delta)])
           (cond
-           [(equal? x +nan.0) x]
+           [(not (= x x)) x]
            [(or (equal? x +inf.0) 
                 (equal? x -inf.0))
             (if (equal? delta +inf.0) +nan.0 x)]
            [(equal? delta +inf.0) 0.0]
-           [(not (= x x)) +nan.0]
+           [(not (= within within)) within]
            [(<= lo 0 hi) (if (exact? x) 0 0.0)]
            [(or (inexact? lo) (inexact? hi))
             (exact->inexact (do-find-between (inexact->exact lo) (inexact->exact hi)))]


### PR DESCRIPTION
Calling `rationalize` with `+nan.0` as the second argument was causing
a "no exact representation error."  This commit changes it to produce
`+nan.0`.

There was an unexercised set of tests for `rationalize` in the test
suite which, once called, demonstrate the bug.

Those tests also specify that `rationalize` should produce an exact
result when the first argument is exact and the second is an infinity.
That's not what the implementation does; it coerces the result to
inexact.  I changed the test cases to match the implementation, which
is consistent with other Schemes (Chez, MIT) and standards (R6RS).