### PR TITLE
Use import-orig-stx instead of import-src-sym when appropriate

### DIFF
--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -360,7 +360,13 @@
                                                      (quasisyntax/loc in
                                                        (rename #,(import-src-mod-path import)
                                                                #,(import-local-id import)
-                                                               #,(import-src-sym import))))))
+                                                               #,(if (eq? (syntax-e (import-orig-stx import))
+                                                                          (import-src-sym import))
+                                                                     (import-orig-stx import)
+                                                                     (datum->syntax
+                                                                      #f
+                                                                      (import-src-sym import)
+                                                                      (import-orig-stx import))))))))
                                    imports)
                               (map (lambda (src)
                                      (mode-wrap (phase+ base-mode (import-source-mode src))


### PR DESCRIPTION
The equivalent, for imports, of commit 66a8436bc1 and PR #3758 for
exports.