### PR TITLE
Fix typo and trailing whitespace in a doc of macros

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/macros.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/macros.scrbl
@@ -19,11 +19,11 @@ This chapter provides an introduction to Racket macros, but see
 @hyperlink["http://www.greghendershott.com/fear-of-macros/"]{@italic{Fear of
 Macros}} for an introduction from a different perspective.
 
-Racket includes addional support for macro development: 
-A @hyperlink["https://docs.racket-lang.org/macro-debugger/index.html"]{@italic{macro 
+Racket includes additional support for macro development:
+A @hyperlink["https://docs.racket-lang.org/macro-debugger/index.html"]{@italic{macro
 debugger}} to make it easier for experienced programmers
-to debug their macros and for novices to study their behavior, 
-and of macros. And the @hyperlink["https://docs.racket-lang.org/syntax/index.html"]{@italic{syntax/parse 
+to debug their macros and for novices to study their behavior,
+and of macros. And the @hyperlink["https://docs.racket-lang.org/syntax/index.html"]{@italic{syntax/parse
 library}} for writing macros and specifying syntax that
 automatically validates macro uses and reports syntax
 errors.


### PR DESCRIPTION
Hello,

I found a typo and trailing whitespaces in `pkgs/racket-doc/scribblings/guide/macros.scrbl`, so I just fixed it.
(Originally I found it on https://docs.racket-lang.org/guide/macros.html )

I hope you Racket developers and others have nice year 2021!