### PR TITLE
Use export-orig-stx instead of export-out-sym when appropriate

### DIFF
--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -763,7 +763,13 @@
                                        (export-local-id export)
                                        (quasisyntax/loc out
                                          (rename #,(export-local-id export)
-                                                 #,(export-out-sym export))))]
+                                                 #,(if (eq? (syntax-e (export-orig-stx export))
+                                                            (export-out-sym export))
+                                                       (export-orig-stx export)
+                                                       (datum->syntax
+                                                        #f
+                                                        (export-out-sym export)
+                                                        (export-orig-stx export))))))]
                                   [mode (export-mode export)])
                               (let ([phased
                                      (cond


### PR DESCRIPTION
Forms like rename-out supply the export-id syntax as export-orig-stx,
as well as the symbolic value as export-out-sym. In that case, expand
using export-orig-stx. That way, the piece of syntax representing the
export-id will have srcloc and other properties. This may be useful to
tools that deal with renaming provides.

This commit tries to be conservative by doing the old behavior unless
(eq? (syntax-e (export-orig-stx export)) (export-out-sym export)).

This commit doesn't update documentation for `export-orig-stx`.
Instead the spirit of this commit is to treat this as a private
implementation detail of `rename-out`, as opposed to stating some new
official API for renaming provide transformers in general.