### PR TITLE
fix the documentation for make-input-port

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/custom-ports.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-ports.scrbl
@@ -83,7 +83,7 @@ The arguments implement the port as follows:
       @item{a @tech{synchronizable event} (see @secref["sync"]) other
       than a pipe input port or procedure of arity four; the event
       becomes ready when the read is complete (roughly): the event's
-      value can be one of the above three results or another event like
+      value can be one of the above four results or another event like
       itself; in the last case, a reading process loops with
       @racket[sync] until it gets a non-event result.}
 


### PR DESCRIPTION
since 
```
(define-values (in out) (make-pipe))
(write 'hello-pipe out)

(define sema (make-semaphore))

(for/list ([i (list in (lambda args 'hello-world))])
  (define hi (wrap-evt sema (lambda _ i)))
  (semaphore-post sema)

  (define (foo-evt s)
    hi)

  (define (bar f n mevt)
    eof)



  (read (make-input-port 'test
                         foo-evt
                         bar
                         void)))

```
works, I think four is the correct number. 