### PR TITLE
add warning about regexp-match-exact?

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -620,12 +620,15 @@ first found match is to the entire content of @racket[input].
 ]
 
 Beware that @racket[regexp-match-exact?] can return @racket[#f] if
-@racket[pattern] generates a partial match for @racket[input] first,
-even if @racket[pattern] could also generate a complete match.
+@racket[pattern] generates a partial match for @racket[input] first, even if
+@racket[pattern] could also generate a complete match. To check if there is any
+match of @racket[pattern] that covers all of @racket[input], use
+@racket[rexexp-match?] with @elem{@litchar{^(?:}@racket[pattern]@litchar{)$}}
+instead.
 
 @examples[
 (regexp-match-exact? #rx"a|ab" "ab")
-(regexp-match? #rx"^(a|ab)$" "ab")
+(regexp-match? #rx"^(?:a|ab)$" "ab")
 ]}
 
 

--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -629,6 +629,15 @@ instead.
 @examples[
 (regexp-match-exact? #rx"a|ab" "ab")
 (regexp-match? #rx"^(?:a|ab)$" "ab")
+]
+
+The @litchar{(?:)} grouping is necessary because concatenation has
+lower precedence than alternation; the regular expression without it,
+@litchar{^a|ab$}, matches any input that either starts with
+@litchar{a} or ends with @litchar{ab}.
+
+@examples[
+(regexp-match? #rx"^a|ab$" "123ab")
 ]}
 
 

--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -617,6 +617,15 @@ entire content of @racket[input] matches @racket[pattern].
 @examples[
 (regexp-match-exact? #rx"x." "12x4x6")
 (regexp-match-exact? #rx"1.*x." "12x4x6")
+]
+
+Beware that @racket[regexp-match-exact?] can return @racket[#f] if
+@racket[pattern] generates a partial match for @racket[input] first,
+even if @racket[pattern] could also generate a complete match.
+
+@examples[
+(regexp-match-exact? #rx"a|ab" "ab")
+(regexp-match? #rx"^(a|ab)$" "ab")
 ]}
 
 

--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -612,7 +612,7 @@ match succeeds, @racket[#f] otherwise.
           boolean?]{
 
 Like @racket[regexp-match?], but @racket[#t] is only returned when the
-entire content of @racket[input] matches @racket[pattern].
+first found match is to the entire content of @racket[input].
 
 @examples[
 (regexp-match-exact? #rx"x." "12x4x6")


### PR DESCRIPTION
This subtlety just bit me again, so here's a reminder for the docs.

I assume this is the intended behavior, based on section 9.7 (Alternation) of the Racket Guide. The behavior seems to be consistent between CS and BC.
