### PR TITLE
Various URL improvements

### DIFF
--- a/pkgs/net-doc/net/scribblings/net.scrbl
+++ b/pkgs/net-doc/net/scribblings/net.scrbl
@@ -31,8 +31,10 @@
 @(bibliography
 
  (bib-entry #:key "CGI"
-            #:title "Common Gateway Interface (CGI/1.1)"
-            #:url "http://hoohoo.ncsa.uiuc.edu/cgi/")
+            #:title "The Common Gateway Interface (CGI) Version 1.1"
+            #:location "RFC"
+            #:url "http://www.ietf.org/rfc/rfc3875.txt"
+            #:date "2004")
 
  (bib-entry #:key "RFC822"
             #:title "Standard for the Format of ARPA Internet Text Messages"

--- a/pkgs/racket-doc/scribblings/getting-started/getting-started.scrbl
+++ b/pkgs/racket-doc/scribblings/getting-started/getting-started.scrbl
@@ -33,7 +33,7 @@ through a textbook:
 
 @itemize[
 
- @item{@italic{@link["http://htdp.org/"]{How to Design Programs, Second Edition}}
+ @item{@italic{@link["https://htdp.org/"]{How to Design Programs, Second Edition}}
        is the best place to start.}
 
  @item{@other-manual['(lib "web-server/scribblings/tutorial/continue.scrbl")]

--- a/pkgs/racket-doc/scribblings/guide/guide-utils.rkt
+++ b/pkgs/racket-doc/scribblings/guide/guide-utils.rkt
@@ -24,7 +24,7 @@
   (other-manual '(lib "scribblings/quick/quick.scrbl")))
 
 (define HtDP
-  (italic (link "http://www.htdp.org" "How to Design Programs")))
+  (italic (link "https://htdp.org" "How to Design Programs")))
 
 (define (tool name . desc)
   (apply item (bold name) ", " desc))

--- a/pkgs/racket-doc/scribblings/guide/macros.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/macros.scrbl
@@ -16,7 +16,7 @@ use. Racket also supports arbitrary macro transformers that are
 implemented in Racket---or in a macro-extended variant of Racket.
 
 This chapter provides an introduction to Racket macros, but see
-@hyperlink["http://www.greghendershott.com/fear-of-macros/"]{@italic{Fear of
+@hyperlink["https://www.greghendershott.com/fear-of-macros/"]{@italic{Fear of
 Macros}} for an introduction from a different perspective.
 
 Racket includes addional support for macro development: 

--- a/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
@@ -29,7 +29,7 @@ popular among Racketeers as well.
        provides thorough syntax highlighting and DrRacket-style REPL
        and buffer execution support for Emacs.
 
-       Racket mode can be installed via @hyperlink["http://melpa.milkbox.net"]{MELPA}
+       Racket mode can be installed via @hyperlink["https://melpa.org/"]{MELPA}
        or manually from the Github repository.}
 
  @item{@hyperlink["http://www.neilvandyke.org/quack/"]{Quack} is an

--- a/pkgs/racket-doc/scribblings/guide/other.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other.scrbl
@@ -36,6 +36,6 @@ includes documentation for packages in that catalog, updated daily.
 For more information about packages, see see @other-manual['(lib
 "pkg/scribblings/pkg.scrbl")].
 
-@link["https://planet.racket.org/"]{@|PLaneT|} serves packages that
+@link["https://planet.racket-lang.org/"]{@|PLaneT|} serves packages that
 were developed using an older package system. Racket packages should
 use the newer system, instead.

--- a/pkgs/racket-doc/scribblings/guide/other.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other.scrbl
@@ -36,6 +36,6 @@ includes documentation for packages in that catalog, updated daily.
 For more information about packages, see see @other-manual['(lib
 "pkg/scribblings/pkg.scrbl")].
 
-@link["http://planet.plt-racket.org/"]{@|PLaneT|} serves packages that
+@link["https://planet.racket.org/"]{@|PLaneT|} serves packages that
 were developed using an older package system. Racket packages should
 use the newer system, instead.

--- a/pkgs/racket-doc/scribblings/guide/qq.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/qq.scrbl
@@ -42,7 +42,7 @@ certain patterns.
 Or even to cheaply construct expressions programmatically. (Of course, 9 times out of 10,
 you should be using a @seclink["macros"]{macro} to do this 
 (the 10th time being when you're working through
-a textbook like @hyperlink["http://www.cs.brown.edu/~sk/Publications/Books/ProgLangs/"]{PLAI}).)
+a textbook like @hyperlink["https://www.cs.brown.edu/~sk/Publications/Books/ProgLangs/"]{PLAI}).)
 
 @examples[(define (build-exp n)
             (add-lets n (make-sum n)))

--- a/racket/collects/file/zip.rkt
+++ b/racket/collects/file/zip.rkt
@@ -10,7 +10,7 @@
   ;; An msdos-time or an msdos-date is an exact-integer in the respective format
   ;; described at:
   ;;
-  ;;     http://msdn.microsoft.com/library/en-us/com/htm/cmf_a2c_25gl.asp
+  ;;     https://web.archive.org/web/20050209013515/http://msdn.microsoft.com/library/en-us/com/htm/cmf_a2c_25gl.asp
 
   ;; metadata : path * bytes * boolean * integer * integer * nat * integer
   (define-struct metadata

--- a/racket/collects/racket/random.rkt
+++ b/racket/collects/racket/random.rkt
@@ -54,7 +54,7 @@
     (vector->list samples)]))
 
 (define (random-sample/out-replacement seq n prng)
-  ;; Based on: http://rosettacode.org/wiki/Knuth's_algorithm_S#Racket
+  ;; Based on: https://rosettacode.org/wiki/Knuth's_algorithm_S#Racket
   (define samples (make-vector n not-there))
   (for ([elt seq]
         [i   (in-naturals)])

--- a/racket/src/mac/README.txt
+++ b/racket/src/mac/README.txt
@@ -11,7 +11,7 @@ MMTabBarView
 
 Download from
 
-  http://mimo42.github.io/MMTabBarView/
+  https://mimo42.github.io/MMTabBarView/
 
 PSMTabBarControl
 ----------------


### PR DESCRIPTION
Fix up some URLs

- fix up stale links that are available elsewhere
- use wayback for some stale documents that are gone
- use https for servers that don't redirect
- use htdp.org instead of www.htdp.org
- fix old planet server URL