### PR TITLE
expander: another improvement to make-readtable's error message

### DIFF
--- a/racket/src/bc/src/startup.inc
+++ b/racket/src/bc/src/startup.inc
@@ -54518,7 +54518,7 @@ static const char *startup_source =
 "(if(char? mode_0)"
 "                                                                   \"expected readtable or #f argument after character argument\""
 "                                                                   \"expected procedure argument after symbol argument\")"
-"                                                                 \"given\""
+"                                                                 (if (char? mode_0) \"character\" \"symbol\")"
 " mode_0))"
 "(void))"
 "(values))))"

--- a/racket/src/expander/read/readtable.rkt
+++ b/racket/src/expander/read/readtable.rkt
@@ -81,7 +81,8 @@
                                (if (char? mode)
                                    "expected readtable or #f argument after character argument"
                                    "expected procedure argument after symbol argument")
-                               "given" mode))
+                               (if (char? mode) "character" "symbol")
+                               mode))
       (define target (caddr args))
       
       ;; Update the readtable


### PR DESCRIPTION
Currently `(make-readtable #f #\a 'dispatch-macro)` produces the error
message

```
; make-readtable: expected procedure argument after symbol argument
;   given: 'dispatch-macro
```

which is very confusing, because it sounds like `'dispatch-macro` is
incorrect, but it is in fact correct already.

This PR adjusts the error message to:

```
; make-readtable: expected procedure argument after symbol argument
;   symbol: 'dispatch-macro
```

which is the convention that is already used when the mode argument is not given.