### PR TITLE
work around Mac OS dlopen restrictions

### DIFF
--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -267,6 +267,9 @@
                   (build-path dir (bytes->path (cadr m)))))]
           [else null])))
 
+(module+ private-for-testing
+  (provide make-macosx-default-get-fallbacks))
+
 ;; String -> (Listof Path-String)
 (define default-get-fallbacks
   (case (system-type 'os)


### PR DESCRIPTION
Recent versions of Mac OS (by 11.2, but probably several versions
before that) restrict the OS library search path for dlopen. The man
page for dlopen has the following note:

> Note: If the main executable is a set[ug]id binary *or codesigned
> with entitlements*, then all environment variables are ignored, and
> only a full path can be used.

Thus a call to ffi-lib with a plain library name, where the library is
expected to be in a system location like /usr/local/lib, will succeed
when run with a locally-built Racket but fail when run with a (signed)
release Racket.

The note above isn't completely accurate: the entitlement
com.apple.security.cs.allow-dyld-environment-variables, which Racket
has, has the following effect:
- DYLD_LIBRARY_PATH is not ignored; if set to /usr/local/lib:/usr/lib
  then Racket does find libraries in those locations, but the variable
  is not set by default.
- DYLD_FALLBACK_LIBRARY_PATH is visible to Racket's getenv, but it is
  ignored by dlopen.

This commit works around this behavior by explicitly searching the OS
library locations (set by the DYLD_FALLBACK_{LIBRARY,FRAMEWORK}_PATH
variables).

----

See rmculpepper/racket-zeromq#6.

This PR still needs documentation.
Would a parameter be better?
