### PR TITLE
Rephrasing distinction between variable and object

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/eval-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/eval-model.scrbl
@@ -220,7 +220,7 @@ modifies the content of a vector.
 
 To explain such modifications to data, we must distinguish between
 @tech{values}, which are the results of expressions, and
-@deftech{objects}, which hold the data referenced by a value.
+@deftech{objects}, which actually hold data.
 
 A few kinds of @tech{objects} can serve directly as values, including
 booleans, @racket[(void)], and small exact integers. More generally,


### PR DESCRIPTION
I found the text as written slightly misleading. The phrase "referenced by a value" intends to describe a state of being; generally, a value *is* a reference. One might misinterpret this English phrase, though, as describing an action that can occur: "reference" being an action that a value can perform, like "walk", "jump", or "skip". Further, because objects aren't limited to holding merely those data that some variable references, I thought it improved reading to remove that qualification.