### PR TITLE
Improve errors for forbidden ops on weak sets

### DIFF
--- a/racket/collects/racket/private/set-types.rkt
+++ b/racket/collects/racket/private/set-types.rkt
@@ -682,7 +682,7 @@
                     "given ~a: ~e\n"
                     "argument position: 1st")
      method-name
-     (if immut "(not/c set-mutable?)" "set-mutable?")
+     (if immut "(not/c (or/c set-mutable? set-weak?))" "(or/c set-mutable? set-weak?)")
      (if immut "mutable set" "immutable set")
      s)
     (current-continuation-marks))))


### PR DESCRIPTION
Forbidden set operations on weak sets produced slightly confusing error messages:

```racket
> (define s (weak-set))
> (set-add s 42)
; set-add:
; expected: (not/c set-mutable?)
; given mutable set: (weak-set)
; argument position: 1st
> (set-mutable? s)
#f
```

Invoking an operation that required an immutable set gave a message saying that a `(not/c set-mutable?)` was expected, but a `weak-set` is not recognized by `set-mutable?`, which only recognizes mutable sets with strongly-held keys. Changing `set-mutable?` to recognize weak sets seems undesirable (and a breaking change).

This patch changes the error message so that the above example produces the following error:

```racket
> (define s (weak-set))
> (set-add s 42)
; set-add:
; expected: (not/c (or/c set-mutable? set-weak?))
; given mutable set: (weak-set)
; argument position: 1st
```

It does make the error message a bit longer, but it might save some people from some confusion.

There might be a cleaner way to clarify this. Could the "not a mutable or weak set" be simplified to "an immutable set"? I.e. changing the error to `expected: set?`? Or would that be confusing in a different way, because it's okay to pass in, e.g., a `list?`?