### PR TITLE
inside: note necessary entitlement to embed CS using hardened runtime

### DIFF
--- a/pkgs/racket-doc/scribblings/inside/cs-embedding.scrbl
+++ b/pkgs/racket-doc/scribblings/inside/cs-embedding.scrbl
@@ -33,7 +33,9 @@ To embed Racket CS in a program, follow these steps:
   standard framework search path, or your embedding executable must
   provide a specific path to the framework (possibly an
   executable-relative path using the Mach-O @tt["@executable_path"]
-  prefix).}
+  prefix). When targeting the Hardened Runtime, you must enable the
+  ``Allow Unsigned Executable Memory'' entitlement, otherwise you will
+  run into ``out of memory'' errors when calling @cppi{racket_boot}.}
 
  @item{For each C file that uses Racket library functions,
   @cpp{#include} the files @as-index{@filepath{chezscheme.h}}


### PR DESCRIPTION
I spent a good chunk of time today on this before realizing that the problem wasn't the way I was embedding things, but that I forgot to turn on this entitlement (despite having run into this same thing a couple times before!).