### PR TITLE
build: fix `make install` for cross builds

### DIFF
--- a/racket/src/bc/configure-parent.ac
+++ b/racket/src/bc/configure-parent.ac
@@ -36,17 +36,23 @@ MAKE_LOCAL_RACKET=no-local-racket
 
 if test "${enable_racket}" = "auto" ; then
   MAKE_LOCAL_RACKET="local/bc/racket3m"
+  enable_racket="${MAKE_LOCAL_RACKET}"
 fi
 RUN_LOCAL_RACKET="local/bc/racket3m"
 CONFIGURE_LOCAL_RACKET=--enable-bc
 
 if test "${enable_cgcdefault}" = "yes" ; then
   MAIN_VARIANT=cgc
-else  
+else
   MAIN_VARIANT=3m
 fi
 MAIN_MAKE_TARGET="${MAIN_VARIANT}"
-RUN_RACKET="bc/racket${MAIN_VARIANT}"
+
+if test "${enable_racket}" != "" ; then
+  RUN_RACKET="${enable_racket}"
+else
+  RUN_RACKET="bc/racket${MAIN_VARIANT}"
+fi
 
 AC_SUBST(RUN_RACKET)
 AC_SUBST(MAKE_LOCAL_RACKET)

--- a/racket/src/cfg-bc
+++ b/racket/src/cfg-bc
@@ -2326,6 +2326,7 @@ MAKE_LOCAL_RACKET=no-local-racket
 
 if test "${enable_racket}" = "auto" ; then
   MAKE_LOCAL_RACKET="local/bc/racket3m"
+  enable_racket="${MAKE_LOCAL_RACKET}"
 fi
 RUN_LOCAL_RACKET="local/bc/racket3m"
 CONFIGURE_LOCAL_RACKET=--enable-bc
@@ -2336,7 +2337,12 @@ else
   MAIN_VARIANT=3m
 fi
 MAIN_MAKE_TARGET="${MAIN_VARIANT}"
-RUN_RACKET="bc/racket${MAIN_VARIANT}"
+
+if test "${enable_racket}" != "" ; then
+  RUN_RACKET="${enable_racket}"
+else
+  RUN_RACKET="bc/racket${MAIN_VARIANT}"
+fi
 
 
 

--- a/racket/src/cfg-cs
+++ b/racket/src/cfg-cs
@@ -2235,6 +2235,7 @@ MAKE_LOCAL_RACKET=no-local-racket
 
 if test "${enable_racket}" = "auto" ; then
   MAKE_LOCAL_RACKET="local/cs/c/racketcs"
+  enable_racket="${MAKE_LOCAL_RACKET}"
 fi
 RUN_LOCAL_RACKET="local/cs/c/racketcs"
 CONFIGURE_LOCAL_RACKET=--enable-cs
@@ -2242,7 +2243,11 @@ CONFIGURE_LOCAL_RACKET=--enable-cs
 MAIN_MAKE_TARGET=racketcs
 MAIN_VARIANT=3m
 
-RUN_RACKET="cs/c/racketcs"
+if test "${enable_racket}" != "" ; then
+  RUN_RACKET="${enable_racket}"
+else
+  RUN_RACKET="cs/c/racketcs"
+fi
 
 
 

--- a/racket/src/cs/c/configure-parent.ac
+++ b/racket/src/cs/c/configure-parent.ac
@@ -26,6 +26,7 @@ MAKE_LOCAL_RACKET=no-local-racket
 
 if test "${enable_racket}" = "auto" ; then
   MAKE_LOCAL_RACKET="local/cs/c/racketcs"
+  enable_racket="${MAKE_LOCAL_RACKET}"
 fi
 RUN_LOCAL_RACKET="local/cs/c/racketcs"
 CONFIGURE_LOCAL_RACKET=--enable-cs
@@ -33,7 +34,11 @@ CONFIGURE_LOCAL_RACKET=--enable-cs
 MAIN_MAKE_TARGET=racketcs
 MAIN_VARIANT=3m
 
-RUN_RACKET="cs/c/racketcs"
+if test "${enable_racket}" != "" ; then
+  RUN_RACKET="${enable_racket}"
+else
+  RUN_RACKET="cs/c/racketcs"
+fi
 
 AC_SUBST(RUN_RACKET)
 AC_SUBST(MAKE_LOCAL_RACKET)


### PR DESCRIPTION
W/o this change, some targets in the "parent" Makefile (like `copytree-run`) may fail because they try to run the target Racket executable instead of the host.