### PR TITLE
cs: add pariah for slow path of define-inline

### DIFF
--- a/racket/src/cs/rumble/inline.ss
+++ b/racket/src/cs/rumble/inline.ss
@@ -17,7 +17,7 @@
               #'(let ([arg tmp] ...)
                   (if guard
                       op
-                      (orig-app orig-id arg ...)))]
+                      (pariah (orig-app orig-id arg ...))))]
              [(_ . args)
               #'(orig-id . args)]
              [_ #'orig-id])))]))


### PR DESCRIPTION
 The performance improvement is measurable on my machine. 
For example:
```racket
#lang racket

(struct A (a b c d) #:mutable)

(define (g x)
  (let g ([x x])
    (match x
      [(A a b c d)
       (g a) (g b) (g c) (g d)]
      [else (void)])))

;;; normal case
(define t (let f ([n 13])
            (cond
              [(= n 0) 1]
              [else
               (define a (f (sub1 n)))
               (A a a a a)])))

(collect-garbage)
(time (g t))

;;; contracted case
(define t1 (let f ([n 11])
             (cond
               [(= n 0) 1]
               [else
                (define a (f (sub1 n)))
                (contract (struct/c A any/c any/c any/c any/c)
                          (A a a a a)
                          'pos 'neg)])))

(collect-garbage)
(time (g t1))
```

from
```
cpu time: 270 real time: 272 gc time: 0
cpu time: 397 real time: 405 gc time: 5
```
to
```
cpu time: 241 real time: 243 gc time: 0
cpu time: 401 real time: 410 gc time: 5
```