### PR TITLE
Add `license` field for package info.rkt files

### DIFF
--- a/pkgs/at-exp-lib/info.rkt
+++ b/pkgs/at-exp-lib/info.rkt
@@ -8,3 +8,6 @@
 (define pkg-authors '(eli mflatt))
 
 (define version "1.2")
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -24,3 +24,6 @@
 (define pkg-desc "Racket libraries that are currently always available")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/compiler-lib/info.rkt
+++ b/pkgs/compiler-lib/info.rkt
@@ -14,3 +14,6 @@
 (define pkg-authors '(mflatt))
 
 (define version "1.10")
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/compiler-test/info.rkt
+++ b/pkgs/compiler-test/info.rkt
@@ -20,3 +20,6 @@
 		     "dynext-lib"
 		     "mzscheme-lib"))
 (define update-implies '("compiler-lib"))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/compiler/info.rkt
+++ b/pkgs/compiler/info.rkt
@@ -8,3 +8,6 @@
 (define pkg-desc "Racket compilation tools, such as `raco exe'")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/net-doc/info.rkt
+++ b/pkgs/net-doc/info.rkt
@@ -14,3 +14,6 @@
                      "web-server-doc"
                      "web-server-lib"))
 (define update-implies '("net-lib"))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/net-lib/info.rkt
+++ b/pkgs/net-lib/info.rkt
@@ -7,3 +7,6 @@
 (define pkg-desc "implementation (no documentation) part of \"net\"")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/net-test/info.rkt
+++ b/pkgs/net-test/info.rkt
@@ -16,3 +16,6 @@
                      "sandbox-lib"
                      "web-server-lib"))
 (define update-implies '("net-lib"))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/net/info.rkt
+++ b/pkgs/net/info.rkt
@@ -8,3 +8,6 @@
 (define pkg-desc "Networking libraries")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-benchmarks/info.rkt
+++ b/pkgs/racket-benchmarks/info.rkt
@@ -15,3 +15,6 @@
 
 (define pkg-desc "Racket benchmarks")
 (define pkg-authors '(eli jay mflatt robby samth stamourv))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-build-guide/info.rkt
+++ b/pkgs/racket-build-guide/info.rkt
@@ -14,3 +14,6 @@
 (define pkg-desc "Racket build and contribution documentation")
 
 (define pkg-authors '(mflatt))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-doc/info.rkt
+++ b/pkgs/racket-doc/info.rkt
@@ -44,3 +44,6 @@
 (define pkg-authors '(eli jay matthias mflatt robby ryanc samth))
 
 (define version "1.1")
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
@@ -1342,6 +1342,56 @@ The following @filepath{info.rkt} fields are used by the package manager:
        set up (plus collections for global documentation indexes and
        links).}
 
+ @item{@definfofield{license} --- a @deftech{license s-expression}
+  specifying the package's license. A license s-expression represents an @deftech{SPDX}
+  @hyperlink["https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/"]{
+   license expression} as a datum with the quoted form:
+
+  @racketgrammar[#:literals (AND OR WITH) license-sexp
+                 license-id
+                 (license-id WITH exception-id)
+                 (license-sexp AND license-sexp)
+                 (license-sexp OR license-sexp)]
+
+  @margin-note{See @elemref["spdx-plus-operator"]{further details below}
+   about @racket[_license-id] and the @litchar{+} operator.}
+
+  where a:
+
+  @itemize[
+ @item{@racket[_license-id] is a short-form identifier from the
+    @hyperlink["https://spdx.org/licenses/index.html"]{SPDX License List},
+    e.g@._ @racketvalfont{LGPL-3.0-or-later}, @racketvalfont{Apache-2.0},
+    or @racket[BSD-3-Clause]; and an}
+ @item{@racket[_exception-id] is an identifier from the
+    @hyperlink["https://spdx.org/licenses/exceptions-index.html"]{
+     SPDX License Exceptions} list, e.g@._ @racketvalfont{Classpath-exception-2.0}.}]
+
+  For example, packages in the main Racket distribution
+  define @racketidfont{license} as:
+  @racketblock[(define license
+                 '(Apache-2.0 OR MIT))]
+
+  The grammar of @tech{license s-expressions} is designed so that
+  @racket[(format "~s" license)] produces a string conforming to the grammar in
+  @hyperlink["https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/"]{
+  Appendix IV} and
+  @hyperlink["https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/"]{
+  Appendix V}
+  of the SPDX Specification v2.2.0,
+  which is specified in terms of character sequences.
+
+  @elemtag["spdx-plus-operator"]{If the @litchar{+} operator is used,}
+  it must be written as part of the @racket[_license-id],
+  e.g@._ @racketvalfont{AFL-2.0+}.
+  Note that the @hyperlink["https://spdx.dev/ids/"]{SPDX Workgroup has deprecated}
+  (under ``Allowing later versions of a license'') the use of the @litchar{+}
+  operator with GNU licenses: thus, one writes
+  @racketvalfont{AFL-2.0} or @racketvalfont{AFL-2.0+} but
+  @racketvalfont{GPL-3.0-only} or @racketvalfont{GPL-3.0-or-later}
+  (and neither @racket[GPL-3.0] nor @racket[GPL-3.0+] are correct).
+ }
+
  @item{@definfofield{distribution-preference} --- either
        @racket['source], @racket['built], or @racket['binary],
        indicating the most suitable distribution mode for the package
@@ -1367,7 +1417,8 @@ The following @filepath{info.rkt} fields are used by the package manager:
 ]
 
 @history[#:changed "6.1.0.5" @elem{Added @racketidfont{update-implies}.}
-         #:changed "6.1.1.6" @elem{Added @racketidfont{distribution-preference}.}]
+         #:changed "6.1.1.6" @elem{Added @racketidfont{distribution-preference}.}
+         #:changed "8.1.0.8" @elem{Added @racketidfont{license}.}]
 
 @; ----------------------------------------
 

--- a/pkgs/racket-index/info.rkt
+++ b/pkgs/racket-index/info.rkt
@@ -26,3 +26,6 @@
                             "scribblings/main/user/compiled/release_scrbl.zo"
                             "scribblings/main/user/compiled/search_scrbl.zo"
                             "scribblings/main/user/compiled/start_scrbl.zo"))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-lib/info.rkt
+++ b/pkgs/racket-lib/info.rkt
@@ -20,3 +20,6 @@
 (define pkg-desc "Combines platform-specific native libraries that are useful for base Racket")
 
 (define pkg-authors '(eli jay matthias mflatt robby ryanc samth))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-test-core/info.rkt
+++ b/pkgs/racket-test-core/info.rkt
@@ -18,3 +18,6 @@
 (define pkg-desc "Minimal core version of Racket test suites")
 
 (define pkg-authors '(eli jay matthias mflatt robby ryanc samth))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-test-extra/info.rkt
+++ b/pkgs/racket-test-extra/info.rkt
@@ -10,3 +10,6 @@
                      "scheme-lib"
                      "rackunit-lib"
                      "serialize-cstruct-lib"))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/racket-test/info.rkt
+++ b/pkgs/racket-test/info.rkt
@@ -41,3 +41,6 @@
 (define pkg-desc "Base Racket test suites")
 
 (define pkg-authors '(eli jay matthias mflatt robby ryanc samth))
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/pkgs/zo-lib/info.rkt
+++ b/pkgs/zo-lib/info.rkt
@@ -9,3 +9,6 @@
 (define pkg-authors '(mflatt))
 
 (define version "1.3")
+
+(define license
+  '(Apache-2.0 OR MIT))

--- a/racket/collects/pkg/private/new.rkt
+++ b/racket/collects/pkg/private/new.rkt
@@ -63,7 +63,7 @@
     (parameterize ([current-directory name])
 
       ;; LICENSE files
-      (displayln "Generating LICENSE-APACHE and LICENSE-MIT files. You are free to change the license.")
+      (displayln "Initializing license (Apache-2.0 OR MIT). You are free to change the license.")
       (with-output-to-file "LICENSE-MIT"
         (lambda () (expand/display #<<EOS
 <<name>> 
@@ -167,6 +167,7 @@ EOS
 (define pkg-desc "Description Here")
 (define version "0.0")
 (define pkg-authors '(<<user>>))
+(define license '(Apache-2.0 OR MIT))
 
 EOS
 )))


### PR DESCRIPTION
I propose adding a `license` field to the package metadata in `info.rkt` files.

[SPDX license expressions](https://spdx.dev/ids/) are used to encode license metadata in a variety of projects and package systems, including [Cabal](https://cabal.readthedocs.io/en/latest/cabal-package.html#pkg-field-license), [Cargo](https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields), [RubyGems](https://guides.rubygems.org/specification-reference/#license=), [NPM](https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license), Python's proposed [PEP 639](https://www.python.org/dev/peps/pep-0639/), and the [Linux kernel](https://www.kernel.org/doc/html/latest/process/license-rules.html#license-identifier-syntax). For Racket, I propose an s-expression syntax for SPDX expressions.

# Updated Summary

> See <https://github.com/racket/racket/pull/3760#issuecomment-820800099>. See also the original proposal below. 

An *SPDX License S-Expression* is a datum with the following grammar:

```                                   
  <license-sexp> = <license-id>                            
                 | (<license-id> WITH <exception-id>)
                 | (<license-sexp> AND <license-sexp>)               
                 | (<license-sexp> OR <license-sexp>)
```

Where:
  - `license-id` is an identifier from the [SPDX License List](https://spdx.org/licenses/index.html); and
  - `exception-id` is an identifier from the [https://spdx.org/licenses/exceptions-index.html"]{SPDX License Exceptions} list (like `Classpath-exception-2.0`).

For example:
https://github.com/racket/racket/blob/d20a1c7f117e385dfbd852d75545b351f8b66166/pkgs/base/info.rkt#L28-L29 

The s-expression grammar is designed so that `(format "~s" license-sexp)` produces a string conforming to the grammar in [Appendix IV](https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/) and [Appendix V](https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/) of the SPDX Specification v2.2.0, which is specified in terms of character sequences.

Concretely, this pull request documents the proposed field and adds it to the `info.rkt` files of the packages in this repository, as well as those added by `raco pkg new`. It does not add any other tools, leaving those for other packages and pull requests. (I plan to make some.)

# Original Proposal

```
  <license-datum> = (SPDX-License-Identifier: <compound-expr>)        
                  | <compound-expr>                                   
                                                                  
  <compound-expr> = <versioned-license-id>                            
                  | (<versioned-license-id> WITH <license-exception-id>)
                  | (<compound-expr> AND <compound-expr>)               
                  | (<compound-expr> OR <compound-expr>)  
```
For example:
```racket
(define license
  '(SPDX-License-Identifier: (Apache-2.0 OR MIT)))
```

If written in the usual way (i.e. what `write` would produce—no unusual escape sequences), a s-expression matching this grammar should also conform to the syntax in [Appendix IV](https://spdx.github.io/spdx-spec/appendix-IV-SPDX-license-expressions/) and [Appendix V](https://spdx.github.io/spdx-spec/appendix-V-using-SPDX-short-identifiers-in-source-files/) of the SPDX Specification v2.2.0, which is specified in terms of character sequences. This represents a slightly different implied AST than the specification, which has a `license-id` and a `+` operator rather than a `versioned-license-id`. The `versioned-license-id` approach seems especially justified since the current SPDX specification (see [here](https://spdx.dev/ids/), under “Allowing later versions of a license”) handles versioning differently for GNU and non-GNU licenses: you write `AFL-2.0` or `AFL-2.0+` but `GPL-3.0-only` or `GPL-3.0-or-later` (and neither `GPL-3.0` nor `GPL-3.0+` are allowed). So a tool handling versioning properly really needs the license list metadata, not just the expression syntax.

(Making optional parentheses mandatory is presumably a less remarkable change.)

--------

Concretely, this pull request documents the proposed field and adds it to the `info.rkt` files for the packages in this repository: it doesn't add any tools. A linter in `raco pkg` might be a nice addition, but it raises the question of whether to include the SPDX data and validate that the `versioned-license-id` and `license-exception-id` are defined. If it goes in this repository, I'm inclined to think not, but it might be useful for, say, the pkgs.racket-lang.org website.