### PR TITLE
cs,alloc: close off sweep_next chain along with thread local segment

### DIFF
--- a/racket/src/ChezScheme/IMPLEMENTATION.md
+++ b/racket/src/ChezScheme/IMPLEMENTATION.md
@@ -985,8 +985,8 @@ machine-specific linking dierctives can appear. In the case of
 address), `arm32-call` (call an asolute address while setting the link
 register), and a`arm32-jump` (jump to an asolute address). These are
 turned into relocation entries associated with compiled code by steps
-in "compile.ss". Relocaiton entires are used when loding an GCing with
-update routines implemented in "fasl.c".
+in "compile.ss". Relocation entries are used when loading and GCing
+with update routines implemented in "fasl.c".
 
 Typically, a linking directive is written just after some code that is
 generated as installing a dummy value, and theen the update routine in

--- a/racket/src/ChezScheme/c/alloc.c
+++ b/racket/src/ChezScheme/c/alloc.c
@@ -36,6 +36,7 @@ void S_alloc_init() {
               S_G.main_thread_gc.base_loc[g][s] = FIX(0);
               S_G.main_thread_gc.next_loc[g][s] = FIX(0);
               S_G.main_thread_gc.bytes_left[g][s] = 0;
+              S_G.main_thread_gc.sweep_next[g][s] = NULL;
               S_G.bytes_of_space[g][s] = 0;
             }
         }
@@ -287,6 +288,7 @@ void S_close_off_thread_local_segment(ptr tc, ISPC s, IGEN g) {
   tgc->bytes_left[g][s] = 0;
   tgc->next_loc[g][s] = (ptr)0;
   tgc->sweep_loc[g][s] = (ptr)0;
+  tgc->sweep_next[g][s] = NULL;
 }
 
 /* S_reset_allocation_pointer is always called with allocation mutex

--- a/racket/src/ChezScheme/c/gc.c
+++ b/racket/src/ChezScheme/c/gc.c
@@ -126,7 +126,7 @@
    Parallel mode runs `sweep_generation` concurrently in multiple
    sweeper threads. It relies on a number of invariants:
 
-    * There are no attempts to take tc_mutex suring sweeping. To the
+    * There are no attempts to take tc_mutex during sweeping. To the
       degree that locking is needed (e.g., to allocate new segments),
       the allocation mutex is used. No other locks can be taken while
       that one is held.
@@ -167,7 +167,7 @@
 
     * Normally, a sweeper that encounters a remote reference can
       continue sweeping and eventually register the remote re-sweep.
-      An object is swept by only one sweeper at a time; if mmultiple
+      An object is swept by only one sweeper at a time; if multiple
       remote references to different sweepers are discovered in an
       object, it is sent to only one of the remote sweepers, and that
       sweeper will eventually send on the object to the other sweeper.
@@ -1907,7 +1907,7 @@ static iptr sweep_generation_pass(thread_gc *tgc) {
     for (from_g = MIN_TG; from_g <= MAX_TG; from_g += 1) {
 
       sweep_space(space_impure, from_g, {
-          /* only pairs in theses spaces in backreference mode */
+          /* only pairs in these spaces in backreference mode */
           FLUSH_REMOTE_BLOCK
           SET_BACKREFERENCE(TYPE(TO_PTR(pp), type_pair));
           relocate_impure_help(pp, p, from_g);


### PR DESCRIPTION
After a GC, the `sweep_next` chain for recent segments could point to segments that have since been assigned to other generations or even freed. This is a better fix for the issue I ran into in https://github.com/racket/racket/pull/3630/commits/cc208bafb8b4fd9707c00d72ff4a39557bc7d1f7 and it took a more complex Racket program to trigger it again. I *think* this is a safe change, because thread-local segments are always closed off before any GC-related allocations can be made (and so we don't run the risk of leaking anything here), but let me know if I have that wrong.