### PR TITLE
rewrote explanation of one example in 16.2.6.2 Phases and Modules

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/phases.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/phases.scrbl
@@ -302,7 +302,7 @@ it doesn't:
 ]
 
 In the definition of module @racket[a], the variable
-@racket[see-button] is at phase 0 and its value is the syntax object
+@racket[see-button] is at phase 0, and its value is the syntax object
 for @racket[button], which shows the only visible @racket[button]
 binding is at the same phase. (That is the key detail.)
 As discussed, the @racket[for-syntax] import shifts the phase level of @emph{both}
@@ -312,7 +312,7 @@ into phase 1, which refers to @racket[button] in @racket[a] at phase
 1.
 The fact that in module @racket[b] there is also a phase 0 variable
 @racket[button] from a different instantiation of module @racket[a]
-does not matter because there is no way to reach it
+does not matter, because there is no way to reach it
 from the (shifted) @racket[see-button] from  @racket[a].
 
 This kind of phase-level mismatch between instantiations can be repaired 

--- a/pkgs/racket-doc/scribblings/guide/phases.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/phases.scrbl
@@ -301,15 +301,19 @@ it doesn't:
   (m))
 ]
 
-The @racket[see-button] inside macro @racket[m] comes from the
-@racket[(for-syntax 'a)] import.  For macro @racket[m] to work, it needs to 
-have @racket[button] bound at phase 0. That binding exists---it's implied by
-@racket[(require 'a)].  However, @racket[(require 'a)] and
-@racket[(require (for-syntax 'a))] are @emph{different instantiations}
-of the same module.  The @racket[see-button] at phase 1 only refers to
-the @racket[button] at phase 1, not the @racket[button] bound at
-phase 0 from a different instantiation---even from the same source
-module.
+In the definition of module @racket[a], the variable
+@racket[see-button] is at phase 0 and its value is the syntax object
+for @racket[button], which shows the only visible @racket[button]
+binding is at the same phase. (That is the key detail.)
+As discussed, the @racket[for-syntax] import shifts the phase level of @emph{both}
+up one, so the phase 1 binding of @racket[see-button] used in module
+@racket[b] is the binding from the module @racket[a] that is shifted
+into phase 1, which refers to @racket[button] in @racket[a] at phase
+1.
+The fact that in module @racket[b] there is also a phase 0 variable
+@racket[button] from a different instantiation of module @racket[a]
+does not matter because there is no way to reach it
+from the (shifted) @racket[see-button] from  @racket[a].
 
 This kind of phase-level mismatch between instantiations can be repaired 
 with @racket[syntax-shift-phase-level]. Recall that a syntax object like 


### PR DESCRIPTION
Directly trace through the bindings to explain why the example does not end up in phase 0.
This is a new explanation of why importing a module into two different phases will not (by itself) solve a phase-level mismatch in macro expansion.
