### PR TITLE
Add maybe-char to cptypes

### DIFF
--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -1192,8 +1192,17 @@
     '(lambda (x) (when (or (not x) (vector? x)) (when x (vector? x))))
     '(lambda (x) (when (or (not x) (vector? x)) (when x #t))))
   (cptypes-equivalent-expansion?
+    '(lambda (x) (when (or (not x) (char? x)) (when x (char? x))))
+    '(lambda (x) (when (or (not x) (char? x)) (when x #t))))
+  (cptypes-equivalent-expansion?
     '(lambda (s) (define x (string->number s)) (when x (number? x)))
     '(lambda (s) (define x (string->number s)) (when x #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (p) (define x (get-char p)) (not x))
+    '(lambda (p) (define x (get-char p)) #f))
+  (cptypes-equivalent-expansion?
+    '(lambda (p) (define x (get-char p)) (box? x))
+    '(lambda (p) (define x (get-char p)) #f))
 )
 
 (mat cptypes-unreachable

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -998,27 +998,27 @@ Notes:
                    [ir `(call ,preinfo ,pr ,n)])
                (cond
                  [(predicate-implies? r 'char)
-                  (values ir ptr-pred ntypes #f #f)] ; should be maybe-symbol
+                  (values ir maybe-symbol-pred ntypes #f #f)]
                  [(predicate-implies? r 'symbol)
-                  (values ir ptr-pred ntypes #f #f)] ; should be maybe-char
+                  (values ir maybe-char-pred ntypes #f #f)]
                  [(and (predicate-disjoint? r 'char)
                        (predicate-disjoint? r 'symbol))
                   (values ir 'bottom pred-env-bottom #f #f)]
                  [else
-                  (values ir ptr-pred                ; should be maybe-(union 'char 'symbol)
-                          (pred-env-add/ref ntypes n true-pred  plxc) #f #f)]))] ; should be (union 'char 'symbol)
+                  (values ir (predicate-union maybe-char-pred 'symbol)
+                          (pred-env-add/ref ntypes n (predicate-union 'char 'symbol) plxc) #f #f)]))]
         [(n c) (let ([rn (get-type n)]
                      [rc (get-type c)]
                      [ir `(call ,preinfo ,pr ,n ,c)])
                  (cond
                    [(or (predicate-disjoint? rn 'symbol)
-                        (predicate-disjoint? rc ptr-pred)) ; should be maybe-char
+                        (predicate-disjoint? rc maybe-char-pred))
                     (values ir 'bottom pred-env-bottom #f #f)]
                    [else
                     (values ir void-rec
                             (pred-env-add/ref (pred-env-add/ref ntypes
                                                                 n 'symbol plxc)
-                                              c ptr-pred plxc) ; should be maybe-char
+                                              c maybe-char-pred plxc)
                              #f #f)]))])
 
       (define-specialize/unrestricted 2 call-with-values


### PR DESCRIPTION
chars are immediates, so the previous change doesn't add automatically the combinations like `maybe-char`. Add also `eof/char` that is commonly used and has the same problem.

I notice a small problem with the names: `eof/char` means `eof or char` but `$immediate/true` means `$immediate and true`. All the other use or `/` in primdata.ss means also `or` so I think it's better to rename `$immediate/true` that is used only internally in cptypes. But I don't like the alternatives like `$true-immediate` or `true-$immediate`, so I didn't rename it. Does anyone have a better alternative? 