### PR TITLE
Use build-path in a collapse-module-path test.

### DIFF
--- a/pkgs/racket-test/tests/syntax/modcollapse.rkt
+++ b/pkgs/racket-test/tests/syntax/modcollapse.rkt
@@ -145,7 +145,7 @@
        "x/banana.rkt")
 (check (collapse-module-path-index dirrel
                                    here)
-       (build-path here-dir "x/banana.rkt"))
+       (build-path here-dir "x" "banana.rkt"))
 
 (define rel-dirrel (module-path-index-join
                     "apple.rkt"


### PR DESCRIPTION
Fixes the test failure triggered in racket#3563.

The PR racket#3563 runs `tests/syntax` on Windows.