### PR TITLE
Improve flat-murec-contract with random generation

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/equivalent.rkt
+++ b/pkgs/racket-test/tests/racket/contract/equivalent.rkt
@@ -352,6 +352,15 @@
       (define x (flat-rec-contract x (first-or/c (cons/c x '()) '())))
       (,test #:test-case-name 'flat-rec.2 #t contract-equivalent? x (first-or/c (cons/c x '()) '()))))
   
+  (contract-eval
+   `(let ()
+      (define x (flat-murec-contract ([x (or/c (cons/c x '()) '())]) x))
+      (,test #:test-case-name 'flat-murec.1 #t contract-equivalent? x (or/c (cons/c x '()) '()))))
+  (contract-eval
+   `(let ()
+      (define x (flat-murec-contract ([x (first-or/c (cons/c x '()) '())]) x))
+      (,test #:test-case-name 'flat-murec.2 #t contract-equivalent? x (first-or/c (cons/c x '()) '()))))
+
   (ctest #f contract-equivalent? "x" string?)
   (ctest #f contract-equivalent? string? "x")
 

--- a/pkgs/racket-test/tests/racket/contract/first-order.rkt
+++ b/pkgs/racket-test/tests/racket/contract/first-order.rkt
@@ -91,6 +91,13 @@
 
   (ctest #f contract-first-order-passes? (flat-rec-contract the-name) 1)
 
+  (ctest #f contract-first-order-passes?
+         (flat-murec-contract ([one 1]) one)
+         0)
+  (ctest #t contract-first-order-passes?
+         (flat-murec-contract ([one 1]) one)
+         1)
+
   (ctest #t contract-first-order-passes?
          (couple/c any/c any/c)
          (make-couple 1 2))

--- a/pkgs/racket-test/tests/racket/contract/name.rkt
+++ b/pkgs/racket-test/tests/racket/contract/name.rkt
@@ -359,6 +359,7 @@
   (test-name '(box/c boolean?) (box/c boolean?))
   (test-name '(box/c boolean?) (box/c (flat-contract boolean?)))
   (test-name 'the-name (flat-rec-contract the-name))
+  (test-name 'the-name (flat-murec-contract ([the-name none/c]) the-name))
 
   (test-name '(object-contract) (object-contract))
   (test-name '(object-contract (field x integer?)) (object-contract (field x integer?)))

--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -133,6 +133,14 @@
 (check-not-exn
  (λ ()
    (test-contract-generation
+    (flat-murec-contract
+     ([even-length-list/c '() (cons/c any/c odd-length-list/c)]
+      [odd-length-list/c (cons/c any/c even-length-list/c)])
+     even-length-list/c))))
+
+(check-not-exn
+ (λ ()
+   (test-contract-generation
     null?)))
 
 (check-not-exn
@@ -195,6 +203,19 @@
                        [l tree/c]
                        [r tree/c])
             #f)))))
+
+(check-not-exn
+ (λ ()
+   (struct node (v l r) #:transparent)
+   (struct red node () #:transparent)
+   (struct black node () #:transparent)
+   (test-contract-generation
+    (flat-murec-contract
+      ([red-or-black/c red/c black/c]
+       [red/c (struct/c red integer? black/c black/c)]
+       [black/c (struct/c black integer? red-or-black/c red-or-black/c)
+                null])
+      red-or-black/c))))
 
 (check-exn exn:fail? (λ () ((test-contract-generation (-> char? integer?)) 0)))
 (check-not-exn (λ () ((test-contract-generation (-> integer? integer?)) 1)))

--- a/pkgs/racket-test/tests/racket/contract/stronger.rkt
+++ b/pkgs/racket-test/tests/racket/contract/stronger.rkt
@@ -348,6 +348,15 @@
       (define x (flat-rec-contract x (first-or/c (cons/c x '()) '())))
       (,test #t trust/not-stronger? x (first-or/c (cons/c x '()) '()))))
 
+  (contract-eval
+   `(let ()
+      (define x (flat-murec-contract ([x (or/c (cons/c x '()) '())]) x))
+      (,test #t trust/not-stronger? x (or/c (cons/c x '()) '()))))
+  (contract-eval
+   `(let ()
+      (define x (flat-murec-contract ([x (first-or/c (cons/c x '()) '())]) x))
+      (,test #t trust/not-stronger? x (first-or/c (cons/c x '()) '()))))
+
   (ctest #t trust/not-stronger? "x" string?)
   (ctest #f trust/not-stronger? string? "x")
 

--- a/racket/collects/racket/contract/private/misc.rkt
+++ b/racket/collects/racket/contract/private/misc.rkt
@@ -11,8 +11,7 @@
          "generate.rkt"
          "generate-base.rkt")
 
-(provide flat-murec-contract
-         not/c
+(provide not/c
          =/c >=/c <=/c </c >/c between/c
          renamed->-ctc renamed-<-ctc
          char-in
@@ -62,37 +61,6 @@
          (struct-out <-ctc)
          (struct-out >-ctc)
          renamed-between/c)
-
-(define-syntax (flat-murec-contract stx)
-  (syntax-case stx  ()
-    [(_ ([name ctc ...] ...) body1 body ...)
-     (andmap identifier? (syntax->list (syntax (name ...))))
-     (with-syntax ([((ctc-id ...) ...) (map generate-temporaries
-                                            (syntax->list (syntax ((ctc ...) ...))))]
-                   [(pred-id ...) (generate-temporaries (syntax (name ...)))]
-                   [((pred-arm-id ...) ...) (map generate-temporaries
-                                                 (syntax->list (syntax ((ctc ...) ...))))])
-       (syntax 
-        (let* ([pred-id flat-murec-contract/init] ...
-               [name (flat-contract (let ([name (λ (x) (pred-id x))]) name))] ...)
-          (let-values ([(ctc-id ...) (values (coerce-flat-contract 'flat-rec-contract ctc) ...)] ...)
-            (set! pred-id
-                  (let ([pred-arm-id (flat-contract-predicate ctc-id)] ...)
-                    (λ (x)
-                      (or (pred-arm-id x) ...)))) ...
-            body1
-            body ...))))]
-    [(_ ([name ctc ...] ...) body1 body ...)
-     (for-each (λ (name)
-                 (unless (identifier? name)
-                   (raise-syntax-error 'flat-rec-contract
-                                       "expected an identifier" stx name)))
-               (syntax->list (syntax (name ...))))]
-    [(_ ([name ctc ...] ...))
-     (raise-syntax-error 'flat-rec-contract "expected at least one body expression" stx)]))
-
-(define (flat-murec-contract/init x) (error 'flat-murec-contract "applied too soon"))
-
 
 (define false/c #f)
 


### PR DESCRIPTION
This PR adds support for generation, strength checking, and equivalence checking to `flat-murec-contract`. It does this by changing the expansion of `flat-murec-contract` to use the same contract struct as `flat-rec-contract` (which supports these features) instead of predicates.