### PR TITLE
bc: make srcloc->string compatible with cs

### DIFF
--- a/pkgs/racket-test-core/tests/racket/read.rktl
+++ b/pkgs/racket-test-core/tests/racket/read.rktl
@@ -1472,6 +1472,15 @@
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; srcloc->string
 
+(test "x.rkt::#f" srcloc->string (make-srcloc "x.rkt" #f #f #f #f))
+(test "x.rkt::90" srcloc->string (make-srcloc "x.rkt" #f #f 90 #f))
+(test "x.rkt::#f" srcloc->string (make-srcloc "x.rkt" #f 80 #f #f))
+
+(test "x.rkt::90" srcloc->string (make-srcloc "x.rkt" #f 80 90 #f))
+(test "x.rkt::90" srcloc->string (make-srcloc "x.rkt" 70 #f 90 #f))
+(test "x.rkt:70:80" srcloc->string (make-srcloc "x.rkt" 70 80 #f #f))
+(test "x.rkt:70:80" srcloc->string (make-srcloc "x.rkt" 70 80 90 #f))
+
 (test "x.rkt:10:11" srcloc->string (make-srcloc "x.rkt" 10 11 100 8))
 (test "x.rkt::100" srcloc->string (make-srcloc "x.rkt" #f #f 100 8))
 (test "x.rkt::100" srcloc->string (chaperone-struct (make-srcloc "x.rkt" #f #f 100 8)

--- a/pkgs/racket-test-core/tests/racket/read.rktl
+++ b/pkgs/racket-test-core/tests/racket/read.rktl
@@ -1472,9 +1472,9 @@
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; srcloc->string
 
-(test "x.rkt::#f" srcloc->string (make-srcloc "x.rkt" #f #f #f #f))
+(test "x.rkt" srcloc->string (make-srcloc "x.rkt" #f #f #f #f))
 (test "x.rkt::90" srcloc->string (make-srcloc "x.rkt" #f #f 90 #f))
-(test "x.rkt::#f" srcloc->string (make-srcloc "x.rkt" #f 80 #f #f))
+(test "x.rkt" srcloc->string (make-srcloc "x.rkt" #f 80 #f #f))
 
 (test "x.rkt::90" srcloc->string (make-srcloc "x.rkt" #f 80 90 #f))
 (test "x.rkt::90" srcloc->string (make-srcloc "x.rkt" 70 #f 90 #f))

--- a/racket/src/bc/src/error.c
+++ b/racket/src/bc/src/error.c
@@ -2120,9 +2120,6 @@ static char *make_srcloc_string(Scheme_Object *src, intptr_t line, intptr_t col,
     return NULL;
   }
 
-  if (col < 0)
-    col = pos + 1;
-
   if (src && SCHEME_PATHP(src)) {
     /* Strip off prefix matching the current directory: */
     src = scheme_remove_current_directory_prefix(src);
@@ -2144,12 +2141,18 @@ static char *make_srcloc_string(Scheme_Object *src, intptr_t line, intptr_t col,
 
   result = (char *)scheme_malloc_atomic(srclen + 15);
 
-  if (col >= 0) {
+  if (line >= 0 && col >= 0) {
+    /* If both line and column are available, use the format :line:col */
     rlen = scheme_sprintf(result, srclen + 15, "%t:%L%ld",
-			  srcstr, srclen, line, col-1);
+                          srcstr, srclen, line, col-1);
+  } else if (pos >= 0) {
+    /* If pos is available, use the format ::pos */
+    rlen = scheme_sprintf(result, srclen + 15, "%t::%ld",
+                          srcstr, srclen, pos);
   } else {
-    rlen = scheme_sprintf(result, srclen + 15, "%t::",
-			  srcstr, srclen);
+    /* Otherwise, use the format ::#f */
+    rlen = scheme_sprintf(result, srclen + 15, "%t::#f",
+                          srcstr, srclen);
   }
 
   if (len) *len = rlen;

--- a/racket/src/bc/src/error.c
+++ b/racket/src/bc/src/error.c
@@ -2142,16 +2142,16 @@ static char *make_srcloc_string(Scheme_Object *src, intptr_t line, intptr_t col,
   result = (char *)scheme_malloc_atomic(srclen + 15);
 
   if (line >= 0 && col >= 0) {
-    /* If both line and column are available, use the format :line:col */
+    /* If both line and column are available, use the format `path:line:col` */
     rlen = scheme_sprintf(result, srclen + 15, "%t:%L%ld",
                           srcstr, srclen, line, col-1);
   } else if (pos >= 0) {
-    /* If pos is available, use the format ::pos */
+    /* If pos is available, use the format `path::pos` */
     rlen = scheme_sprintf(result, srclen + 15, "%t::%ld",
                           srcstr, srclen, pos);
   } else {
-    /* Otherwise, use the format ::#f */
-    rlen = scheme_sprintf(result, srclen + 15, "%t::#f",
+    /* Otherwise, use the format `path` */
+    rlen = scheme_sprintf(result, srclen + 15, "%t",
                           srcstr, srclen);
   }
 

--- a/racket/src/cs/schemified/io.scm
+++ b/racket/src/cs/schemified/io.scm
@@ -31582,8 +31582,10 @@
              (let ((app_0 (adjust-path (srcloc-source s_0))))
                (let ((app_1 (srcloc-line s_0)))
                  (1/format "~a:~s:~s" app_0 app_1 (srcloc-column s_0))))
-             (let ((app_0 (adjust-path (srcloc-source s_0))))
-               (1/format "~a::~s" app_0 (srcloc-position s_0))))
+             (if (srcloc-position s_0)
+               (let ((app_0 (adjust-path (srcloc-source s_0))))
+                 (1/format "~a::~s" app_0 (srcloc-position s_0)))
+               (1/format "~a" (adjust-path (srcloc-source s_0)))))
            #f))))))
 (define adjust-path
   (lambda (p_0) (if (is-path? p_0) (relative-to-user-directory p_0) p_0)))

--- a/racket/src/io/srcloc/main.rkt
+++ b/racket/src/io/srcloc/main.rkt
@@ -16,10 +16,13 @@
                   (adjust-path (srcloc-source s))
                   (srcloc-line s)
                   (srcloc-column s))]
-         [else
+         [(srcloc-position s)
           (format "~a::~s"
                   (adjust-path (srcloc-source s))
-                  (srcloc-position s))])))
+                  (srcloc-position s))]
+         [else
+          (format "~a"
+                  (adjust-path (srcloc-source s)))])))
 
 (define (adjust-path p)
   (cond


### PR DESCRIPTION
Currently, in Racket BC, the following program:

```
(srcloc->string (make-srcloc "x.rkt" #f #f 90 #f))
(srcloc->string (make-srcloc "x.rkt" #f 80 #f #f))
(srcloc->string (make-srcloc "x.rkt" #f #f #f #f))

(srcloc->string (make-srcloc "x.rkt" #f 80 90 #f))
(srcloc->string (make-srcloc "x.rkt" 70 #f 90 #f))
(srcloc->string (make-srcloc "x.rkt" 70 80 #f #f))
(srcloc->string (make-srcloc "x.rkt" 70 80 90 #f))
```

results in:

```
"x.rkt::90"
"x.rkt::80"
"x.rkt::-1"
"x.rkt::80"
"x.rkt:70:90"
"x.rkt:70:80"
"x.rkt:70:80"
```

This output is very confusing and inconsistent.
When we see "x.rkt::90", we can never be sure if it's a srcloc
whose position is 90, or a srcloc whose column is 90.
The same applies for "x.rkt:70:90".

Moreover, the srloc "x.rkt::-1" is weird and is arguably incorrect
(see #1371).

Code-wise, the line
https://github.com/racket/racket/blob/e71c217758f744d3c8dfb30dd152b8c7d08a2735/racket/src/bc/src/error.c#L2151
is a dead code, because if col < 0, then col will be set to pos + 1
which is guaranteed to be non-negative. This offers another evidence
that the current srcloc->string is incorrect.

In Racket CS, the program results in:

```
"x.rkt::90"
"x.rkt::#f"
"x.rkt::#f"
"x.rkt::90"
"x.rkt::90"
"x.rkt:70:80"
"x.rkt:70:80"
```

which is consistent and makes sense.

This PR makes the behavior of srcloc->string in Racket BC matches
that of Racket CS.

Fixes #1371