### PR TITLE
Added dictionary contracts

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/dicts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/dicts.scrbl
@@ -188,7 +188,7 @@ values all satisfy the @racket[value-contract].
 @defproc[(heterogeneous-dictof [#:mandatory-keys? mandatory-keys? boolean? #t]
                                [#:exact-keys? exact-keys? boolean? #f]
                                [#:immutable? immutable? boolean? #t]
-                               key-contract value-contract ... ...)
+                               [key-contract contract?] [value-contract contract?] ... ...)
          contract?]{
 Recognizes a dictionary for which every key that satsifies a key contract maps
 to a value satisfying the corresponding value contract.
@@ -198,26 +198,26 @@ total number of non-keyword arguments is even.
 @examples[
 #:eval dict-eval
 
-((heterogenous-dictof symbol? integer? intger? symbol?) '())
-((heterogenous-dictof symbol? integer? intger? symbol?) '((a . 5) (6 . b)))
-((heterogenous-dictof symbol? integer? intger? symbol?) '((a . 5) (a . b)))
-((heterogenous-dictof symbol? integer? intger? symbol?) '((a . 5)))
-((heterogenous-dictof symbol? integer? intger? symbol?) '((6 . b)))
-((heterogenous-dictof 'a integer?) '((a . 5)))
-((heterogenous-dictof 'a integer?) '((b . 5)))
+((heterogeneous-dictof symbol? integer? integer? symbol?) '())
+((heterogeneous-dictof symbol? integer? integer? symbol?) '((a . 5) (6 . b)))
+((heterogeneous-dictof symbol? integer? integer? symbol?) '((a . 5) (a . b)))
+((heterogeneous-dictof symbol? integer? integer? symbol?) '((a . 5)))
+((heterogeneous-dictof symbol? integer? integer? symbol?) '((6 . b)))
+((heterogeneous-dictof 'a integer?) '((a . 5)))
+((heterogeneous-dictof 'a integer?) '((b . 5)))
 ]
 
-If @racket[exact-keys] is specified, then the @racket[key-contracts] are
+If @racket[exact-keys?] is specified, then the @racket[key-contract]s are
 interpreted as keys in contracted dictionary, and the dictionary is required to
 contain exactly the keys specified.
 
 @examples[
 #:eval dict-eval
-((heterogenous-dictof #:exact-keys? #f 'a integer?) '((a . 5)))
-((heterogenous-dictof #:exact-keys? #f 'a integer?) '((a . 5) (b . 5)))
+((heterogeneous-dictof #:exact-keys? #f 'a integer?) '((a . 5)))
+((heterogeneous-dictof #:exact-keys? #f 'a integer?) '((a . 5) (b . 5)))
 ]
 
-If @racket[mandatory-keys] is specified (the default), then a key matching each
+If @racket[mandatory-keys?] is specified (the default), then a key matching each
 key contracts is required to be in the dictionary.
 Otherwise, contracted keys are optional, but if present, their value must match
 the corresponding contract.
@@ -225,11 +225,11 @@ the corresponding contract.
 @examples[
 #:eval dict-eval
 
-((heterogenous-dictof #:mandatory-keys? #f symbol? integer? intger? symbol?) '())
-((heterogenous-dictof #:mandatory-keys? #f 'a integer?) '((b . 6)))
-((heterogenous-dictof #:mandatory-keys? #f 'a integer?) '((a . 5)))
-((heterogenous-dictof #:mandatory-keys? #f 'a integer?) '((a . 5) (b . 6)))
-((heterogenous-dictof #:mandatory-keys? #f 'a integer?) '((a . b)))
+((heterogeneous-dictof #:mandatory-keys? #f symbol? integer? integer? symbol?) '())
+((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((b . 6)))
+((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((a . 5)))
+((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((a . 5) (b . 6)))
+((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((a . b)))
 ]
 
 If @racket[immutable?] is specified (the default), then the contracted
@@ -238,12 +238,12 @@ if it is mutable.
 
 @examples[
 #:eval dict-eval
-((heterogenous-dictof 'a integer?) '((a . b)))
-((heterogenous-dictof #:immutable? #f 'a integer?) '((a . b)))
-((heterogenous-dictof 'a integer?) (make-hash))
-((heterogenous-dictof #:immutable? #f 'a integer?) (make-hash))
-((heterogenous-dictof 'a integer?) (make-immutable-hash))
-((heterogenous-dictof #:immutable? #f 'a integer?) (make-immutable-hash))
+((heterogeneous-dictof 'a integer?) '((a . 5)))
+((heterogeneous-dictof #:immutable? #f 'a integer?) '((a . 5)))
+((heterogeneous-dictof 'a integer?) (make-hash '((a . 5))))
+((heterogeneous-dictof #:immutable? #f 'a integer?) (make-hash '((a . 5))))
+((heterogeneous-dictof 'a integer?) (hash 'a 5))
+((heterogeneous-dictof #:immutable? #f 'a integer?) (hash 'a 5))
 ]
 }
 

--- a/pkgs/racket-doc/scribblings/reference/dicts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/dicts.scrbl
@@ -172,8 +172,8 @@ Equivalent to @racket[(dict-implements? d 'dict-set)].
 ]}
 
 
-@defproc[(homogenous-dictof [key-contract contract?] [value-contract contract?])
-          contract?]{
+@defproc[(homogenous-dictof [key-contract flat-contract?] [value-contract flat-contract?])
+          flat-contract?]{
 Recognizes a dictionary whose all satisfy the @racket[key-contract] and whose
 values all satisfy the @racket[value-contract].
 
@@ -188,8 +188,8 @@ values all satisfy the @racket[value-contract].
 @defproc[(heterogeneous-dictof [#:mandatory-keys? mandatory-keys? boolean? #t]
                                [#:exact-keys? exact-keys? boolean? #f]
                                [#:immutable? immutable? boolean? #t]
-                               [key-contract contract?] [value-contract contract?] ... ...)
-         contract?]{
+                               [key-contract flat-contract?] [value-contract flat-contract?] ... ...)
+         flat-contract?]{
 Recognizes a dictionary for which every key that satsifies a key contract maps
 to a value satisfying the corresponding value contract.
 Each @racket[key-contract] must be followed by a @racket[value-contract], so the

--- a/pkgs/racket-test/tests/generic/dict-contracts.rkt
+++ b/pkgs/racket-test/tests/generic/dict-contracts.rkt
@@ -83,4 +83,22 @@
 
   (check-true
    ((heterogeneous-dictof 'a integer? 'b integer?)
-    '((a . 5) (b . 6) (c . 7)))))
+    '((a . 5) (b . 6) (c . 7))))
+
+  (check-true
+   ((heterogeneous-dictof #:immutable? #t 'a integer?) '((a . 5))))
+
+  (check-false
+   ((heterogeneous-dictof #:immutable? #f 'a integer?) '((a . 5))))
+
+  (check-false
+   ((heterogeneous-dictof #:immutable? #t 'a integer?) (make-hash '((a . 5)))))
+
+  (check-true
+   ((heterogeneous-dictof #:immutable? #f 'a integer?) (make-hash '((a . 5)))))
+
+  (check-true
+   ((heterogeneous-dictof #:immutable? #t 'a integer?) (make-immutable-hash '((a . 5)))))
+
+  (check-false
+   ((heterogeneous-dictof #:immutable? #f 'a integer?) (make-immutable-hash '((a . 5))))))

--- a/pkgs/racket-test/tests/generic/dict-contracts.rkt
+++ b/pkgs/racket-test/tests/generic/dict-contracts.rkt
@@ -1,0 +1,86 @@
+#lang racket/base
+
+(require
+ racket/dict)
+
+(module+ test
+  (require rackunit)
+
+  (check-true
+   ((dict-mutability/c #f) '((a . 5))))
+
+  (check-true
+   ((dict-mutability/c #t) '((a . 5))))
+
+  (check-false
+   ((dict-mutability/c #t) (make-immutable-hash)))
+
+  (check-true
+   ((dict-mutability/c #t) (make-hash)))
+
+  (check-true
+   ((homogeneous-dictof symbol? integer?) '((a . 5))))
+
+  (check-true
+   ((homogeneous-dictof symbol? integer?) '((a . 5) (b . 5))))
+
+  (check-false
+   ((homogeneous-dictof symbol? integer?) '((a . b) (b . 5))))
+
+  (check-false
+   ((homogeneous-dictof symbol? integer?) '((a . b))))
+
+  (check-false
+   ((homogeneous-dictof symbol? integer?) '((5 . 6))))
+
+  (check-true
+   ((heterogeneous-dictof 'a integer?) '((a . 5))))
+
+  (check-false
+   ((heterogeneous-dictof 'a integer?) '((b . 5))))
+
+  (check-false
+   ((heterogeneous-dictof 'a integer?) '((a . b))))
+
+  (check-true
+   ((heterogeneous-dictof 'a integer?) '((a . 5) (b . 6))))
+
+  (check-false
+   ((heterogeneous-dictof #:exact-keys? #t 'a integer?) '((a . 5) (b . 6))))
+
+  (check-true
+   ((heterogeneous-dictof #:exact-keys? #t 'a integer? 'b integer?)
+    '((a . 5) (b . 6))))
+
+  (check-true
+   ((heterogeneous-dictof 'a integer? 'b integer?)
+    '((a . 5) (b . 6))))
+
+  (check-true
+   ((heterogeneous-dictof 'a integer? 'b integer?)
+    '((a . 5) (b . 6) (c . 7))))
+
+  (check-true
+   ((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((b . 5))))
+
+  (check-true
+   ((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((a . 5) (b . 5))))
+
+  (check-false
+   ((heterogeneous-dictof #:mandatory-keys? #f 'a integer?) '((a . b) (b . 5))))
+
+  (check-true
+   ((heterogeneous-dictof symbol? integer?) '((a . 5) (b . 6))))
+
+  (check-false
+   ((heterogeneous-dictof symbol? integer? 'b 5) '((a . 5) (b . 6))))
+
+  (check-true
+   ((heterogeneous-dictof symbol? integer? 'b 6) '((a . 5) (b . 6))))
+
+  (check-false
+   ((heterogeneous-dictof symbol? symbol? 'b 6) '((a . 5) (b . 6))))
+
+  (check-true
+   ((heterogeneous-dictof 'a integer? 'b integer?)
+    '((a . 5) (b . 6) (c . 7)))))

--- a/pkgs/racket-test/tests/generic/dict-contracts.rkt
+++ b/pkgs/racket-test/tests/generic/dict-contracts.rkt
@@ -9,7 +9,7 @@
   (check-true
    ((dict-mutability/c #f) '((a . 5))))
 
-  (check-true
+  (check-false
    ((dict-mutability/c #t) '((a . 5))))
 
   (check-false

--- a/racket/collects/racket/dict.rkt
+++ b/racket/collects/racket/dict.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require racket/contract/base
          "private/dict.rkt"
+         "private/dict-contracts.rkt"
          "private/keyword-apply-dict.rkt"
          "private/custom-hash.rkt")
 
@@ -272,7 +273,22 @@
  [dict-implements?
   (->* [dict?] [] #:rest (listof dict-method-name/c) boolean?)]
  [dict-implements/c
-  (->* [] [] #:rest (listof dict-method-name/c) flat-contract?)])
+  (->* [] [] #:rest (listof dict-method-name/c) flat-contract?)]
+
+
+ [dict-mutability/c
+   (-> boolean? (-> any/c boolean?))]
+ [dict-immutability/c
+  (-> boolean? (-> any/c boolean?))]
+ [homogeneous-dictof
+  (-> contract? contract? (-> any/c boolean?))]
+ [heterogeneous-dictof
+  (->* () (#:mandatory-keys? boolean?
+           #:exact-keys? boolean?
+           #:immutable? boolean?)
+       #:rest (and/c (lambda (x) (even? (length x)))
+                     (listof contract?))
+       (-> any/c boolean?))])
 
 (provide gen:dict
          prop:dict

--- a/racket/collects/racket/dict.rkt
+++ b/racket/collects/racket/dict.rkt
@@ -281,13 +281,13 @@
  [dict-immutability/c
   (-> boolean? (-> any/c boolean?))]
  [homogeneous-dictof
-  (-> contract? contract? (-> any/c boolean?))]
+  (-> flat-contract? flat-contract? (-> any/c boolean?))]
  [heterogeneous-dictof
   (->* () (#:mandatory-keys? boolean?
            #:exact-keys? boolean?
            #:immutable? boolean?)
        #:rest (and/c (lambda (x) (even? (length x)))
-                     (listof contract?))
+                     (listof flat-contract?))
        (-> any/c boolean?))])
 
 (provide gen:dict

--- a/racket/collects/racket/private/dict-contracts.rkt
+++ b/racket/collects/racket/private/dict-contracts.rkt
@@ -1,0 +1,61 @@
+#lang racket/base
+
+(provide
+ dict-mutability/c
+ dict-immutability/c
+ homogeneous-dictof
+ heterogeneous-dictof)
+
+(require
+ "dict.rkt"
+ racket/contract/base
+ "../list.rkt"
+ "../set.rkt")
+
+(define ((dict-mutability/c b) d)
+  (and (dict? d)
+       ((if b values not) (dict-mutable? d))))
+
+(define (dict-immutability/c b)
+  (dict-mutability/c (not b)))
+
+;; Generalizes hash/c, but uses the same naming convention as listof and vectorof
+(define ((homogeneous-dictof key-contract value-contract) d)
+  (for/and ([(k c) (in-dict d)])
+    (and
+     (key-contract k)
+     (value-contract c))))
+
+(define (unzip-args . args)
+  #;(->* () #:rest (and/c (lambda (x) (even? (length x)))
+                        (listof contract?))
+       (list/c (listof contract?) (listof contract?)))
+  (let ([x (box 0)])
+    (group-by (lambda (y)
+                (begin
+                  (set-box! x (add1 (unbox x)))
+                  (even? (unbox x))))
+              args)))
+
+(define ((heterogeneous-dictof
+                   #:mandatory-keys? [mandatory-keys? #t]
+                   #:exact-keys? [exact? #f]
+                   #:immutable? [immutable? #t]
+                   . key-value-args) d)
+  (let* ([k/v-contracts (apply unzip-args key-value-args)]
+         [key-contracts (first k/v-contracts)]
+         [value-contracts (second k/v-contracts)])
+    (and (dict-immutability/c immutable?)
+         (if exact?
+             (set=? (dict-keys d) key-contracts)
+             #t)
+         (for/and ([kc key-contracts]
+                   [vc value-contracts])
+           (let ([found-key (box #f)])
+             (and
+              (for/and ([(k v) (in-dict d)]
+                       #:when ((flat-contract-predicate kc) k))
+               (set-box! found-key #t)
+               ((flat-contract-predicate vc) v))
+              (if mandatory-keys? (unbox found-key) #t)))))))
+

--- a/racket/collects/racket/private/dict-contracts.rkt
+++ b/racket/collects/racket/private/dict-contracts.rkt
@@ -45,7 +45,7 @@
   (let* ([k/v-contracts (apply unzip-args key-value-args)]
          [key-contracts (first k/v-contracts)]
          [value-contracts (second k/v-contracts)])
-    (and (dict-immutability/c immutable?)
+    (and ((dict-immutability/c immutable?) d)
          (if exact?
              (set=? (dict-keys d) key-contracts)
              #t)


### PR DESCRIPTION
Added advanced dictionary contracts for recognizing dictionaries with
contracted keys and values. In particular:
+ homogeneous-dictof, where all keys and values satisfy contracts uniformly
+ heterogeneous-dictof, where keys and values satisfy matching pairs of
  contracts, and keys can be optional.
+ dict-mutability/c, a convenience for recognizing mutable dicts based on an
  input
+ dict-immutability/c, a convenience for recognizing immutable dicts based on an
  input

Design informed by discussions with Jonathan Chan, Philip McGrath, Ben Greenman, Robby
Findler, Jack Firth, and George Neuner.
https://groups.google.com/g/racket-users/c/EuIcgVj2ILk/m/wNarkW7xBwAJ