### PR TITLE
adding different indentation to XML

### DIFF
--- a/racket/collects/xml/private/writer.rkt
+++ b/racket/collects/xml/private/writer.rkt
@@ -2,11 +2,15 @@
 (require racket/contract
          "structures.rkt")
 
+; Within this file, `Dent` is used in comments and `dent` is used in code
+; to refer to this contract:
+(define indentation? (or/c 'none 'classic 'peek 'scan))
+
 (provide/contract
  [write-xml ((document?) (output-port?) . ->* . void?)]
- [display-xml ((document?) (output-port?) . ->* . void?)]
+ [display-xml ((document?) (output-port? #:indentation indentation?) . ->* . void?)]
  [write-xml/content ((content/c) (output-port?) . ->* . void?)]
- [display-xml/content ((content/c) (output-port?) . ->* . void?)]
+ [display-xml/content ((content/c) (output-port? #:indentation indentation?) . ->* . void?)]
  [empty-tag-shorthand (parameter/c (or/c (symbols 'always 'never) (listof symbol?)))]
  [html-empty-tags (listof symbol?)])
 
@@ -22,10 +26,6 @@
          x
          (error 'empty-tag-shorthand "expected 'always, 'never, or a list of symbols: received ~e" x)))))
 
-;; gen-write/display-xml/content : (Nat Output-port -> Void) -> Content [Output-Port]-> Void
-(define (gen-write/display-xml/content dent)
-  (lambda (c [out (current-output-port)]) (write-xml-content c 0 dent out)))
-
 ;; indent : Nat Output-port -> Void
 (define (indent n out)
   (newline out)
@@ -35,20 +35,27 @@
       (loop (sub1 n)))))
 
 ;; write-xml/content : Content [Output-port] -> Void
-(define write-xml/content (gen-write/display-xml/content void))
+(define (write-xml/content c [out (current-output-port)])
+  (display-xml/content c out #:indentation 'none))
 
-;; display-xml/content : Content [Output-port] -> Void
-(define display-xml/content (gen-write/display-xml/content indent))
+;; display-xml/content : Content [Output-port] [#:indentation Dent] -> Void
+(define (display-xml/content c [out (current-output-port)]
+                             #:indentation [dent 'classic])
+  (write-xml-content c 0 dent out))
 
-;; gen-write/display-xml : (Content [Output-port] -> Void) -> Document [Output-port] -> Void
-(define (gen-write/display-xml output-content)
-  (lambda (doc [out (current-output-port)])
-    (let ([prolog (document-prolog doc)])
-      (display-outside-misc (prolog-misc prolog) out)
-      (display-dtd (prolog-dtd prolog) out)
-      (display-outside-misc (prolog-misc2 prolog) out))
-    (output-content (document-element doc) out)
-    (display-outside-misc (document-misc doc) out)))
+;; write-xml : Document [Output-port] -> Void
+(define (write-xml doc [out (current-output-port)])
+  (display-xml doc out #:indentation 'none))
+
+;; display-xml : Document [Output-port] [#:indentation Dent] -> Void
+(define (display-xml doc [out (current-output-port)]
+                     #:indentation [dent 'classic])
+  (let ([prolog (document-prolog doc)])
+    (display-outside-misc (prolog-misc prolog) out)
+    (display-dtd (prolog-dtd prolog) out)
+    (display-outside-misc (prolog-misc2 prolog) out))
+  (display-xml/content (document-element doc) out #:indentation dent)
+  (display-outside-misc (document-misc doc) out))
 
 ; display-dtd : document-type oport -> void
 (define (display-dtd dtd out)
@@ -66,22 +73,16 @@
     (display ">" out)
     (newline out)))
 
-;; write-xml : Document [Output-port] -> Void
-(define write-xml (gen-write/display-xml write-xml/content))
-
-;; display-xml : Document [Output-port] -> Void
-(define display-xml (gen-write/display-xml display-xml/content))
-
 ;; display-outside-misc : (listof Misc) Output-port -> Void
 (define (display-outside-misc misc out)
   (for-each (lambda (x)
               ((cond
                  [(comment? x) write-xml-comment]
-                 [(p-i? x) write-xml-p-i]) x 0 void out)
+                 [(p-i? x) write-xml-p-i]) x 0 'none out)
               (newline out))
             misc))
 
-;; write-xml-content : Content Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+;; write-xml-content : Content Nat Dent Output-Stream -> Void
 (define (write-xml-content el over dent out)
   ((cond
      [(element? el) write-xml-element]
@@ -93,14 +94,16 @@
      [else (error 'write-xml-content "received ~e" el)])
    el over dent out))
 
-;; write-xml-element : Element Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+(define whitespace-sensitive? pcdata?)
+
+;; write-xml-element : Element Nat Dent Output-Stream -> Void
 (define (write-xml-element el over dent out)
   (let* ([name (element-name el)]
-         [start (lambda (str) 
+         [start (lambda (str dent)
                   (write-xml-base str over dent out)
                   (display name out))]
          [content (element-content el)])
-    (start "<")
+    (start "<" dent)
     (for ([att (in-list (element-attributes el))])
       (fprintf out " ~a=\"~a\"" (attribute-name att)
                (escape (attribute-value att) escape-attribute-table)))
@@ -111,11 +114,20 @@
                  [(never) #f]
                  [else (memq (lowercase-symbol name) short)])))
         (display " />" out)
-        (begin
+        (let ([dent-kids (case dent
+                           [(peek)
+                            (if (whitespace-sensitive? (car content))
+                                'none
+                                dent)]
+                           [(scan)
+                            (if (ormap whitespace-sensitive? content)
+                                'none
+                                dent)]
+                           [else dent])])
           (display ">" out)
           (for ([c (in-list content)])
-            (write-xml-content c (incr over) dent out))
-          (start "</")
+            (write-xml-content c (incr over) dent-kids out))
+          (start "</" dent-kids)
           (display ">" out)))))
 
 ; : sym -> sym
@@ -127,29 +139,35 @@
           (hash-set! lowercases x s)
           s))))
 
-;; write-xml-base : (U String Char Symbol) Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+;; write-xml-base : (U String Char Symbol) Nat Dent Output-Stream -> Void
 (define (write-xml-base el over dent out)
-  (dent over out)
+  (case dent
+    [(classic peek scan)
+     (indent over out)]
+    [(none)
+     (void)]
+    [else
+     (error "Bug in xml package - unexpected indentation: " dent)])
   (display el out))
 
-;; write-xml-pcdata : Pcdata Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+;; write-xml-pcdata : Pcdata Nat Dent Output-Stream -> Void
 (define (write-xml-pcdata str over dent out)
   (write-xml-base (escape (pcdata-string str) escape-table) over dent out))
 
-;; write-xml-cdata : Cdata Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+;; write-xml-cdata : Cdata Nat Dent Output-Stream -> Void
 (define (write-xml-cdata cdata over dent out)
   ;; XXX: Different kind of quote is needed, for assume the user includes the <![CDATA[...]]> with proper quoting
   (write-xml-base (format "~a" (cdata-string cdata)) over dent out))
 
-;; write-xml-p-i : Processing-instruction Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+;; write-xml-p-i : Processing-instruction Nat Dent Output-Stream -> Void
 (define (write-xml-p-i p-i over dent out)
   (write-xml-base (format "<?~a ~a?>" (p-i-target-name p-i) (p-i-instruction p-i)) over dent out))
 
-;; write-xml-comment : Comment Nat (Nat Output-Stream -> Void) Output-Stream -> Void
+;; write-xml-comment : Comment Nat Dent Output-Stream -> Void
 (define (write-xml-comment comment over dent out)
   (write-xml-base (format "<!--~a-->" (comment-text comment)) over dent out))
 
-;; write-xml-entity : Entity Nat (Nat Output-stream -> Void) Output-stream -> Void
+;; write-xml-entity : Entity Nat Dent Output-stream -> Void
 (define (write-xml-entity entity over dent out)
   (let ([n (entity-text entity)])
     (fprintf out (if (number? n) "&#~a;" "&~a;") n)))

--- a/racket/collects/xml/private/xexpr.rkt
+++ b/racket/collects/xml/private/xexpr.rkt
@@ -163,11 +163,11 @@
        (write-string ";" out)]
       ; Embedded XML
       [(cdata? x)
-       (write-xml-cdata x 0 void out)]
+       (write-xml-cdata x 0 'none out)]
       [(comment? x)
-       (write-xml-comment x 0 void out)]
+       (write-xml-comment x 0 'none out)]
       [(p-i? x)
-       (write-xml-p-i x 0 void out)]))
+       (write-xml-p-i x 0 'none out)]))
   (void))
 
 ;; given a string, encode it in the style required for attributes. Specifically,


### PR DESCRIPTION
Working on issue #3678.

I still need to update the documentation and add some more tests, but I want to get your thoughts on this approach first. (This PR should be marked as a draft in Github.)

The 4 indentation styles are:

- `'none` No indentation. Behaves the same as `write-xml`.
- `'classic` Indents every node. Keeps the same behavior that `display-xml` has today.
- `'scan` If any child node is "whitespace-sensitive", then none of the children are indented.
- `'peek` If the first child node is "whitespace-sensitive", then none of the children are indented.

Both `peek` and `scan` work well for XML that represents boring DTOs. More precisely, I mean XML that meets both of these conditions:

1. The only whitespace-sensitive nodes are pcdata nodes.
2. A pcdata node never has a non-pcdata sibling. (No mixed content.)

### HTML Support?
Currently `whitespace-sensitive?` is defined as `pcdata?`. It is possible that allowing the caller to provide their own predicate could help indent HTML better. For example, the caller might have a list of HTML tags to be considered whitespace-sensitive, as @sorawee suggested in #3678. This might work well enough in practice.

However, I'm not sure if "correct HTML indentation" can be well-defined in the general case. For example, `div` is not commonly whitespace-sensitive, but it's easy to write CSS that makes this untrue. So I'm not sure if it is worth adding this functionality and attempting to explain the caveats, or if we should just say "use `#:indentation 'none` when correctness matters."