### PR TITLE
json: make ordering of emitted object keys opt-in

### DIFF
--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -4,6 +4,12 @@
 
 @(define website @link["http://json.org"]{JSON web site})
 @(define rfc @link["http://www.ietf.org/rfc/rfc4627.txt"]{JSON RFC})
+@; FIXME:
+@;  - RFC 4627 was obsoleted by RFC 8259,
+@;    which more explicitly discusses object keys.
+@;  - Should probably mention ECMA-404.
+@;    https://www.ecma-international.org/publications/files/ECMA-ST/ECMA-404.pdf
+@;  - Consider using bibliography forms.
 
 @(begin (require scribble/eval)
         (define ev (make-base-eval))
@@ -67,6 +73,7 @@ the @rfc for more information about JSON.
 
 @defproc[(write-json [x jsexpr?] [out output-port? (current-output-port)]
                      [#:null jsnull any/c (json-null)]
+                     [#:sort-keys? sort-keys? any/c #f]
                      [#:encode encode (or/c 'control 'all) 'control])
          any]{
   Writes the @racket[x] @tech{jsexpr}, encoded as JSON, to the
@@ -80,20 +87,32 @@ the @rfc for more information about JSON.
   the range of @tt{U+10000} and above are encoded as two @tt{\uHHHH}
   escapes, see Section 2.5 of the @|rfc|.
 
+  If @racket[sort-keys?] is given and is not @racket[#false],
+  the key--value pairs comprising a JSON object are emitted
+  in a deterministic order, as with @racket[hash-map]
+  when called with a non-false third argument.
+  Otherwise, and by default, the order of key--value pairs
+  is unspecified.
+  Interoperable uses of JSON can not rely on the order
+  of key--value pairs:
+  see @secref["The_JS-Expression_Data_Type"] for further discussion.
+
 @examples[#:eval ev
-  (with-output-to-string
-    (λ () (write-json #hasheq((waffle . (1 2 3))))))
-  (with-output-to-string
-    (λ () (write-json #hasheq((와플 . (1 2 3)))
-                      #:encode 'all)))
+  (write-json #hasheq((waffle . (1 2 3))))
+  (write-json #hasheq((b . #t) (a . #t))
+              #:sort-keys? #t)
+  (write-json #hasheq((와플 . (1 2 3)))
+              #:encode 'all)
 ]
 }
 
 @defproc[(jsexpr->string [x jsexpr?]
                          [#:null jsnull any/c (json-null)]
+                         [#:sort-keys? sort-keys? any/c #f]
                          [#:encode encode (or/c 'control 'all) 'control])
          string?]{
-  Generates a JSON source string for the @tech{jsexpr} @racket[x].
+  Like @racket[write-json], but
+  generates a JSON source string for the @tech{jsexpr} @racket[x].
 
 @examples[#:eval ev
   (jsexpr->string #hasheq((waffle . (1 2 3))))
@@ -102,9 +121,11 @@ the @rfc for more information about JSON.
 
 @defproc[(jsexpr->bytes [x jsexpr?]
                         [#:null jsnull any/c (json-null)]
+                        [#:sort-keys? sort-keys? any/c #f]
                         [#:encode encode (or/c 'control 'all) 'control])
          bytes?]{
-  Generates a JSON source byte string for the @tech{jsexpr} @racket[x].
+  Like @racket[write-json], but
+  generates a JSON source byte string for the @tech{jsexpr} @racket[x].
   (The byte string is encoded in UTF-8.)
 
 @examples[#:eval ev

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -88,7 +88,9 @@
         ;; and that the same holds for keys
         (jsexpr->string (string->jsexpr "{\"\U0010FFFF\":\"\U0010FFFF\"}"))
           => "{\"\U0010FFFF\":\"\U0010FFFF\"}"
-	(jsexpr->string #hash[(a . 1) (b . 2)]) => "{\"a\":1,\"b\":2}"
+        ;; test for ordered jsexpr->string
+	(jsexpr->string #hash[(a . 1) (b . 2)] #:sort-keys? #t)
+          => "{\"a\":1,\"b\":2}"
         (jsexpr->string (string->jsexpr "{\"\U0010FFFF\":\"\U0010FFFF\"}")
                         #:encode 'all)
           => "{\"\\udbff\\udfff\":\"\\udbff\\udfff\"}"


### PR DESCRIPTION
The commit <https://github.com/racket/racket/commit/6369646>
added support for emitting objects' key-value pairs in a deterministic order.

This commit adds an optional keyword argument `#:sort-keys?`
to `write-json`, `jsexper->string`, and `jsexpr->bytes`
to control the new deterministic mode.
It restores the previous default behavior,
in which key-value pairs are emitted in an unspecified order.

Related to https://github.com/racket/racket/issues/3537
Related to https://github.com/racket/racket/commit/bff1a3c
Related to https://github.com/racket/racket/pull/3582
Related to https://github.com/racket/racket/commit/f6b7f93