### PR TITLE
bc: fix build for iOS

### DIFF
--- a/racket/src/bc/sconfig.h
+++ b/racket/src/bc/sconfig.h
@@ -654,7 +654,9 @@
 #  define SCHEME_ARCH "arm"
 # elif defined(__arm64__)
 #  define SCHEME_ARCH "aarch64"
-#  define MZ_USE_MAP_JIT
+#  if !defined(TARGET_OS_IPHONE)
+#   define MZ_USE_MAP_JIT
+#  endif
 #  define USE_DLOPEN_GLOBAL_BY_DEFAULT
 # elif defined(__x86_64__)
 #   define SCHEME_ARCH "x86_64"


### PR DESCRIPTION
On iOS, `MAP_JIT` is available but does not work w/o special entitlements and `pthread_jit_write_protect_np` is not available at all. I've verified that I can build 3m and CGC with these changes and I'm able to link against and run Racket CGC on iOS.