### PR TITLE
ChezScheme: fix signatures of `$fx+?` and `$fx-?`

### DIFF
--- a/racket/src/ChezScheme/s/primdata.ss
+++ b/racket/src/ChezScheme/s/primdata.ss
@@ -2147,10 +2147,10 @@
   ($ftype-guardian-oops [flags])
   ($ftype-pointer? [sig [(ptr) -> (boolean)]] [flags pure unrestricted mifoldable])
   ($fxaddress [flags single-valued unrestricted alloc])
-  ($fx-? [sig [(maybe-fixnum maybe-fixnum) -> (maybe-fixnum)]] [flags pure]) ; not boolean
+  ($fx-? [sig [(ptr ptr) -> (maybe-fixnum)]] [flags unrestricted pure]) ; not boolean
   ($fx/ [flags single-valued])
   ($fx* [flags single-valued])
-  ($fx+? [sig [(maybe-fixnum maybe-fixnum) -> (maybe-fixnum)]] [flags pure]) ; not boolean
+  ($fx+? [sig [(ptr ptr) -> (maybe-fixnum)]] [flags unrestricted pure]) ; not boolean
   ($fxu< [flags single-valued pure cp02])
   ($fxvector-ref-check? [sig [(ptr ptr) -> (boolean)]] [flags unrestricted pure])
   ($fxvector-set!-check? [sig [(ptr ptr) -> (boolean)]] [flags unrestricted discard])


### PR DESCRIPTION
Exposed by `fx+/carry`. A smarter cptypes may reduce arguments to just `#f` in oops clauses.
https://github.com/racket/racket/blob/5c2949d051374579200194aa85b1734195f95a3b/racket/src/ChezScheme/s/5_3.ss#L3322-L3329