### PR TITLE
cs: fix {u,s}16vector-{ref,set!} when memory is not `bytes?`

### DIFF
--- a/pkgs/racket-test-core/tests/racket/unsafe.rktl
+++ b/pkgs/racket-test-core/tests/racket/unsafe.rktl
@@ -1040,5 +1040,26 @@
 (test (+ (expt 2 100) #x55AA) bxor (+ #x5555 (expt 2 100)))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Make sure {u,s}16vector-{ref,set!} work when underlying
+;; memory is not `bytes?`
+
+(module mem racket/base
+  (provide c-malloc)
+  (require ffi/unsafe)
+  (define c-malloc
+    (get-ffi-obj 'malloc (ffi-lib #f) (_fun _int -> (_cpointer #f)))))
+
+(require 'mem)
+(let ((uv (u16vector 0)))
+  (unsafe-struct*-set! uv 0 (c-malloc 2))
+  (test (void) u16vector-set! uv 0 99)
+  (test 99 u16vector-ref uv 0))
+
+(let ((sv (s16vector 0)))
+  (unsafe-struct*-set! sv 0 (c-malloc 2))
+  (test (void) s16vector-set! sv 0 -99)
+  (test -99 s16vector-ref sv 0))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (report-errs)

--- a/racket/src/cs/rumble/unsafe.ss
+++ b/racket/src/cs/rumble/unsafe.ss
@@ -121,14 +121,14 @@
          [k (fx* k 2)])
     (if (bytes? mem)
         (bytevector-s16-native-ref mem k)
-        (foreign-ref 'int16 mem k))))
+        (foreign-ref 'integer-16 mem k))))
 (define (unsafe-s16vector-set! s16 k v)
   (let* ([cptr (unsafe-struct*-ref s16 0)]
          [mem (cpointer-memory cptr)]
          [k (fx* k 2)])
     (if (bytes? mem)
         (bytevector-s16-native-set! mem k v)
-        (foreign-set! 'int16 mem k v))))
+        (foreign-set! 'integer-16 mem k v))))
 
 (define (unsafe-u16vector-ref u16 k)
   (let* ([cptr (unsafe-struct*-ref u16 0)]
@@ -136,14 +136,14 @@
          [k (fx* k 2)])
     (if (bytes? mem)
         (bytevector-u16-native-ref mem k)
-        (foreign-ref 'uint16 mem k))))
+        (foreign-ref 'unsigned-16 mem k))))
 (define (unsafe-u16vector-set! u16 k v)
   (let* ([cptr (unsafe-struct*-ref u16 0)]
          [mem (cpointer-memory cptr)]
          [k (fx* k 2)])
     (if (bytes? mem)
         (bytevector-u16-native-set! mem k v)
-        (foreign-set! 'uint16 mem k v))))
+        (foreign-set! 'unsigned-16 mem k v))))
 
 (define (unsafe-f64vector-ref f64 k)
   (let* ([cptr (unsafe-struct*-ref f64 0)]


### PR DESCRIPTION
When a {u,s}16vector points to memory that's not bytes (e.g. from ffi)
then referencing or setting the memory results in a Chez error:

```
foreign-set!: unrecognized type 'int16
```

The fix is to change the type argument to `'integer-16` and
`'unsigned-16`.