### PR TITLE
ci: fix iOS build

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -88,7 +88,7 @@ jobs:
         tar -xvjf racketcs-macos-x64_git${{ github.sha }}.tar.bz2 -C host-racket --strip-components 1
     - name: Build iOS Racket
       run: |
-        set -euo pipefail
+        set -euxo pipefail
         mkdir -p racket/src/build-ios
         pushd racket/src/build-ios
         ../configure \
@@ -97,4 +97,8 @@ jobs:
           --enable-racket=${{ github.workspace }}/host-racket/bin/racket \
           --enable-scheme=${{ github.workspace }}/host-racket/src/build/cs/c
         make
+        (cd cs/c/ && make install-cross)
+        mkdir -p ../../lib
+        cp cs/c/compile-xpatch.tarm64osx ../../lib/
+        cp cs/c/library-xpatch.tarm64osx ../../lib/
         make install


### PR DESCRIPTION
The `make install` step no longer copies the xpatch files into the
"lib/" directory as of 30effc9 so we have to do it manually here.