### PR TITLE
cs: add support for cross-compiling to iOS

### DIFF
--- a/racket/collects/compiler/cm.rkt
+++ b/racket/collects/compiler/cm.rkt
@@ -15,9 +15,6 @@
          make-compile-lock
          compile-lock->parallel-lock-client
 
-         ;; re-used in setup/setup-core and setup/private/pkg-deps
-         cross-multi-compile?
-
          (contract-out
           [current-path->mode
            (parameter/c (or/c #f (-> path? (and/c path? relative-path?))))]))

--- a/racket/collects/compiler/cm.rkt
+++ b/racket/collects/compiler/cm.rkt
@@ -15,6 +15,9 @@
          make-compile-lock
          compile-lock->parallel-lock-client
 
+         ;; re-used in setup/setup-core and setup/private/pkg-deps
+         cross-multi-compile?
+
          (contract-out
           [current-path->mode
            (parameter/c (or/c #f (-> path? (and/c path? relative-path?))))]))

--- a/racket/collects/compiler/cross.rkt
+++ b/racket/collects/compiler/cross.rkt
@@ -1,0 +1,8 @@
+#lang racket/base
+
+(require "private/cm-minimal.rkt")
+
+(provide
+ ;; Publicly re-provide cross-multi-compile? for tools that need to be
+ ;; aware of cross-multi mode (like `raco setup').
+ cross-multi-compile?)

--- a/racket/collects/compiler/embed.rkt
+++ b/racket/collects/compiler/embed.rkt
@@ -15,6 +15,7 @@
          racket/private/so-search
          racket/private/share-search
          setup/cross-system
+         "private/cm-minimal.rkt"
          "private/winsubsys.rkt"
          "private/macfw.rkt"
          "private/mach-o.rkt"
@@ -515,34 +516,38 @@
                                      ""
                                      submod-path)))])
         (hash-set! working filename full-name)
-        (let ([code (or ready-code
-                        (get-module-code just-filename
-                                         #:submodule-path submod-path
-                                         (let ([l (use-compiled-file-paths)])
-                                           (if (pair? l)
-                                               (car l)
-                                               "compiled"))
-                                         compiler
-                                         (if on-extension
-                                             (lambda (f l?)
-                                               (on-extension f l?)
-                                               #f)
-                                             (lambda (file _loader?)
-                                               (if _loader?
-                                                   (error 'create-embedding-executable
-                                                          "cannot use a _loader extension: ~e"
-                                                          file)
-                                                   (make-extension file))))
-                                         #:choose
-                                         ;; Prefer extensions, if we're handling them:
-                                         (lambda (src zo so)
-                                           (set! actual-filename src) ; remember convert source name
-                                           (if on-extension
-                                               #f
-                                               (if (and (file-exists? so)
-                                                        ((file-date so) . >= . (file-date zo)))
-                                                   'so
-                                                   #f)))))])
+        (let* ([get-module-code*
+                ;; Re-used when swapping code during cross-compilation.
+                (lambda (#:roots [roots (current-compiled-file-roots)])
+                  (get-module-code just-filename
+                                   #:roots roots
+                                   #:submodule-path submod-path
+                                   (let ([l (use-compiled-file-paths)])
+                                     (if (pair? l)
+                                         (car l)
+                                         "compiled"))
+                                   compiler
+                                   (if on-extension
+                                       (lambda (f l?)
+                                         (on-extension f l?)
+                                         #f)
+                                       (lambda (file _loader?)
+                                         (if _loader?
+                                             (error 'create-embedding-executable
+                                                    "cannot use a _loader extension: ~e"
+                                                    file)
+                                             (make-extension file))))
+                                   #:choose
+                                   ;; Prefer extensions, if we're handling them:
+                                   (lambda (src zo so)
+                                     (set! actual-filename src) ; remember convert source name
+                                     (if on-extension
+                                         #f
+                                         (if (and (file-exists? so)
+                                                  ((file-date so) . >= . (file-date zo)))
+                                             'so
+                                             #f)))))]
+               [code (or ready-code (get-module-code*))])
           (cond
            [(extension? code)
             (when verbose?
@@ -556,82 +561,83 @@
                             (unbox codes)))]
            [code
             (let ([importss (module-compiled-imports code)])
-              (let ([all-file-imports (filter (keep-import-dependency? keep-full? actual-filename)
-                                              (apply append (map cdr importss)))]
-                    [extra-paths 
-                     (map symbol-to-lib-form (append (if keep-full?
-                                                         (extract-full-imports module-path actual-filename code)
-                                                         null)
-                                                     (if use-source?
-                                                         (list 'compiler/private/read-bstr)
-                                                         null)
-                                                     (get-extra-imports actual-filename code)))])
-                (let* ([runtime-paths
-                        (if (module-compiled-cross-phase-persistent? code)
-                            ;; avoid potentially trying to redeclare cross-phase persistent modules,
-                            ;; since redeclaration isn't allowed:
+              (let* ([all-file-imports (filter (keep-import-dependency? keep-full? actual-filename)
+                                               (apply append (map cdr importss)))]
+                     [extra-paths
+                      (map symbol-to-lib-form (append (if keep-full?
+                                                          (extract-full-imports module-path actual-filename code)
+                                                          null)
+                                                      (if use-source?
+                                                          (list 'compiler/private/read-bstr)
+                                                          null)
+                                                      (get-extra-imports actual-filename code)))]
+                     [extract-submods
+                      (lambda (submods)
+                        (if use-source?
                             null
-                            ;; check for run-time paths by visiting the module in an
-                            ;; expand-time namespace:
-                            (parameterize ([current-namespace expand-namespace])
-                              (let ([module-path
-                                     (if (path? module-path)
-                                         (path->complete-path module-path)
-                                         module-path)])
-                                (unless (module-declared? module-path)
-                                  (parameterize ([current-module-declare-name
-                                                  (module-path-index-resolve (module-path-index-join
-                                                                              module-path
-                                                                              #f))])
-                                    (eval code)))
-                                (define e (expand `(,#'module m racket/kernel
-                                                     (#%require (only ,module-path)
-                                                                racket/runtime-path)
-                                                     (runtime-paths ,module-path))))
-                                (syntax-case e (quote)
-                                  [(_ m mz (#%mb req (quote (spec ...))))
-                                   (for/list ([p (in-list (syntax->datum #'(spec ...)))])
-                                     ;; Strip variable reference from 'module specs, because
-                                     ;; we don't need them and they retain the namespace:
-                                     (if (and (pair? p) (eq? 'module (car p)))
-                                         (list 'module (cadr p))
-                                         p))]
-                                  [_else (error 'create-empbedding-executable
-                                                "expansion mismatch when getting external paths: ~e"
-                                                (syntax->datum e))]))))]
-
-                       [extra-runtime-paths (filter
-                                             values
-                                             (map (lambda (p)
-                                                    (and (pair? p)
-                                                         (eq? (car p) 'module)
-                                                         (cadr p)))
-                                                  runtime-paths))]
-                       [renamed-code (if (symbol? (module-compiled-name code))
-                                         code
-                                         (module-compiled-name code (last (module-compiled-name code))))]
-                       [extract-submods (lambda (l)
-                                          (if use-source?
-                                              null
-                                              (for/list ([m (in-list l)]
-                                                         #:when (or (member (last (module-compiled-name m)) use-submods)
-                                                                    (declares-always-preserved? m)))
-                                                m)))]
-                       [pre-submods (extract-submods (module-compiled-submodules renamed-code #t))]
-                       [post-submods (extract-submods (module-compiled-submodules renamed-code #f))]
-                       [code (if keep-full?
-                                 code
-                                 (module-compiled-submodules (module-compiled-submodules
-                                                              renamed-code
-                                                              #f
-                                                              null)
-                                                             #t
-                                                             null))])
-                  (let ([sub-files (map (lambda (i) 
+                            (for/list ([m (in-list submods)]
+                                       #:when (or (member (last (module-compiled-name m)) use-submods)
+                                                  (declares-always-preserved? m)))
+                              m)))]
+                     [prepare-code&submods
+                      (lambda (code)
+                        (define name (module-compiled-name code))
+                        (define renamed-code
+                          (cond
+                            [(symbol? name) code]
+                            [else (module-compiled-name code (last name))]))
+                        (define pre-submods (extract-submods (module-compiled-submodules renamed-code #t)))
+                        (define post-submods (extract-submods (module-compiled-submodules renamed-code #f)))
+                        (define new-code
+                          (cond
+                            [keep-full? code]
+                            [else (module-compiled-submodules
+                                   (module-compiled-submodules renamed-code #f null) #t null)]))
+                        (values new-code pre-submods post-submods))])
+                (let*-values ([(runtime-paths)
+                               (if (module-compiled-cross-phase-persistent? code)
+                                   ;; avoid potentially trying to redeclare cross-phase persistent modules,
+                                   ;; since redeclaration isn't allowed:
+                                   null
+                                   ;; check for run-time paths by visiting the module in an
+                                   ;; expand-time namespace:
+                                   (parameterize ([current-namespace expand-namespace])
+                                     (let ([module-path
+                                            (if (path? module-path)
+                                                (path->complete-path module-path)
+                                                module-path)])
+                                       (unless (module-declared? module-path)
+                                         (parameterize ([current-module-declare-name
+                                                         (module-path-index-resolve (module-path-index-join
+                                                                                     module-path
+                                                                                     #f))])
+                                           (eval code)))
+                                       (define e (expand `(,#'module m racket/kernel
+                                                                     (#%require (only ,module-path)
+                                                                                racket/runtime-path)
+                                                                     (runtime-paths ,module-path))))
+                                       (syntax-case e (quote)
+                                         [(_ m mz (#%mb req (quote (spec ...))))
+                                          (for/list ([p (in-list (syntax->datum #'(spec ...)))])
+                                            ;; Strip variable reference from 'module specs, because
+                                            ;; we don't need them and they retain the namespace:
+                                            (if (and (pair? p) (eq? 'module (car p)))
+                                                (list 'module (cadr p))
+                                                p))]
+                                         [_else (error 'create-empbedding-executable
+                                                       "expansion mismatch when getting external paths: ~e"
+                                                       (syntax->datum e))]))))]
+                              [(extra-runtime-paths) (filter-map (lambda (p)
+                                                                   (and (pair? p)
+                                                                        (eq? (car p) 'module)
+                                                                        (cadr p)))
+                                                                 runtime-paths)]
+                              [(code pre-submods post-submods) (prepare-code&submods code)])
+                  (let ([sub-files (map (lambda (i)
                                           ;; use `just-filename', because i has submod name embedded
                                           (normalize (resolve-module-path-index i just-filename)))
                                         all-file-imports)]
-                        [sub-paths (map (lambda (i) 
+                        [sub-paths (map (lambda (i)
                                           ;; use `root-module-path', because i has submod name embedded
                                           (collapse-module-path-index i root-module-path))
                                         all-file-imports)]
@@ -738,25 +744,42 @@
                                                    (append sub-paths extra-runtime-paths)))
                                       (map get-submod-mapping pre-submods)))])
                           ;; Record the module
-                          (set-box! codes
-                                    (cons (make-mod filename module-path code 
-                                                    name full-name
-                                                    mappings-box
-                                                    runtime-paths
-                                                    ;; extract runtime-path module symbols:
-                                                    (let loop ([runtime-paths runtime-paths]
-                                                               [extra-files extra-files])
-                                                      (cond
-                                                       [(null? runtime-paths) null]
-                                                       [(let ([p (car runtime-paths)])
-                                                          (and (pair? p) (eq? (car p) 'module)))
-                                                        (cons (lookup-full-name (car extra-files))
-                                                              (loop (cdr runtime-paths) (cdr extra-files)))]
-                                                       [else
-                                                        (cons #f (loop (cdr runtime-paths) extra-files))]))
-                                                    actual-filename
-                                                    use-source?)
-                                          (unbox codes)))
+                          ;; HACK: We are currently unable to read fasl data for machines other than the host so
+                          ;; cross-compilation is tricky: we use modules compiled for the host to figure out the general
+                          ;; layout of things but then swap the actual code of those modules with code for the target
+                          ;; machine. This works out as long as the code for both targets is in sync, which ought to be
+                          ;; the case by virtue of the cross-compilation flags (see `cross-multi-compile?`) used to get here.
+                          (let ([code (cond
+                                        [(cross-compiling?)
+                                         (when verbose?
+                                           (eprintf "Swapping host code of ~s for target platform~n" module-path))
+                                         (define target-code
+                                           (get-module-code* #:roots (cdr (current-compiled-file-roots))))
+                                         ;; Apply the same trasformations to the target code that were made to the host code.
+                                         (define-values (prepared-code _pre-submods _post-submods)
+                                           (prepare-code&submods target-code))
+                                         prepared-code]
+                                        [else
+                                         code])])
+                            (set-box! codes
+                                      (cons (make-mod filename module-path code
+                                                      name full-name
+                                                      mappings-box
+                                                      runtime-paths
+                                                      ;; extract runtime-path module symbols:
+                                                      (let loop ([runtime-paths runtime-paths]
+                                                                 [extra-files extra-files])
+                                                        (cond
+                                                          [(null? runtime-paths) null]
+                                                          [(let ([p (car runtime-paths)])
+                                                             (and (pair? p) (eq? (car p) 'module)))
+                                                           (cons (lookup-full-name (car extra-files))
+                                                                 (loop (cdr runtime-paths) (cdr extra-files)))]
+                                                          [else
+                                                           (cons #f (loop (cdr runtime-paths) extra-files))]))
+                                                      actual-filename
+                                                      use-source?)
+                                            (unbox codes))))
                           ;; Add code for post submodules:
                           (for-each get-one-submodule-code post-submods)
                           ;; Add post-submodule mappings:
@@ -813,7 +836,8 @@
 (define (compile-using-kernel e)
   (let ([ns (make-empty-namespace)])
     (namespace-attach-module (current-namespace) ''#%kernel ns)
-    (parameterize ([current-namespace ns])
+    (parameterize ([current-namespace ns]
+                   [current-compile-target-machine (get-compile-target-machine)])
       (namespace-require ''#%kernel)
       (compile e))))
 
@@ -1404,7 +1428,8 @@
                              #:on-extension [on-extension #f]
                              #:expand-namespace [expand-namespace (current-namespace)]
                              #:compiler [compiler (lambda (expr)
-                                                    (parameterize ([current-namespace expand-namespace])
+                                                    (parameterize ([current-namespace expand-namespace]
+                                                                   [current-compile-target-machine (get-compile-target-machine)])
                                                       (compile expr)))]
                              #:src-filter [src-filter (lambda (filename) #f)]
                              #:get-extra-imports [get-extra-imports (lambda (filename code) null)])
@@ -1417,6 +1442,14 @@
                           src-filter get-extra-imports
                           void
 			  #f)) ; don't accumulate embedded DLLs
+
+(define (cross-compiling?)
+  (cross-multi-compile? (current-compiled-file-roots)))
+
+(define (get-compile-target-machine)
+  (if (cross-compiling?)
+      (cross-system-type 'target-machine)
+      (system-type 'target-machine)))
 
 
 ;; The old interface:

--- a/racket/collects/compiler/embed.rkt
+++ b/racket/collects/compiler/embed.rkt
@@ -744,11 +744,9 @@
                                                    (append sub-paths extra-runtime-paths)))
                                       (map get-submod-mapping pre-submods)))])
                           ;; Record the module
-                          ;; HACK: We are currently unable to read fasl data for machines other than the host so
-                          ;; cross-compilation is tricky: we use modules compiled for the host to figure out the general
-                          ;; layout of things but then swap the actual code of those modules with code for the target
-                          ;; machine. This works out as long as the code for both targets is in sync, which ought to be
-                          ;; the case by virtue of the cross-compilation flags (see `cross-multi-compile?`) used to get here.
+                          ;; For cross-compilation, we need to be able to execute code using the host Racket (to find
+                          ;; dependencies and runtime paths), but then we have to swap in code for the target Racket
+                          ;; here, before writing it to the output.
                           (let ([code (cond
                                         [(cross-compiling?)
                                          (when verbose?

--- a/racket/collects/compiler/private/cm-minimal.rkt
+++ b/racket/collects/compiler/private/cm-minimal.rkt
@@ -67,12 +67,14 @@
 
          managed-compiled-context-key
          make-compilation-context-error-display-handler
-         
+
          parallel-lock-client
-         
+
          install-module-hashes!
 
-         current-path->mode)
+         current-path->mode
+
+         cross-multi-compile?)
 
 (module+ cm-internal
   (provide try-file-time

--- a/racket/collects/setup/private/pkg-deps.rkt
+++ b/racket/collects/setup/private/pkg-deps.rkt
@@ -13,6 +13,7 @@
          setup/dirs
          setup/doc-db
          version/utils
+         (only-in compiler/cm cross-multi-compile?)
          compiler/private/dep
          "time.rkt")
 
@@ -407,10 +408,17 @@
 
   ;; ----------------------------------------
   (define (find-compiled-directories path)
-    ;; Find all directories that can hold compiled bytecode for `path`
+    ;; Find all directories that can hold compiled bytecode for
+    ;; `path`.  When cross-compiling, only list directories targeting
+    ;; the host machine.
+    (define roots
+      (let ([roots (current-compiled-file-roots)])
+        (if (cross-multi-compile? roots)
+            (list (car roots))
+            roots)))
     (filter
      values
-     (for*/list ([root (in-list (current-compiled-file-roots))]
+     (for*/list ([root (in-list roots)]
                  [mode (in-list (use-compiled-file-paths))])
        (define compiled-dir
          (cond

--- a/racket/collects/setup/private/pkg-deps.rkt
+++ b/racket/collects/setup/private/pkg-deps.rkt
@@ -13,7 +13,7 @@
          setup/dirs
          setup/doc-db
          version/utils
-         (only-in compiler/cm cross-multi-compile?)
+         compiler/cross
          compiler/private/dep
          "time.rkt")
 

--- a/racket/collects/setup/setup-core.rkt
+++ b/racket/collects/setup/setup-core.rkt
@@ -12,6 +12,7 @@
          racket/string
          compiler/cm
          compiler/compilation-path
+         compiler/cross
          planet/planet-archives
          planet/private/planet-shared
          (only-in planet/resolver resolve-planet-path)

--- a/racket/collects/setup/setup-core.rkt
+++ b/racket/collects/setup/setup-core.rkt
@@ -2094,9 +2094,7 @@
   (setup-printf "version" "~a" (version))
   (setup-printf "platform" "~a [~a]" (cross-system-library-subpath #f) (cross-system-type 'gc))
   (setup-printf "target machine" "~a" (or (current-compile-target-machine)
-                                          ;; Check for `cross-multi-compile?` mode like compiler/cm:
-                                          (and ((length (current-compiled-file-roots)) . > . 1)
-                                               (cross-installation?)
+                                          (and (cross-multi-compile? (current-compiled-file-roots))
                                                (cross-system-type 'target-machine))
                                           'any))
   (when (cross-installation?)

--- a/racket/src/ChezScheme/IMPLEMENTATION.md
+++ b/racket/src/ChezScheme/IMPLEMENTATION.md
@@ -31,7 +31,7 @@ compiler to build a Chez Scheme compiler. The compiler and makefiles
 support cross-compilation, so you can work from an already supported
 host to cross-compile the boot files and produce the header files for
 a new platform. In particular, the `pb` (portable bytecode) machine
-type can run on any supported hardward and operating system, so having
+type can run on any supported hardware and operating system, so having
 `pb` boot files is one way to get started in a new environment.
 
 # Build System

--- a/racket/src/ChezScheme/c/Mf-arm64osx
+++ b/racket/src/ChezScheme/c/Mf-arm64osx
@@ -16,7 +16,7 @@
 m ?= arm64osx
 Cpu ?= AARCH64
 
-mdinclude = -I/opt/X11/include/ 
+mdinclude = -I/opt/X11/include/
 o = o
 mdsrc ?= arm32le.c
 mdobj ?= arm32le.o
@@ -39,7 +39,7 @@ ${Scheme}: ${Kernel} ${KernelLinkDeps} ${Main}
 	$C -o ${Scheme} ${Main} ${Kernel} ${KernelLinkLibs} ${LDFLAGS} ${LIBS}
 
 ../zlib/configure.log:
-	(cd ../zlib; ${SetConfigEnv} CFLAGS="${CFLAGS}" ./configure)
+	(cd ../zlib; ${SetConfigEnv} CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure)
 
 ../lz4/lib/liblz4.a: ${LZ4Sources}
-	(cd ../lz4/lib; ${SetConfigEnv} CFLAGS="${CFLAGS}" ${MAKE} liblz4.a)
+	(cd ../lz4/lib; ${SetConfigEnv} CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ${MAKE} liblz4.a)

--- a/racket/src/ChezScheme/c/Mf-arm64osx
+++ b/racket/src/ChezScheme/c/Mf-arm64osx
@@ -39,7 +39,7 @@ ${Scheme}: ${Kernel} ${KernelLinkDeps} ${Main}
 	$C -o ${Scheme} ${Main} ${Kernel} ${KernelLinkLibs} ${LDFLAGS} ${LIBS}
 
 ../zlib/configure.log:
-	(cd ../zlib; ${SetConfigEnv} CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure)
+	(cd ../zlib; ${SetConfigEnv} CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ./configure)
 
 ../lz4/lib/liblz4.a: ${LZ4Sources}
-	(cd ../lz4/lib; ${SetConfigEnv} CPPFLAGS="${CPPFLAGS}" CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ${MAKE} liblz4.a)
+	(cd ../lz4/lib; ${SetConfigEnv} CFLAGS="${CFLAGS}" LDFLAGS="${LDFLAGS}" ${MAKE} liblz4.a)

--- a/racket/src/ChezScheme/c/alloc.c
+++ b/racket/src/ChezScheme/c/alloc.c
@@ -34,9 +34,6 @@ void S_alloc_init() {
             S_G.bytes_of_generation[g] = 0;
             for (s = 0; s <= max_real_space; s++) {
               S_G.main_thread_gc.base_loc[g][s] = FIX(0);
-#if defined(WRITE_XOR_EXECUTE_CODE)
-              S_G.main_thread_gc.base_bytes[g][s] = 0;
-#endif
               S_G.main_thread_gc.next_loc[g][s] = FIX(0);
               S_G.main_thread_gc.bytes_left[g][s] = 0;
               S_G.bytes_of_space[g][s] = 0;
@@ -257,9 +254,6 @@ ptr S_find_more_gc_room(thread_gc *tgc, ISPC s, IGEN g, iptr n, ptr old) {
   new_bytes = nsegs * bytes_per_segment;
 
   tgc->base_loc[g][s] = new;
-#if defined(WRITE_XOR_EXECUTE_CODE)
-  tgc->base_bytes[g][s] = new_bytes;
-#endif
   tgc->sweep_loc[g][s] = new;
   tgc->bytes_left[g][s] = (new_bytes - n) - ptr_bytes;
   tgc->next_loc[g][s] = (ptr)((uptr)new + n);

--- a/racket/src/ChezScheme/c/alloc.c
+++ b/racket/src/ChezScheme/c/alloc.c
@@ -33,8 +33,11 @@ void S_alloc_init() {
         for (g = 0; g <= static_generation; g++) {
             S_G.bytes_of_generation[g] = 0;
             for (s = 0; s <= max_real_space; s++) {
-              S_G.main_thread_gc.base_loc[g][s] = FIX(0); 
-              S_G.main_thread_gc.next_loc[g][s] = FIX(0); 
+              S_G.main_thread_gc.base_loc[g][s] = FIX(0);
+#if defined(WRITE_XOR_EXECUTE_CODE)
+              S_G.main_thread_gc.base_bytes[g][s] = 0;
+#endif
+              S_G.main_thread_gc.next_loc[g][s] = FIX(0);
               S_G.main_thread_gc.bytes_left[g][s] = 0;
               S_G.bytes_of_space[g][s] = 0;
             }
@@ -224,6 +227,9 @@ static void close_off_segment(thread_gc *tgc, ptr old, ptr base_loc, ptr sweep_l
     /* in case this is during a GC, add to sweep list */
     si = SegInfo(addr_get_segment(base_loc));
     si->sweep_start = sweep_loc;
+#if defined(WRITE_XOR_EXECUTE_CODE)
+    si->sweep_bytes = bytes;
+#endif
     si->sweep_next = tgc->sweep_next[g][s];
     tgc->sweep_next[g][s] = si;
   }
@@ -251,9 +257,21 @@ ptr S_find_more_gc_room(thread_gc *tgc, ISPC s, IGEN g, iptr n, ptr old) {
   new_bytes = nsegs * bytes_per_segment;
 
   tgc->base_loc[g][s] = new;
+#if defined(WRITE_XOR_EXECUTE_CODE)
+  tgc->base_bytes[g][s] = new_bytes;
+#endif
   tgc->sweep_loc[g][s] = new;
   tgc->bytes_left[g][s] = (new_bytes - n) - ptr_bytes;
   tgc->next_loc[g][s] = (ptr)((uptr)new + n);
+
+#if defined(WRITE_XOR_EXECUTE_CODE)
+  if (s == space_code) {
+    /* Ensure allocated code segments are writable. The caller should
+       already have bracketed the writes with calls to start and stop
+       so there is no need for a stop here. */
+    S_thread_start_code_write(tgc->tc, 0, 1, NULL);
+  }
+#endif
 
   if (tgc->during_alloc == 1) maybe_queue_fire_collector(tgc);
 
@@ -272,6 +290,9 @@ void S_close_off_thread_local_segment(ptr tc, ISPC s, IGEN g) {
   close_off_segment(tgc, tgc->next_loc[g][s], tgc->base_loc[g][s], tgc->sweep_loc[g][s], s, g);
 
   tgc->base_loc[g][s] = (ptr)0;
+#if defined(WRITE_XOR_EXECUTE_CODE)
+  tgc->base_loc[g][s] = 0;
+#endif
   tgc->bytes_left[g][s] = 0;
   tgc->next_loc[g][s] = (ptr)0;
   tgc->sweep_loc[g][s] = (ptr)0;

--- a/racket/src/ChezScheme/c/arm32le.c
+++ b/racket/src/ChezScheme/c/arm32le.c
@@ -19,6 +19,10 @@
 #include <sys/types.h>
 #include <sys/mman.h>
 
+#ifdef TARGET_OS_IPHONE
+# include <libkern/OSCacheControl.h>
+#endif
+
 /* we don't count on having the right value for correctness,
  * but the right value will give maximum efficiency */
 #define DEFAULT_L1_MAX_CACHE_LINE_SIZE 32
@@ -35,7 +39,11 @@ void S_doflush(uptr start, uptr end) {
   printf("  doflush(%x, %x)\n", start, end); fflush(stdout);
 #endif
 
+#ifdef TARGET_OS_IPHONE
+  sys_icache_invalidate((void *)start, (char *)end-(char *)start);
+#else
   __clear_cache((char *)start, (char *)end);
+#endif
 }
 
 void S_machine_init() {

--- a/racket/src/ChezScheme/c/expeditor.c
+++ b/racket/src/ChezScheme/c/expeditor.c
@@ -741,7 +741,7 @@ static ptr s_ee_get_screen_size(void) {
   static IBOOL tried_resize = 0;
  /* attempt to work around 10.6 tty driver / xterm bug */
   if (ee_rows == 0 && ee_cols == 0 && !tried_resize) {
-    system("exec /usr/X11/bin/resize >& /dev/null");
+    SYSTEM("exec /usr/X11/bin/resize >& /dev/null");
     tried_resize = 1;
     return s_ee_get_screen_size();
   }

--- a/racket/src/ChezScheme/c/externs.h
+++ b/racket/src/ChezScheme/c/externs.h
@@ -393,8 +393,8 @@ extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_adjustmembytes PROTO((iptr amt));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
-extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg));
-extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg));
+extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg, ptr hint));
+extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg, ptr hint));
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/racket/src/ChezScheme/c/externs.h
+++ b/racket/src/ChezScheme/c/externs.h
@@ -393,8 +393,8 @@ extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_adjustmembytes PROTO((iptr amt));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
-extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg, IBOOL current, ptr hint));
-extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg, IBOOL current, ptr hint));
+extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg, IBOOL current, void *hint));
+extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg, IBOOL current, void *hint));
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/racket/src/ChezScheme/c/externs.h
+++ b/racket/src/ChezScheme/c/externs.h
@@ -393,8 +393,8 @@ extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_adjustmembytes PROTO((iptr amt));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
-extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg, ptr hint));
-extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg, ptr hint));
+extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg, IBOOL current, ptr hint));
+extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg, IBOOL current, ptr hint));
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/racket/src/ChezScheme/c/externs.h
+++ b/racket/src/ChezScheme/c/externs.h
@@ -393,8 +393,8 @@ extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_adjustmembytes PROTO((iptr amt));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
-extern void S_thread_start_code_write PROTO((IGEN mingen, IGEN maxgen));
-extern void S_thread_end_code_write PROTO((IGEN mingen, IGEN maxgen));
+extern void S_thread_start_code_write PROTO((IGEN maxg));
+extern void S_thread_end_code_write PROTO((IGEN maxg));
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/racket/src/ChezScheme/c/externs.h
+++ b/racket/src/ChezScheme/c/externs.h
@@ -393,8 +393,8 @@ extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_adjustmembytes PROTO((iptr amt));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
-extern void S_thread_start_code_write PROTO((IGEN maxg));
-extern void S_thread_end_code_write PROTO((IGEN maxg));
+extern void S_thread_start_code_write PROTO((ptr tc, IGEN maxg));
+extern void S_thread_end_code_write PROTO((ptr tc, IGEN maxg));
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/racket/src/ChezScheme/c/externs.h
+++ b/racket/src/ChezScheme/c/externs.h
@@ -393,8 +393,8 @@ extern uptr S_maxmembytes PROTO((void));
 extern void S_resetmaxmembytes PROTO((void));
 extern void S_adjustmembytes PROTO((iptr amt));
 extern void S_move_to_chunk_list PROTO((chunkinfo *chunk, chunkinfo **pchunk_list));
-extern void S_thread_start_code_write(void);
-extern void S_thread_end_code_write(void);
+extern void S_thread_start_code_write PROTO((IGEN mingen, IGEN maxgen));
+extern void S_thread_end_code_write PROTO((IGEN mingen, IGEN maxgen));
 
 /* stats.c */
 extern void S_stats_init PROTO((void));

--- a/racket/src/ChezScheme/c/fasl.c
+++ b/racket/src/ChezScheme/c/fasl.c
@@ -508,7 +508,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
         Scompact_heap();
       }
 
-      S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
+      S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
 
       switch (ty) {
         case fasl_type_gzip:
@@ -557,7 +557,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
           return (ptr)0;
       }
       S_flush_instruction_cache(tc);
-      S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
+      S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
       return x;
     } else {
       uf_skipbytes(uf, size);
@@ -569,7 +569,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   ptr x; ptr strbuf = S_G.null_string;
   struct faslFileObj ffo;
 
-  S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
+  S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
 
   if (ty == fasl_type_vfasl) {
     x = S_vfasl(bv, NULL, offset, len);
@@ -585,7 +585,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   }
 
   S_flush_instruction_cache(tc);
-  S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
+  S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
   
   return x;
 }

--- a/racket/src/ChezScheme/c/fasl.c
+++ b/racket/src/ChezScheme/c/fasl.c
@@ -508,7 +508,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
         Scompact_heap();
       }
 
-      S_thread_start_code_write();
+      S_thread_start_code_write(0, 0);
 
       switch (ty) {
         case fasl_type_gzip:
@@ -557,7 +557,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
           return (ptr)0;
       }
       S_flush_instruction_cache(tc);
-      S_thread_end_code_write();
+      S_thread_end_code_write(0, 0);
       return x;
     } else {
       uf_skipbytes(uf, size);
@@ -569,7 +569,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   ptr x; ptr strbuf = S_G.null_string;
   struct faslFileObj ffo;
 
-  S_thread_start_code_write();
+  S_thread_start_code_write(0, static_generation);
 
   if (ty == fasl_type_vfasl) {
     x = S_vfasl(bv, NULL, offset, len);
@@ -585,7 +585,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   }
 
   S_flush_instruction_cache(tc);
-  S_thread_end_code_write();
+  S_thread_end_code_write(0, static_generation);
   
   return x;
 }

--- a/racket/src/ChezScheme/c/fasl.c
+++ b/racket/src/ChezScheme/c/fasl.c
@@ -508,7 +508,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
         Scompact_heap();
       }
 
-      S_thread_start_code_write(S_vfasl_boot_mode ? static_generation : 0);
+      S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
 
       switch (ty) {
         case fasl_type_gzip:
@@ -557,7 +557,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
           return (ptr)0;
       }
       S_flush_instruction_cache(tc);
-      S_thread_end_code_write(S_vfasl_boot_mode ? static_generation : 0);
+      S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
       return x;
     } else {
       uf_skipbytes(uf, size);
@@ -569,7 +569,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   ptr x; ptr strbuf = S_G.null_string;
   struct faslFileObj ffo;
 
-  S_thread_start_code_write(S_vfasl_boot_mode ? static_generation : 0);
+  S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
 
   if (ty == fasl_type_vfasl) {
     x = S_vfasl(bv, NULL, offset, len);
@@ -585,7 +585,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   }
 
   S_flush_instruction_cache(tc);
-  S_thread_end_code_write(S_vfasl_boot_mode ? static_generation : 0);
+  S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0);
   
   return x;
 }

--- a/racket/src/ChezScheme/c/fasl.c
+++ b/racket/src/ChezScheme/c/fasl.c
@@ -508,7 +508,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
         Scompact_heap();
       }
 
-      S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
+      S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, 1, NULL);
 
       switch (ty) {
         case fasl_type_gzip:
@@ -557,7 +557,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
           return (ptr)0;
       }
       S_flush_instruction_cache(tc);
-      S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
+      S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, 1, NULL);
       return x;
     } else {
       uf_skipbytes(uf, size);
@@ -569,7 +569,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   ptr x; ptr strbuf = S_G.null_string;
   struct faslFileObj ffo;
 
-  S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
+  S_thread_start_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, 1, NULL);
 
   if (ty == fasl_type_vfasl) {
     x = S_vfasl(bv, NULL, offset, len);
@@ -585,8 +585,8 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   }
 
   S_flush_instruction_cache(tc);
-  S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, NULL);
-  
+  S_thread_end_code_write(tc, S_vfasl_boot_mode ? static_generation : 0, 1, NULL);
+
   return x;
 }
 

--- a/racket/src/ChezScheme/c/fasl.c
+++ b/racket/src/ChezScheme/c/fasl.c
@@ -508,7 +508,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
         Scompact_heap();
       }
 
-      S_thread_start_code_write(0, 0);
+      S_thread_start_code_write(S_vfasl_boot_mode ? static_generation : 0);
 
       switch (ty) {
         case fasl_type_gzip:
@@ -557,7 +557,7 @@ static ptr fasl_entry(ptr tc, IFASLCODE situation, unbufFaslFile uf, ptr externa
           return (ptr)0;
       }
       S_flush_instruction_cache(tc);
-      S_thread_end_code_write(0, 0);
+      S_thread_end_code_write(S_vfasl_boot_mode ? static_generation : 0);
       return x;
     } else {
       uf_skipbytes(uf, size);
@@ -569,7 +569,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   ptr x; ptr strbuf = S_G.null_string;
   struct faslFileObj ffo;
 
-  S_thread_start_code_write(0, static_generation);
+  S_thread_start_code_write(S_vfasl_boot_mode ? static_generation : 0);
 
   if (ty == fasl_type_vfasl) {
     x = S_vfasl(bv, NULL, offset, len);
@@ -585,7 +585,7 @@ static ptr bv_fasl_entry(ptr tc, ptr bv, int ty, uptr offset, uptr len, unbufFas
   }
 
   S_flush_instruction_cache(tc);
-  S_thread_end_code_write(0, static_generation);
+  S_thread_end_code_write(S_vfasl_boot_mode ? static_generation : 0);
   
   return x;
 }

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -2951,7 +2951,7 @@ static s_thread_rv_t start_sweeper(void *_sweeper) {
   gc_sweeper *sweeper = _sweeper;
 
 #if !defined(WRITE_XOR_EXECUTE_CODE)
-  S_thread_start_code_write(NULL, static_generation, 0, NULL); /* never ended */
+  S_thread_start_code_write((ptr)0, static_generation, 0, NULL); /* never ended */
 #endif
 
   (void)s_thread_mutex_lock(&sweep_mutex);

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -870,7 +870,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
 
     GET_REAL_TIME(astart);
 
-    S_thread_start_code_write(MAX_TG);
+    S_thread_start_code_write(tc, MAX_TG);
 
    /* flush instruction cache: effectively clear_code_mod but safer */
     for (ls = S_threads; ls != Snil; ls = Scdr(ls)) {
@@ -1679,7 +1679,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
     if (MAX_CG >= S_G.min_free_gen) S_free_chunks();
 
     S_flush_instruction_cache(tc);
-    S_thread_end_code_write(MAX_TG);
+    S_thread_end_code_write(tc, MAX_TG);
 
 #ifndef NO_DIRTY_NEWSPACE_POINTERS
     /* mark dirty those newspace cards to which we've added wrong-way pointers */

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -870,7 +870,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
 
     GET_REAL_TIME(astart);
 
-    S_thread_start_code_write(tc, MAX_TG);
+    S_thread_start_code_write(tc, MAX_TG, NULL);
 
    /* flush instruction cache: effectively clear_code_mod but safer */
     for (ls = S_threads; ls != Snil; ls = Scdr(ls)) {
@@ -1679,7 +1679,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
     if (MAX_CG >= S_G.min_free_gen) S_free_chunks();
 
     S_flush_instruction_cache(tc);
-    S_thread_end_code_write(tc, MAX_TG);
+    S_thread_end_code_write(tc, MAX_TG, NULL);
 
 #ifndef NO_DIRTY_NEWSPACE_POINTERS
     /* mark dirty those newspace cards to which we've added wrong-way pointers */
@@ -2951,7 +2951,7 @@ static s_thread_rv_t start_sweeper(void *_sweeper) {
   gc_sweeper *sweeper = _sweeper;
 
 #if !defined(WRITE_XOR_EXECUTE_CODE)
-  S_thread_start_code_write(get_thread_context(), static_generation); /* never ended */
+  S_thread_start_code_write(get_thread_context(), static_generation, NULL); /* never ended */
 #endif
 
   (void)s_thread_mutex_lock(&sweep_mutex);

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -870,7 +870,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
 
     GET_REAL_TIME(astart);
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, MAX_TG);
 
    /* flush instruction cache: effectively clear_code_mod but safer */
     for (ls = S_threads; ls != Snil; ls = Scdr(ls)) {
@@ -1679,7 +1679,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
     if (MAX_CG >= S_G.min_free_gen) S_free_chunks();
 
     S_flush_instruction_cache(tc);
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, MAX_TG);
 
 #ifndef NO_DIRTY_NEWSPACE_POINTERS
     /* mark dirty those newspace cards to which we've added wrong-way pointers */
@@ -2950,7 +2950,7 @@ static void setup_sweepers(thread_gc *tgc) {
 static s_thread_rv_t start_sweeper(void *_sweeper) {
   gc_sweeper *sweeper = _sweeper;
 
-  S_thread_start_code_write(); /* never ended */
+  S_thread_start_code_write(0, static_generation); /* never ended */
 
   (void)s_thread_mutex_lock(&sweep_mutex);
   while (1) {

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -870,7 +870,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
 
     GET_REAL_TIME(astart);
 
-    S_thread_start_code_write(tc, MAX_TG, NULL);
+    S_thread_start_code_write(tc, MAX_TG, 0, NULL);
 
    /* flush instruction cache: effectively clear_code_mod but safer */
     for (ls = S_threads; ls != Snil; ls = Scdr(ls)) {
@@ -1679,7 +1679,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
     if (MAX_CG >= S_G.min_free_gen) S_free_chunks();
 
     S_flush_instruction_cache(tc);
-    S_thread_end_code_write(tc, MAX_TG, NULL);
+    S_thread_end_code_write(tc, MAX_TG, 0, NULL);
 
 #ifndef NO_DIRTY_NEWSPACE_POINTERS
     /* mark dirty those newspace cards to which we've added wrong-way pointers */
@@ -2951,7 +2951,7 @@ static s_thread_rv_t start_sweeper(void *_sweeper) {
   gc_sweeper *sweeper = _sweeper;
 
 #if !defined(WRITE_XOR_EXECUTE_CODE)
-  S_thread_start_code_write(get_thread_context(), static_generation, NULL); /* never ended */
+  S_thread_start_code_write(NULL, static_generation, 0, NULL); /* never ended */
 #endif
 
   (void)s_thread_mutex_lock(&sweep_mutex);

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -2951,7 +2951,7 @@ static s_thread_rv_t start_sweeper(void *_sweeper) {
   gc_sweeper *sweeper = _sweeper;
 
 #if !defined(WRITE_XOR_EXECUTE_CODE)
-  S_thread_start_code_write(static_generation); /* never ended */
+  S_thread_start_code_write(get_thread_context(), static_generation); /* never ended */
 #endif
 
   (void)s_thread_mutex_lock(&sweep_mutex);

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -870,7 +870,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
 
     GET_REAL_TIME(astart);
 
-    S_thread_start_code_write(0, MAX_TG);
+    S_thread_start_code_write(MAX_TG);
 
    /* flush instruction cache: effectively clear_code_mod but safer */
     for (ls = S_threads; ls != Snil; ls = Scdr(ls)) {
@@ -1679,7 +1679,7 @@ ptr GCENTRY(ptr tc, ptr count_roots_ls) {
     if (MAX_CG >= S_G.min_free_gen) S_free_chunks();
 
     S_flush_instruction_cache(tc);
-    S_thread_end_code_write(0, MAX_TG);
+    S_thread_end_code_write(MAX_TG);
 
 #ifndef NO_DIRTY_NEWSPACE_POINTERS
     /* mark dirty those newspace cards to which we've added wrong-way pointers */
@@ -2950,7 +2950,9 @@ static void setup_sweepers(thread_gc *tgc) {
 static s_thread_rv_t start_sweeper(void *_sweeper) {
   gc_sweeper *sweeper = _sweeper;
 
-  S_thread_start_code_write(0, static_generation); /* never ended */
+#if !defined(WRITE_XOR_EXECUTE_CODE)
+  S_thread_start_code_write(static_generation); /* never ended */
+#endif
 
   (void)s_thread_mutex_lock(&sweep_mutex);
   while (1) {

--- a/racket/src/ChezScheme/c/gcwrapper.c
+++ b/racket/src/ChezScheme/c/gcwrapper.c
@@ -1193,6 +1193,9 @@ ptr S_do_gc(IGEN max_cg, IGEN min_tg, IGEN max_tg, ptr count_roots) {
           ptr t_tc = (ptr)THREADTC(Scar(ls));
           thread_gc *tgc = THREAD_GC(t_tc);
           tgc->base_loc[new_g][s] = tgc->base_loc[old_g][s]; tgc->base_loc[old_g][s] = (ptr)0;
+#if defined(WRITE_XOR_EXECUTE_CODE)
+          tgc->base_bytes[new_g][s] = tgc->base_bytes[old_g][s]; tgc->base_bytes[old_g][s] = 0;
+#endif
           tgc->next_loc[new_g][s] = tgc->next_loc[old_g][s]; tgc->next_loc[old_g][s] = (ptr)0;
           tgc->bytes_left[new_g][s] = tgc->bytes_left[old_g][s]; tgc->bytes_left[old_g][s] = 0;
           tgc->sweep_loc[new_g][s] = tgc->sweep_loc[old_g][s]; tgc->sweep_loc[old_g][s] = 0;

--- a/racket/src/ChezScheme/c/gcwrapper.c
+++ b/racket/src/ChezScheme/c/gcwrapper.c
@@ -1193,9 +1193,6 @@ ptr S_do_gc(IGEN max_cg, IGEN min_tg, IGEN max_tg, ptr count_roots) {
           ptr t_tc = (ptr)THREADTC(Scar(ls));
           thread_gc *tgc = THREAD_GC(t_tc);
           tgc->base_loc[new_g][s] = tgc->base_loc[old_g][s]; tgc->base_loc[old_g][s] = (ptr)0;
-#if defined(WRITE_XOR_EXECUTE_CODE)
-          tgc->base_bytes[new_g][s] = tgc->base_bytes[old_g][s]; tgc->base_bytes[old_g][s] = 0;
-#endif
           tgc->next_loc[new_g][s] = tgc->next_loc[old_g][s]; tgc->next_loc[old_g][s] = (ptr)0;
           tgc->bytes_left[new_g][s] = tgc->bytes_left[old_g][s]; tgc->bytes_left[old_g][s] = 0;
           tgc->sweep_loc[new_g][s] = tgc->sweep_loc[old_g][s]; tgc->sweep_loc[old_g][s] = 0;

--- a/racket/src/ChezScheme/c/prim.c
+++ b/racket/src/ChezScheme/c/prim.c
@@ -228,7 +228,7 @@ static void s_instantiate_code_object() {
     cookie = S_get_scheme_arg(tc, 2);
     proc = S_get_scheme_arg(tc, 3);
 
-    S_thread_start_code_write(tc, 0);
+    S_thread_start_code_write(tc, 0, NULL);
 
     new = S_code(tc, CODETYPE(old), CODELEN(old));
 
@@ -280,7 +280,7 @@ static void s_instantiate_code_object() {
     }
     S_flush_instruction_cache(tc);
 
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, NULL);
 
     AC0(tc) = new;
 }
@@ -289,7 +289,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
     ptr t, tc = get_thread_context();
     uptr a, m, n;
 
-    S_thread_start_code_write(tc, 0);
+    S_thread_start_code_write(tc, 0, NULL);
     t = CODERELOC(co);
     m = RELOCSIZE(t);
     a = 0;
@@ -308,7 +308,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
         S_set_code_obj("gc", RELOC_TYPE(entry), co, a, Scar(objs), item_off);
         objs = Scdr(objs);
     }
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, NULL);
 }
 
 static INT s_check_heap_enabledp(void) {

--- a/racket/src/ChezScheme/c/prim.c
+++ b/racket/src/ChezScheme/c/prim.c
@@ -228,7 +228,7 @@ static void s_instantiate_code_object() {
     cookie = S_get_scheme_arg(tc, 2);
     proc = S_get_scheme_arg(tc, 3);
 
-    S_thread_start_code_write(tc, 0, NULL);
+    S_thread_start_code_write(tc, 0, 0, NULL);
 
     new = S_code(tc, CODETYPE(old), CODELEN(old));
 
@@ -280,7 +280,7 @@ static void s_instantiate_code_object() {
     }
     S_flush_instruction_cache(tc);
 
-    S_thread_end_code_write(tc, 0, NULL);
+    S_thread_end_code_write(tc, 0, 0, NULL);
 
     AC0(tc) = new;
 }
@@ -289,7 +289,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
     ptr t, tc = get_thread_context();
     uptr a, m, n;
 
-    S_thread_start_code_write(tc, 0, NULL);
+    S_thread_start_code_write(tc, 0, 0, NULL);
     t = CODERELOC(co);
     m = RELOCSIZE(t);
     a = 0;
@@ -308,7 +308,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
         S_set_code_obj("gc", RELOC_TYPE(entry), co, a, Scar(objs), item_off);
         objs = Scdr(objs);
     }
-    S_thread_end_code_write(tc, 0, NULL);
+    S_thread_end_code_write(tc, 0, 0, NULL);
 }
 
 static INT s_check_heap_enabledp(void) {

--- a/racket/src/ChezScheme/c/prim.c
+++ b/racket/src/ChezScheme/c/prim.c
@@ -228,7 +228,7 @@ static void s_instantiate_code_object() {
     cookie = S_get_scheme_arg(tc, 2);
     proc = S_get_scheme_arg(tc, 3);
 
-    S_thread_start_code_write(0, 0);
+    S_thread_start_code_write(0);
 
     new = S_code(tc, CODETYPE(old), CODELEN(old));
 
@@ -280,7 +280,7 @@ static void s_instantiate_code_object() {
     }
     S_flush_instruction_cache(tc);
 
-    S_thread_end_code_write(0, 0);
+    S_thread_end_code_write(0);
 
     AC0(tc) = new;
 }
@@ -288,7 +288,7 @@ static void s_instantiate_code_object() {
 static void s_link_code_object(co, objs) ptr co, objs; {
     ptr t; uptr a, m, n;
 
-    S_thread_start_code_write(0, 0);
+    S_thread_start_code_write(0);
     t = CODERELOC(co);
     m = RELOCSIZE(t);
     a = 0;
@@ -307,7 +307,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
         S_set_code_obj("gc", RELOC_TYPE(entry), co, a, Scar(objs), item_off);
         objs = Scdr(objs);
     }
-    S_thread_end_code_write(0, 0);
+    S_thread_end_code_write(0);
 }
 
 static INT s_check_heap_enabledp(void) {

--- a/racket/src/ChezScheme/c/prim.c
+++ b/racket/src/ChezScheme/c/prim.c
@@ -228,7 +228,7 @@ static void s_instantiate_code_object() {
     cookie = S_get_scheme_arg(tc, 2);
     proc = S_get_scheme_arg(tc, 3);
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
 
     new = S_code(tc, CODETYPE(old), CODELEN(old));
 
@@ -280,15 +280,16 @@ static void s_instantiate_code_object() {
     }
     S_flush_instruction_cache(tc);
 
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     AC0(tc) = new;
 }
 
 static void s_link_code_object(co, objs) ptr co, objs; {
-    ptr t; uptr a, m, n;
+    ptr t, tc = get_thread_context();
+    uptr a, m, n;
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     t = CODERELOC(co);
     m = RELOCSIZE(t);
     a = 0;
@@ -307,7 +308,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
         S_set_code_obj("gc", RELOC_TYPE(entry), co, a, Scar(objs), item_off);
         objs = Scdr(objs);
     }
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 }
 
 static INT s_check_heap_enabledp(void) {

--- a/racket/src/ChezScheme/c/prim.c
+++ b/racket/src/ChezScheme/c/prim.c
@@ -228,7 +228,7 @@ static void s_instantiate_code_object() {
     cookie = S_get_scheme_arg(tc, 2);
     proc = S_get_scheme_arg(tc, 3);
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, 0);
 
     new = S_code(tc, CODETYPE(old), CODELEN(old));
 
@@ -280,7 +280,7 @@ static void s_instantiate_code_object() {
     }
     S_flush_instruction_cache(tc);
 
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, 0);
 
     AC0(tc) = new;
 }
@@ -288,7 +288,7 @@ static void s_instantiate_code_object() {
 static void s_link_code_object(co, objs) ptr co, objs; {
     ptr t; uptr a, m, n;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, 0);
     t = CODERELOC(co);
     m = RELOCSIZE(t);
     a = 0;
@@ -307,7 +307,7 @@ static void s_link_code_object(co, objs) ptr co, objs; {
         S_set_code_obj("gc", RELOC_TYPE(entry), co, a, Scar(objs), item_off);
         objs = Scdr(objs);
     }
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, 0);
 }
 
 static INT s_check_heap_enabledp(void) {

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -879,10 +879,10 @@ static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
     I8 *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
     a = (I8 *)TO_VOIDP((uptr)p + UNFIX(n));
+    S_thread_start_code_write(tc, 0, a);
     *a = (I8)UNFIX(x);
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, a);
 
     return Svoid;
 }
@@ -891,10 +891,10 @@ static ptr s_set_code_word(p, n, x) ptr p, n, x; {
     I16 *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
     a = (I16 *)TO_VOIDP((uptr)p + UNFIX(n));
+    S_thread_start_code_write(tc, 0, a);
     *a = (I16)UNFIX(x);
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, a);
 
     return Svoid;
 }
@@ -903,10 +903,10 @@ static ptr s_set_code_long(p, n, x) ptr p, n, x; {
     I32 *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
+    S_thread_start_code_write(tc, 0, a);
     *a = (I32)(Sfixnump(x) ? UNFIX(x) : Sinteger_value(x));
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, a);
 
     return Svoid;
 }
@@ -915,20 +915,20 @@ static void s_set_code_long2(p, n, h, l) ptr p, n, h, l; {
     I32 *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
+    S_thread_start_code_write(tc, 0, a);
     *a = (I32)((UNFIX(h) << 16) + UNFIX(l));
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, a);
 }
 
 static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
     I64 *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
     a = (I64 *)TO_VOIDP((uptr)p + UNFIX(n));
+    S_thread_start_code_write(tc, 0, a);
     *a = Sfixnump(x) ? UNFIX(x) : S_int64_value("\\#set-code-quad!", x);
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, a);
 
     return Svoid;
 }
@@ -937,10 +937,10 @@ static ptr s_set_reloc(p, n, e) ptr p, n, e; {
     iptr *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
+    S_thread_start_code_write(tc, 0, &CODERELOC(p));
     a = (iptr *)(&RELOCIT(CODERELOC(p), UNFIX(n)));
     *a = Sfixnump(e) ? UNFIX(e) : Sinteger_value(e);
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, &CODERELOC(p));
 
     return e;
 }
@@ -955,7 +955,7 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
     ptr co;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
+    S_thread_start_code_write(tc, 0, NULL);
 
     co = S_code(tc, type_code | (flags << code_flags_offset), n);
     CODEFREE(co) = free;
@@ -967,7 +967,7 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
       S_G.profile_counters = Scons(S_weak_cons(co, pinfos), S_G.profile_counters);
     }
 
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, NULL);
 
     return co;
 }
@@ -975,10 +975,10 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
 static ptr s_make_reloc_table(codeobj, n) ptr codeobj, n; {
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0);
+    S_thread_start_code_write(tc, 0, &CODERELOC(codeobj));
     CODERELOC(codeobj) = S_relocation_table(UNFIX(n));
     RELOCCODE(CODERELOC(codeobj)) = codeobj;
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, &CODERELOC(codeobj));
     return Svoid;
 }
 

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -878,10 +878,10 @@ static char *s_getwd() {
 static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
     I8 *a;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
     a = (I8 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I8)UNFIX(x);
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 
     return Svoid;
 }
@@ -889,10 +889,10 @@ static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
 static ptr s_set_code_word(p, n, x) ptr p, n, x; {
     I16 *a;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
     a = (I16 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I16)UNFIX(x);
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 
     return Svoid;
 }
@@ -900,10 +900,10 @@ static ptr s_set_code_word(p, n, x) ptr p, n, x; {
 static ptr s_set_code_long(p, n, x) ptr p, n, x; {
     I32 *a;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I32)(Sfixnump(x) ? UNFIX(x) : Sinteger_value(x));
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 
     return Svoid;
 }
@@ -911,19 +911,19 @@ static ptr s_set_code_long(p, n, x) ptr p, n, x; {
 static void s_set_code_long2(p, n, h, l) ptr p, n, h, l; {
     I32 *a;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I32)((UNFIX(h) << 16) + UNFIX(l));
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 }
 
 static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
     I64 *a;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
     a = (I64 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = Sfixnump(x) ? UNFIX(x) : S_int64_value("\\#set-code-quad!", x);
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 
     return Svoid;
 }
@@ -931,10 +931,10 @@ static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
 static ptr s_set_reloc(p, n, e) ptr p, n, e; {
     iptr *a;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
     a = (iptr *)(&RELOCIT(CODERELOC(p), UNFIX(n)));
     *a = Sfixnump(e) ? UNFIX(e) : Sinteger_value(e);
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 
     return e;
 }
@@ -948,7 +948,7 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
                        iptr flags, free, n; ptr name, arity_mark, info, pinfos; {
     ptr co;
 
-    S_thread_start_code_write(0, static_generation);
+    S_thread_start_code_write(0);
 
     co = S_code(get_thread_context(), type_code | (flags << code_flags_offset), n);
     CODEFREE(co) = free;
@@ -960,16 +960,16 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
       S_G.profile_counters = Scons(S_weak_cons(co, pinfos), S_G.profile_counters);
     }
 
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(0);
 
     return co;
 }
 
 static ptr s_make_reloc_table(codeobj, n) ptr codeobj, n; {
-    S_thread_start_code_write(0, 0);
+    S_thread_start_code_write(0);
     CODERELOC(codeobj) = S_relocation_table(UNFIX(n));
     RELOCCODE(CODERELOC(codeobj)) = codeobj;
-    S_thread_end_code_write(0, 0);
+    S_thread_end_code_write(0);
     return Svoid;
 }
 

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -877,64 +877,70 @@ static char *s_getwd() {
 
 static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
     I8 *a;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     a = (I8 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I8)UNFIX(x);
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     return Svoid;
 }
 
 static ptr s_set_code_word(p, n, x) ptr p, n, x; {
     I16 *a;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     a = (I16 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I16)UNFIX(x);
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     return Svoid;
 }
 
 static ptr s_set_code_long(p, n, x) ptr p, n, x; {
     I32 *a;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I32)(Sfixnump(x) ? UNFIX(x) : Sinteger_value(x));
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     return Svoid;
 }
 
 static void s_set_code_long2(p, n, h, l) ptr p, n, h, l; {
     I32 *a;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I32)((UNFIX(h) << 16) + UNFIX(l));
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 }
 
 static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
     I64 *a;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     a = (I64 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = Sfixnump(x) ? UNFIX(x) : S_int64_value("\\#set-code-quad!", x);
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     return Svoid;
 }
 
 static ptr s_set_reloc(p, n, e) ptr p, n, e; {
     iptr *a;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     a = (iptr *)(&RELOCIT(CODERELOC(p), UNFIX(n)));
     *a = Sfixnump(e) ? UNFIX(e) : Sinteger_value(e);
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     return e;
 }
@@ -947,10 +953,11 @@ static ptr s_flush_instruction_cache() {
 static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
                        iptr flags, free, n; ptr name, arity_mark, info, pinfos; {
     ptr co;
+    ptr tc = get_thread_context();
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
 
-    co = S_code(get_thread_context(), type_code | (flags << code_flags_offset), n);
+    co = S_code(tc, type_code | (flags << code_flags_offset), n);
     CODEFREE(co) = free;
     CODENAME(co) = name;
     CODEARITYMASK(co) = arity_mark;
@@ -960,16 +967,18 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
       S_G.profile_counters = Scons(S_weak_cons(co, pinfos), S_G.profile_counters);
     }
 
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     return co;
 }
 
 static ptr s_make_reloc_table(codeobj, n) ptr codeobj, n; {
-    S_thread_start_code_write(0);
+    ptr tc = get_thread_context();
+
+    S_thread_start_code_write(tc, 0);
     CODERELOC(codeobj) = S_relocation_table(UNFIX(n));
     RELOCCODE(CODERELOC(codeobj)) = codeobj;
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
     return Svoid;
 }
 

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -880,9 +880,9 @@ static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I8 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, a);
+    S_thread_start_code_write(tc, 0, 0, a);
     *a = (I8)UNFIX(x);
-    S_thread_end_code_write(tc, 0, a);
+    S_thread_end_code_write(tc, 0, 0, a);
 
     return Svoid;
 }
@@ -892,9 +892,9 @@ static ptr s_set_code_word(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I16 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, a);
+    S_thread_start_code_write(tc, 0, 0, a);
     *a = (I16)UNFIX(x);
-    S_thread_end_code_write(tc, 0, a);
+    S_thread_end_code_write(tc, 0, 0, a);
 
     return Svoid;
 }
@@ -904,9 +904,9 @@ static ptr s_set_code_long(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, a);
+    S_thread_start_code_write(tc, 0, 0, a);
     *a = (I32)(Sfixnump(x) ? UNFIX(x) : Sinteger_value(x));
-    S_thread_end_code_write(tc, 0, a);
+    S_thread_end_code_write(tc, 0, 0, a);
 
     return Svoid;
 }
@@ -916,9 +916,9 @@ static void s_set_code_long2(p, n, h, l) ptr p, n, h, l; {
     ptr tc = get_thread_context();
 
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, a);
+    S_thread_start_code_write(tc, 0, 0, a);
     *a = (I32)((UNFIX(h) << 16) + UNFIX(l));
-    S_thread_end_code_write(tc, 0, a);
+    S_thread_end_code_write(tc, 0, 0, a);
 }
 
 static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
@@ -926,9 +926,9 @@ static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I64 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, a);
+    S_thread_start_code_write(tc, 0, 0, a);
     *a = Sfixnump(x) ? UNFIX(x) : S_int64_value("\\#set-code-quad!", x);
-    S_thread_end_code_write(tc, 0, a);
+    S_thread_end_code_write(tc, 0, 0, a);
 
     return Svoid;
 }
@@ -937,10 +937,10 @@ static ptr s_set_reloc(p, n, e) ptr p, n, e; {
     iptr *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0, &CODERELOC(p));
+    S_thread_start_code_write(tc, 0, 0, &CODERELOC(p));
     a = (iptr *)(&RELOCIT(CODERELOC(p), UNFIX(n)));
     *a = Sfixnump(e) ? UNFIX(e) : Sinteger_value(e);
-    S_thread_end_code_write(tc, 0, &CODERELOC(p));
+    S_thread_end_code_write(tc, 0, 0, &CODERELOC(p));
 
     return e;
 }
@@ -955,7 +955,7 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
     ptr co;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0, NULL);
+    S_thread_start_code_write(tc, 0, 0, NULL);
 
     co = S_code(tc, type_code | (flags << code_flags_offset), n);
     CODEFREE(co) = free;
@@ -967,7 +967,7 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
       S_G.profile_counters = Scons(S_weak_cons(co, pinfos), S_G.profile_counters);
     }
 
-    S_thread_end_code_write(tc, 0, NULL);
+    S_thread_end_code_write(tc, 0, 0, NULL);
 
     return co;
 }
@@ -975,10 +975,10 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
 static ptr s_make_reloc_table(codeobj, n) ptr codeobj, n; {
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0, &CODERELOC(codeobj));
+    S_thread_start_code_write(tc, 0, 0, &CODERELOC(codeobj));
     CODERELOC(codeobj) = S_relocation_table(UNFIX(n));
     RELOCCODE(CODERELOC(codeobj)) = codeobj;
-    S_thread_end_code_write(tc, 0, &CODERELOC(codeobj));
+    S_thread_end_code_write(tc, 0, 0, &CODERELOC(codeobj));
     return Svoid;
 }
 

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -880,9 +880,9 @@ static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I8 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, 0, a);
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(a));
     *a = (I8)UNFIX(x);
-    S_thread_end_code_write(tc, 0, 0, a);
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(a));
 
     return Svoid;
 }
@@ -892,9 +892,9 @@ static ptr s_set_code_word(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I16 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, 0, a);
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(a));
     *a = (I16)UNFIX(x);
-    S_thread_end_code_write(tc, 0, 0, a);
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(a));
 
     return Svoid;
 }
@@ -904,9 +904,9 @@ static ptr s_set_code_long(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, 0, a);
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(a));
     *a = (I32)(Sfixnump(x) ? UNFIX(x) : Sinteger_value(x));
-    S_thread_end_code_write(tc, 0, 0, a);
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(a));
 
     return Svoid;
 }
@@ -916,9 +916,9 @@ static void s_set_code_long2(p, n, h, l) ptr p, n, h, l; {
     ptr tc = get_thread_context();
 
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, 0, a);
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(a));
     *a = (I32)((UNFIX(h) << 16) + UNFIX(l));
-    S_thread_end_code_write(tc, 0, 0, a);
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(a));
 }
 
 static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
@@ -926,9 +926,9 @@ static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
     ptr tc = get_thread_context();
 
     a = (I64 *)TO_VOIDP((uptr)p + UNFIX(n));
-    S_thread_start_code_write(tc, 0, 0, a);
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(a));
     *a = Sfixnump(x) ? UNFIX(x) : S_int64_value("\\#set-code-quad!", x);
-    S_thread_end_code_write(tc, 0, 0, a);
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(a));
 
     return Svoid;
 }
@@ -937,10 +937,10 @@ static ptr s_set_reloc(p, n, e) ptr p, n, e; {
     iptr *a;
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0, 0, &CODERELOC(p));
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(&CODERELOC(p)));
     a = (iptr *)(&RELOCIT(CODERELOC(p), UNFIX(n)));
     *a = Sfixnump(e) ? UNFIX(e) : Sinteger_value(e);
-    S_thread_end_code_write(tc, 0, 0, &CODERELOC(p));
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(&CODERELOC(p)));
 
     return e;
 }
@@ -975,10 +975,10 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
 static ptr s_make_reloc_table(codeobj, n) ptr codeobj, n; {
     ptr tc = get_thread_context();
 
-    S_thread_start_code_write(tc, 0, 0, &CODERELOC(codeobj));
+    S_thread_start_code_write(tc, 0, 0, TO_VOIDP(&CODERELOC(codeobj)));
     CODERELOC(codeobj) = S_relocation_table(UNFIX(n));
     RELOCCODE(CODERELOC(codeobj)) = codeobj;
-    S_thread_end_code_write(tc, 0, 0, &CODERELOC(codeobj));
+    S_thread_end_code_write(tc, 0, 0, TO_VOIDP(&CODERELOC(codeobj)));
     return Svoid;
 }
 

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -878,10 +878,10 @@ static char *s_getwd() {
 static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
     I8 *a;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
     a = (I8 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I8)UNFIX(x);
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 
     return Svoid;
 }
@@ -889,10 +889,10 @@ static ptr s_set_code_byte(p, n, x) ptr p, n, x; {
 static ptr s_set_code_word(p, n, x) ptr p, n, x; {
     I16 *a;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
     a = (I16 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I16)UNFIX(x);
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 
     return Svoid;
 }
@@ -900,10 +900,10 @@ static ptr s_set_code_word(p, n, x) ptr p, n, x; {
 static ptr s_set_code_long(p, n, x) ptr p, n, x; {
     I32 *a;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I32)(Sfixnump(x) ? UNFIX(x) : Sinteger_value(x));
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 
     return Svoid;
 }
@@ -911,19 +911,19 @@ static ptr s_set_code_long(p, n, x) ptr p, n, x; {
 static void s_set_code_long2(p, n, h, l) ptr p, n, h, l; {
     I32 *a;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
     a = (I32 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = (I32)((UNFIX(h) << 16) + UNFIX(l));
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 }
 
 static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
     I64 *a;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
     a = (I64 *)TO_VOIDP((uptr)p + UNFIX(n));
     *a = Sfixnump(x) ? UNFIX(x) : S_int64_value("\\#set-code-quad!", x);
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 
     return Svoid;
 }
@@ -931,10 +931,10 @@ static ptr s_set_code_quad(p, n, x) ptr p, n, x; {
 static ptr s_set_reloc(p, n, e) ptr p, n, e; {
     iptr *a;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
     a = (iptr *)(&RELOCIT(CODERELOC(p), UNFIX(n)));
     *a = Sfixnump(e) ? UNFIX(e) : Sinteger_value(e);
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 
     return e;
 }
@@ -948,7 +948,7 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
                        iptr flags, free, n; ptr name, arity_mark, info, pinfos; {
     ptr co;
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, static_generation);
 
     co = S_code(get_thread_context(), type_code | (flags << code_flags_offset), n);
     CODEFREE(co) = free;
@@ -960,16 +960,16 @@ static ptr s_make_code(flags, free, name, arity_mark, n, info, pinfos)
       S_G.profile_counters = Scons(S_weak_cons(co, pinfos), S_G.profile_counters);
     }
 
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
 
     return co;
 }
 
 static ptr s_make_reloc_table(codeobj, n) ptr codeobj, n; {
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, 0);
     CODERELOC(codeobj) = S_relocation_table(UNFIX(n));
     RELOCCODE(CODERELOC(codeobj)) = codeobj;
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, 0);
     return Svoid;
 }
 

--- a/racket/src/ChezScheme/c/scheme.c
+++ b/racket/src/ChezScheme/c/scheme.c
@@ -109,7 +109,7 @@ static void main_init() {
       VIRTREG(tc, i) = FIX(0);
     }
 
-    S_thread_start_code_write(0);
+    S_thread_start_code_write(tc, 0);
     p = S_code(tc, type_code, size_rp_header);
     CODERELOC(p) = S_relocation_table(0);
     CODENAME(p) = Sfalse;
@@ -123,7 +123,7 @@ static void main_init() {
         (uptr)TO_PTR(&RPHEADERTOPLINK(TO_PTR(&CODEIT(p, 0)))) - (uptr)p;
     S_protect(&S_G.dummy_code_object);
     S_G.dummy_code_object = p;
-    S_thread_end_code_write(0);
+    S_thread_end_code_write(tc, 0);
 
     S_protect(&S_G.error_invoke_code_object);
     S_G.error_invoke_code_object = Snil;

--- a/racket/src/ChezScheme/c/scheme.c
+++ b/racket/src/ChezScheme/c/scheme.c
@@ -109,7 +109,7 @@ static void main_init() {
       VIRTREG(tc, i) = FIX(0);
     }
 
-    S_thread_start_code_write();
+    S_thread_start_code_write(0, 0);
     p = S_code(tc, type_code, size_rp_header);
     CODERELOC(p) = S_relocation_table(0);
     CODENAME(p) = Sfalse;
@@ -123,7 +123,7 @@ static void main_init() {
         (uptr)TO_PTR(&RPHEADERTOPLINK(TO_PTR(&CODEIT(p, 0)))) - (uptr)p;
     S_protect(&S_G.dummy_code_object);
     S_G.dummy_code_object = p;
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, 0);
 
     S_protect(&S_G.error_invoke_code_object);
     S_G.error_invoke_code_object = Snil;

--- a/racket/src/ChezScheme/c/scheme.c
+++ b/racket/src/ChezScheme/c/scheme.c
@@ -109,7 +109,7 @@ static void main_init() {
       VIRTREG(tc, i) = FIX(0);
     }
 
-    S_thread_start_code_write(0, 0);
+    S_thread_start_code_write(0);
     p = S_code(tc, type_code, size_rp_header);
     CODERELOC(p) = S_relocation_table(0);
     CODENAME(p) = Sfalse;
@@ -123,7 +123,7 @@ static void main_init() {
         (uptr)TO_PTR(&RPHEADERTOPLINK(TO_PTR(&CODEIT(p, 0)))) - (uptr)p;
     S_protect(&S_G.dummy_code_object);
     S_G.dummy_code_object = p;
-    S_thread_end_code_write(0, 0);
+    S_thread_end_code_write(0);
 
     S_protect(&S_G.error_invoke_code_object);
     S_G.error_invoke_code_object = Snil;

--- a/racket/src/ChezScheme/c/scheme.c
+++ b/racket/src/ChezScheme/c/scheme.c
@@ -109,7 +109,7 @@ static void main_init() {
       VIRTREG(tc, i) = FIX(0);
     }
 
-    S_thread_start_code_write(tc, 0);
+    S_thread_start_code_write(tc, 0, NULL);
     p = S_code(tc, type_code, size_rp_header);
     CODERELOC(p) = S_relocation_table(0);
     CODENAME(p) = Sfalse;
@@ -123,7 +123,7 @@ static void main_init() {
         (uptr)TO_PTR(&RPHEADERTOPLINK(TO_PTR(&CODEIT(p, 0)))) - (uptr)p;
     S_protect(&S_G.dummy_code_object);
     S_G.dummy_code_object = p;
-    S_thread_end_code_write(tc, 0);
+    S_thread_end_code_write(tc, 0, NULL);
 
     S_protect(&S_G.error_invoke_code_object);
     S_G.error_invoke_code_object = Snil;

--- a/racket/src/ChezScheme/c/scheme.c
+++ b/racket/src/ChezScheme/c/scheme.c
@@ -109,7 +109,7 @@ static void main_init() {
       VIRTREG(tc, i) = FIX(0);
     }
 
-    S_thread_start_code_write(tc, 0, NULL);
+    S_thread_start_code_write(tc, 0, 0, NULL);
     p = S_code(tc, type_code, size_rp_header);
     CODERELOC(p) = S_relocation_table(0);
     CODENAME(p) = Sfalse;
@@ -123,7 +123,7 @@ static void main_init() {
         (uptr)TO_PTR(&RPHEADERTOPLINK(TO_PTR(&CODEIT(p, 0)))) - (uptr)p;
     S_protect(&S_G.dummy_code_object);
     S_G.dummy_code_object = p;
-    S_thread_end_code_write(tc, 0, NULL);
+    S_thread_end_code_write(tc, 0, 0, NULL);
 
     S_protect(&S_G.error_invoke_code_object);
     S_G.error_invoke_code_object = Snil;

--- a/racket/src/ChezScheme/c/schsig.c
+++ b/racket/src/ChezScheme/c/schsig.c
@@ -392,7 +392,7 @@ static void do_error(type, who, s, args) iptr type; const char *who, *s; ptr arg
 #endif /* PTHREADS */
 
     /* in case error is during fasl read: */
-    S_thread_end_code_write(0, static_generation);
+    S_thread_end_code_write(static_generation);
     
     TRAP(tc) = (ptr)1;
     AC0(tc) = (ptr)1;
@@ -786,7 +786,7 @@ void S_schsig_init() {
         S_protect(&S_G.collect_request_pending_id);
         S_G.collect_request_pending_id = S_intern((const unsigned char *)"$collect-request-pending");
 
-        S_thread_start_code_write(0, 0);
+        S_thread_start_code_write(0);
         p = S_code(get_thread_context(), type_code | (code_flag_continuation << code_flags_offset), 0);
         CODERELOC(p) = S_relocation_table(0);
         CODENAME(p) = Sfalse;
@@ -794,7 +794,7 @@ void S_schsig_init() {
         CODEFREE(p) = 0;
         CODEINFO(p) = Sfalse;
         CODEPINFOS(p) = Snil;
-        S_thread_end_code_write(0, 0);
+        S_thread_end_code_write(0);
 
         S_set_symbol_value(S_G.null_continuation_id,
             S_mkcontinuation(space_new,

--- a/racket/src/ChezScheme/c/schsig.c
+++ b/racket/src/ChezScheme/c/schsig.c
@@ -392,8 +392,8 @@ static void do_error(type, who, s, args) iptr type; const char *who, *s; ptr arg
 #endif /* PTHREADS */
 
     /* in case error is during fasl read: */
-    S_thread_end_code_write(tc, static_generation, NULL);
-    
+    S_thread_end_code_write(tc, static_generation, 0, NULL);
+
     TRAP(tc) = (ptr)1;
     AC0(tc) = (ptr)1;
     CP(tc) = S_symbol_value(S_G.error_id);
@@ -787,7 +787,7 @@ void S_schsig_init() {
         S_protect(&S_G.collect_request_pending_id);
         S_G.collect_request_pending_id = S_intern((const unsigned char *)"$collect-request-pending");
 
-        S_thread_start_code_write(tc, 0, NULL);
+        S_thread_start_code_write(tc, 0, 0, NULL);
         p = S_code(tc, type_code | (code_flag_continuation << code_flags_offset), 0);
         CODERELOC(p) = S_relocation_table(0);
         CODENAME(p) = Sfalse;
@@ -795,7 +795,7 @@ void S_schsig_init() {
         CODEFREE(p) = 0;
         CODEINFO(p) = Sfalse;
         CODEPINFOS(p) = Snil;
-        S_thread_end_code_write(tc, 0, NULL);
+        S_thread_end_code_write(tc, 0, 0, NULL);
 
         S_set_symbol_value(S_G.null_continuation_id,
             S_mkcontinuation(space_new,

--- a/racket/src/ChezScheme/c/schsig.c
+++ b/racket/src/ChezScheme/c/schsig.c
@@ -392,7 +392,7 @@ static void do_error(type, who, s, args) iptr type; const char *who, *s; ptr arg
 #endif /* PTHREADS */
 
     /* in case error is during fasl read: */
-    S_thread_end_code_write();
+    S_thread_end_code_write(0, static_generation);
     
     TRAP(tc) = (ptr)1;
     AC0(tc) = (ptr)1;
@@ -786,7 +786,7 @@ void S_schsig_init() {
         S_protect(&S_G.collect_request_pending_id);
         S_G.collect_request_pending_id = S_intern((const unsigned char *)"$collect-request-pending");
 
-	S_thread_start_code_write();
+        S_thread_start_code_write(0, 0);
         p = S_code(get_thread_context(), type_code | (code_flag_continuation << code_flags_offset), 0);
         CODERELOC(p) = S_relocation_table(0);
         CODENAME(p) = Sfalse;
@@ -794,7 +794,7 @@ void S_schsig_init() {
         CODEFREE(p) = 0;
         CODEINFO(p) = Sfalse;
         CODEPINFOS(p) = Snil;
-	S_thread_end_code_write();
+        S_thread_end_code_write(0, 0);
 
         S_set_symbol_value(S_G.null_continuation_id,
             S_mkcontinuation(space_new,

--- a/racket/src/ChezScheme/c/schsig.c
+++ b/racket/src/ChezScheme/c/schsig.c
@@ -392,7 +392,7 @@ static void do_error(type, who, s, args) iptr type; const char *who, *s; ptr arg
 #endif /* PTHREADS */
 
     /* in case error is during fasl read: */
-    S_thread_end_code_write(tc, static_generation);
+    S_thread_end_code_write(tc, static_generation, NULL);
     
     TRAP(tc) = (ptr)1;
     AC0(tc) = (ptr)1;
@@ -787,7 +787,7 @@ void S_schsig_init() {
         S_protect(&S_G.collect_request_pending_id);
         S_G.collect_request_pending_id = S_intern((const unsigned char *)"$collect-request-pending");
 
-        S_thread_start_code_write(tc, 0);
+        S_thread_start_code_write(tc, 0, NULL);
         p = S_code(tc, type_code | (code_flag_continuation << code_flags_offset), 0);
         CODERELOC(p) = S_relocation_table(0);
         CODENAME(p) = Sfalse;
@@ -795,7 +795,7 @@ void S_schsig_init() {
         CODEFREE(p) = 0;
         CODEINFO(p) = Sfalse;
         CODEPINFOS(p) = Snil;
-        S_thread_end_code_write(tc, 0);
+        S_thread_end_code_write(tc, 0, NULL);
 
         S_set_symbol_value(S_G.null_continuation_id,
             S_mkcontinuation(space_new,

--- a/racket/src/ChezScheme/c/schsig.c
+++ b/racket/src/ChezScheme/c/schsig.c
@@ -392,7 +392,7 @@ static void do_error(type, who, s, args) iptr type; const char *who, *s; ptr arg
 #endif /* PTHREADS */
 
     /* in case error is during fasl read: */
-    S_thread_end_code_write(static_generation);
+    S_thread_end_code_write(tc, static_generation);
     
     TRAP(tc) = (ptr)1;
     AC0(tc) = (ptr)1;
@@ -775,6 +775,7 @@ static void init_signal_handlers() {
 void S_schsig_init() {
     if (S_boot_time) {
         ptr p;
+        ptr tc = get_thread_context();
 
         S_protect(&S_G.nuate_id);
         S_G.nuate_id = S_intern((const unsigned char *)"$nuate");
@@ -786,15 +787,15 @@ void S_schsig_init() {
         S_protect(&S_G.collect_request_pending_id);
         S_G.collect_request_pending_id = S_intern((const unsigned char *)"$collect-request-pending");
 
-        S_thread_start_code_write(0);
-        p = S_code(get_thread_context(), type_code | (code_flag_continuation << code_flags_offset), 0);
+        S_thread_start_code_write(tc, 0);
+        p = S_code(tc, type_code | (code_flag_continuation << code_flags_offset), 0);
         CODERELOC(p) = S_relocation_table(0);
         CODENAME(p) = Sfalse;
         CODEARITYMASK(p) = FIX(0);
         CODEFREE(p) = 0;
         CODEINFO(p) = Sfalse;
         CODEPINFOS(p) = Snil;
-        S_thread_end_code_write(0);
+        S_thread_end_code_write(tc, 0);
 
         S_set_symbol_value(S_G.null_continuation_id,
             S_mkcontinuation(space_new,

--- a/racket/src/ChezScheme/c/segment.c
+++ b/racket/src/ChezScheme/c/segment.c
@@ -587,7 +587,7 @@ static void contract_segment_table(uptr base, uptr end) {
    off of it.
 */
 
-void S_thread_start_code_write(ptr tc, IGEN maxg, IBOOL current, ptr hint) {
+void S_thread_start_code_write(ptr tc, IGEN maxg, IBOOL current, void *hint) {
 #if defined(WRITE_XOR_EXECUTE_CODE)
   enable_code_write(tc, maxg, 1, current, hint);
 #else
@@ -599,7 +599,7 @@ void S_thread_start_code_write(ptr tc, IGEN maxg, IBOOL current, ptr hint) {
 #endif
 }
 
-void S_thread_end_code_write(ptr tc, IGEN maxg, IBOOL current, ptr hint) {
+void S_thread_end_code_write(ptr tc, IGEN maxg, IBOOL current, void *hint) {
 #if defined(WRITE_XOR_EXECUTE_CODE)
   enable_code_write(tc, maxg, 0, current, hint);
 #else
@@ -632,7 +632,7 @@ static IBOOL is_unused_seg(chunkinfo *chunk, seginfo *si) {
 }
 # endif
 
-static void enable_code_write(ptr tc, IGEN maxg, IBOOL on, IBOOL current, ptr hint) {
+static void enable_code_write(ptr tc, IGEN maxg, IBOOL on, IBOOL current, void *hint) {
   thread_gc *tgc;
   chunkinfo *chunk;
   seginfo si, *sip;

--- a/racket/src/ChezScheme/c/segment.c
+++ b/racket/src/ChezScheme/c/segment.c
@@ -88,14 +88,14 @@ void *S_getmem(iptr bytes, IBOOL zerofill, UNUSED IBOOL for_code) {
 
   if ((addr = malloc(bytes)) == (void *)0) out_of_memory();
 
-  debug(printf("getmem(%ld) -> %p\n", bytes, addr))
+  debug(printf("getmem(%p) -> %p\n", TO_VOIDP(bytes), addr))
   if ((membytes += bytes) > maxmembytes) maxmembytes = membytes;
   if (zerofill) memset(addr, 0, bytes);
   return addr;
 }
 
 void S_freemem(void *addr, iptr bytes) {
-  debug(printf("freemem(%p, %ld)\n", addr, bytes))
+  debug(printf("freemem(%p, %p)\n", addr, TO_VOIDP(bytes)))
   free(addr);
   membytes -= bytes;
 }
@@ -108,7 +108,7 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 
   if ((uptr)bytes < S_pagesize) {
     if ((addr = malloc(bytes)) == (void *)0) out_of_memory();
-    debug(printf("getmem malloc(%p) -> %p\n", bytes, addr))
+    debug(printf("getmem malloc(%p) -> %p\n", TO_VOIDP(bytes), addr))
     if ((membytes += bytes) > maxmembytes) maxmembytes = membytes;
     if (zerofill) memset(addr, 0, bytes);
   } else {
@@ -116,7 +116,7 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
     int perm = (for_code ? PAGE_EXECUTE_READWRITE : PAGE_READWRITE);
     if ((addr = VirtualAlloc((void *)0, (SIZE_T)p_bytes, MEM_COMMIT, perm)) == (void *)0) out_of_memory();
     if ((membytes += p_bytes) > maxmembytes) maxmembytes = membytes;
-    debug(printf("getmem VirtualAlloc(%p => %p) -> %p\n", bytes, p_bytes, addr))
+    debug(printf("getmem VirtualAlloc(%p => %p) -> %p\n", TO_VOIDP(bytes), TO_VOIDP(p_bytes), addr))
   }
 
   return addr;
@@ -146,7 +146,7 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 
   if ((uptr)bytes < S_pagesize) {
     if ((addr = malloc(bytes)) == (void *)0) out_of_memory();
-    debug(printf("getmem malloc(%ld) -> %p\n", bytes, addr))
+    debug(printf("getmem malloc(%p) -> %p\n", TO_VOIDP(bytes), addr))
     if ((membytes += bytes) > maxmembytes) maxmembytes = membytes;
     if (zerofill) memset(addr, 0, bytes);
   } else {
@@ -160,13 +160,13 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 #endif
       if ((addr = mmap(NULL, p_bytes, perm, flags, -1, 0)) == (void *)-1) {
         out_of_memory();
-        debug(printf("getmem mmap(%ld) -> %p\n", bytes, addr))
+        debug(printf("getmem mmap(%p) -> %p\n", TO_VOIDP(bytes), addr))
       }
 #ifdef MAP_32BIT
     }
 #endif
     if ((membytes += p_bytes) > maxmembytes) maxmembytes = membytes;
-    debug(printf("getmem mmap(%ld => %ld) -> %p\n", bytes, p_bytes, addr))
+    debug(printf("getmem mmap(%p => %p) -> %p\n", TO_VOIDP(bytes), TO_VOIDP(p_bytes), addr))
   }
 
   return addr;
@@ -174,12 +174,12 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 
 void S_freemem(void *addr, iptr bytes) {
   if ((uptr)bytes < S_pagesize) {
-    debug(printf("freemem free(%p, %ld)\n", addr, bytes))
+    debug(printf("freemem free(%p, %p)\n", addr, TO_VOIDP(bytes)))
     free(addr);
     membytes -= bytes;
   } else {
     uptr n = S_pagesize - 1; iptr p_bytes = (iptr)(((uptr)bytes + n) & ~n);
-    debug(printf("freemem munmap(%p, %ld => %ld)\n", addr, bytes, p_bytes))
+    debug(printf("freemem munmap(%p, %p => %p)\n", addr, TO_VOIDP(bytes), TO_VOIDP(p_bytes)))
     munmap(addr, p_bytes);
     membytes -= p_bytes;
   }

--- a/racket/src/ChezScheme/c/segment.c
+++ b/racket/src/ChezScheme/c/segment.c
@@ -656,7 +656,7 @@ static void enable_code_write(ptr tc, IGEN maxg, IBOOL on, IBOOL current, void *
     if (addr == NULL) {
       return;
     }
-    bytes = tgc->base_bytes[0][space_code];
+    bytes = (char*)tgc->next_loc[0][space_code] - (char*)tgc->base_loc[0][space_code] + tgc->bytes_left[0][space_code] + ptr_bytes;
     if (mprotect(addr, bytes, flags) != 0) {
       S_error_abort("failed to protect current allocation segments");
     }

--- a/racket/src/ChezScheme/c/segment.c
+++ b/racket/src/ChezScheme/c/segment.c
@@ -587,26 +587,18 @@ static void contract_segment_table(uptr base, uptr end) {
    off of it.
 */
 
-void S_thread_start_code_write(ptr tc, IGEN maxg, IBOOL current, void *hint) {
+void S_thread_start_code_write(WX_UNUSED ptr tc, WX_UNUSED IGEN maxg, WX_UNUSED IBOOL current, WX_UNUSED void *hint) {
 #if defined(WRITE_XOR_EXECUTE_CODE)
   enable_code_write(tc, maxg, 1, current, hint);
 #else
-  (void)tc;
-  (void)maxg;
-  (void)current;
-  (void)hint;
   S_ENABLE_CODE_WRITE(1);
 #endif
 }
 
-void S_thread_end_code_write(ptr tc, IGEN maxg, IBOOL current, void *hint) {
+void S_thread_end_code_write(WX_UNUSED ptr tc, WX_UNUSED IGEN maxg, WX_UNUSED IBOOL current, WX_UNUSED void *hint) {
 #if defined(WRITE_XOR_EXECUTE_CODE)
   enable_code_write(tc, maxg, 0, current, hint);
 #else
-  (void)tc;
-  (void)maxg;
-  (void)current;
-  (void)hint;
   S_ENABLE_CODE_WRITE(0);
 #endif
 }

--- a/racket/src/ChezScheme/c/segment.c
+++ b/racket/src/ChezScheme/c/segment.c
@@ -581,7 +581,7 @@ static void contract_segment_table(uptr base, uptr end) {
    say, while Scheme is collecting garbage and needs to write to
    executable pages.  However, on platforms where such a disposition
    is enforced (eg. iOS), we provide a best-effort implementation that
-   flips pages between W and X for the minimal set of generations
+   flips pages between W and X for the minimal set of segments
    possible (depending on the context) in an effort to minimize the
    chances of a page being flipped while a thread is executing code
    off of it.

--- a/racket/src/ChezScheme/c/segment.c
+++ b/racket/src/ChezScheme/c/segment.c
@@ -88,14 +88,14 @@ void *S_getmem(iptr bytes, IBOOL zerofill, UNUSED IBOOL for_code) {
 
   if ((addr = malloc(bytes)) == (void *)0) out_of_memory();
 
-  debug(printf("getmem(%p) -> %p\n", bytes, addr))
+  debug(printf("getmem(%ld) -> %p\n", bytes, addr))
   if ((membytes += bytes) > maxmembytes) maxmembytes = membytes;
   if (zerofill) memset(addr, 0, bytes);
   return addr;
 }
 
 void S_freemem(void *addr, iptr bytes) {
-  debug(printf("freemem(%p, %p)\n", addr, bytes))
+  debug(printf("freemem(%p, %ld)\n", addr, bytes))
   free(addr);
   membytes -= bytes;
 }
@@ -146,7 +146,7 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 
   if ((uptr)bytes < S_pagesize) {
     if ((addr = malloc(bytes)) == (void *)0) out_of_memory();
-    debug(printf("getmem malloc(%p) -> %p\n", bytes, addr))
+    debug(printf("getmem malloc(%ld) -> %p\n", bytes, addr))
     if ((membytes += bytes) > maxmembytes) maxmembytes = membytes;
     if (zerofill) memset(addr, 0, bytes);
   } else {
@@ -160,13 +160,13 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 #endif
       if ((addr = mmap(NULL, p_bytes, perm, flags, -1, 0)) == (void *)-1) {
         out_of_memory();
-        debug(printf("getmem mmap(%p) -> %p\n", bytes, addr))
+        debug(printf("getmem mmap(%ld) -> %p\n", bytes, addr))
       }
 #ifdef MAP_32BIT
     }
 #endif
     if ((membytes += p_bytes) > maxmembytes) maxmembytes = membytes;
-    debug(printf("getmem mmap(%p => %p) -> %p\n", bytes, p_bytes, addr))
+    debug(printf("getmem mmap(%ld => %ld) -> %p\n", bytes, p_bytes, addr))
   }
 
   return addr;
@@ -174,12 +174,12 @@ void *S_getmem(iptr bytes, IBOOL zerofill, IBOOL for_code) {
 
 void S_freemem(void *addr, iptr bytes) {
   if ((uptr)bytes < S_pagesize) {
-    debug(printf("freemem free(%p, %p)\n", addr, bytes))
+    debug(printf("freemem free(%p, %ld)\n", addr, bytes))
     free(addr);
     membytes -= bytes;
   } else {
     uptr n = S_pagesize - 1; iptr p_bytes = (iptr)(((uptr)bytes + n) & ~n);
-    debug(printf("freemem munmap(%p, %p => %p)\n", addr, bytes, p_bytes))
+    debug(printf("freemem munmap(%p, %ld => %ld)\n", addr, bytes, p_bytes))
     munmap(addr, p_bytes);
     membytes -= p_bytes;
   }
@@ -273,7 +273,7 @@ iptr S_find_segments(creator, s, g, n) thread_gc *creator; ISPC s; IGEN g; iptr 
 
   if (g != static_generation) S_G.number_of_nonstatic_segments += n;
 
-  debug(printf("attempting to find %d segments for space %d, generation %d\n", n, s, g))
+  debug(printf("attempting to find %ld segments for space %d, generation %d\n", n, s, g))
 
   chunks = (for_code ? S_code_chunks : S_chunks);
 

--- a/racket/src/ChezScheme/c/thread.c
+++ b/racket/src/ChezScheme/c/thread.c
@@ -256,7 +256,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
       S_scan_dirty((ptr *)EAP(tc), (ptr *)REAL_EAP(tc));
 
      /* close off thread-local allocation */
-      S_thread_start_code_write(tc, static_generation);
+      S_thread_start_code_write(tc, static_generation, NULL);
       {
         ISPC s; IGEN g;
         thread_gc *tgc = THREAD_GC(tc);
@@ -265,7 +265,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
             if (tgc->next_loc[g][s])
               S_close_off_thread_local_segment(tc, s, g);
       }
-      S_thread_end_code_write(tc, static_generation);
+      S_thread_end_code_write(tc, static_generation, NULL);
 
       alloc_mutex_release();
 

--- a/racket/src/ChezScheme/c/thread.c
+++ b/racket/src/ChezScheme/c/thread.c
@@ -256,7 +256,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
       S_scan_dirty((ptr *)EAP(tc), (ptr *)REAL_EAP(tc));
 
      /* close off thread-local allocation */
-      S_thread_start_code_write(0, static_generation);
+      S_thread_start_code_write(static_generation);
       {
         ISPC s; IGEN g;
         thread_gc *tgc = THREAD_GC(tc);
@@ -265,7 +265,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
             if (tgc->next_loc[g][s])
               S_close_off_thread_local_segment(tc, s, g);
       }
-      S_thread_end_code_write(0, static_generation);
+      S_thread_end_code_write(static_generation);
 
       alloc_mutex_release();
 

--- a/racket/src/ChezScheme/c/thread.c
+++ b/racket/src/ChezScheme/c/thread.c
@@ -90,6 +90,9 @@ ptr S_create_thread_object(who, p_tc) const char *who; ptr p_tc; {
       for (g = 0; g <= static_generation; g++) {
         for (s = 0; s <= max_real_space; s++) {
           tgc->base_loc[g][s] = (ptr)0;
+#if defined(WRITE_XOR_EXECUTE_CODE)
+          tgc->base_bytes[g][s] = 0;
+#endif
           tgc->next_loc[g][s] = (ptr)0;
           tgc->bytes_left[g][s] = 0;
           tgc->sweep_loc[g][s] = (ptr)0;
@@ -256,7 +259,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
       S_scan_dirty((ptr *)EAP(tc), (ptr *)REAL_EAP(tc));
 
      /* close off thread-local allocation */
-      S_thread_start_code_write(tc, static_generation, NULL);
+      S_thread_start_code_write(tc, static_generation, 0, NULL);
       {
         ISPC s; IGEN g;
         thread_gc *tgc = THREAD_GC(tc);
@@ -265,7 +268,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
             if (tgc->next_loc[g][s])
               S_close_off_thread_local_segment(tc, s, g);
       }
-      S_thread_end_code_write(tc, static_generation, NULL);
+      S_thread_end_code_write(tc, static_generation, 0, NULL);
 
       alloc_mutex_release();
 

--- a/racket/src/ChezScheme/c/thread.c
+++ b/racket/src/ChezScheme/c/thread.c
@@ -256,7 +256,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
       S_scan_dirty((ptr *)EAP(tc), (ptr *)REAL_EAP(tc));
 
      /* close off thread-local allocation */
-      S_thread_start_code_write(static_generation);
+      S_thread_start_code_write(tc, static_generation);
       {
         ISPC s; IGEN g;
         thread_gc *tgc = THREAD_GC(tc);
@@ -265,7 +265,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
             if (tgc->next_loc[g][s])
               S_close_off_thread_local_segment(tc, s, g);
       }
-      S_thread_end_code_write(static_generation);
+      S_thread_end_code_write(tc, static_generation);
 
       alloc_mutex_release();
 

--- a/racket/src/ChezScheme/c/thread.c
+++ b/racket/src/ChezScheme/c/thread.c
@@ -90,9 +90,6 @@ ptr S_create_thread_object(who, p_tc) const char *who; ptr p_tc; {
       for (g = 0; g <= static_generation; g++) {
         for (s = 0; s <= max_real_space; s++) {
           tgc->base_loc[g][s] = (ptr)0;
-#if defined(WRITE_XOR_EXECUTE_CODE)
-          tgc->base_bytes[g][s] = 0;
-#endif
           tgc->next_loc[g][s] = (ptr)0;
           tgc->bytes_left[g][s] = 0;
           tgc->sweep_loc[g][s] = (ptr)0;

--- a/racket/src/ChezScheme/c/thread.c
+++ b/racket/src/ChezScheme/c/thread.c
@@ -256,7 +256,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
       S_scan_dirty((ptr *)EAP(tc), (ptr *)REAL_EAP(tc));
 
      /* close off thread-local allocation */
-      S_thread_start_code_write();
+      S_thread_start_code_write(0, static_generation);
       {
         ISPC s; IGEN g;
         thread_gc *tgc = THREAD_GC(tc);
@@ -265,7 +265,7 @@ static IBOOL destroy_thread(tc) ptr tc; {
             if (tgc->next_loc[g][s])
               S_close_off_thread_local_segment(tc, s, g);
       }
-      S_thread_end_code_write();
+      S_thread_end_code_write(0, static_generation);
 
       alloc_mutex_release();
 

--- a/racket/src/ChezScheme/c/types.h
+++ b/racket/src/ChezScheme/c/types.h
@@ -186,7 +186,7 @@ typedef struct _chunkinfo {
   iptr base;                                /* first segment */
   iptr bytes;                               /* size in bytes */
   iptr segs;                                /* size in segments */
-  iptr nused_segs;                          /* number of segments currently in used use */ 
+  iptr nused_segs;                          /* number of segments currently in use */
   struct _chunkinfo **prev;                 /* pointer to previous chunk's next */
   struct _chunkinfo *next;                  /* next chunk */
   struct _seginfo *unused_segs;             /* list of unused segments */

--- a/racket/src/ChezScheme/c/types.h
+++ b/racket/src/ChezScheme/c/types.h
@@ -158,6 +158,9 @@ typedef struct _seginfo {
   struct _seginfo *next;                    /* pointer to the next seginfo (used in occupied_segments and unused_segs) */
   struct _seginfo *sweep_next;              /* next in list of segments allocated during GC => need to sweep */
   ptr sweep_start;                          /* address within segment to start sweep */
+#if defined(WRITE_XOR_EXECUTE_CODE)
+  iptr sweep_bytes;                         /* total number of bytes starting at sweep_start */
+#endif
   struct _seginfo **dirty_prev;             /* pointer to the next pointer on the previous seginfo in the DirtySegments list */
   struct _seginfo *dirty_next;              /* pointer to the next seginfo on the DirtySegments list */
   ptr trigger_ephemerons;                   /* ephemerons to re-check if object in segment is copied out */
@@ -480,6 +483,9 @@ typedef struct thread_gc {
   struct thread_gc *next;
 
   ptr base_loc[static_generation+1][max_real_space+1];
+#if defined(WRITE_XOR_EXECUTE_CODE)
+  iptr base_bytes[static_generation+1][max_real_space+1]; /* number of bytes in allocation segments */
+#endif
   ptr next_loc[static_generation+1][max_real_space+1];
   iptr bytes_left[static_generation+1][max_real_space+1];
   ptr orig_next_loc[max_real_space+1];

--- a/racket/src/ChezScheme/c/types.h
+++ b/racket/src/ChezScheme/c/types.h
@@ -483,9 +483,6 @@ typedef struct thread_gc {
   struct thread_gc *next;
 
   ptr base_loc[static_generation+1][max_real_space+1];
-#if defined(WRITE_XOR_EXECUTE_CODE)
-  iptr base_bytes[static_generation+1][max_real_space+1]; /* number of bytes in allocation segments */
-#endif
   ptr next_loc[static_generation+1][max_real_space+1];
   iptr bytes_left[static_generation+1][max_real_space+1];
   ptr orig_next_loc[max_real_space+1];

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -327,6 +327,7 @@ typedef int tputsputcchar;
 /* for both iPhone and iPhoneSimulator */
 #if defined(TARGET_OS_IPHONE)
 # define SYSTEM(s) ((void)s, -1)
+# define S_PROT_CODE (PROT_WRITE | PROT_READ)
 # define WRITE_XOR_EXECUTE_CODE
 #endif
 #if defined(__arm64__)

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -326,7 +326,11 @@ typedef int tputsputcchar;
 #endif
 #if defined(__arm64__)
 # define S_MAP_CODE  MAP_JIT
-# define S_ENABLE_CODE_WRITE(on) pthread_jit_write_protect_np(!(on))
+# if defined(TARGET_OS_IPHONE)
+#  define SYSTEM(s) ((void)s, -1)
+# else
+#  define S_ENABLE_CODE_WRITE(on) pthread_jit_write_protect_np(!(on))
+# endif
 # define CANNOT_READ_DIRECTLY_INTO_CODE
 # include <pthread.h>
 #elif defined(__x86_64__)

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -329,6 +329,7 @@ typedef int tputsputcchar;
 # define SYSTEM(s) ((void)s, -1)
 # define S_PROT_CODE (PROT_WRITE | PROT_READ)
 # define WRITE_XOR_EXECUTE_CODE
+# define WX_UNUSED
 #endif
 #if defined(__arm64__)
 # if !defined(TARGET_OS_IPHONE)
@@ -512,6 +513,12 @@ typedef char tputsputcchar;
 #endif
 #ifndef S_ENABLE_CODE_WRITE
 # define S_ENABLE_CODE_WRITE(on) do { } while (0)
+#endif
+
+/* Signals that an argument is unused when W&X memory pages are
+   supported. Relevant in relation to WRITE_XOR_EXECUTE_CODE. */
+#ifndef WX_UNUSED
+# define WX_UNUSED UNUSED
 #endif
 
 #ifdef PTHREADS

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -329,7 +329,9 @@ typedef int tputsputcchar;
 # define SYSTEM(s) ((void)s, -1)
 #endif
 #if defined(__arm64__)
-# if !defined(TARGET_OS_IPHONE)
+# if defined(TARGET_OS_IPHONE)
+#  define WRITE_XOR_EXECUTE_CODE
+# else
 #  define S_MAP_CODE MAP_JIT
 #  define S_ENABLE_CODE_WRITE(on) pthread_jit_write_protect_np(!(on))
 # endif

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -327,11 +327,10 @@ typedef int tputsputcchar;
 /* for both iPhone and iPhoneSimulator */
 #if defined(TARGET_OS_IPHONE)
 # define SYSTEM(s) ((void)s, -1)
+# define WRITE_XOR_EXECUTE_CODE
 #endif
 #if defined(__arm64__)
-# if defined(TARGET_OS_IPHONE)
-#  define WRITE_XOR_EXECUTE_CODE
-# else
+# if !defined(TARGET_OS_IPHONE)
 #  define S_MAP_CODE MAP_JIT
 #  define S_ENABLE_CODE_WRITE(on) pthread_jit_write_protect_np(!(on))
 # endif

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -324,11 +324,13 @@ typedef int tputsputcchar;
 #if !defined(__POWERPC__)
 # define LITTLE_ENDIAN_IEEE_DOUBLE
 #endif
+/* for both iPhone and iPhoneSimulator */
+#if defined(TARGET_OS_IPHONE)
+# define SYSTEM(s) ((void)s, -1)
+#endif
 #if defined(__arm64__)
-# define S_MAP_CODE  MAP_JIT
-# if defined(TARGET_OS_IPHONE)
-#  define SYSTEM(s) ((void)s, -1)
-# else
+# if !defined(TARGET_OS_IPHONE)
+#  define S_MAP_CODE MAP_JIT
 #  define S_ENABLE_CODE_WRITE(on) pthread_jit_write_protect_np(!(on))
 # endif
 # define CANNOT_READ_DIRECTLY_INTO_CODE

--- a/racket/src/Makefile.in
+++ b/racket/src/Makefile.in
@@ -265,6 +265,13 @@ install-pdf:
 # Clean ----------------------------------------
 
 clean:
+	if [ -f cs/c/Makefile ]; then $(MAKE) clean-cs; fi
+	if [ -f bc/Makefile ]; then $(MAKE) clean-bc; fi
+
+clean-cs:
+	cd cs/c && $(MAKE) clean
+
+clean-bc:
 	cd bc && $(MAKE) clean
 	rm -rf compiled
 	rm -f TAGS

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -428,10 +428,11 @@ Chez Scheme build folder as follows (all on one line)
             --enable-racket=/path/to/racket/bin/racket
             --enable-scheme=/path/to/racket/src/build/cs/c
 
-Cross-compilation of Racket CS to iOS currently has limited support
-for multi-threading due to the platform's poor support for JIT
-compilation.  Avoid futures and dynamic code evaluation (`eval`,
-`dynamic-require`, etc.) within places.
+Currently, iOS enforces strict W^X protection on memory pages. See the
+note about "writes to `space_code` memory" in "ChezScheme/c/segment.c"
+for the implications this has on Racket CS. In principle, if you avoid
+passing newly-allocated code between threads and avoid `#:blocking?`
+foreign callbacks, you should not run into any issues.
 
 
 ========================================================================

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -397,11 +397,11 @@ the [comp] of your choice and the [platform] used to compile.
  Cross-compiling for iOS
 ========================================================================
 
-[Currently, cross-compilation works only for the Racket BC
- implementation.]
+[Cross-compilation works for both the BC and CS variants of Racket,
+ but the CS variant currently crashes at runtime.]
 
 To compile the Racket runtime system as a Framework for iOS, use (all
-on one line)
+on one line) for BC
 
   configure --host=[arch]-apple-darwin
             --enable-ios="[sdk]"
@@ -411,6 +411,17 @@ where [arch] is one of
 
  - armv7, armv7s, or aarch64: to run on iOS
  - i386 or x86_64: to run on the simulator
+
+To cross-compile for CS, you must supply a Chez Scheme compiler.  For
+example, assuming you have built Racket CS for your machine at
+"/path/to/racket" using the default `make` target, you can configure
+the cross build using that Racket binary and a path to the Chez Scheme
+build folder like so:
+
+  configure --host=[arch]-apple-darwin
+            --enable-ios="[sdk]"
+            --enable-racket=/path/to/racket/bin/racket
+            --enable-scheme=/path/to/racket/src/build/cs/c
 
 The [sdk] argument is a path to an iOS SDK, but if it is "iPhoneOS" or
 "iPhoneSimulator", then the corresponding SDK is located in the

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -397,9 +397,6 @@ the [comp] of your choice and the [platform] used to compile.
  Cross-compiling for iOS
 ========================================================================
 
-[Cross-compilation works for both the BC and CS variants of Racket,
- but the CS variant currently crashes at runtime.]
-
 To compile the Racket runtime system as a Framework for iOS, use (all
 on one line) for BC
 

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -412,11 +412,11 @@ where [arch] is one of
  - armv7, armv7s, or aarch64: to run on iOS
  - i386 or x86_64: to run on the simulator
 
-To cross-compile for CS, you must supply a Chez Scheme compiler.  For
-example, assuming you have built Racket CS for your machine at
-"/path/to/racket" using the default `make` target, you can configure
-the cross build using that Racket binary and a path to the Chez Scheme
-build folder like so:
+To cross-compile for CS, you must supply the Chez Scheme compiler that
+Racket CS was built with.  Assuming you have built Racket CS for your
+machine at "/path/to/racket" using the default `make` target, you can
+configure the cross build using that Racket binary and a path to the
+Chez Scheme build folder like so:
 
   configure --host=[arch]-apple-darwin
             --enable-ios="[sdk]"

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -409,17 +409,6 @@ where [arch] is one of
  - armv7, armv7s, or aarch64: to run on iOS
  - i386 or x86_64: to run on the simulator
 
-To cross-compile for CS, you must supply the Chez Scheme compiler that
-Racket CS was built with.  Assuming you have built Racket CS for your
-machine at "/path/to/racket" using the default `make` target, you can
-configure the cross build using that Racket binary and a path to the
-Chez Scheme build folder like so:
-
-  configure --host=[arch]-apple-darwin
-            --enable-ios="[sdk]"
-            --enable-racket=/path/to/racket/bin/racket
-            --enable-scheme=/path/to/racket/src/build/cs/c
-
 The [sdk] argument is a path to an iOS SDK, but if it is "iPhoneOS" or
 "iPhoneSimulator", then the corresponding SDK is located in the
 standard place within the XCode application. For example, "iPhoneOS"
@@ -427,6 +416,22 @@ becomes the path (all on one line)
 
   /Applications/Xcode.app/Contents/Developer/Platforms/
     iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk
+
+To cross-compile for CS, you must supply the Chez Scheme compiler that
+Racket CS was built with.  Assuming you have built Racket CS for your
+machine at "/path/to/racket" using the default `make` target, you can
+configure the cross build using that Racket binary and a path to the
+Chez Scheme build folder as follows (all on one line)
+
+  configure --host=[arch]-apple-darwin
+            --enable-ios="[sdk]"
+            --enable-racket=/path/to/racket/bin/racket
+            --enable-scheme=/path/to/racket/src/build/cs/c
+
+Cross-compilation of Racket CS to iOS currently has limited support
+for multi-threading due to the platform's poor support for JIT
+compilation.  Avoid futures and dynamic code evaluation (`eval`,
+`dynamic-require`, etc.) within places.
 
 
 ========================================================================

--- a/racket/src/ac/sdk_ios.m4
+++ b/racket/src/ac/sdk_ios.m4
@@ -1,0 +1,22 @@
+if test "${enable_ios}" != "" ; then
+  case "$host_cpu" in
+    aarch64)
+     IOS_ARCH=arm64
+     ;;
+    *)
+     IOS_ARCH=$host_cpu
+     ;;
+  esac
+  case "${enable_ios}" in
+    iPhoneOS|iPhoneSimulator)
+     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     echo "=== Using inferred iOS SDK path ${ios_sdk}"
+     ;;
+    *)
+     ios_sdk="${enable_ios}"
+     ;;
+  esac
+  IOS_PHONE_VERS="6.0"
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+fi

--- a/racket/src/ac/sdk_show.m4
+++ b/racket/src/ac/sdk_show.m4
@@ -32,7 +32,7 @@ if test "${enable_sdk6}" != "" ; then
    echo "=== Using Mac OS 10.6 SDK directory ${enable_sdk6}"
 fi
 if test "${enable_ios}" != "" ; then
-   echo "=== Using ios SDK directory ${enable_ios}"
+   echo "=== Using iOS SDK directory ${enable_ios}"
 fi
 
 if test "${enable_sysroot}" != "" ; then

--- a/racket/src/bc/configure
+++ b/racket/src/bc/configure
@@ -3388,7 +3388,7 @@ if test "${enable_sdk6}" != "" ; then
    echo "=== Using Mac OS 10.6 SDK directory ${enable_sdk6}"
 fi
 if test "${enable_ios}" != "" ; then
-   echo "=== Using ios SDK directory ${enable_ios}"
+   echo "=== Using iOS SDK directory ${enable_ios}"
 fi
 
 if test "${enable_sysroot}" != "" ; then
@@ -3600,17 +3600,19 @@ if test "${enable_ios}" != "" ; then
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
      ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     echo "=== Using inferred iOS SDK path ${ios_sdk}"
      ;;
     *)
      ios_sdk="${enable_ios}"
      ;;
   esac
   IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1"
-  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1"
-  PREFLAGS="$PREFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  CPPFLAGS="$CPPFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
   LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+fi
+
+if test "${enable_ios}" != "" ; then
+  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
   SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} CFLAGS="'"'"${CFLAGS}"'"'
   SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} CPPFLAGS="'"'"${PREFLAGS}"'"'
   SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} LDFLAGS="'"'"${LDFLAGS}"'"'

--- a/racket/src/bc/configure.ac
+++ b/racket/src/bc/configure.ac
@@ -379,29 +379,9 @@ if test "${enable_sysroot}" != "" ; then
    SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} LDFLAGS="'"'"${LDFLAGS}"'"'
 fi
 
+m4_include(../ac/sdk_ios.m4)
 if test "${enable_ios}" != "" ; then
-  case "$host_cpu" in
-    aarch64)
-     IOS_ARCH=arm64
-     ;;
-    *)
-     IOS_ARCH=$host_cpu
-     ;;
-  esac
-  case "${enable_ios}" in
-    iPhoneOS|iPhoneSimulator)
-     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
-     ;;
-    *)
-     ios_sdk="${enable_ios}"
-     ;;
-  esac
-  IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1"
-  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1"
-  PREFLAGS="$PREFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  CPPFLAGS="$CPPFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
   SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} CFLAGS="'"'"${CFLAGS}"'"'
   SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} CPPFLAGS="'"'"${PREFLAGS}"'"'
   SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} LDFLAGS="'"'"${LDFLAGS}"'"'

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -388,6 +388,10 @@ plain-install-upcased:
 install-cross:
 	$(MAKE) compile-xpatch.$(TARGET_MACH)
 	$(MAKE) library-xpatch.$(TARGET_MACH)
+	rm -f "$(DESTDIR)$(libpltdir)/compile-xpatch.$(TARGET_MACH)"
+	rm -f "$(DESTDIR)$(libpltdir)/library-xpatch.$(TARGET_MACH)"
+	$(ICP) compile-xpatch.$(TARGET_MACH) "$(DESTDIR)$(libpltdir)/compile-xpatch.$(TARGET_MACH)"
+	$(ICP) library-xpatch.$(TARGET_MACH) "$(DESTDIR)$(libpltdir)/library-xpatch.$(TARGET_MACH)"
 
 SCHEME_XPATCH = $(SCHEME_WORKAREA)/$(TARGET_MACH)/s/xpatch
 

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -87,8 +87,12 @@ cs:
 	$(MAKE) starter
 	$(MAKE) repack-@INSTALL_LIBS_ENABLE@-libs
 
+clean:
+	cd $(SCHEME_WORKAREA); $(MAKE) clean
+	cd rktio; $(MAKE) clean
+
 SETUP_BOOT_MODE = @SETUP_BOOT_MODE@
-BOOT_COMPILED_SUBDIR = 
+BOOT_COMPILED_SUBDIR =
 SETUP_COMMON_BOOT = -l- setup $(SETUP_BOOT_MODE) $(srcdir)/../../setup-go.rkt $(builddir)/compiled$(BOOT_COMPILED_SUBDIR)
 
 ABS_SCHEME_WORKAREA = "`$(SCHEME) --script $(srcdir)/../absify.ss --no-trailing-sep $(SCHEME_WORKAREA)`"

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -472,7 +472,13 @@ install@NOT_MINGW@:
 	$(MAKE) setup-install $(PROPAGATE_VARIABLES)
 
 setup-install:
+	$(MAKE) do-setup-install@T_CROSS_MODE@
+
+do-setup-install:
 	@RUN_RACKET@ $(SELF_ROOT_CONFIG) $(SETUP_ARGS)
+
+do-setup-install-cross:
+	@RUN_RACKET@ $(SELF_ROOT_CONFIG) -C -M -R 'compiled_host:' --cross-compiler $(TARGET_MACH) "$(DESTDIR)$(libpltdir)" $(SETUP_ARGS)
 
 no-setup-install:
 	echo done

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -258,8 +258,8 @@ $(GRACKET_BIN): grmain.o $(RKTFW) $(GRAPPSKEL)
 	$(CC) $(CFLAGS) -o $(GRACKET_BIN)_raw grmain.o $(MACLIBRKT_LINK_@MACLIBRKT_LINK_MODE@)
 	$(MAKE) mac-embed-boot-@MACLIBRKT_LINK_MODE@ EMBED_SRC=$(GRACKET_BIN)_raw EMBED_DEST=$(GRACKET_BIN)
 	/usr/bin/install_name_tool -change "Racket.framework/Versions/$(FWVERSION)_CS/Racket" "@executable_path/../../../Racket.framework/Versions/$(FWVERSION)_CS/Racket" $(GRACKET_BIN)
-	$(RESTORE_SIGNATURE) $(GRACKET_BIN)
 	rm $(GRACKET_BIN)_raw
+	$(RESTORE_SIGNATURE) $(GRACKET_BIN)
 
 $(GRAPPSKEL): $(srcdir)/../../mac/osx_appl.rkt  $(srcdir)/../../version/racket_version.h $(srcdir)/../../mac/icon/GRacket.icns
 	$(BOOTSTRAP_RACKET) $(srcdir)/../../mac/osx_appl.rkt $(srcdir)/../.. "CS"

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -478,7 +478,7 @@ do-setup-install:
 	@RUN_RACKET@ $(SELF_ROOT_CONFIG) $(SETUP_ARGS)
 
 do-setup-install-cross:
-	@RUN_RACKET@ $(SELF_ROOT_CONFIG) -C -M -R 'compiled_host:' --cross-compiler $(TARGET_MACH) "$(DESTDIR)$(libpltdir)" $(SETUP_ARGS)
+	@RUN_RACKET@ $(SELF_ROOT_CONFIG) -C -M -R 'compiled_host:$(TARGET_MACH)' --cross-compiler $(TARGET_MACH) "$(DESTDIR)$(libpltdir)" $(SETUP_ARGS)
 
 no-setup-install:
 	echo done

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -2922,7 +2922,7 @@ if test "${enable_sdk6}" != "" ; then
    echo "=== Using Mac OS 10.6 SDK directory ${enable_sdk6}"
 fi
 if test "${enable_ios}" != "" ; then
-   echo "=== Using ios SDK directory ${enable_ios}"
+   echo "=== Using iOS SDK directory ${enable_ios}"
 fi
 
 if test "${enable_sysroot}" != "" ; then
@@ -3214,6 +3214,30 @@ enable_pthread_by_default=yes
 cs_auto_flags=--disable-auto-flags
 
 ###### Autoconfigure #######
+
+if test "${enable_ios}" != "" ; then
+  case "$host_cpu" in
+    aarch64)
+     IOS_ARCH=arm64
+     ;;
+    *)
+     IOS_ARCH=$host_cpu
+     ;;
+  esac
+  case "${enable_ios}" in
+    iPhoneOS|iPhoneSimulator)
+     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     echo "=== Using inferred iOS SDK path ${ios_sdk}"
+     ;;
+    *)
+     ios_sdk="${enable_ios}"
+     ;;
+  esac
+  IOS_PHONE_VERS="6.0"
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+fi
+
 
 ac_ext=c
 ac_cpp='$CPP $CPPFLAGS'
@@ -4252,31 +4276,6 @@ fi
 fi
 if test "$ARFLAGS" = '' ; then
   ARFLAGS=rc
-fi
-
-if test "${enable_ios}" != "" ; then
-  case "$host_cpu" in
-    aarch64)
-     IOS_ARCH=arm64
-     ;;
-    *)
-     IOS_ARCH=$host_cpu
-     ;;
-  esac
-  case "${enable_ios}" in
-    iPhoneOS|iPhoneSimulator)
-     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
-     ;;
-    *)
-     ios_sdk="${enable_ios}"
-     ;;
-  esac
-  IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1"
-  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1"
-  PREFLAGS="$PREFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  CPPFLAGS="$CPPFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
 fi
 
 

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -5482,8 +5482,7 @@ fi
 
 ############## other inferred machine properties ################
 
-if test "${enable_ios}" = "" ; then
-  # The cast to long int works around a bug in the HP C Compiler
+# The cast to long int works around a bug in the HP C Compiler
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
 # This bug is HP SR number 8606223364.
@@ -5517,14 +5516,13 @@ _ACEOF
 
 
 
-  if test "${ac_cv_sizeof_void_p}" != "4" ; then
+if test "${ac_cv_sizeof_void_p}" != "4" ; then
   if test "${ac_cv_sizeof_void_p}" != "8" ; then
     echo "Something has gone wrong getting the pointer size; see config.log"
     exit 1
   fi
 fi
 
-fi
 
 ############## subconfigure ################
 

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -4254,6 +4254,32 @@ if test "$ARFLAGS" = '' ; then
   ARFLAGS=rc
 fi
 
+if test "${enable_ios}" != "" ; then
+  case "$host_cpu" in
+    aarch64)
+     IOS_ARCH=arm64
+     ;;
+    *)
+     IOS_ARCH=$host_cpu
+     ;;
+  esac
+  case "${enable_ios}" in
+    iPhoneOS|iPhoneSimulator)
+     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     ;;
+    *)
+     ios_sdk="${enable_ios}"
+     ;;
+  esac
+  IOS_PHONE_VERS="6.0"
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1"
+  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1"
+  PREFLAGS="$PREFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  CPPFLAGS="$CPPFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+fi
+
+
 WINDRES=windres
 
 ############## platform tests ################
@@ -4456,8 +4482,10 @@ case "$host_os" in
     # -pthread is not needed and triggers a warning
     use_flag_pthread=no
 
-    # ncurses.h is always available
-    disable_curses_arg=""
+    # ncurses.h is always available, except on iOS
+    if test "${enable_ios}" == "" ; then
+      disable_curses_arg=""
+    fi
     ;;
   nto-qnx*)
     MACH_OS=qnx
@@ -5455,7 +5483,8 @@ fi
 
 ############## other inferred machine properties ################
 
-# The cast to long int works around a bug in the HP C Compiler
+if test "${enable_ios}" = "" ; then
+  # The cast to long int works around a bug in the HP C Compiler
 # version HP92453-01 B.11.11.23709.GP, which incorrectly rejects
 # declarations like `int a3[[(sizeof (unsigned char)) >= 0]];'.
 # This bug is HP SR number 8606223364.
@@ -5489,13 +5518,14 @@ _ACEOF
 
 
 
-if test "${ac_cv_sizeof_void_p}" != "4" ; then
+  if test "${ac_cv_sizeof_void_p}" != "4" ; then
   if test "${ac_cv_sizeof_void_p}" != "8" ; then
     echo "Something has gone wrong getting the pointer size; see config.log"
     exit 1
   fi
 fi
 
+fi
 
 ############## subconfigure ################
 

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -192,6 +192,32 @@ if test "$ARFLAGS" = '' ; then
   ARFLAGS=rc
 fi
 
+if test "${enable_ios}" != "" ; then
+  case "$host_cpu" in
+    aarch64)
+     IOS_ARCH=arm64
+     ;;
+    *)
+     IOS_ARCH=$host_cpu
+     ;;
+  esac
+  case "${enable_ios}" in
+    iPhoneOS|iPhoneSimulator)
+     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     ;;
+    *)
+     ios_sdk="${enable_ios}"
+     ;;
+  esac
+  IOS_PHONE_VERS="6.0"
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1"
+  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1"
+  PREFLAGS="$PREFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  CPPFLAGS="$CPPFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+fi
+
+
 WINDRES=windres
 
 ############## platform tests ################
@@ -317,8 +343,10 @@ case "$host_os" in
     # -pthread is not needed and triggers a warning
     use_flag_pthread=no
 
-    # ncurses.h is always available
-    disable_curses_arg=""
+    # ncurses.h is always available, except on iOS
+    if test "${enable_ios}" == "" ; then
+      disable_curses_arg=""
+    fi
     ;;
   nto-qnx*)
     MACH_OS=qnx
@@ -611,9 +639,11 @@ fi
 
 ############## other inferred machine properties ################
 
-AC_CHECK_SIZEOF([void *])
+if test "${enable_ios}" = "" ; then
+  AC_CHECK_SIZEOF([void *])
 
-m4_include(../ac/valid_sizeof.m4)
+  m4_include(../ac/valid_sizeof.m4)
+fi
 
 ############## subconfigure ################
 

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -167,6 +167,8 @@ cs_auto_flags=--disable-auto-flags
 
 ###### Autoconfigure #######
 
+m4_include(../ac/sdk_ios.m4)
+
 AC_PROG_CC
 
 m4_include(../ac/is_gcc.m4)
@@ -190,31 +192,6 @@ if test "$AR" = '' ; then
 fi
 if test "$ARFLAGS" = '' ; then 
   ARFLAGS=rc
-fi
-
-if test "${enable_ios}" != "" ; then
-  case "$host_cpu" in
-    aarch64)
-     IOS_ARCH=arm64
-     ;;
-    *)
-     IOS_ARCH=$host_cpu
-     ;;
-  esac
-  case "${enable_ios}" in
-    iPhoneOS|iPhoneSimulator)
-     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
-     ;;
-    *)
-     ios_sdk="${enable_ios}"
-     ;;
-  esac
-  IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1"
-  CPPFLAGS="$CPPFLAGS -DTARGET_OS_IPHONE=1"
-  PREFLAGS="$PREFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  CPPFLAGS="$CPPFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
 fi
 
 

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -616,11 +616,9 @@ fi
 
 ############## other inferred machine properties ################
 
-if test "${enable_ios}" = "" ; then
-  AC_CHECK_SIZEOF([void *])
+AC_CHECK_SIZEOF([void *])
 
-  m4_include(../ac/valid_sizeof.m4)
-fi
+m4_include(../ac/valid_sizeof.m4)
 
 ############## subconfigure ################
 


### PR DESCRIPTION
Closes #3605 .

This gets everything to compile cleanly for iOS. The result can then be linked and run o a real device, but memory allocation fails because `MAP_JIT` is not supported on iOS so more work is required to get everything working. This seems like a good first step.