### PR TITLE
Check numeric argument to `real->decimal-string` (fixes #3565)

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -1132,7 +1132,7 @@ that the @racket[read-single-flonum] parameter affects @racket[read].
          #:changed "7.3.0.5" @elem{Added the @racket[single-mode] argument.}]}
 
 
-@defproc[(real->decimal-string [n real?] [decimal-digits exact-nonnegative-integer? 2])
+@defproc[(real->decimal-string [n rational?] [decimal-digits exact-nonnegative-integer? 2])
          string?]{
 
 Prints @racket[n] into a string and returns the string. The printed

--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -1147,6 +1147,12 @@ process is an exact number whose decimal representation has no more
 than @racket[decimal-digits] digits after the decimal (and it is
 padded with trailing zeros if necessary).
 
+If @racket[n] is a real number with no decimal representation (e.g.
+@racket[+nan.0], @racket[+inf.0]), then the @exnraise[exn:fail:contract].
+(Any real number that is convertible to decimal notation is rational, 
+so @racket[n] must be @racket[rational?], despite the name of the 
+function.)
+
 @mz-examples[
 #:eval math-eval
 (real->decimal-string pi)

--- a/racket/collects/racket/private/string.rkt
+++ b/racket/collects/racket/private/string.rkt
@@ -17,7 +17,7 @@
   (define (real->decimal-string n [digits 2])
     (unless (rational? n)
       (raise-argument-error 'real->decimal-string "rational?"
-                            digits))  
+                            n))
     (unless (exact-nonnegative-integer? digits)
       (raise-argument-error 'real->decimal-string "exact-nonnegative-integer?"
                             digits))

--- a/racket/collects/racket/private/string.rkt
+++ b/racket/collects/racket/private/string.rkt
@@ -15,6 +15,9 @@
 
   ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
   (define (real->decimal-string n [digits 2])
+    (unless (rational? n)
+      (raise-argument-error 'real->decimal-string "rational?"
+                            digits))  
     (unless (exact-nonnegative-integer? digits)
       (raise-argument-error 'real->decimal-string "exact-nonnegative-integer?"
                             digits))


### PR DESCRIPTION
Check that the argument to `real->decimal-string` is a real number that can be converted to an exact, i.e. it's rational.

This commit adds a check to the implementation and updates the contract in the documentation, but leaves the function name alone.