### PR TITLE
Fix error formatting for non-empty-listof contract

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/list.rkt
+++ b/pkgs/racket-test/tests/racket/contract/list.rkt
@@ -47,6 +47,12 @@
   (test/pos-blame 
    'nelistof5
    '(contract (non-empty-listof integer?) (list #f #t) 'pos 'neg))
+  (contract-error-test
+   'nelistof6
+   '(contract (non-empty-listof integer?) '() 'pos 'neg)
+   (lambda (e)
+     (regexp-match? #rx"promised: [(]and/c list[?] pair[?][)]"
+                    (exn-message e))))
   
   (test/spec-passed/result 
    'imlistof1

--- a/racket/collects/racket/contract/private/list.rkt
+++ b/racket/collects/racket/contract/private/list.rkt
@@ -135,7 +135,7 @@
                      '(expected: "~s" given: "~e")
                      (if empty-ok?
                          'list?
-                         (format "~s" `(and/c list? pair?)))
+                         '(and/c list? pair?))
                      val))
 
 (define (blame-add-listof-context blame) (blame-add-context blame "an element of"))


### PR DESCRIPTION
The error message for `non-empty-listof` had extra quotes due to a duplicated call to `format`:

```
; foo: broke its own contract
;   promised: "(and/c list? pair?)"
;   produced: '()
```