### PR TITLE
Copyediting syntax model in Reference

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -311,7 +311,7 @@ syntactic-form names refer to the bindings defined in
 
 In a fully expanded program for a namespace whose @tech{base phase} is
 0, the relevant @tech{phase level} for a binding in the program is
-@math{N} if the bindings has @math{N} surrounding
+@math{N} if the binding has @math{N} surrounding
 @racket[begin-for-syntax] and @racket[define-syntaxes] forms---not
 counting any @racket[begin-for-syntax] forms that wrap a
 @racket[module] or @racket[module*] form for the body of the @racket[module]

--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -529,7 +529,7 @@ core syntactic forms are encountered:
        @tech{phase level} 1 (i.e., the @tech{transformer environment}
        is extended). More generally, @racket[begin-for-syntax] forms
        can be nested, and each @racket[begin-for-syntax] shifts its
-       body definition by one @tech{phase level}.}
+       body by one @tech{phase level}.}
 
  @item{When a @racket[let-values] form is encountered, the body of the
        @racket[let-values] form is extended (by creating new

--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -528,7 +528,7 @@ core syntactic forms are encountered:
        @racket[define-values] and @racket[define-syntaxes], but at
        @tech{phase level} 1 (i.e., the @tech{transformer environment}
        is extended). More generally, @racket[begin-for-syntax] forms
-       can be nested, an each @racket[begin-for-syntax] shifts its
+       can be nested, and each @racket[begin-for-syntax] shifts its
        body definition by one @tech{phase level}.}
 
  @item{When a @racket[let-values] form is encountered, the body of the

--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -520,7 +520,7 @@ core syntactic forms are encountered:
  @item{When a @racket[define], @racket[define-values],
        @racket[define-syntax], or @racket[define-syntaxes] form is
        encountered at the top level or module level, a binding is
-       added @tech{phase level} 0 (i.e., the @tech{base environment}
+       added to @tech{phase level} 0 (i.e., the @tech{base environment}
        is extended) for each defined identifier.}
 
  @item{When a @racket[begin-for-syntax] form is encountered at the top

--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -312,7 +312,7 @@ syntactic-form names refer to the bindings defined in
 In a fully expanded program for a namespace whose @tech{base phase} is
 0, the relevant @tech{phase level} for a binding in the program is
 @math{N} if the binding has @math{N} surrounding
-@racket[begin-for-syntax] and @racket[define-syntaxes] forms---not
+@racket[begin-for-syntax] and/or @racket[define-syntaxes] forms---not
 counting any @racket[begin-for-syntax] forms that wrap a
 @racket[module] or @racket[module*] form for the body of the @racket[module]
 or @racket[module*], unless a @racket[module*] form has @racket[#f] in place


### PR DESCRIPTION
I make some small edits to the syntax-model section of the Racket reference, up through 1.2.3.5.