### PR TITLE
format-id: verify first input is syntax

### DIFF
--- a/pkgs/racket-test/tests/syntax/racket-syntax.rkt
+++ b/pkgs/racket-test/tests/syntax/racket-syntax.rkt
@@ -24,6 +24,15 @@
 (check-equal? (format-symbol "~a?" 'null) 'null?)
 (check-equal? (format-symbol "~a?" "null") 'null?)
 
+(check-exn
+ exn:fail:contract?
+ (lambda ()
+   (format-id 'here "wrong--first-arg-is-not-syntax")))
+
+(check free-identifier=?
+       (format-id #f "cb~a" #'a)
+       #'cba)
+
 ;; ----
 
 (check-equal? (syntax->datum

--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -113,6 +113,8 @@
                    #:subs? [subs? #f]
                    #:subs-intro [subs-intro (default-intro)]
                    fmt . args)
+  (unless (or (syntax? lctx) (eq? lctx #f))
+    (raise-argument-error 'format-id "(or/c syntax? #f)" lctx))
   (check-restricted-format-string 'format-id fmt)
   (define arg-strs (map (lambda (a) (->string a 'format-id)) args))
   (define str (apply format fmt arg-strs))

--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -114,7 +114,7 @@
                    #:subs-intro [subs-intro (default-intro)]
                    fmt . args)
   (unless (or (syntax? lctx) (eq? lctx #f))
-    (raise-argument-error 'format-id "(or/c syntax? #f)" 0 lctx args))
+    (apply raise-argument-error 'format-id "(or/c syntax? #f)" 0 lctx fmt args))
   (check-restricted-format-string 'format-id fmt)
   (define arg-strs (map (lambda (a) (->string a 'format-id)) args))
   (define str (apply format fmt arg-strs))

--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -114,7 +114,7 @@
                    #:subs-intro [subs-intro (default-intro)]
                    fmt . args)
   (unless (or (syntax? lctx) (eq? lctx #f))
-    (raise-argument-error 'format-id "(or/c syntax? #f)" lctx))
+    (raise-argument-error 'format-id "(or/c syntax? #f)" 0 lctx args))
   (check-restricted-format-string 'format-id fmt)
   (define arg-strs (map (lambda (a) (->string a 'format-id)) args))
   (define str (apply format fmt arg-strs))


### PR DESCRIPTION
Error if the first input to `format-id` is not syntax? or false. Omitting the `lctx` (first) argument previously resulted in the difficult to decipher message: 
```
regexp-match?: contract violation
  expected: (or/c bytes? string? input-port? path?)
```
