### PR TITLE
Fix temp-dir path in submodule tests for Windows.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/submodule.rktl
+++ b/pkgs/racket-test-core/tests/racket/submodule.rktl
@@ -636,7 +636,7 @@
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Directory for testing
 
-(define temp-dir (make-temporary-file "submodule-tests-~s" 'directory))
+(define temp-dir (make-temporary-file "submodule-tests-~a" 'directory))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Check submodule resolution of relative paths:


### PR DESCRIPTION
The function `make-temporary-file` supplies a string argument consisting of digits to the format function.

Therefore, if the template uses the `~s` formatting escape, `make-temporary-file` will attempt to create a temporary directory with double quotes in the path.

Such paths are not allowed on Windows. To fix the issue, this pull request changes `~s` to `~a`.