### PR TITLE
Stop keyworded functions from changing args' name. Fixes #2425.

### DIFF
--- a/pkgs/racket-test-core/tests/racket/procs.rktl
+++ b/pkgs/racket-test-core/tests/racket/procs.rktl
@@ -785,4 +785,58 @@
 
 ;; ----------------------------------------
 
+(module kw-defns racket/base
+  (provide (all-defined-out))
+
+  (define (func-name/opt.1 arg [opt.1 (lambda (x) x)])
+    (object-name arg))
+
+  (define (func-name/opt.2 arg [opt.2 (lambda (x) x)])
+    (object-name opt.2))
+
+  (define (func-name/kw.1 arg1 #:kw.1 arg2)
+    (object-name arg1))
+
+  (define (func-name/kw.2 arg1 #:kw.2 arg2)
+    (object-name arg2))
+
+  (define (func-name/kw.opt.1 arg #:kw.opt.1 [kw.opt.1 (lambda (x) x)])
+    (object-name arg))
+
+  (define (func-name/kw.opt.2 arg #:kw.opt.2 [kw.opt.2 (lambda (x) x)])
+    (object-name kw.opt.2))
+  )
+(require 'kw-defns)
+
+(define ((proc-has-name? name) s)
+  (and (symbol? s) (regexp-match? name (symbol->string s))))
+
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/opt.1 (lambda (z) z)))
+
+;; the default value of the optional argument picks up
+;; the name of the optional argument
+(test #t (proc-has-name? #rx"opt[.]2")
+         (func-name/opt.2 (lambda (z) z)))
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/opt.2 (lambda (z) z) (lambda (w) w)))
+
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/kw.1 (lambda (z) z) #:kw.1 (lambda (w) w)))
+
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/kw.2 (lambda (z) z) #:kw.2 (lambda (w) w)))
+
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/kw.opt.1 (lambda (z) z)))
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/kw.opt.1 (lambda (z) z) #:kw.opt.1 (lambda (w) w)))
+
+(test #t (proc-has-name? #rx"kw[.]opt[.]2")
+         (func-name/kw.opt.2 (lambda (z) z)))
+(test #t (proc-has-name? #rx"procs.rktl:")
+         (func-name/kw.opt.2 (lambda (z) z) #:kw.opt.2 (lambda (w) w)))
+
+;; ----------------------------------------
+
 (report-errs)


### PR DESCRIPTION
This PR prevents keyworded functions from affecting the inferred names for their (non-keyword) arguments. With this PR the following two expressions from the tests produce the correct names:
```
(func-name/kw.1     (lambda (z) z) #:kw.1 (lambda (w) w))
(func-name/kw.opt.1 (lambda (z) z))
(func-name/kw.opt.1 (lambda (z) z) #:kw.opt.1 (lambda (w) w))
```
I have tried replacing let expressions `(let x = e1 in e2)` with `((lambda (x) e2) e1)` in the implementation of keywords to avoid affecting inferred names, but directly attaching syntax properties to non-keyword arguments is more consistent with the behavior of keyword arguments.

Fixes #2425.

Alternative solution:
```diff
diff --git a/racket/collects/racket/private/kw.rkt b/racket/collects/racket/private/kw.rkt
index 0ebc8257ea..91ae91a5ea 100644
--- a/racket/collects/racket/private/kw.rkt
+++ b/racket/collects/racket/private/kw.rkt
@@ -1251,19 +1251,22 @@
                           [cnt (+ 1 (length args))])
                      (check-arity (- cnt 2))
                      (syntax-protect
-                      (quasisyntax/loc stx
-                        (let #,(reverse bind-accum)
-                          #,(generate-direct 
-                             (cdr args) sorted-kws #t
-                             (quasisyntax/loc stx
-                               ((checked-procedure-check-and-extract struct:keyword-procedure
-                                                                     #,(car args)
-                                                                     keyword-procedure-extract 
-                                                                     '#,(map car sorted-kws) 
-                                                                     #,cnt)
-                                '#,(map car sorted-kws)
-                                (list #,@(map cdr sorted-kws))
-                                . #,(cdr args))))))))]
+                      (let ([reversed-bind-accum (reverse bind-accum)])
+                        (quasisyntax/loc stx
+                          ;; use lambdas to hide binding name
+                          ((lambda #,(map car reversed-bind-accum)
+                             #,(generate-direct 
+                                (cdr args) sorted-kws #t
+                                (quasisyntax/loc stx
+                                  ((checked-procedure-check-and-extract struct:keyword-procedure
+                                                                        #,(car args)
+                                                                        keyword-procedure-extract 
+                                                                        '#,(map car sorted-kws) 
+                                                                        #,cnt)
+                                   '#,(map car sorted-kws)
+                                   (list #,@(map cdr sorted-kws))
+                                   . #,(cdr args)))))
+                           . #,(map cadr reversed-bind-accum))))))]
                   [(keyword? (syntax-e (car l)))
                    (loop (cddr l)
                          (cdr ids)
@@ -1346,8 +1349,8 @@
                                                  (if (not lifted?)
                                                      ;; caller didn't lift expressions out
                                                      (let ([ids (generate-temporaries args)])
-                                                       #`(let #,(map list ids args)
-                                                           #,(k ids)))
+                                                       #`((lambda #,ids #,(k ids))
+                                                          . #,args))
                                                      ;; caller already lifted expression:
                                                      (k args)))])
                                (or
```
