### PR TITLE
Cleaning causality in rejected alternative application

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/eval-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/eval-model.scrbl
@@ -386,9 +386,9 @@ an @tech{object}, so evaluating @racket[(f 7)] starts with a
 Unlike in algebra, however, the @tech{value} associated with a procedure
 argument variable can be changed in the body of a procedure by using
 @racket[set!], as in the example @racket[(lambda (x) (begin (set! x 3)
-x))]. Since the @tech{value} associated with argument variable @racket[x] can be
-changed, the value cannot be substituted for @racket[x] when
-the procedure is first applied.
+x))]. Since the @tech{value} associated with argument variable @racket[x] should be
+able to change, we cannot just substitute the value in for @racket[x] when
+we first apply the procedure.
 
 @margin-note{We do not use the term ``parameter variable'' to refer to
 the argument variable names declared with a function. This choice avoids


### PR DESCRIPTION
I imagine a reader misunderstanding the causal relationship in the sentence as currently written. I hope for this to disambiguate. I believe this point in the document describes a design decision we the reader are presently considering. The reader should not imagine that an existing capacity to change `x` itself materially /prevents/ substitution---that we cannot substitute---the way a buoy's ability to float prevents it from sinking. I believe the writer means to say that the intended goal, supporting mutation, makes us (the author + the reader) reject direct substitution as an evaluation strategy.