### PR TITLE
Allow variables in unquote-splicing terms

### DIFF
--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -786,7 +786,7 @@
             (list es en)]))
 
    (comp '((1 2 3 4) (6 7) (9))
-         (match (range 10)
+         (match '(0 1 2 3 4 5 6 7 8 9)
            [`(0 ,@a 5 ,@b 8 ,@c)
             (list a b c)]))
 

--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -785,6 +785,11 @@
            [`(begin ,es ... ,en)
             (list es en)]))
 
+   (comp '((1 2 3 4) (6 7) (9))
+         (match (range 10)
+           [`(0 ,@a 5 ,@b 8 ,@c)
+            (list a b c)]))
+
    (comp '(a b c)
 	 (let ()
 

--- a/racket/collects/racket/match/parse-quasi.rkt
+++ b/racket/collects/racket/match/parse-quasi.rkt
@@ -11,6 +11,7 @@
   (cond [(Pair? pat) (null-terminated? (Pair-d pat))]
         [(GSeq? pat) (null-terminated? (GSeq-tail pat))]
         [(Null? pat) #t]
+        [(Var? pat) #t]
         [else #f]))
 
 ;; combine a null-terminated pattern with another pattern to match afterwards
@@ -23,6 +24,12 @@
                                (append-pats (GSeq-tail p1) p2)
                                (GSeq-mutable? p1))]
         [(Null? p1) p2]
+        [(Var? p1) (make-GSeq (list (list p1))
+                              (list #f)
+                              (list #f)
+                              (list #f)
+                              p2
+                              #f)]
         [else (error 'match "illegal input to append-pats")]))
 
 (define hard-case?


### PR DESCRIPTION
This PR attempts to fix https://github.com/racket/racket/issues/3403 by allowing variables to be unquote-spliced inside patterns. It does so by extending the `null-terminated?` function inside `parse-unquote`.

Broadly speaking, `,@v` inside a quasi-quoted pattern is equivalent to `,@(list v ...)`. That means ambiguous cases, like `(quasiquote (,@v ,@w))` will be resolved with greedy matching. Since the ambiguity already exists with `(quasiquote (,v ... ,w ...))` it does not seem harmful.

The value of this change is greater symmetry between quasiquotation for constructing objects, and patterns for matching them.

The fix works by adding variable patterns to `null-terminated?`. I think that in general, `null-terminated?` should admit all patterns that _could_ match a list, instead of just the ones that _only_ match a list. That means that `(app f)` patterns and many others should also be valid, though those are harder to implement, so I haven't tried those yet. They seem less likely to be useful, because they aren't symmetric to a constructor term. I think this PR should be merged without those being implemented.