### PR TITLE
cs: optimize pattern matching on authentic structs

### DIFF
--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -696,6 +696,18 @@
       (define-record-type ,my-rec (fields a))
       (define-record-type ,my-sub-rec (fields a) (parent ,my-rec) (sealed #t))
       (lambda (x) (and (my-rec? x) (list 'ok (#3%$sealed-record-instance? x (record-type-descriptor ,my-sub-rec)))))))
+
+  ;; obviously incompatible rtds
+  ;; the third pass is needed to eliminate #3%$value
+  (parameterize ([run-cp0 (lambda (cp0 x) (cp0 (cp0 (cp0 x))))])
+    (cptypes-equivalent-expansion?
+     `(let ()
+        (define-record I (a))
+        (define A (make-record-type-descriptor* 'a #f #f #f #f 1 0))
+        (lambda (x) (and ((record-predicate A) x) (I? x))))
+     `(begin
+        (make-record-type-descriptor* 'a #f #f #f #f 1 0)
+        (lambda (x) #f))))
 )
 
 (mat cptypes-unsafe

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -528,7 +528,10 @@ Notes:
           (make-pred-$record/rtd d)]
          [(ref ,maybe-src ,x)
           (guard (not (prelex-assigned x)))
-          (make-pred-$record/ref x)]
+          (make-pred-$record/ref x #f)]
+         [(record-type ,rtd (ref ,maybe-src ,x))
+          (guard (not (prelex-assigned x)))
+          (make-pred-$record/ref x rtd)]
          [(record-type ,rtd ,e)
           (rtd->record-predicate e extend?)]
          [else (if (not extend?) 'bottom '$record)])]


### PR DESCRIPTION
This eliminates the branch of `unsafe-struct-ref` on cptypes level. 

A benchmark:
https://gist.github.com/yjqww6/d20134c86a749cf19a1946e8a2aaecbc

Results (on a M1 Mac):
master
```
cpu time: 1458 real time: 1481 gc time: 261
420000
```
this
```
cpu time: 1088 real time: 1107 gc time: 333
420000
```

Alternative approach may be making `match` generate `unsafe-struct*-ref` directly.