### PR TITLE
Fail random generation of range contracts with bad bounds

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -245,7 +245,9 @@
                      (exn-message x))))
 (check-exn cannot-generate-exn? (λ () (test-contract-generation some-crazy-predicate?)))
 (check-exn cannot-generate-exn? (λ () (test-contract-generation (list/c some-crazy-predicate?))))
-
+(check-exn cannot-generate-exn? (λ () (test-contract-generation (between/c 10 0))))
+(check-exn cannot-generate-exn? (λ () (test-contract-generation (integer-in 10 0))))
+(check-exn cannot-generate-exn? (λ () (test-contract-generation (char-in #\z #\a))))
 
 (check-not-exn (lambda () (test-contract-generation (or/c #f number?))))
 (check-not-exn (lambda () (test-contract-generation (first-or/c #f number?))))

--- a/racket/collects/racket/contract/private/and.rkt
+++ b/racket/collects/racket/contract/private/and.rkt
@@ -348,9 +348,11 @@
     [(or start end)
      (define _start (or start (- end max-random-range)))
      (define _end (or end (+ start max-random-range)))
+     (define upper-bound (min 4294967087 (+ (- _end _start) 1)))
      (λ (fuel)
-       (λ ()
-         (+ _start (random (min 4294967087 (+ (- _end _start) 1))))))]
+       (and (>= upper-bound 1)
+            (λ ()
+              (+ _start (random upper-bound)))))]
     [else
      (λ (fuel)
        (λ ()

--- a/racket/collects/racket/contract/private/guts.rkt
+++ b/racket/collects/racket/contract/private/guts.rkt
@@ -723,8 +723,9 @@
      (define high (char->integer (char-in/c-high ctc)))
      (define delta (+ (- high low) 1))
      (λ (fuel)
-       (λ ()
-         (integer->char (+ low (random delta))))))))
+       (and (>= delta 1)
+            (λ ()
+              (integer->char (+ low (random delta)))))))))
 
 (define (regexp/c-equivalent this that)
   (and (regexp/c? that)

--- a/racket/collects/racket/contract/private/misc.rkt
+++ b/racket/collects/racket/contract/private/misc.rkt
@@ -127,6 +127,7 @@
                      (* 1.0 choice)
                      choice))]
         [else choice]))]
+    [(> n m) #f]
     [else
      (λ ()
        (rand-choice


### PR DESCRIPTION
Contracts that describe ranges of values (`between/c`, `integer-in`, `char-in`) didn't fail gracefully when generating random instances in the case of improper bounds (where lower is greater than upper). For `integer-in` and `char-in`, it raised an internal error, and for `between/c` it actually generated values that didn't satisfy the contract.