### PR TITLE
Split the testing steps in the Windows CI workflow

### DIFF
--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -45,24 +45,60 @@ jobs:
       shell: cmd
       run: |
         call racket\raco.exe pkg install --auto --no-docs racket-test unstable-flonum-lib net-test
-    - name: Test
+    - name: Run tests/racket/test
       shell: cmd
-      run: |
-        call racket\raco.exe test -l tests/racket/test
-        call racket\racket.exe -l tests/racket/contract/all
-        call racket\raco.exe test -l tests/json/json
-        call racket\raco.exe test -l tests/file/main
-        call racket\raco.exe test -l tests/net/head
-        call racket\raco.exe test -l tests/net/uri-codec
-        call racket\raco.exe test -l tests/net/url
-        call racket\raco.exe test -l tests/net/url-port
-        call racket\raco.exe test -l tests/net/encoders
-        call racket\raco.exe test -l tests/openssl/basic
-        call racket\raco.exe test -l tests/openssl/https
-        call racket\raco.exe test -l tests/match/main
-        call racket\raco.exe test -l tests/zo-path
-        call racket\raco.exe test -c tests/xml
-        call racket\raco.exe test -c tests/future
-        call racket\raco.exe test -l tests/db/all-tests
-        racket\raco.exe test -c tests/stxparse
-        call racket\raco.exe test -c tests/syntax
+      run: racket\raco.exe test -l tests/racket/test
+    - name: Run tests/racket/contract/all
+      shell: cmd
+      run: racket\racket.exe -l tests/racket/contract/all
+    - name: Run tests/json/json
+      shell: cmd
+      run: racket\raco.exe test -l tests/json/json
+    - name: Run tests/file/main
+      shell: cmd
+      run: racket\raco.exe test -l tests/file/main
+    - name: Run tests/net/head
+      shell: cmd
+      run: racket\raco.exe test -l tests/net/head
+    - name: Run tests/net/uri-codec
+      shell: cmd
+      run: racket\raco.exe test -l tests/net/uri-codec
+    - name: Run tests/net/url
+      shell: cmd
+      run: racket\raco.exe test -l tests/net/url
+    - name: Run tests/net/url-port
+      shell: cmd
+      run: racket\raco.exe test -l tests/net/url-port
+    - name: Run tests/net/encoders
+      shell: cmd
+      run: racket\raco.exe test -l tests/net/encoders
+    - name: Run tests/openssl/basic
+      shell: cmd
+      run: racket\raco.exe test -l tests/openssl/basic
+    - name: Run tests/openssl/https
+      shell: cmd
+      run: racket\raco.exe test -l tests/openssl/https
+    - name: Run tests/match/main
+      shell: cmd
+      run: racket\raco.exe test -l tests/match/main
+    - name: Run tests/zo-path
+      shell: cmd
+      run: racket\raco.exe test -l tests/zo-path
+    - name: Run tests/xml
+      shell: cmd
+      run: racket\raco.exe test -c tests/xml
+    - name: Run tests/future
+      shell: cmd
+      run: racket\raco.exe test -c tests/future
+    - name: Install db tests dependency
+      shell: cmd
+      run: racket\raco.exe pkg install --auto db-test
+    - name: Run db tests
+      shell: cmd
+      run: racket\raco.exe test -l tests/db/all-tests
+    - name: Run tests/stxparse
+      shell: cmd
+      run: racket\raco.exe test -c tests/stxparse
+    - name: Run syntax tests
+      shell: cmd
+      run: racket\raco.exe test -c tests/syntax


### PR DESCRIPTION
* cmd.exe only returns the error level of the last executed command and does not support fail-fast. So testing should be done in individual steps.

  See <https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions> for more information.

* Also installs db-test dependencies.

A core test in the subprocess section is failing on Windows, so the CI check won't pass.
