### PR TITLE
ChezScheme: Add a pass to lift well-known closures

### DIFF
--- a/racket/src/ChezScheme/rktboot/constant.rkt
+++ b/racket/src/ChezScheme/rktboot/constant.rkt
@@ -86,7 +86,8 @@
   prelex-was-flags-offset
   prelex-sticky-mask
   prelex-is-mask
-  scheme-version)
+  scheme-version
+  code-flag-lift-barrier)
 
 (provide record-ptr-offset)
 (define record-ptr-offset 1)

--- a/racket/src/ChezScheme/rktboot/scheme-lang.rkt
+++ b/racket/src/ChezScheme/rktboot/scheme-lang.rkt
@@ -104,6 +104,7 @@
          $compile-profile
          compile-profile
          $optimize-closures
+         $lift-closures
          $profile-block-data?
          run-cp0
          generate-interrupt-trap
@@ -932,6 +933,7 @@
 (define $compile-profile (make-parameter #f))
 (define compile-profile $compile-profile)
 (define $optimize-closures (make-parameter #t))
+(define $lift-closures (make-parameter #t))
 (define $profile-block-data? (make-parameter #f))
 (define run-cp0 (make-parameter error))
 (define generate-interrupt-trap (make-parameter #t))

--- a/racket/src/ChezScheme/rktboot/scheme-lang.rkt
+++ b/racket/src/ChezScheme/rktboot/scheme-lang.rkt
@@ -333,7 +333,8 @@
          priminfo-libraries
          $c-bufsiz
          $foreign-procedure
-         make-guardian)
+         make-guardian
+         $lambda/lift-barrier)
 
 (module+ callback
   (provide set-current-expand-set-callback!))
@@ -1290,3 +1291,7 @@
     [() #f]
     [(v) (void)]
     [(v rep) (void)]))
+
+(define-syntax $lambda/lift-barrier
+  (syntax-rules ()
+    [(_ fmls body ...) (lambda fmls body ...)]))

--- a/racket/src/ChezScheme/rktboot/scheme-lang.rkt
+++ b/racket/src/ChezScheme/rktboot/scheme-lang.rkt
@@ -704,6 +704,7 @@
            [(prelex-was-flags-offset) prelex-was-flags-offset]
            [(prelex-sticky-mask) prelex-sticky-mask]
            [(prelex-is-mask) prelex-is-mask]
+           [(code-flag-lift-barrier) code-flag-lift-barrier]
            [else (error 'constant "unknown: ~s" #'id)])]))
 
 (define $target-machine (make-parameter (string->symbol target-machine)))

--- a/racket/src/ChezScheme/s/cmacros.ss
+++ b/racket/src/ChezScheme/s/cmacros.ss
@@ -869,13 +869,14 @@
 
 ;; Flags that matter to the GC must apply only to static-generation
 ;; objects, and they must not overlap with `forward-marker`
-(define-constant code-flag-system           #b0000001)
-(define-constant code-flag-continuation     #b0000010)
-(define-constant code-flag-template         #b0000100)
-(define-constant code-flag-guardian         #b0001000)
-(define-constant code-flag-mutable-closure  #b0010000)
-(define-constant code-flag-arity-in-closure #b0100000)
-(define-constant code-flag-single-valued    #b1000000)
+(define-constant code-flag-system           #b00000001)
+(define-constant code-flag-continuation     #b00000010)
+(define-constant code-flag-template         #b00000100)
+(define-constant code-flag-guardian         #b00001000)
+(define-constant code-flag-mutable-closure  #b00010000)
+(define-constant code-flag-arity-in-closure #b00100000)
+(define-constant code-flag-single-valued    #b01000000)
+(define-constant code-flag-lift-barrier     #b10000000)
 
 (define-constant fixnum-bits
   (case (constant ptr-bits)

--- a/racket/src/ChezScheme/s/compile.ss
+++ b/racket/src/ChezScheme/s/compile.ss
@@ -559,6 +559,7 @@
                    [$compile-profile ($compile-profile)]
                    [generate-interrupt-trap (generate-interrupt-trap)]
                    [$optimize-closures ($optimize-closures)]
+                   [$lift-closures ($lift-closures)]
                    [enable-cross-library-optimization (enable-cross-library-optimization)]
                    [generate-covin-files (generate-covin-files)]
                    [enable-arithmetic-left-associative (enable-arithmetic-left-associative)]

--- a/racket/src/ChezScheme/s/compile.ss
+++ b/racket/src/ChezScheme/s/compile.ss
@@ -70,7 +70,7 @@
     (with-output-language (Lsrc Expr)
       ($c-make-closure
         ; pretending main is a library routine to avoid argument-count check
-        (let ([x `(case-lambda ,(make-preinfo-lambda #f #f (lookup-libspec main)) (clause () 0 ,x))])
+        (let ([x `(case-lambda ,(make-preinfo-lambda #f #f (lookup-libspec main) #f (constant code-flag-lift-barrier)) (clause () 0 ,x))])
           ($np-compile x #f))))))
 
 (define c-set-code-quad!
@@ -647,7 +647,7 @@
         (with-output-language (Lsrc Expr)
           (define (lambda-chunk lsrc)
             ; pretending main is a library routine to avoid argument-count check
-            `(case-lambda ,(make-preinfo-lambda #f #f (lookup-libspec main))
+            `(case-lambda ,(make-preinfo-lambda #f #f (lookup-libspec main) #f (constant code-flag-lift-barrier))
                (clause () 0 ,lsrc)))
           (define (visit lsrc e* rchunk*)
             (define (rchunks) (cons (make-visit-chunk (lambda-chunk lsrc)) rchunk*))

--- a/racket/src/ChezScheme/s/cprep.ss
+++ b/racket/src/ChezScheme/s/cprep.ss
@@ -131,7 +131,8 @@
                    '(let $primitive quote begin case-lambda
                       library-case-lambda lambda if set!
                       letrec letrec* $foreign-procedure
-                      $foreign-callable eval-when))))
+                      $foreign-callable eval-when
+                      $lambda/lift-barrier))))
              (nanopass-case (Lsrc Expr) x
                [(ref ,maybe-src ,x) (get-name x)]
                [(call ,preinfo0 (case-lambda ,preinfo1 (clause (,x* ...) ,interface ,body)) ,e* ...)
@@ -198,7 +199,10 @@
                   (lambda ()
                     (let ((cl* (map uncprep-lambda-clause cl*)))
                       (if (and (not (null? cl*)) (null? (cdr cl*)))
-                          `(lambda ,@(car cl*))
+                          (if (fx= (bitwise-and (constant code-flag-lift-barrier) (preinfo-lambda-flags preinfo))
+                                   (constant code-flag-lift-barrier))
+                              `($lambda/lift-barrier ,@(car cl*))
+                              `(lambda ,@(car cl*)))
                           `(case-lambda ,@cl*)))))]
                [(if ,[e0] ,[e1] ,[e2]) `(if ,e0 ,e1 ,e2)]
                [(set! ,maybe-src ,x ,[e]) `(set! ,(get-name x) ,e)]

--- a/racket/src/ChezScheme/s/front.ss
+++ b/racket/src/ChezScheme/s/front.ss
@@ -170,6 +170,7 @@
   compile-whole-library
   compile-whole-program
   ($dynamic-closure-counts compile)
+  ($lift-closures compile)
   ($loop-unroll-limit compile)
   make-boot-file
   ($make-boot-file make-boot-file)

--- a/racket/src/ChezScheme/s/primdata.ss
+++ b/racket/src/ChezScheme/s/primdata.ss
@@ -2452,6 +2452,7 @@
   ($enable-pass-timing [flags single-valued])
   ($expeditor-history-file [feature expeditor] [flags single-valued])
   ($fasl-target [flags single-valued])
+  ($lift-closures [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   ($optimize-closures [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   ($suppress-primitive-inlining [sig [() -> (boolean)] [(ptr) -> (void)]] [flags unrestricted])
   ($sfd [flags single-valued])

--- a/racket/src/ChezScheme/s/primdata.ss
+++ b/racket/src/ChezScheme/s/primdata.ss
@@ -1044,6 +1044,7 @@
 )
 
 (define-symbol-flags* ([libraries] [flags keyword])
+  ($lambda/lift-barrier [flags])
   ($system [flags library-uid])
   (add-prefix [flags])
   (alias [flags])


### PR DESCRIPTION
Related to #3535 .
Compared with lambda lifting passes on rumble and schemify layers, this pass is just before closure conversion and after free variables, loops and well-known lambdas discovered, which probably opens up more optimization opportunities.
For chez bootstrapping, the numbers of gc collections and bytes allocated are reduced by about 18%, but the changes on build time are insignificant.
no lift:
```
(time (for-each (lambda (...) ...) ...))
    638 collections
    11.861290102s elapsed cpu time, including 4.161334000s collecting
    11.917565000s elapsed real time, including 4.172969000s collecting
    10216836448 bytes allocated, including 10214525280 bytes reclaimed
```
lift:
```
(time (for-each (lambda (...) ...) ...))
    525 collections
    11.675721869s elapsed cpu time, including 4.086355000s collecting
    11.699825000s elapsed real time, including 4.098280000s collecting
    8382610368 bytes allocated, including 8380233600 bytes reclaimed
```
More benchmarks might be needed, though.