### PR TITLE
change json parser to be more strict about whitespace (matching the spec)

### DIFF
--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -162,6 +162,9 @@ the @rfc for more information about JSON.
       "false42" (code:comment "invalid JSON text sequence")
       (λ () (read-json))))
 ]
+
+@history[#:changed "8.1.0.2" @list{Adjusted the whitespace handling to reject whitespace that isn't either
+           @racket[#\space], @racket[#\tab], @racket[#\newline], or @racket[#\return].}]
 }
 
 @defproc[(string->jsexpr [str string?] [#:null jsnull any/c (json-null)])

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -151,6 +151,20 @@
         ;; Invalid UTF-8 input.
         (bytes->jsexpr #"\"\377\377\377\"") =error> exn:fail?
 
+        ;; whitespace should be only the four allowed charactes
+        (string->jsexpr (string-append
+                         "{ \"x\" :"
+                         (string #\u00A0)
+                         " 123 }"))
+        =error>
+        #rx"whitespace that is not allowed"
+        (string->jsexpr (string-append
+                         "[ 1,"
+                         (string #\u00A0)
+                         " 2 ]"))
+        =error>
+        #rx"whitespace that is not allowed"
+
         ;; More string escapes:
         (string->jsexpr @T{ "hel\"lo" }) => "hel\"lo"
         (string->jsexpr @T{ "\\//\\\\//" }) => "\\//\\\\//"

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -188,7 +188,7 @@
           (read-char i)
           (skip-whitespace)]
          [(char-whitespace? ch)
-          (err "found whitespace that is not allowed by the json spec\n  char: ~s"
+          (err "found whitespace that is not allowed by the JSON specification\n  char: ~s"
                ch)]
          [else ch])]
       [else ch]))

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -174,12 +174,23 @@
     (define-values [l c p] (port-next-location i))
     (raise-read-error (format "~a: ~a" who (apply format fmt args))
                       (object-name i) l c p #f))
+  (define (json-whitespace? ch)
+    (or (eq? ch #\space)
+        (eq? ch #\tab)
+        (eq? ch #\newline)
+        (eq? ch #\return)))
   (define (skip-whitespace)
     (define ch (peek-char i))
     (cond
-      [(and (char? ch) (char-whitespace? ch))
-       (read-char i)
-       (skip-whitespace)]
+      [(char? ch)
+       (cond
+         [(json-whitespace? ch)
+          (read-char i)
+          (skip-whitespace)]
+         [(char-whitespace? ch)
+          (err "found whitespace that is not allowed by the json spec\n  char: ~s"
+               ch)]
+         [else ch])]
       [else ch]))
   (define (byte-char=? b ch)
     (eqv? b (char->integer ch)))


### PR DESCRIPTION
Looks like other languages get upset about whitespace characters and [this place](http://seriot.ch/parsing_json.php) also declares this to be an error, so let's think about changing it.