### PR TITLE
racket/src/{bc,cs/c}/configure fix arg stripping

### DIFF
--- a/racket/src/bc/configure
+++ b/racket/src/bc/configure
@@ -7283,7 +7283,7 @@ for fixup_arg
 do
   case $fixup_arg in
   # Strip away all feature choices
-  -enable* | --enable* | -disable* | --disable*)
+  -enable* | --enable* | -disable* | --disable* | -collect* | --collect*)
     ;;
   *)
     case $fixup_arg in

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -5643,7 +5643,7 @@ for fixup_arg
 do
   case $fixup_arg in
   # Strip away all feature choices
-  -enable* | --enable* | -disable* | --disable*)
+  -enable* | --enable* | -disable* | --disable* | -collect* | --collect*)
     ;;
   *)
     case $fixup_arg in


### PR DESCRIPTION
rktio doesn't know how to handle the --collectsdir argument and will
stop the build process if it is passed to racket/src/configure, this
fixes the immediate issue but the underlying issue remains and other
unhandled arguments are likely to break rktio configure as well