### PR TITLE
patterns.scrbl:  Clarified phase 0 use of require for syntax-parser

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/patterns.scrbl
@@ -888,7 +888,10 @@ repetition. They are useful for matching, for example, keyword
 arguments where the keywords may come in any order. Multiple
 alternatives are grouped together via @racket[~alt].
 
-@examples[#:eval the-eval
+Note:  @racketid[syntax-parser] is used in phase 0, so we need to use @racket[(require syntax/parse)] instead of @racket[(require (for-syntax syntax/parse))] as we would use for the phase 1 @racketid[syntax-parse].
+  
+  @examples[#:eval the-eval
+  (require syntax/parse)
 (define parser1
   (syntax-parser
    [((~alt (~once (~seq #:a x) #:name "#:a keyword")


### PR DESCRIPTION
Modified the documentation at https://docs.racket-lang.org/syntax/stxparse-patterns.html?q=syntax-parser#%28part._.Ellipsis-head_.Patterns%29 to mention the need for (require syntax/parse) when using syntax-parser instead of (require (for-syntax syntax/parse))