### PR TITLE
Fix a contract test

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/stronger.rkt
+++ b/pkgs/racket-test/tests/racket/contract/stronger.rkt
@@ -720,6 +720,7 @@
         (struct/dc s
                    [a (>=/c c)]
                    [b (a) (>=/c a)]))
+      (set! mk mk) ;suppress inlining
       (define one (mk 1))
       (define two (mk 2))
       (,test #f trust/not-stronger? one two)


### PR DESCRIPTION
https://github.com/racket/racket/runs/1592098995#step:11:69
This test assumes `mk` is not inlined so that `procedure-closure-contents-eq?` could return `#t` for closures from `one` and `two`, which is no longer true in current RacketCS(related to #3571).
https://github.com/racket/racket/blob/33fd201947a121fded031ff32a91215903c65d73/pkgs/racket-test/tests/racket/contract/stronger.rkt#L719-L726