### PR TITLE
hashes.scrbl, hash-intersect: Fix the contract on h0.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -758,7 +758,7 @@ h
 
 }
 
-@defproc[(hash-intersect [h0 (and/c hash? (not/c immutable?))]
+@defproc[(hash-intersect [h0 (and/c hash? immutable?)]
 			 [h hash?] ...
                          [#:combine combine
                                     (-> any/c any/c any/c)


### PR DESCRIPTION
The contract on the first argument `h0` of `hash-intersect` shown in the Scribble docs is not the same as in the actual code.  This PR fixes the contract in the documentation.