### PR TITLE
cs: optimize unsafe struct operations

### DIFF
--- a/racket/src/cs/rumble/box.ss
+++ b/racket/src/cs/rumble/box.ss
@@ -6,8 +6,8 @@
 
 ;; ----------------------------------------
 
-(define-record box-chaperone chaperone (ref set))
-(define-record box-impersonator impersonator (ref set))
+(define-impersonator-record box-chaperone chaperone (ref set))
+(define-impersonator-record box-impersonator impersonator (ref set))
 
 (define (box? v)
   (or (#%box? v)
@@ -136,10 +136,10 @@
            [else (loop next val)]))]))]))
 
 (define (set-box-impersonator-hash!)
-  (record-type-hash-procedure (record-type-descriptor box-chaperone)
+  (record-type-hash-procedure (impersonator-descriptor box-chaperone)
                               (lambda (c hash-code)
                                 (hash-code (box (unbox c)))))
-  (record-type-hash-procedure (record-type-descriptor box-impersonator)
+  (record-type-hash-procedure (impersonator-descriptor box-impersonator)
                               (lambda (i hash-code)
                                 (hash-code (box (unbox i))))))
 

--- a/racket/src/cs/rumble/control.ss
+++ b/racket/src/cs/rumble/control.ss
@@ -1564,8 +1564,8 @@
 (define-record-type (continuation-mark-key create-continuation-mark-key authentic-continuation-mark-key?)
   (fields (mutable name))) ; `mutable` ensures that `create-...` allocates
 
-(define-record continuation-mark-key-impersonator impersonator (get set))
-(define-record continuation-mark-key-chaperone chaperone (get set))
+(define-impersonator-record continuation-mark-key-impersonator impersonator (get set))
+(define-impersonator-record continuation-mark-key-chaperone chaperone (get set))
 
 (define make-continuation-mark-key
   (case-lambda
@@ -1673,8 +1673,8 @@
       (and (impersonator? v)
            (authentic-continuation-prompt-tag? (impersonator-val v)))))
 
-(define-record continuation-prompt-tag-impersonator impersonator (procs))
-(define-record continuation-prompt-tag-chaperone chaperone (procs))
+(define-impersonator-record continuation-prompt-tag-impersonator impersonator (procs))
+(define-impersonator-record continuation-prompt-tag-chaperone chaperone (procs))
 
 (define-record continuation-prompt-tag-procs (handler abort cc-guard cc-impersonate))
 

--- a/racket/src/cs/rumble/hash.ss
+++ b/racket/src/cs/rumble/hash.ss
@@ -901,9 +901,9 @@
   (record-type-hash-procedure (record-type-descriptor mutable-hash)
                               hash-hash-code)
 
-  (record-type-hash-procedure (record-type-descriptor hash-impersonator)
+  (record-type-hash-procedure (impersonator-descriptor hash-impersonator)
                               hash-hash-code)
-  (record-type-hash-procedure (record-type-descriptor hash-chaperone)
+  (record-type-hash-procedure (impersonator-descriptor hash-chaperone)
                               hash-hash-code))
 
 ;; ----------------------------------------
@@ -912,8 +912,8 @@
 ;; `impersonator-of?` and `chaperone-of?`:
 (define-record hash-procs (ref set remove key clear equal-key))
 
-(define-record hash-impersonator impersonator (procs))
-(define-record hash-chaperone chaperone (procs))
+(define-impersonator-record hash-impersonator impersonator (procs))
+(define-impersonator-record hash-chaperone chaperone (procs))
 
 (define/who (impersonate-hash ht ref set remove key . args)
   (check who

--- a/racket/src/cs/rumble/inline.ss
+++ b/racket/src/cs/rumble/inline.ss
@@ -83,9 +83,9 @@
   |#%app/no-return|)
 
 (define-inline (unsafe-struct-ref s i)
-  (not (impersonator? s))
+  (unsafe-struct-not-impersonator? s)
   (unsafe-struct*-ref s i))
 
 (define-inline (unsafe-struct-set! s i v)
-  (not (impersonator? s))
+  (unsafe-struct-not-impersonator? s)
   (unsafe-struct*-set! s i v))

--- a/racket/src/cs/rumble/procedure.ss
+++ b/racket/src/cs/rumble/procedure.ss
@@ -603,11 +603,11 @@
 
 ;; ----------------------------------------
 
-(define-record procedure-impersonator impersonator (wrapper arity-mask))
-(define-record procedure-chaperone chaperone (wrapper arity-mask))
+(define-impersonator-record procedure-impersonator impersonator (wrapper arity-mask))
+(define-impersonator-record procedure-chaperone chaperone (wrapper arity-mask))
 
-(define-record procedure*-impersonator procedure-impersonator ())
-(define-record procedure*-chaperone procedure-chaperone ())
+(define-impersonator-record procedure*-impersonator procedure-impersonator ())
+(define-impersonator-record procedure*-chaperone procedure-chaperone ())
 
 (define-values (impersonator-prop:application-mark application-mark? application-mark-ref)
   (make-impersonator-property 'application-mark))
@@ -806,10 +806,10 @@
               (apply p args)]))]))])))
 
 (define (set-procedure-impersonator-hash!)
-  (record-type-hash-procedure (record-type-descriptor procedure-chaperone)
+  (record-type-hash-procedure (impersonator-descriptor procedure-chaperone)
                               (lambda (c hash-code)
                                 (hash-code (impersonator-next c))))
-  (record-type-hash-procedure (record-type-descriptor procedure-impersonator)
+  (record-type-hash-procedure (impersonator-descriptor procedure-impersonator)
                               (lambda (i hash-code)
                                 (hash-code (impersonator-next i)))))
 
@@ -867,8 +867,8 @@
 
 ;; ----------------------------------------
 
-(define-record unsafe-procedure-impersonator impersonator (replace-proc))
-(define-record unsafe-procedure-chaperone chaperone (replace-proc))
+(define-impersonator-record unsafe-procedure-impersonator impersonator (replace-proc))
+(define-impersonator-record unsafe-procedure-chaperone chaperone (replace-proc))
 
 (define/who (unsafe-impersonate-procedure proc replace-proc . props)
   (do-unsafe-impersonate-procedure who make-unsafe-procedure-impersonator
@@ -1067,26 +1067,26 @@
            (lambda (rtd)
              (register-procedure-impersonator-struct-type! rtd)
              (struct-property-set! prop:procedure-arity rtd 4))])
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure-chaperone))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure-impersonator))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure*-chaperone))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure*-impersonator))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure-struct-chaperone))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure-struct-impersonator))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure~-struct-chaperone))
-      (register-procedure-impersonator-struct-type! (record-type-descriptor procedure~-struct-impersonator)))
-    (register-procedure-impersonator-struct-type! (record-type-descriptor procedure-struct-undefined-chaperone))
-    (register-procedure-impersonator-struct-type! (record-type-descriptor procedure~-struct-undefined-chaperone)))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure-chaperone))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure-impersonator))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure*-chaperone))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure*-impersonator))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure-struct-chaperone))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure-struct-impersonator))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure~-struct-chaperone))
+      (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure~-struct-impersonator)))
+    (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure-struct-undefined-chaperone))
+    (register-procedure-impersonator-struct-type! (impersonator-descriptor procedure~-struct-undefined-chaperone)))
 
   (let ([register-procedure-incomplete-arity!
          (lambda (rtd)
            (struct-property-set! prop:incomplete-arity rtd #t))])
-    (register-procedure-incomplete-arity! (record-type-descriptor procedure~-struct-chaperone))
-    (register-procedure-incomplete-arity! (record-type-descriptor procedure~-struct-impersonator))
-    (register-procedure-incomplete-arity! (record-type-descriptor procedure~-struct-undefined-chaperone)))
+    (register-procedure-incomplete-arity! (impersonator-descriptor procedure~-struct-chaperone))
+    (register-procedure-incomplete-arity! (impersonator-descriptor procedure~-struct-impersonator))
+    (register-procedure-incomplete-arity! (impersonator-descriptor procedure~-struct-undefined-chaperone)))
 
   (let ([register-unsafe-procedure-impersonator-struct-type!
          (lambda (rtd)
            (struct-property-set! prop:procedure rtd 'unsafe))])
-    (register-unsafe-procedure-impersonator-struct-type! (record-type-descriptor unsafe-procedure-chaperone))
-    (register-unsafe-procedure-impersonator-struct-type! (record-type-descriptor unsafe-procedure-impersonator))))
+    (register-unsafe-procedure-impersonator-struct-type! (impersonator-descriptor unsafe-procedure-chaperone))
+    (register-unsafe-procedure-impersonator-struct-type! (impersonator-descriptor unsafe-procedure-impersonator))))

--- a/racket/src/cs/rumble/vector.ss
+++ b/racket/src/cs/rumble/vector.ss
@@ -30,8 +30,8 @@
 
 ;; ----------------------------------------
 
-(define-record vector-chaperone chaperone (ref set))
-(define-record vector-impersonator impersonator (ref set))
+(define-impersonator-record vector-chaperone chaperone (ref set))
+(define-impersonator-record vector-impersonator impersonator (ref set))
 
 (define/who (chaperone-vector vec ref set . props)
   (check who vector? vec)
@@ -61,10 +61,10 @@
         (make-props-impersonator val vec props))))
 
 (define (set-vector-impersonator-hash!)
-  (record-type-hash-procedure (record-type-descriptor vector-chaperone)
+  (record-type-hash-procedure (impersonator-descriptor vector-chaperone)
                               (lambda (c hash-code)
                                 (hash-code (vector-copy c))))
-  (record-type-hash-procedure (record-type-descriptor vector-impersonator)
+  (record-type-hash-procedure (impersonator-descriptor vector-impersonator)
                               (lambda (i hash-code)
                                 (hash-code (vector-copy i)))))
 
@@ -77,8 +77,8 @@
 
 ;; ----------------------------------------
 
-(define-record vector*-chaperone vector-chaperone ())
-(define-record vector*-impersonator vector-impersonator ())
+(define-impersonator-record vector*-chaperone vector-chaperone ())
+(define-impersonator-record vector*-impersonator vector-impersonator ())
 
 (define/who (chaperone-vector* vec ref set . props)
   (check who vector? vec)
@@ -109,8 +109,8 @@
 
 ;; ----------------------------------------
 
-(define-record vector-unsafe-chaperone chaperone (vec))
-(define-record vector-unsafe-impersonator impersonator (vec))
+(define-impersonator-record vector-unsafe-chaperone chaperone (vec))
+(define-impersonator-record vector-unsafe-impersonator impersonator (vec))
 
 (define/who (unsafe-impersonate-vector vec alt-vec . props)
   (check who mutable-vector? :contract "(and/c vector? (not/c immutable?))" vec)


### PR DESCRIPTION
This intends to make pattern matching on structs faster. It works by ensuring rtds of impersonators themselves share same rtd, so the checks of `unsafe-struct-ref/set!` could be simplified.

A simple benchmark:
```racket
#lang racket
(struct A (a b c d))
           
(define (f n)
  (cond
    [(= n 0) 1]
    [else
     (define a (f (sub1 n)))
     (A a a a a)]))

(define t (f 13))

(define (g x)
  (let g ([x x])
    (match x
      [(A a b c d)
       (g a) (g b) (g c) (g d)]
      [else (void)])))

(collect-garbage)
(time (g t))
```
on my machine:
master
```
cpu time: 340 real time: 346 gc time: 0
```
here
```
cpu time: 246 real time: 251 gc time: 0
```
bc
```
cpu time: 215 real time: 216 gc time: 0
```

This makes the performance of pattern matching on struct closer to bc, but still slower. Another drawback is that it defeats optimization introduced in #3531. So this might be not good enough currently.
Also, the `define-impersonator-record` might need more syntax checks.