### PR TITLE
Ignore some objects in LeakSanitizer.

### DIFF
--- a/racket/src/rktio/lsan-suppressions.supp
+++ b/racket/src/rktio/lsan-suppressions.supp
@@ -1,0 +1,15 @@
+# LeakSanitizer suppressions for Racket CS.
+# These are intentional, process-lifetime allocations that are referenced
+# only from the Chez Scheme GC heap (which LSan does not scan), so LSan
+# reports them as leaks. Each matches a frame in the allocation stack.
+
+# --- rktio persistent state (held by the rktio_t / Racket) ---
+leak:rktio_converter_open
+leak:rktio_system_fd
+leak:rktio_ltps_open
+leak:rktio_get_current_directory
+
+# --- Chez Scheme runtime globals ---
+leak:S_make_mutex
+leak:S_make_condition
+leak:racket_boot

--- a/racket/src/rktio/rktio_convert.c
+++ b/racket/src/rktio/rktio_convert.c
@@ -501,6 +501,13 @@ rktio_converter_t *rktio_converter_open(rktio_t *rktio, const char *to_enc, cons
 
   cvt = malloc(sizeof(rktio_converter_t));
   cvt->cd = cd;
+  /* The converter (and the iconv state reachable through cvt->cd) is held
+     for the process lifetime via the Racket/Chez GC heap, which LeakSanitizer
+     does not scan; mark it ignored so it is not a false-positive leak.
+     (PR #3853 places this at the io/converter custodian layer so only
+     custodian-managed converters are ignored; this is the rktio-level
+     demonstration.) */
+  rktio_lsan_ignore_object(cvt);
   return cvt;
 }
 

--- a/racket/src/rktio/rktio_main.c
+++ b/racket/src/rktio/rktio_main.c
@@ -104,3 +104,25 @@ void rktio_free(void *p)
 {
   free(p);
 }
+
+/* __has_feature(address_sanitizer) is the Clang spelling; define a fallback
+   so the check also compiles on GCC/MSVC, which use __SANITIZE_ADDRESS__. */
+#ifndef __has_feature
+# define __has_feature(x) 0
+#endif
+
+#if defined(__SANITIZE_ADDRESS__) || __has_feature(address_sanitizer)
+# include <sanitizer/lsan_interface.h>
+# define RKTIO_HAS_LSAN 1
+#endif
+
+/* Tell LeakSanitizer that O is intentionally retained: it is referenced only
+   from the Racket/Chez Scheme GC heap, which LSan does not scan, so it would
+   otherwise be reported as a false-positive leak. A no-op without ASan/LSan. */
+void rktio_lsan_ignore_object(void *o)
+{
+#ifdef RKTIO_HAS_LSAN
+  __lsan_ignore_object(o);
+#endif
+  (void)o;
+}

--- a/racket/src/rktio/rktio_private.h
+++ b/racket/src/rktio/rktio_private.h
@@ -42,6 +42,10 @@
 struct background_sleep_t;
 #endif
 
+/* Marks an intentionally-retained allocation so LeakSanitizer does not
+   report it (see rktio_main.c). No-op without ASan/LSan. */
+void rktio_lsan_ignore_object(void *o);
+
 /*========================================================================*/
 /* File-descriptor actions without a rktio_t                              */
 /*========================================================================*/


### PR DESCRIPTION
Really this should ignore fewer than this, but it's not yet clear
where the calls should go.

Related to #3839.