### PR TITLE
"in time" -> "in constant time"

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -627,8 +627,8 @@ about modifying @racket[hash] within @racket[proc].
 Returns the number of keys mapped by @racket[hash].
 
 For the @tech{CS} implementation of Racket, the result is always
-computed in time and atomically. For the @tech{BC} implementation of
-Racket, the result is computed in constant time and atomically only if
+computed in constant time and atomically. For the @tech{BC} implementation
+of Racket, the result is computed in constant time and atomically only if
 @racket[hash] does not retain keys weakly or like an @tech{ephemeron},
 otherwise, a traversal is required to count the keys.}
 


### PR DESCRIPTION
This is based solely on the wording in the documentation, but should that say "constant time" as in this change I propose?