### PR TITLE
Chez Scheme: fix too much propagation of numbers in cptypes

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -7110,5 +7110,25 @@
          h)))))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Regression test related to propagation of flonums
+;; from eqv? tests in CS
+
+(test #t
+      (lambda ()
+        ; optimizer unfriendly 1
+        (define (one)
+          (let ([r (random 2)])
+            (if (= r 0) (one) r)))
+
+        (define (f x y)
+          (define first-comparison (eq? x y))
+          (when (and (eqv? x 7.0)
+                     (eqv? y 7.0))
+            (define second-comparison (eq? x y))
+            (eq? first-comparison second-comparison)))
+
+        (f (+ 6.0 (one)) (+ 6.0 (one)))))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (report-errs)

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -922,8 +922,7 @@
 ;Test types inference for string?
 (test-arg-types '(string-length string?) 'fixnum? 'may-omit)
 (test-arg-types '(string-ref string? fixnum?) 'char?)
-(unless (eq? (system-type 'vm) 'chez-scheme) ;; cptypes doesn't know that void? => eq? to (void)
-  (test-arg-types '(string-set! string? fixnum? char?) 'void?))
+(test-arg-types '(string-set! string? fixnum? char?) 'void?)
 (test-arg-types '(string->immutable-string string?) 'string? 'may-omit)
 (test-arg-types '(string-append) 'string? 'may-omit)
 (test-arg-types '(string-append string?) 'string? 'may-omit)
@@ -934,8 +933,7 @@
 ;Test types inference for bytes?
 (test-arg-types '(bytes-length bytes?) 'fixnum? 'may-omit)
 (test-arg-types '(bytes-ref bytes? fixnum?) 'fixnum?)
-(unless (eq? (system-type 'vm) 'chez-scheme) ;; cptypes doesn't know that void? => eq? to (void)
-  (test-arg-types '(bytes-set! bytes? fixnum? fixnum?) 'void?))
+(test-arg-types '(bytes-set! bytes? fixnum? fixnum?) 'void?)
 (unless (eq? (system-type 'vm) 'chez-scheme) ;; ???
   (test-arg-types '(bytes->immutable-bytes bytes?) 'bytes? 'may-omit))
 (unless (eq? (system-type 'vm) 'chez-scheme) ;; bytes-append is not primitive

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -85,6 +85,12 @@
     '(pair? (list)) 
     #f)
   (cptypes-equivalent-expansion?
+    '(eq? (newline) (void))
+    '(begin (newline) #t))
+  (cptypes-equivalent-expansion?
+    '(eq? (newline) 0)
+    '(begin (newline) #f))
+  (cptypes-equivalent-expansion?
     '(lambda (x) (vector-set! x 0 0) (vector? x))
     '(lambda (x) (vector-set! x 0 0) #t))
   (cptypes-equivalent-expansion?
@@ -574,11 +580,12 @@
   (test-chain* '(fixnum? integer? real?))
   (test-chain* '(fixnum? exact? number?)) ; exact? may raise an error
   (test-chain* '(bignum? exact? number?)) ; exact? may raise an error
-  (test-chain* '((lambda (x) (eq? x (expt 256 100))) bignum? real? number?))
+  (test-chain '((lambda (x) (eqv? x (expt 256 100))) bignum? real? number?))
   (test-chain '((lambda (x) (eqv? 0.0 x)) flonum? real? number?))
   (test-chain* '((lambda (x) (or (eqv? x 0.0) (eqv? x 3.14))) flonum? real? number?))
   (test-chain* '((lambda (x) (or (eq? x 0) (eqv? x 3.14))) real? number?))
   (test-chain '(gensym? symbol?))
+  (test-chain '((lambda (x) (eq? x 'banana)) symbol?))
   (test-chain '(not boolean?))
   (test-chain '((lambda (x) (eq? x #t)) boolean?))
   (test-chain* '(record? #3%$record?))
@@ -594,6 +601,7 @@
   (test-disjoint '(pair? box? fixnum? flonum? (lambda (x) (eq? #t x))))
   (test-disjoint '((lambda (x) (eq? x 0)) (lambda (x) (eq? x 1)) flonum?))
   (test-disjoint '((lambda (x) (eqv? x 0.0)) (lambda (x) (eqv? x 1.0)) fixnum?))
+  (test-disjoint '((lambda (x) (eq? x 'banana)) (lambda (x) (eq? x 'apple))))
   (test-disjoint* '(list? record? vector?))
   (not (test-disjoint* '(list? null?)))
   (not (test-disjoint* '(list? pair?)))

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -1476,6 +1476,11 @@ Notes:
               [(Lsrc? t)
                (nanopass-case (Lsrc Expr) t
                  [(quote ,d)
+                  (guard (or (not (number? d))
+                             ; To avoid problems with cross compilation and eq?-ness
+                             ; ensure that it's a fixnum in both machines.
+                             (and (fixnum? d)
+                                  (target-fixnum? d))))
                   (values t t types #f #f)]
                  [else
                   (values ir t types #f #f)])]


### PR DESCRIPTION
In this example, after the check with `eq?` or `eqv?` the value of  the variables `x` and `y` are known, so `cptypes` replaced the reference to the variable with it. 

But it can interact badly with the `eq?` test, for example in this case the first `(eq? x y)` can be `#f` and the second be reduced by the compiler to `#t`.

In spite this is technically correct because `eq?` cannot be used to compare numbers reliably, this behavior is too confusing and it's better to avoid it.

    (define (one)
      (let ([r (random 2)])
        (if (= r 0) (one) r)))

    (define (f x y)
      (define first-comparison (eq? x y))
        (when (and (eqv? x 7.0)
               (eqv? y 7.0))
          (define second-comparison (eq? x y))
          (eq? first-comparison second-comparison)))

    (f (+ 6.0 (one)) (+ 6.0 (one)))))


I had to check that the number is a `fixnum?` and a `target-fixnum?` to avoid problems cross compiling from a 32 bits machine to a 64 bits machine, where the number can be different `bignums?` while compiling, and the same `fixnum?` at run time. (Another possibility is to remove the `mifoldable` flag in the signature of `eq?` and add and add a custom version of fold that understand the cross compilation problems.) 

---

The second commit is a small improvement to `eq?` and `eqv?`. Improve `eq?` and `eq?` handling to reduce expressions like
`(eq? (newline) (void)) => (begin (newline) #t)`. It "fix" a few test in optimize.rktl.