### PR TITLE
xexpr: micro-optimize xexpr-write

### DIFF
--- a/racket/collects/xml/private/xexpr.rkt
+++ b/racket/collects/xml/private/xexpr.rkt
@@ -1,11 +1,11 @@
 #lang racket/base
-(require racket/pretty
+(require racket/contract
          racket/list
-         racket/contract
-         "xexpr-core.rkt"
-         "structures.rkt"
+         racket/symbol
          "reader.rkt"
-         "writer.rkt")
+         "structures.rkt"
+         "writer.rkt"
+         "xexpr-core.rkt")
 
 ;; sorting is no longer necessary, since xt3d uses xml->zxexpr, which sorts.
 
@@ -122,45 +122,46 @@
              (values (cadr x) (cddr x))
              (values null (cdr x))))
        ; Write opening tag
-       (write-string "<" out)
-       (display name out)
+       (write-bytes #"<" out)
+       (write-string (symbol->immutable-string name) out)
        ; Write attributes
        (for ([att (in-list attrs)])
-         (write-string " " out)
-         (display (car att) out)
-         (write-string "=\"" out)
+         (write-bytes #" " out)
+         (write-string (symbol->immutable-string (car att)) out)
+         (write-bytes #"=\"" out)
          (write-string/escape (cadr att) escape-attribute-table out)
-         (write-string "\"" out))
+         (write-bytes #"\"" out))
        (when insert-newlines?
          (newline out))
        ; Write end of opening tag
-       (if (and (null? content)
-                (case short
-                    [(always) #t]
-                    [(never) #f]
-                    [else (memq (lowercase-symbol name) short)]))
-           (write-string "/>" out)
-           (begin
-             (write-string ">" out)
-             ; Write body
-             (for ([xe (in-list content)])
-               (loop xe))
-             ; Write closing tag
-             (write-string "</" out)
-             (display name out)
-             (write-string ">" out)))]
+       (cond
+         [(and (null? content)
+               (case short
+                 [(always) #t]
+                 [(never) #f]
+                 [else (memq (lowercase-symbol name) short)]))
+          (write-bytes #"/>" out)]
+         [else
+          (write-bytes #">" out)
+          ; Write body
+          (for ([xe (in-list content)])
+            (loop xe))
+          ; Write closing tag
+          (write-bytes #"</" out)
+          (write-string (symbol->immutable-string name) out)
+          (write-bytes #">" out)])]
       ; PCData
       [(string? x)
        (write-string/escape x escape-table out)]
       ; Entities
       [(symbol? x)
-       (write-string "&" out)
-       (display x out)
-       (write-string ";" out)]
+       (write-bytes #"&" out)
+       (write-string (symbol->immutable-string x) out)
+       (write-bytes #";" out)]
       [(valid-char? x)
-       (write-string "&#" out)
-       (display x out)
-       (write-string ";" out)]
+       (write-bytes #"&#" out)
+       (write-string (number->string x) out)
+       (write-bytes #";" out)]
       ; Embedded XML
       [(cdata? x)
        (write-xml-cdata x 0 void out)]


### PR DESCRIPTION
This improves write performance by between 10% and 40% on large xexprs in [this benchmark](https://gist.github.com/Bogdanp/73d168da046c295f6c3b99b92d07550b).

Before (matchacha.ro):

```
cpu time: 1270 real time: 1309 gc time: 42
```

After (matchacha.ro):

```
cpu time: 1002 real time: 1033 gc time: 60
```

Before (nytimes.com):

```
cpu time: 7440 real time: 7695 gc time: 387
```

After (nytimes.com):

```
cpu time: 6134 real time: 6343 gc time: 359
```
