### PR TITLE
Fix typo and trailing whitespace in box-cas! docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/data.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/data.scrbl
@@ -106,19 +106,19 @@ boxes that are not @tech{impersonators}.
 
 
 @defproc[(box-cas! [box (and/c box? (not/c immutable?) (not/c impersonator?))]
-                   [old any/c] 
-                   [new any/c]) 
+                   [old any/c]
+                   [new any/c])
          boolean?]{
   Atomically updates the contents of @racket[box] to @racket[new], provided
   that @racket[box] currently contains a value that is @racket[eq?] to
-  @racket[old], and returns @racket[#t] in that case.  If @racket[box] 
+  @racket[old], and returns @racket[#t] in that case.  If @racket[box]
   does not contain @racket[old], then the result is @racket[#f].
 
   If no other @tech{threads} or @tech{futures} attempt to access
-  @racket[box], the operation is equivalent to 
+  @racket[box], the operation is equivalent to
 
   @racketblock[
-  (and (eq? old (unbox loc)) (set-box! loc new) #t)]
+  (and (eq? old (unbox box)) (set-box! box new) #t)]
 
   except that @racket[box-cas!] can spuriously fail on some platforms.
   That is, with low probability, the result can be @racket[#f] with the

--- a/pkgs/racket-doc/scribblings/reference/data.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/data.scrbl
@@ -106,16 +106,16 @@ boxes that are not @tech{impersonators}.
 
 
 @defproc[(box-cas! [box (and/c box? (not/c immutable?) (not/c impersonator?))]
-                   [old any/c]
-                   [new any/c])
+                   [old any/c] 
+                   [new any/c]) 
          boolean?]{
   Atomically updates the contents of @racket[box] to @racket[new], provided
   that @racket[box] currently contains a value that is @racket[eq?] to
-  @racket[old], and returns @racket[#t] in that case.  If @racket[box]
+  @racket[old], and returns @racket[#t] in that case.  If @racket[box] 
   does not contain @racket[old], then the result is @racket[#f].
 
   If no other @tech{threads} or @tech{futures} attempt to access
-  @racket[box], the operation is equivalent to
+  @racket[box], the operation is equivalent to 
 
   @racketblock[
   (and (eq? old (unbox box)) (set-box! box new) #t)]


### PR DESCRIPTION
Closes  #3600 

my editor picked up the trailing whitespace, I can remove it if you dont want to affect the blame too much

Thanks!