### PR TITLE
doc: improve the documentation for generic interfaces

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/generic.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/generic.scrbl
@@ -147,7 +147,7 @@ Raised for @techlink{generic methods} that do not support the given
 @defform[(define/generic local-id method-id)]{
 
 When used inside the method definitions associated with the @racket[#:methods],
-@racket[#:fallbacks], @racket[#:defaults] or @racket[#:fast-defaults] keyword,
+@racket[#:fallbacks], @racket[#:defaults] or @racket[#:fast-defaults] keywords,
 binds @racket[local-id] to the generic for @racket[method-id]. This form is
 useful for method specializations to use generic methods (as opposed to the
 local specialization) on other values.

--- a/pkgs/racket-doc/scribblings/reference/generic.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/generic.scrbl
@@ -160,7 +160,7 @@ The @racket[define/generic] form is only allowed inside:
        @racket[#:fast-defaults] in @racket[define-generics]}
 ]
 
-Using this form elsewhere is a syntax error.
+Using @racket[define/generic] elsewhere is a syntax error.
 }
 
 


### PR DESCRIPTION
1. fix the doc on define/generic
2. make the use of `define/generic` necessary in the example code