### PR TITLE
make-temporary-file: accept keyword arguments

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -1,5 +1,6 @@
 #lang scribble/doc
 @(require "mz.rkt"
+          scribble/core
           (for-label framework/preferences
                      racket/runtime-path
                      launcher/launcher
@@ -680,7 +681,7 @@ directory.}
 
 @defparam*[current-directory-for-user path path-string? (and/c path? complete-path?)]{
 
-Like @racket[current-directory], but use only by
+Like @racket[current-directory], but for use only by
 @racket[srcloc->string] for reporting paths relative to a
 directory.
 
@@ -1390,43 +1391,125 @@ will not create it.
 
 
 @defproc[(make-temporary-file [template string? "rkttmp~a"]
-                              [copy-from-filename (or/c path-string? #f 'directory) #f]
-                              [directory (or/c path-string? #f) #f])
-         path?]{
+                              [#:copy-from copy-from (or/c path-string? #f 'directory) #f]
+                              [#:base-dir base-dir (or/c path-string? #f) #f]
+                              [compat-copy-from (or/c path-string? #f 'directory) copy-from]
+                              [compat-base-dir (or/c path-string? #f) base-dir])
+         (and/c path? complete-path?)]{
 
-Creates a new temporary file and returns a pathname string for the
-file.  Instead of merely generating a fresh file name, the file is
+Creates a new temporary file and returns its path.
+Instead of merely generating a fresh file name, the file is
 actually created; this prevents other threads or processes from
 picking the same temporary name.
 
-The @racket[template] argument must be a format string suitable
-for use with @racket[format] and one additional string argument (where
-the string contains only digits). If the resulting string is a
-relative path, it is combined with the result of
-@racket[(find-system-path 'temp-dir)], unless @racket[directory] is
-provided and non-@racket[#f], in which case the
-file name generated from @racket[template] is combined with
-@racket[directory] to obtain a full path.
+The @racket[template] argument must be a format string
+suitable for use with @racket[format] and one additional
+string argument (which will contain only digits). By
+default, if @racket[template] produces a relative path, it
+is combined with the result of
+@racket[(find-system-path 'temp-dir)] using
+@racket[build-path]; alternatively, @racket[template] may
+produce an absolute path, in which case
+@racket[(find-system-path 'temp-dir)] is not consulted. If
+@racket[base-dir] is provided and non-@racket[#false],
+@racket[template] must not produce a @tech{complete} path,
+and @racket[base-dir] will be used instead of
+@racket[(find-system-path 'temp-dir)]. Using
+@racket[base-dir] is generally more reliable than including
+directory components in @racket[template]: it avoids subtle
+bugs from manipulating paths as string and eleminates the
+need to sanitize @racket[format] escape sequences.
 
-The @racket[template] argument's default is only the string @racket["rkttmp~a"]
-when there is no source location information for the callsite of
-@racket[make-temporary-file] (or if @racket[make-temporary-file] is
-used in a higher-order position). If there is such information, then the template
-string is based on the source location.
+On Windows, @racket[template] may produce an absolute path
+which is not a complete path (see @secref["windowspaths"])
+when @racket[base-dir] is absent or @racket[#f] (in which
+case it will be resolved relative to
+@racket[(current-directory)]) or if @racket[base-dir] is a
+drive specification (in which case it will be used as with
+@racket[build-path]). If @racket[base-dir] is any other kind
+of path, it is an error for @racket[template] to produce an
+absolute path.
 
-If @racket[copy-from-filename] is provided as path, the temporary file
+When the @racket[template] argument is not provided, if
+there is source location information for the callsite of
+@racket[make-temporary-file], a template string is generated
+based on the source location: the default is
+@racket["rkttmp~a"] only when no source location information
+is available (e.g@._ if @racket[make-temporary-file] is used
+in a higher-order position).
+
+If @racket[copy-from] is provided as path, the temporary file
 is created as a copy of the named file (using @racket[copy-file]). If
-@racket[copy-from-filename] is @racket[#f], the temporary file is
-created as empty. If @racket[copy-from-filename] is
-@racket['directory], then the temporary ``file'' is created as a
-directory.
+@racket[copy-from] is @racket[#f], the temporary file is
+created as empty. As a special case, for backwards compatibility,
+if @racket[copy-from] is @racket['directory],
+then the temporary ``file'' is created as a directory:
+for clarity, prefer @racket[make-temporary-directory] for creating
+temporary directories.
 
 When a temporary file is created, it is not opened for reading or
-writing when the pathname is returned. The client program calling
+writing when the path is returned. The client program calling
 @racket[make-temporary-file] is expected to open the file with the
 desired access and flags (probably using the @racket['truncate] flag;
 see @racket[open-output-file]) and to delete it when it is no longer
-needed.}
+needed.
+
+The by-position arguments @racket[compat-copy-from] and
+@racket[compat-base-dir] are for backwards compatibility:
+if provided, they take precedence over the @racket[#:copy-from] and
+@racket[#:base-dir] keyword variants.
+Supplying by-position arguments prevents @racket[make-temporary-file]
+from generating a @racket[template] using the source location.
+
+@history[
+ #:changed "8.4.0.3"
+ @elem{Added the @racket[#:copy-from] and @racket[#:base-dir] arguments.}
+ ]}
+
+@defproc[(make-temporary-directory [template string? "rkttmp~a"]
+                                   [#:base-dir base-dir (or/c path-string? #f) #f])
+         (and/c path? complete-path?)]{
+
+ Like @racket[make-temporary-file], but
+ creates a directory, rather than a regular file.
+
+ As with @racket[make-temporary-file], if the
+ @racket[template] argument is not provided, a template
+ string is generated from the source location of the call to
+ @racket[make-temporary-directory] when possible: the default
+ is @racket["rkttmp~a"] only when no source location
+ information is available.
+
+@history[
+ #:added "8.4.0.3"
+ ]}
+
+@deftogether[
+ (@defproc[(make-temporary-file* [prefix bytes?]
+                                 [suffix bytes?]
+                                 [#:copy-from copy-from (or/c path-string? #f) #f]
+                                 [#:base-dir base-dir (or/c path-string? #f) #f])
+           (and/c path? complete-path?)]
+   @defproc[(make-temporary-directory* [prefix bytes?]
+                                       [suffix bytes?]
+                                       [#:base-dir base-dir (or/c path-string? #f) #f])
+            (and/c path? complete-path?)])]{
+
+ Like @racket[make-temporary-file] and
+ @racket[make-temporary-directory], respectively, but, rather
+ than using a template for @racket[format], the path is based
+ on @racket[(bytes-append prefix generated suffix)], where
+ @racket[generated] is a byte string chosen by the
+ implementation to produce a unique path. If there is source
+ location information for the callsite of
+ @racket[make-temporary-file*] or
+ @racket[make-temporary-directory*], @racket[generated] will
+ incorporate that information. The resulting path is combined
+ with @racket[base-dir] as with @racket[make-temorary-file].
+
+ @history[
+ #:added "8.4.0.3"
+ ]}
 
 @defproc[(call-with-atomic-output-file [file path-string?] 
                                        [proc ([port output-port?] [tmp-path path?]  . -> . any)]

--- a/racket/collects/racket/file.rkt
+++ b/racket/collects/racket/file.rkt
@@ -9,7 +9,11 @@
          copy-directory/files
          make-directory*
          make-parent-directory*
+
          make-temporary-file
+         make-temporary-directory
+         make-temporary-file*
+         make-temporary-directory*
 
          get-preference
          put-preferences
@@ -148,100 +152,408 @@
     ;; Do nothing with an immediately relative path or a root directory
     (void)]))
 
-(define-syntax (make-temporary-file stx)
-  (with-syntax ([app (datum->syntax stx #'#%app stx)])
-    (syntax-case stx ()
-      [x (identifier? #'x) #'make-temporary-file/proc]
-      [(_)
-       (let ()
-         (define line   (syntax-line stx))
-         (define col    (syntax-column stx))
-         (define source (syntax-source stx))
-         (define pos    (syntax-position stx))
-         (define str-src
-           (cond [(path? source)
-                  (regexp-replace #rx"^<(.*?)>(?=/)"
-                                  (path->relative-string/library source)
-                                  (lambda (_ s) (string-upcase s)))]
-                 [(string? source) source]
-                 [else #f]))
-         (define str-loc
-           (cond [(and line col) (format "-~a-~a" line col)]
-                 [pos (format "--~a" pos)]
-                 [else ""]))
-         (define combined-str (string-append (or str-src "rkttmp") str-loc))
-         (define sanitized-str (regexp-replace* #rx"[<>:\"/\\|]" combined-str "-"))
-         (define max-len 50) ;; must be even
-         (define not-too-long-str
-           (cond [(< max-len (string-length sanitized-str))
-                  (string-append (substring sanitized-str 0 (- (/ max-len 2) 2))
-                                 "----"
-                                 (substring sanitized-str
-                                            (- (string-length sanitized-str)
-                                               (- (/ max-len 2) 2))))]
-                 [else sanitized-str]))
-         #`(app make-temporary-file/proc
-                #,(string-append not-too-long-str "_~a")))]
-      [(_ . whatever)
-       #'(app make-temporary-file/proc . whatever)])))
+;;---------------------------------------------------------------------------------------------------
+;;---------------------------------------------------------------------------------------------------
+;;
+;; MAKING TEMPORARY FILES & DIRECTORIES
+;; ------------------------------------
+;;
+;; There are four related functions defined in this section:
+;;
+;;   1. make-temporary-file        \
+;;                                  > based on `format`
+;;   2. make-temporary-directory   /
+;;
+;;   3. make-temporary-file*       \
+;;                                  > based on `bytes-append`
+;;   4. make-temporary-directory*  /
+;;
+;; All of these are actually macros, to support template generation from context.
+;; The macro `define-temporary-file/directory-transformer` and compile-time function
+;; `temporary-file/directory-transformer` assist in defining those macros,
+;; mostly because we don't have `syntax-parse` here.
+;;
+;; The core logic is in `internal-make-temporary-file/directory`, which essentially
+;; implements the old `make-temporary-file` protocol (before it supported keyword
+;; arguments and had a separate `-directory` variant), except that it accepts a
+;; function to build candidate file names.
+;;
+;; Then there is a lot of argument checking.
+;; The entry point for the variants based on `format` (no `*`) is
+;; `do-make-temporary-file/directory:format`; for the `*` variants,
+;; `do-make-temporary-file/directory:bytes-append`.
+;; Each entry point tail-calls `do-make-temporary-file/directory:check-make-name`,
+;; which tries building a path from the template or prefix+suffix and reports
+;; various possible errors with the result.
+;; If the tests pass, it tail-calls `internal-make-temporary-file/directory`.
 
-(define make-temporary-file/proc
-  (let ()
-    (define (make-temporary-file [template "rkttmp~a"] [copy-from #f] [base-dir #f])
-      (with-handlers ([exn:fail:contract?
-                       (lambda (x)
-                         (raise-arguments-error 'make-temporary-file
-                                                "format string does not expect 1 argument"
-                                                "format string" template))])
-        (format template void))
-      (unless (or (not copy-from)
-                  (path-string? copy-from)
-                  (eq? copy-from 'directory))
-        (raise-argument-error 'make-temporary-file
-                              "(or/c path-string? 'directory #f)"
-                              copy-from))
-      (unless (or (not base-dir) (path-string? base-dir))
-        (raise-argument-error 'make-temporary-file
-                              "(or/c path-string? #f)"
-                              base-dir))
-      (let ([tmpdir (find-system-path 'temp-dir)])
-        (let loop ([s (current-seconds)]
-                   [ms (inexact->exact (truncate (current-inexact-milliseconds)))]
-                   [tries 0])
-          (let ([name (let ([n (format template (format "~a~a" s ms))])
-                        (cond [base-dir (build-path base-dir n)]
-                              [(relative-path? n) (build-path tmpdir n)]
-                              [else n]))])
-            (with-handlers ([(lambda (exn)
-                               (or (exn:fail:filesystem:exists? exn)
-                                   (and (exn:fail:filesystem:errno? exn)
-                                        (let ([errno (exn:fail:filesystem:errno-errno exn)])
-                                          (and (eq? 'windows (cdr errno))
-                                               (eqv? (car errno) 5) ; ERROR_ACCESS_DENIED
-                                               ;; On Windows, if the target path refers to a file
-                                               ;; that has been deleted but is still open
-                                               ;; somewhere, then an access-denied error is reported
-                                               ;; instead of a file-exists error; there appears
-                                               ;; to be no way to detect that it was really a
-                                               ;; file-still-exists error. Try again for a while.
-                                               ;; There's still a small chance that this will
-                                               ;; fail, but it's vanishingly small at 32 tries.
-                                               ;; If ERROR_ACCESS_DENIED really is the right
-                                               ;; error (e.g., because the target directory is not
-                                               ;; writable), we'll take longer to get there.
-                                               (tries . < . 32))))))
-                             (lambda (x)
-                               ;; try again with a new name
-                               (loop (- s (random 10))
-                                     (+ ms (random 10))
-                                     (add1 tries)))])
-              (if copy-from
-                  (if (eq? copy-from 'directory)
-                      (make-directory name)
-                      (copy-file copy-from name))
-                  (close-output-port (open-output-file name)))
-              name)))))
-    make-temporary-file))
+(define (internal-make-temporary-file/directory who copy-from base-dir make-name)
+  (define tmpdir (find-system-path 'temp-dir))
+  (let loop ([s (current-seconds)]
+             [ms (inexact->exact (truncate (current-inexact-milliseconds)))]
+             [tries 0])
+    (define pth
+      (path->complete-path
+       (let ([n (make-name
+                 ;; docs promise argument will be a string containing only digits
+                 (format "~a~a" s ms))])
+         (cond [base-dir (build-path base-dir n)]
+               [(relative-path? n) (build-path tmpdir n)]
+               [else n]))))
+    (with-handlers ([(lambda (exn)
+                       ;; FIXME: There should probably be a maximum number of
+                       ;; tries for other cases, too.
+                       ;; See: https://github.com/racket/racket/pull/3870#discussion_r741177829
+                       (or (exn:fail:filesystem:exists? exn)
+                           (and (exn:fail:filesystem:errno? exn)
+                                (let ([errno (exn:fail:filesystem:errno-errno exn)])
+                                  (and (eq? 'windows (cdr errno))
+                                       (eqv? (car errno) 5) ; ERROR_ACCESS_DENIED
+                                       ;; On Windows, if the target path refers to a file
+                                       ;; that has been deleted but is still open
+                                       ;; somewhere, then an access-denied error is reported
+                                       ;; instead of a file-exists error; there appears
+                                       ;; to be no way to detect that it was really a
+                                       ;; file-still-exists error. Try again for a while.
+                                       ;; There's still a small chance that this will
+                                       ;; fail, but it's vanishingly small at 32 tries.
+                                       ;; If ERROR_ACCESS_DENIED really is the right
+                                       ;; error (e.g., because the target directory is not
+                                       ;; writable), we'll take longer to get there.
+                                       (tries . < . 32))))))
+                     (lambda (x)
+                       ;; try again with a new name
+                       ;; TODO: should this use `crypto-random-bytes`, like FreeBSD, per SEI CERT?
+                       ;; See: https://github.com/racket/racket/pull/3870#issuecomment-957779099
+                       (loop (- s (random 10))
+                             (+ ms (random 10))
+                             (add1 tries)))])
+      (if copy-from
+          (if (eq? copy-from 'directory)
+              (make-directory pth)
+              (copy-file copy-from pth))
+          (close-output-port (open-output-file pth)))
+      pth)))
+
+(define (check-base-dir who base-dir)
+  (unless (or (not base-dir) (path-string? base-dir))
+    (raise-argument-error who "(or/c path-string? #f)" base-dir)))
+
+(define (check-bytes who x)
+  (unless (bytes? x)
+    (raise-argument-error who "bytes?" x)))
+
+(define (do-make-temporary-file/directory:check-make-name
+         who copy-from base-dir make-name
+         #:wrapped-make-name wraped-make-name
+         #:complete-with-base-error complete-with-base-error
+         #:syntactic-directory-error syntactic-directory-error)
+  (define result
+    ;; docs promise argument will be a string containing only digits
+    (wraped-make-name "0"))
+  (when (and base-dir (complete-path? result))
+    ;; On Windows, base-dir could be a drive specification,
+    ;; in which case it is ok for result to be an absolute path without a drive.
+    (complete-with-base-error result))
+  (unless (eq? 'directory copy-from)
+    (when (let-values ([{_base _name must-be-dir?}
+                        (split-path result)])
+            must-be-dir?)
+      (syntactic-directory-error result)))
+  (internal-make-temporary-file/directory who copy-from base-dir make-name))
+
+(define (do-make-temporary-file/directory:format who template copy-from base-dir)
+  (unless (or (not copy-from)
+              (path-string? copy-from)
+              (eq? copy-from 'directory))
+    (raise-argument-error who
+                          "(or/c path-string? 'directory #f)"
+                          copy-from))
+  (check-base-dir who base-dir)
+  (unless (string? template)
+    (raise-argument-error who "string?" template))
+  (define (make-name digits-str)
+    (format template digits-str))
+  (define (bad-result-msg details)
+    ;; i.e. the result is valid as path, but not for our purposes
+    (string-append "given template produced an invalid result;\n " details))
+  (do-make-temporary-file/directory:check-make-name
+   who copy-from base-dir make-name
+   #:wrapped-make-name
+   (λ (digits-str)
+     (define result
+       (with-handlers ([exn:fail:contract?
+                        (lambda (x)
+                          (raise-arguments-error
+                           who
+                           "malformed template"
+                           "expected" (unquoted-printing-string
+                                       "a format string accepting 1 string argument")
+                           "given" template))])
+         (make-name digits-str)))
+     (unless (path-string? result)
+       (raise-arguments-error
+        who
+        "given template produced an invalid path"
+        "promised" (unquoted-printing-string "path-string?")
+        "produced" result
+        "template" template))
+     result)
+   #:complete-with-base-error
+   (λ (result)
+     ;; On Windows, base-dir could be a drive specification,
+     ;; in which case it is ok for result to be an absolute path without a drive.
+     (raise-arguments-error
+      who
+      (bad-result-msg "complete path can not be combined with base-dir")
+      "template" template
+      "produced" result
+      "base-dir" base-dir))
+   #:syntactic-directory-error
+   (λ (result)
+     (raise-arguments-error
+      who
+      (bad-result-msg
+       "syntactic directory path not allowed unless copy-from is 'directory")
+      "template" template
+      "produced" result
+      "copy-from" copy-from))))
+
+(define (do-make-temporary-file/directory:bytes-append
+         ctxt prefix suffix copy-from base-dir
+         #:directory? directory?)
+  (define who
+    (if directory?
+        'make-temporary-directory*
+        'make-temporary-file*))
+  (check-bytes who prefix)
+  (check-bytes who suffix)
+  (check-base-dir who base-dir)
+  (unless (or directory?
+              (not copy-from)
+              (path-string? copy-from))
+    (raise-argument-error who
+                          "(or/c path-string? #f)"
+                          copy-from))
+  (define (make-name/bytes digits-str)
+    (bytes-append prefix
+                  ctxt
+                  (path-element->bytes (string->path-element digits-str))
+                  suffix))
+  (define (bad-result-msg details)
+    ;; i.e. the result is valid as path, but not for our purposes
+    (string-append "given prefix and suffix produced an invalid result;\n " details))
+  (do-make-temporary-file/directory:check-make-name
+   who copy-from base-dir
+   (λ (digits-str)
+     (bytes->path (make-name/bytes digits-str)))
+   #:wrapped-make-name
+   (λ (digits-str)
+     (define bs (make-name/bytes digits-str))
+     (with-handlers ([exn:fail?
+                      (λ (e)
+                        (raise-arguments-error
+                         who
+                         "given prefix and suffix produced an invalid path"
+                         "prefix" prefix
+                         "suffix" suffix
+                         "produced" bs))])
+       (bytes->path bs)))
+   #:syntactic-directory-error
+   (λ (result)
+     (raise-arguments-error
+      who
+      (bad-result-msg "syntactic directory path not allowed")
+      "prefix" prefix
+      "suffix" suffix
+      "produced" result))
+   #:complete-with-base-error
+   (λ (result)
+     ;; On Windows, base-dir could be a drive specification,
+     ;; in which case it is ok for result to be an absolute path without a drive.
+     (raise-arguments-error
+      who
+      (bad-result-msg "complete path can not be combined with base-dir")
+      "prefix" prefix
+      "suffix" suffix
+      "produced" result
+      "base-dir" base-dir))))
+
+(define-for-syntax (syntax->tmp-context-string stx)
+  (define line   (syntax-line stx))
+  (define col    (syntax-column stx))
+  (define source (syntax-source stx))
+  (define pos    (syntax-position stx))
+  (define str-src
+    (cond [(path? source)
+           (regexp-replace #rx"^<(.*?)>(?=/)"
+                           (path->relative-string/library source)
+                           (lambda (_ s) (string-upcase s)))]
+          [(string? source) source]
+          [else #f]))
+  (define str-loc
+    (cond [(and line col) (format "-~a-~a" line col)]
+          [pos (format "--~a" pos)]
+          [else ""]))
+  (define combined-str (string-append (or str-src "rkttmp") str-loc))
+  (define sanitize-rx
+    ;; Keep this in sync with IS_SPEC_CHAR() from racket/src/bc/src/file.c
+    ;; and protect-path-element from racket/src/io/path/protect.rkt.
+    ;; In addition to the characters handled by both of those,
+    ;; we also need to treat ~ as special, since we may be producing
+    ;; format string.
+    #rx"[<>:\"/\\|?*~]")
+  (define sanitized-str (regexp-replace* sanitize-rx combined-str "-"))
+  (define max-len 50) ;; must be even
+  (define not-too-long-str
+    (cond [(< max-len (string-length sanitized-str))
+           (string-append (substring sanitized-str 0 (- (/ max-len 2) 2))
+                          "----"
+                          (substring sanitized-str
+                                     (- (string-length sanitized-str)
+                                        (- (/ max-len 2) 2))))]
+          [else sanitized-str]))
+  not-too-long-str)
+
+(define-for-syntax (infer-temporary-file-template stx)
+  (string-append (syntax->tmp-context-string stx) "_~a"))
+
+(define-for-syntax (infer-temporary-file-context-bytes stx)
+  ;; We rely on the sanitization above having been used
+  ;; successfully by Racket from time immemorial.
+  (string->bytes/utf-8 (syntax->tmp-context-string stx)))
+
+;; temporary-file/directory-transformer
+;;   : (-> identifier? procedure? (-> syntax? syntax?))
+;; Produces a macro transformer procedure.
+;; The first argument must be an identifier bound at run-time
+;; to the function implementation.
+;; The second argument must be a (compile-time) procedure that:
+;;   - must have no required keyword arguments;
+;;   - must NOT permit arbitrary keyword arguments
+;;     (i.e. the second result of procedure-keywords must be a list);
+;;   - must accept two by-position arguments, namely, the full syntax object
+;;     passed to the macro invocation and the run-time identifier from the
+;;     first argument; and
+;;   - may accept additional by-position arguments.
+;; The accepted keywords of the compile-time procedure argument determine
+;; the keywords supported by the resulting macro. The by-position arity of
+;; the compile-time procedure, after adjusting for the two required by-position
+;; arguments, determines the number of by-position arguments supported by the
+;; resulting macro. When the resulting macro is used with a supported combination
+;; of keyword and by-position arguments, the compile-time procedure is invoked in
+;; tail position with the two fixed by-position arguments, plus syntax objects for
+;; the supplied keyword and by-position argument expressions. Otherwise, when the
+;; resulting macro is used with an unsupported combination of arguments, it expands
+;; to a use of the run-time identifier.
+(define-for-syntax ((temporary-file/directory-transformer proc-id infer-proc) stx)
+  (define-values (_required-kws allowed-kws)
+    (procedure-keywords infer-proc))
+  (syntax-case stx ()
+    [x
+     (identifier? #'x)
+     proc-id]
+    [(_ . more-stx)
+     (or (let loop ([args '()]
+                    [kws #hasheq()]
+                    [stx* #'more-stx])
+           (syntax-case stx* ()
+             [()
+              (and (procedure-arity-includes? infer-proc (+ 2 (length args)))
+                   (keyword-apply infer-proc
+                                  (hash-keys kws 'ordered)
+                                  (hash-values kws 'ordered)
+                                  stx
+                                  proc-id
+                                  (reverse args)))]
+             [(kw-stx val . more-stx)
+              (memq (syntax-e #'kw-stx) allowed-kws) ;; implies `keyword?`
+              (let ([kw (syntax-e #'kw-stx)])
+                (and (not (hash-has-key? kws kw))
+                     (not (keyword? (syntax-e #'val)))
+                     (loop args (hash-set kws kw #'val) #'more-stx)))]
+             [(arg . more-stx)
+              (not (keyword? (syntax-e #'arg)))
+              ;; don't check `procedure-arity-includes?` here,
+              ;; because there may be a minimum number of required
+              ;; by-position arguments
+              (loop (cons #'arg args) kws #'more-stx)]
+             [_
+              #f]))
+         #`(#,proc-id . more-stx))]))
+
+;; define-temporary-file/directory-transformer
+;; Definition form of `temporary-file/directory-transformer`,
+;; with support for giving the right inferred name to an
+;; otherwise-anonymous runtime procedure.
+;; See the comments on `temporary-file/directory-transformer` for
+;; further details about the compile-time procedure.
+(define-syntax (define-temporary-file/directory-transformer stx)
+  (syntax-case stx ()
+    [(_ name runtime-proc-expr infer-proc-expr)
+     (with-syntax ([(tmp) (generate-temporaries #'(name))])
+       #`(begin
+           (define tmp
+             (let ([name runtime-proc-expr])
+               name))
+           (define-syntax name
+             (temporary-file/directory-transformer #'tmp infer-proc-expr))))]))
+
+(define-temporary-file/directory-transformer make-temporary-file
+  (λ ([template "rkttmp~a"]
+      #:copy-from [copy-from #f]
+      #:base-dir [base-dir #f]
+      [compat-copy-from copy-from]
+      [compat-base-dir base-dir])
+    (do-make-temporary-file/directory:format 'make-temporary-file
+                                             template compat-copy-from compat-base-dir))
+  (λ (#:copy-from [copy-from #''#f]
+      #:base-dir [base-dir #''#f]
+      stx proc-id)
+    #`(#%app #,proc-id
+             '#,(infer-temporary-file-template stx)
+             #,copy-from
+             #,base-dir)))
+
+(define-temporary-file/directory-transformer make-temporary-directory
+  (λ ([template "rkttmp~a"]
+      #:base-dir [base-dir #f])
+    (do-make-temporary-file/directory:format 'make-temporary-directory
+                                             template 'directory base-dir))
+   (λ (#:base-dir [base-dir #''#f]
+       stx proc-id)
+     #`(#%app #,proc-id
+              '#,(infer-temporary-file-template stx)
+              #:base-dir #,base-dir)))
+
+(define-temporary-file/directory-transformer make-temporary-file*
+  (λ (#:copy-from [copy-from #f]
+      #:base-dir [base-dir #f]
+      prefix suffix)
+    (do-make-temporary-file/directory:bytes-append
+     #"" prefix suffix copy-from base-dir
+     #:directory? #f))
+  (λ (#:copy-from [copy-from #''#f]
+      #:base-dir [base-dir #''#f]
+      stx proc-id prefix suffix)
+    #`(#%app do-make-temporary-file/directory:bytes-append
+             #,(infer-temporary-file-context-bytes stx)
+             #,prefix #,suffix #,copy-from #,base-dir
+             #:directory? #f)))
+
+(define-temporary-file/directory-transformer make-temporary-directory*
+  (λ (#:base-dir [base-dir #f]
+      prefix suffix)
+    (do-make-temporary-file/directory:bytes-append
+     #"" prefix suffix 'directory base-dir
+     #:directory? #t))
+  (λ (#:base-dir [base-dir #''#f]
+      stx proc-id prefix suffix)
+    #`(#%app do-make-temporary-file/directory:bytes-append
+             #,(infer-temporary-file-context-bytes stx)
+             #,prefix #,suffix 'directory #,base-dir
+             #:directory? #t)))
+
 
 ;;  Open a temporary path for writing, automatically renames after,
 ;;  and arranges to delete path if there's an exception. Uses the an
@@ -271,7 +583,7 @@
       (delete-file path)))
   (let ([bp (current-break-parameterization)]
         [tmp-path (parameterize ([current-security-guard (or guard (current-security-guard))])
-                    (make-temporary-file "tmp~a" #f (or (path-only path) (current-directory))))]
+                    (make-temporary-file #:base-dir (or (path-only path) (current-directory))))]
         [ok? #f])
     (dynamic-wind
      void
@@ -305,7 +617,7 @@
                           (rename-file-or-directory tmp-path path #t)
                           void))]
                      [else
-                      (let ([tmp-path2 (make-temporary-file "tmp~a" #f (path-only path))])
+                      (let ([tmp-path2 (make-temporary-file #:base-dir (path-only path))])
                         (with-handlers ([exn:fail:filesystem? void])
                           (rename-file-or-directory path tmp-path2 #t))
                         (rename-file-or-directory tmp-path path #t)

--- a/racket/src/bc/src/file.c
+++ b/racket/src/bc/src/file.c
@@ -523,6 +523,8 @@ Scheme_Object *scheme_make_sized_offset_path(char *chars, intptr_t d, intptr_t l
   return scheme_make_sized_offset_kind_path(chars, d, len, copy, SCHEME_PLATFORM_PATH_KIND);
 }
 
+/* If changing the following, consider also changing
+   syntax->tmp-context-string in racket/collects/racket/file.rkt */
 # define IS_SPEC_CHAR(x) (IS_A_DOS_SEP(x) || ((x) == '"') || ((x) == '|') \
                           || ((x) == ':') || ((x) == '<') || ((x) == '>') \
                           || ((x) == '?') || ((x) == '*'))

--- a/racket/src/io/path/protect.rkt
+++ b/racket/src/io/path/protect.rkt
@@ -38,6 +38,9 @@
                   (or (eqv? b (char->integer #\.))
                       (eqv? b (char->integer #\space))))
              #t]
+            ;; If changing the following,
+            ;; consider also changing syntax->tmp-context-string
+            ;; in racket/collects/racket/file.rkt
             [(or (eqv? b (char->integer #\/))
                  (eqv? b (char->integer #\"))
                  (eqv? b (char->integer #\|))


### PR DESCRIPTION
When `#:base-dir` and `#:copy-from` are passed as keyword arguments,
rather than by position, `make-temporary-file` can still use source
location information to generate a template, rather than having to
fall back to `"rkttmp~a"`.