### PR TITLE
rktio: fix output of newlines in text files in Windows

### DIFF
--- a/racket/src/io/README.txt
+++ b/racket/src/io/README.txt
@@ -7,7 +7,7 @@ Core error support must be provided as a more primitive layer,
 including the exception structures and error functions that do not
 involve formatting, such as `raise-argument-error`. The more primitive
 layer should provide a `error-value->string-handler` paramemeter, but
-this layer sets that parameter (so the primitive error function slike
+this layer sets that parameter (so the primitive error functions like
 `raise-argument-error` won't work right until this layer is loaded).
 
 Thread and event support is similarly provided as a more primitive

--- a/racket/src/io/port/file-port.rkt
+++ b/racket/src/io/port/file-port.rkt
@@ -58,7 +58,7 @@
   (check who path-string? path)
   (define (mode->flags mode)
     (case mode
-      [(test) RKTIO_OPEN_TEXT]
+      [(text) RKTIO_OPEN_TEXT]
       [(truncate truncate/replace) (+ RKTIO_OPEN_TRUNCATE
                                       RKTIO_OPEN_CAN_EXIST)]
       [(must-truncate) (+ RKTIO_OPEN_TRUNCATE


### PR DESCRIPTION
Fix typo so the output files opened in `'text` mode in Windows use `CRLF` for newlines.