### PR TITLE
rktio_process: set child signal handlers to default

### DIFF
--- a/racket/src/rktio/rktio_private.h
+++ b/racket/src/rktio/rktio_private.h
@@ -416,6 +416,7 @@ char *rktio_strndup(char *s, intptr_t len);
 
 #ifdef RKTIO_SYSTEM_UNIX
 void rktio_set_signal_handler(int sig_id, void (*proc)(int));
+void rktio_set_default_signal_handlers_for_subprocess(void);
 #endif
 void rktio_forget_os_signal_handler(rktio_t *rktio);
 

--- a/racket/src/rktio/rktio_process.c
+++ b/racket/src/rktio/rktio_process.c
@@ -1532,6 +1532,10 @@ rktio_process_result_t *rktio_process(rktio_t *rktio,
         _exit(1);
       }
 
+      /* Reset signal handling for new process */
+      rktio_set_default_signal_handlers_for_subprocess();
+
+
       /* Exec new process */
 
       {

--- a/racket/src/rktio/rktio_signal.c
+++ b/racket/src/rktio/rktio_signal.c
@@ -105,4 +105,60 @@ void rktio_set_signal_handler(int sig_id, void (*proc)(int))
   sa.sa_handler = proc;
   sigaction(sig_id, &sa, NULL);
 }
+
+void rktio_set_default_signal_handlers_for_subprocess()
+{
+  /* This is a list of all signals potentially used by Racket. */
+# ifdef SIGBUS
+  rktio_set_signal_handler(SIGBUS, SIG_DFL);
+# endif
+# ifdef SIGCHLD
+  rktio_set_signal_handler(SIGCHLD, SIG_DFL);
+# endif
+# ifdef SIGFPE
+  rktio_set_signal_handler(SIGFPE, SIG_DFL);
+# endif
+# ifdef SIGHUP
+  rktio_set_signal_handler(SIGHUP, SIG_DFL);
+# endif
+# ifdef SIGILL
+  rktio_set_signal_handler(SIGILL, SIG_DFL);
+# endif
+# ifdef SIGINFO
+  rktio_set_signal_handler(SIGINFO, SIG_DFL);
+# endif
+# ifdef SIGINT
+  rktio_set_signal_handler(SIGINT, SIG_DFL);
+# endif
+# ifdef SIGIO
+  rktio_set_signal_handler(SIGIO, SIG_DFL);
+# endif
+# ifdef SIGPIPE
+  rktio_set_signal_handler(SIGPIPE, SIG_DFL);
+# endif
+# ifdef SIGPROF
+  rktio_set_signal_handler(SIGPROF, SIG_DFL);
+# endif
+# ifdef SIGQUIT
+  rktio_set_signal_handler(SIGQUIT, SIG_DFL);
+# endif
+# ifdef SIGSEGV
+  rktio_set_signal_handler(SIGSEGV, SIG_DFL);
+# endif
+# ifdef SIGTERM
+  rktio_set_signal_handler(SIGTERM, SIG_DFL);
+# endif
+# ifdef SIGTSTP
+  rktio_set_signal_handler(SIGTSTP, SIG_DFL);
+# endif
+# ifdef SIGUSR1
+  rktio_set_signal_handler(SIGUSR1, SIG_DFL);
+# endif
+# ifdef SIGUSR2
+  rktio_set_signal_handler(SIGUSR2, SIG_DFL);
+# endif
+# ifdef SIGWINCH
+  rktio_set_signal_handler(SIGWINCH, SIG_DFL);
+# endif
+}
 #endif


### PR DESCRIPTION
This is a sketch of a solution for issue #3609.

I tried to find all the signals that Racket installs handlers for, and set them to `SIG_DFL` before the `execve` call.

There are some improvements that could still be made here:

* There are various `#define` flags that determine whether various signals are actually overridden.  We should probably use those same flags to determine which signals are reset.
* Rather than setting each handler to `SIG_DFL`, we could set them to the values they had before they were overridden.  This is a bigger change, since we would need to capture those values in all the various places they are set by `signal` or `sigaction` and then have them available here at the function call site.

But before trying to do any of that I thought I would start with this since I haven't yet heard anything as far as a thumbs up/down for this kind of change.  At any rate, the current behavior is undocumented and, in my opinion, a bug.