### PR TITLE
doc: change define-struct to struct whenever possible

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/unit.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/unit.scrbl
@@ -73,14 +73,14 @@ racket
 
   (printf "Factory started.\n")
 
-  (define-struct toy (color) #:transparent)
+  (struct toy (color) #:transparent)
 
   (define (build-toys n)
     (for/list ([i (in-range n)])
-      (make-toy 'blue)))
+      (toy 'blue)))
 
   (define (repaint t col)
-    (make-toy col)))
+    (toy col)))
 
 (provide simple-factory@)
 ]
@@ -212,13 +212,13 @@ racket
   (import toy-store^)
   (export toy-factory^)
 
-  (define-struct toy () #:transparent)
+  (struct toy () #:transparent)
 
   (define (toy-color t) (store-color))
 
   (define (build-toys n)
     (for/list ([i (in-range n)])
-      (make-toy)))
+      (toy)))
 
   (define (repaint t col)
     (error "cannot repaint")))
@@ -441,14 +441,14 @@ racket/unit
 
 (printf "Factory started.\n")
 
-(define-struct toy (color) #:transparent)
+(struct toy (color) #:transparent)
 
 (define (build-toys n)
   (for/list ([i (in-range n)])
-    (make-toy 'blue)))
+    (toy 'blue)))
 
 (define (repaint t col)
-  (make-toy col))
+  (toy col))
 ]
 
 The unit @racket[simple-factory@] is automatically provided from the
@@ -500,14 +500,14 @@ racket
 
   (printf "Factory started.\n")
 
-  (define-struct toy (color) #:transparent)
+  (struct toy (color) #:transparent)
 
   (define (build-toys n)
     (for/list ([i (in-range n)])
-      (make-toy 'blue)))
+      (toy 'blue)))
 
   (define (repaint t col)
-    (make-toy col)))
+    (toy col)))
 
 (provide contracted-simple-factory@)
 ]
@@ -553,14 +553,14 @@ racket
 
   (printf "Factory started.\n")
 
-  (define-struct toy (color) #:transparent)
+  (struct toy (color) #:transparent)
 
   (define (build-toys n)
     (for/list ([i (in-range n)])
-      (make-toy 'blue)))
+      (toy 'blue)))
 
   (define (repaint t col)
-    (make-toy col)))
+    (toy col)))
 
 (provide wrapped-simple-factory@)
 ]

--- a/pkgs/racket-doc/scribblings/reference/evts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/evts.scrbl
@@ -379,20 +379,21 @@ and the @racket[prop:input-port] property takes precedence over
 @racket[prop:output-port] for synchronization.
 
 @examples[
-(define-struct wt (base val)
-               #:property prop:evt (struct-field-index base))
+(struct wt (base val)
+  #:property prop:evt (struct-field-index base))
 
 (define sema (make-semaphore))
-(sync/timeout 0 (make-wt sema #f))
+(sync/timeout 0 (wt sema #f))
 (semaphore-post sema)
-(sync/timeout 0 (make-wt sema #f))
+(sync/timeout 0 (wt sema #f))
 (semaphore-post sema)
-(sync/timeout 0 (make-wt (lambda (self) (wt-val self)) sema))
+(sync/timeout 0 (wt (lambda (self) (wt-val self)) sema))
 (semaphore-post sema)
-(define my-wt (make-wt (lambda (self) (wrap-evt
-                                       (wt-val self)
-                                       (lambda (x) self)))
-                       sema))
+(define my-wt (wt (lambda (self)
+                    (wrap-evt
+                     (wt-val self)
+                     (lambda (x) self)))
+                  sema))
 (sync/timeout 0 my-wt)
 (sync/timeout 0 my-wt)
 ]}

--- a/pkgs/racket-doc/scribblings/reference/exns.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/exns.scrbl
@@ -97,12 +97,12 @@ exception handler obtains control, and the handler itself is
 (with-handlers ([number? (lambda (n)
                            (+ n 5))])
   (raise 18 #t))
-(define-struct (my-exception exn:fail:user) ())
+(struct my-exception exn:fail:user ())
 (with-handlers ([my-exception? (lambda (e)
                                  #f)])
-  (+ 5 (raise (make-my-exception
-                "failed"
-                (current-continuation-marks)))))
+  (+ 5 (raise (my-exception
+               "failed"
+               (current-continuation-marks)))))
 (eval:error (raise 'failed #t))
 ]}
 
@@ -916,14 +916,12 @@ As an example,
 ;; prop:exn:srcloc protocol.  It carries
 ;; with it the location of the syntax that
 ;; is guilty.
-(define-struct (exn:fail:he-who-shall-not-be-named
-                exn:fail)
+(struct exn:fail:he-who-shall-not-be-named exn:fail
   (a-srcloc)
   #:property prop:exn:srclocs
   (lambda (a-struct)
     (match a-struct
-      [(struct exn:fail:he-who-shall-not-be-named
-         (msg marks a-srcloc))
+      [(exn:fail:he-who-shall-not-be-named msg marks a-srcloc)
        (list a-srcloc)])))
 
 ;; We can play with this by creating a form that
@@ -935,7 +933,7 @@ As an example,
        [(and (identifier? #'expr)
              (eq? (syntax-e #'expr) 'voldemort))
         (quasisyntax/loc stx
-          (raise (make-exn:fail:he-who-shall-not-be-named
+          (raise (exn:fail:he-who-shall-not-be-named
                   "oh dear don't say his name"
                   (current-continuation-marks)
                   (srcloc '#,(syntax-source #'expr)
@@ -957,8 +955,7 @@ As an example,
 (f 7)
 (g 7)  
 ;; The error should highlight the use
-;; of the one-who-shall-not-be-named
-;; in g.
+;; of voldemort in g.
 }|
 
 @defproc[(exn:srclocs? [v any/c]) boolean?]{

--- a/pkgs/racket-doc/scribblings/reference/generic.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/generic.scrbl
@@ -183,7 +183,7 @@ syntax error.}
                                    #:width w #:height [h 0])
                  (fprintf port "String (~ax~a): ~a" w h s))]))
 
-(define-struct num (v)
+(struct num (v)
   #:methods gen:printable
   [(define/generic super-print gen-print)
    (define (gen-print n [port (current-output-port)])
@@ -194,7 +194,7 @@ syntax error.}
                        #:width w #:height [h 0])
      (fprintf port "Num (~ax~a): ~a" w h (num-v n)))])
 
-(define-struct bool (v)
+(struct bool (v)
   #:methods gen:printable
   [(define/generic super-print gen-print)
    (define (gen-print b [port (current-output-port)])
@@ -207,14 +207,14 @@ syntax error.}
      (fprintf port "Bool (~ax~a): ~a" w h
               (if (bool-v b) "Yes" "No")))])
 
-(define x (make-num 10))
+(define x (num 10))
 (gen-print x)
 (gen-port-print (current-output-port) x)
 (gen-print* x #:width 100 #:height 90)
 
 (gen-print "Strings are printable too!")
 
-(define y (make-bool #t))
+(define y (bool #t))
 (gen-print y)
 (gen-port-print (current-output-port) y)
 (gen-print* y #:width 100 #:height 90)
@@ -227,7 +227,7 @@ syntax error.}
         [gen-print* (->* (printable? #:width exact-nonnegative-integer?)
                          (output-port? #:height exact-nonnegative-integer?)
                          void?)]))
-   make-num)
+   num)
 
 (define z (make-num-contracted 10))
 (eval:error (gen-print* z #:width "not a number" #:height 5))

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -764,7 +764,7 @@ each element in the sequence.
   @let-syntax[([car (make-element-id-transformer
                      (lambda (id) #'@racketidfont{car}))])
     @examples[
-      (define-struct train (car next)
+      (struct train (car next)
         #:property prop:sequence
         (lambda (t)
           (make-do-sequence
@@ -773,10 +773,10 @@ each element in the sequence.
                      (lambda (t) t)
                      (lambda (v) #t)
                      (lambda (t v) #t))))))
-      (for/list ([c (make-train 'engine
-                                (make-train 'boxcar
-                                            (make-train 'caboose
-                                                        #f)))])
+      (for/list ([c (train 'engine
+                           (train 'boxcar
+                                  (train 'caboose
+                                         #f)))])
         c)]]}
 
 @; ----------------------------------------------------------------------

--- a/pkgs/racket-doc/scribblings/reference/struct-inspectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/struct-inspectors.scrbl
@@ -18,7 +18,7 @@ opaque to ``peer'' code that cannot access the parent inspector.
 The @racket[current-inspector] @tech{parameter} determines a default
 inspector argument for new structure types. An alternate inspector can
 be provided though the @racket[#:inspector] option of the
-@racket[define-struct] form (see @secref["define-struct"]), or
+@racket[struct] form (see @secref["define-struct"]), or
 through an optional @racket[inspector] argument to
 @racket[make-struct-type].
 

--- a/pkgs/racket-doc/scribblings/reference/struct.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/struct.scrbl
@@ -723,13 +723,13 @@ default), an error is raised. If it is @racket['return-false],
 the inaccessible fields are omitted from the list.
 
 @examples[#:eval struct-eval
-(define-struct open (u v) #:transparent)
-(struct->list (make-open 'a 'b))
+(struct open (u v) #:transparent)
+(struct->list (open 'a 'b))
 (struct->list #s(pre 1 2 3))
-(define-struct (secret open) (x y))
-(eval:error (struct->list (make-secret 0 1 17 22)))
-(struct->list (make-secret 0 1 17 22) #:on-opaque 'return-false)
-(struct->list (make-secret 0 1 17 22) #:on-opaque 'skip)
+(struct secret open (x y))
+(eval:error (struct->list (secret 0 1 17 22)))
+(struct->list (secret 0 1 17 22) #:on-opaque 'return-false)
+(struct->list (secret 0 1 17 22) #:on-opaque 'skip)
 (struct->list 'not-a-struct #:on-opaque 'return-false)
 (struct->list 'not-a-struct #:on-opaque 'skip)
 ]

--- a/pkgs/racket-doc/syntax/scribblings/struct.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/struct.scrbl
@@ -15,7 +15,7 @@ Parses @racket[stx] as a @racket[define-struct] form, but uses
 @racket[orig-stx] to report syntax errors (under the assumption that
 @racket[orig-stx] is the same as @racket[stx], or that they at least share
 sub-forms). The result is four values: an identifier for the struct
-type name, a identifier or #f for the super-name, a list of
+type name, a identifier or @racket[#f] for the super-name, a list of
 identifiers for fields, and a syntax object for the inspector
 expression.}
 


### PR DESCRIPTION
As documented, `define-struct` "is provided for backwards compatibility;
struct is preferred". This PR changes uses of `define-struct` to
`struct` whenever possible in the docs.