### PR TITLE
Implementation of 3x3 and 4x4 Toom-Cook multiplication.

### DIFF
--- a/racket/src/ChezScheme/mats/5_3.ms
+++ b/racket/src/ChezScheme/mats/5_3.ms
@@ -1690,6 +1690,16 @@
                                  (and (exact? x) (exact? y))
                                  (or (inexact? x) (inexact? y)))
                              (g (+ j 1)))))))))
+    (let ([sb* (foreign-procedure
+		"(cs)mul" (scheme-object scheme-object) scheme-object)])
+      ;; (expt 2 100000) is big enough that all multiplication algorithms
+      ;; are exercised
+      ;; we add a power of 3 so that the number isn't too simple
+      (eqv? (sb* (+ 1 (expt 3 50) (expt 2 100000))
+		 3)
+	    (* (+ 1 (expt 3 50) (expt 2 100000))
+	       3)))
+      
     (error? ; #f is not a fixnum
       (* 3 #f))
     (error? ; #f is not a fixnum


### PR DESCRIPTION
This speeds up `(factorial 1000000)` (using factorial from math/number-theory)
by about 3x, and the conversion of the result to a string by about 2x.

Benchmark:

    #lang racket
    (require math/number-theory)
    (define n (time (factorial 1000000)))
    (define s (time (number->string n)))
    (string-length s)

Current Racket CS:
cpu time: 19135 real time: 19137 gc time: 372
cpu time: 33416 real time: 33418 gc time: 463

Current Racket BC (GMP is really fast):
cpu time: 1465 real time: 1465 gc time: 51
cpu time: 3661 real time: 3659 gc time: 3

This PR:
cpu time: 6173 real time: 6172 gc time: 168
cpu time: 17846 real time: 17847 gc time: 377

Cutoff between Karatsuba and Toom3 estimated by mflatt.
Cutoff between Toom3 & Toom4 guessed.