### PR TITLE
raco pkg new: wrap long output line

### DIFF
--- a/racket/collects/pkg/private/new.rkt
+++ b/racket/collects/pkg/private/new.rkt
@@ -63,7 +63,7 @@
     (parameterize ([current-directory name])
 
       ;; LICENSE files
-      (displayln "Generating LICENSE-APACHE and LICENSE-MIT files. You are free to change the license.")
+      (displayln "Generating LICENSE-APACHE and LICENSE-MIT files.\nYou are free to change the license.")
       (with-output-to-file "LICENSE-MIT"
         (lambda () (expand/display #<<EOS
 <<name>> 


### PR DESCRIPTION
The line was 84 characters, too long for many terminals.