### PR TITLE
cptypes: discard call form around an error

### DIFF
--- a/racket/src/ChezScheme/mats/cp0.ms
+++ b/racket/src/ChezScheme/mats/cp0.ms
@@ -2614,7 +2614,8 @@
                  (begin (#%write 'f) #\y)
                  (begin (#%write 'g) ($zzz-ok))))
              (begin (#%write 'h) 1)))))
-  (expansion-matches?
+  (parameterize ([enable-type-recovery #f])
+   (expansion-matches?
         '(begin (write 'a)
            ((begin (write 'b) string-ref)
             (begin (write 'c)
@@ -2637,7 +2638,7 @@
                  (begin (#%write 'e) ($xxx-ok))
                  (begin (#%write 'f) 'oops)
                  (begin (#%write 'g) ($zzz-ok))))
-             (begin (#%write 'h) 1)))))
+             (begin (#%write 'h) 1))))))
   (expansion-matches?
         `(begin (write 'a)
            ((begin (write 'b) string-ref)
@@ -2730,7 +2731,8 @@
                  (begin (#%write 'f) 121)
                  (begin (#%write 'g) ($zzz-ok))))
              (begin (#%write 'h) 1)))))
-  (expansion-matches?
+  (parameterize ([enable-type-recovery #f])
+   (expansion-matches?
         '(begin (write 'a)
            ((begin (write 'b) fxvector-ref)
             (begin (write 'c)
@@ -2753,7 +2755,7 @@
                  (begin (#%write 'e) ($xxx-ok))
                  (begin (#%write 'f) 'oops)
                  (begin (#%write 'g) ($zzz-ok))))
-             (begin (#%write 'h) 1)))))
+             (begin (#%write 'h) 1))))))
   (expansion-matches?
         `(begin (write 'a)
            ((begin (write 'b) fxvector-ref)
@@ -2894,12 +2896,12 @@
       (expand/optimize
         '(lambda (v)
            (let ([v2 (if (vector? v) v (error))])
-             (let ([q (vector-sort v2)] [n (#3%vector-length v)])
+             (let ([q (vector-sort < v2)] [n (#3%vector-length v)])
                (display "1")
                (list q n))))))
     '(lambda (v)
        (let ([v2 (begin (if (#2%vector? v) (#2%void) (#2%error)) v)])
-         (let ([q (#2%vector-sort v2)] [n (#3%vector-length v)])
+         (let ([q (#2%vector-sort #2%< v2)] [n (#3%vector-length v)])
            (#2%display "1")
            (#2%list q n)))))
   (equivalent-expansion?
@@ -2907,11 +2909,11 @@
       (expand/optimize
         '(lambda (v)
            (let ([v2 (if (vector? v) v (error))])
-             (let ([q (vector-sort v2)] [n (or v 72)])
+             (let ([q (vector-sort < v2)] [n (or v 72)])
                (display "1")
                (list q n))))))
     '(lambda (v)
-       (let ([q (#2%vector-sort (begin (if (#2%vector? v) (#2%void) (#2%error)) v))]
+       (let ([q (#2%vector-sort #2%< (begin (if (#2%vector? v) (#2%void) (#2%error)) v))]
              [n (if v v 72)])
          (#2%display "1")
          (#2%list q n))))
@@ -2923,7 +2925,7 @@
       (syntax-rules ()
         [(_ eqprim) (eqtest eqprim #f)]
         [(_ eqprim generic?)
-         (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f])
+         (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f] [enable-type-recovery #f])
            (let ([arity-mask (procedure-arity-mask eqprim)] [primref `($primitive ,(if (= (optimize-level) 3) 3 2) eqprim)])
              (define-syntax ifsafe
                (syntax-rules ()

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -1205,3 +1205,36 @@
     '(lambda (x) (if (pair? x) (car x) (#2%assert-unreachable)))
     '(lambda (x) (#3%car x))))
 )
+
+(mat cptypes-bottom
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (error 'x "no") (add1 x))
+   '(lambda (x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (f) (f (error 'x "no") f))
+   '(lambda (f) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (f) ((error 'x "no") f f))
+   '(lambda (f) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (if (error 'x "no") (add1 x) (sub1 x)))
+   '(lambda (x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (+ (error 'x "no") x))
+   '(lambda (x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (list x (add1 x) (error 'x "no") (sub1 x)))
+   '(lambda (x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (apply x (add1 x) (error 'x "no") (sub1 x)))
+   '(lambda (x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (apply (error 'x "no") (add1 x) (sub1 x)))
+   '(lambda (x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (let* ([x (add1 x)] [y (error 'x "no")]) (+ x y)))
+   '(lambda (x) (add1 x) (error 'x "no")))
+  (cptypes-equivalent-expansion?
+   '(lambda (x) (list (if (odd? x) (error 'x "no") (error 'x "nah")) 17))
+   '(lambda (x) (if (odd? x) (error 'x "no") (error 'x "nah"))))
+)


### PR DESCRIPTION
For example, `(f (error 'x "x") y x)` turns into `(error 'x "x")`.

@gus-massa @yjqww6 Does this seem worthwhile? Is there a better way to implement it?

I didn't cover all cases in `define-specialize/unrestricted` handler, because they didn't seem especially likely. I experimented briefly with changing cp0 instead of cptypes, but cptypes has more information and already handles other cases.