### PR TITLE
docs: fix upper ASCII limit for control characters

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/regexp.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/regexp.scrbl
@@ -386,7 +386,7 @@ supported are
 
  @item{@litchar{[:blank:]} --- ASCII widthful whitespace: space and tab}
 
- @item{@litchar{[:cntrl:]} --- ``control'' characters: ASCII 0 to 32}
+ @item{@litchar{[:cntrl:]} --- ``control'' characters: ASCII 0 to 31}
 
  @item{@litchar{[:digit:]} --- ASCII digits, same as @litchar{\d}}
 


### PR DESCRIPTION
Character 32 is space, which isn't a control character.