### PR TITLE
Print extra ellipses if the context is truncated

### DIFF
--- a/pkgs/racket-test-core/tests/racket/param.rktl
+++ b/pkgs/racket-test-core/tests/racket/param.rktl
@@ -563,9 +563,9 @@
 
 (test #f regexp-match? #rx"context[.][.][.]"
       (get-repctx-error-message 0))
-(test #t regexp-match? #rx"param[.]rktl:[^\n]*repctx[^\n]*\n   [.][.][.]\n"
+(test #t regexp-match? #rx"param[.]rktl:[^\n]*repctx[^\n]*\n   [.][.][.]\n$"
       (get-repctx-error-message 1))
-(test #t regexp-match? #rx"repeats[^\n]+[0-9]+[^\n]+times[^\n]*\n   [.][.][.]\n"
+(test #t regexp-match? #rx"repeats[^\n]+[0-9]+[^\n]+times[^\n]*\n   [.][.][.]\n$"
       (get-repctx-error-message 2))
 (test #f regexp-match? #rx"[.][.][.]\n"
       (get-repctx-error-message 16))

--- a/pkgs/racket-test-core/tests/racket/param.rktl
+++ b/pkgs/racket-test-core/tests/racket/param.rktl
@@ -542,4 +542,34 @@
 
 ;; ----------------------------------------
 
+; Test error-print-context-length
+(define (repctx n)
+  (if (zero? n)
+      (error 'repctx)
+      (+ 1 (repctx (- n 1)))))
+(define (repctx/extra-context x)
+  (* 2 (repctx x)))
+
+(define (get-repctx-error-message context-length)
+  (define o (open-output-string))
+  (parameterize ([error-print-context-length context-length]
+                 [current-error-port o])
+    (with-handlers ([exn:fail? (λ (e) ((error-display-handler) (exn-message e) e))])
+      ;; 18 repeats the contexts at least 3 times in BC
+      (repctx/extra-context 18)))
+  (begin0
+    (get-output-string o)
+    (close-output-port o)))
+
+(test #f regexp-match? #rx"context[.][.][.]"
+      (get-repctx-error-message 0))
+(test #t regexp-match? #rx"param[.]rktl:[^\n]*repctx[^\n]*\n   [.][.][.]\n"
+      (get-repctx-error-message 1))
+(test #t regexp-match? #rx"repeats[^\n]+[0-9]+[^\n]+times[^\n]*\n   [.][.][.]\n"
+      (get-repctx-error-message 2))
+(test #f regexp-match? #rx"[.][.][.]\n"
+      (get-repctx-error-message 16))
+
+;; ----------------------------------------
+
 (report-errs)

--- a/racket/src/cs/rumble/error.ss
+++ b/racket/src/cs/rumble/error.ss
@@ -734,6 +734,8 @@
                    [prev #f]
                    [repeats 0]
                    [n n])
+          (when (and (pair? l) (zero? n))
+            (eprintf "\n   ..."))
           (unless (or (null? l) (zero? n))
             (let* ([p (car l)]
                    [s (cdr p)])


### PR DESCRIPTION
* Ref: <https://docs.racket-lang.org/reference/exns.html#(def._((quote._~23~25kernel)._error-print-context-length))>

    > a single “...” line is printed if more lines are available after the first cnt lines.
* The extra context, `repctx/extra-context`, is required because BC handles
    top-level contexts in a different way than CS. Without it, there will be only
    2 contexts instead of 3+ for this test:
    ```
    (test #t regexp-match? #rx"repeats[^\n]+[0-9]+[^\n]+times[^\n]*\n   [.][.][.]\n"
          (get-repctx-error-message 2))
    ```

I believe the DB test failures are not related to this PR.