### PR TITLE
Enable inlining for `define-inline` calls as arguments.

### DIFF
--- a/racket/collects/racket/performance-hint.rkt
+++ b/racket/collects/racket/performance-hint.rkt
@@ -99,23 +99,23 @@
                 [(_ arg*:actual ...)
                  ;; let*-bind the actuals, to ensure that they're evaluated
                  ;; only once, and in order
-                 #`(syntax-parameterize
-                    ([name (make-rename-transformer #'internal-name)])
-                    (let* ([arg*.tmp arg*.arg] ...)
-                      #,(let* ([arg-entries     (attribute arg*.for-aux)]
-                               [keyword-entries (filter car arg-entries)]
-                               [positional-entries
-                                (filter (lambda (x) (not (car x)))
-                                        arg-entries)]
-                               [sorted-keyword-entries
-                                (sort keyword-entries
-                                      string<?
-                                      #:key (lambda (kw)
-                                              (keyword->string
-                                               (syntax-e (car kw)))))])
-                          (keyword-apply
-                           function-aux
-                           (map (lambda (x) (syntax-e (car x)))
-                                sorted-keyword-entries)
-                           (map cadr sorted-keyword-entries)
-                           (map cadr positional-entries)))))])))))]))
+                 #`(let* ([arg*.tmp arg*.arg] ...)
+                     (syntax-parameterize
+                         ([name (make-rename-transformer #'internal-name)])
+                       #,(let* ([arg-entries     (attribute arg*.for-aux)]
+                                [keyword-entries (filter car arg-entries)]
+                                [positional-entries
+                                 (filter (lambda (x) (not (car x)))
+                                         arg-entries)]
+                                [sorted-keyword-entries
+                                 (sort keyword-entries
+                                       string<?
+                                       #:key (lambda (kw)
+                                               (keyword->string
+                                                (syntax-e (car kw)))))])
+                           (keyword-apply
+                            function-aux
+                            (map (lambda (x) (syntax-e (car x)))
+                                 sorted-keyword-entries)
+                            (map cadr sorted-keyword-entries)
+                            (map cadr positional-entries)))))])))))]))


### PR DESCRIPTION
A seemingly-unintentional choice made the following not behave
as expected:

    (define-inline (f x) (+ x 1))
    (f (f 2))

because the `(f 2)` was not inlined.

Reported by @mflatt and Liwei Chou.