### PR TITLE
Fix typo in _bytes/nul-teriminated

### DIFF
--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -1238,7 +1238,7 @@
                                (let ([s (make-bytes n)])
                                  (memcpy s x n)
                                  s))))]
-    [(_ . xs) (_bytes/nul-teriminated . xs)]
+    [(_ . xs) (_bytes/nul-terminated . xs)]
     [_ _bytes/nul-terminated]))
 
 ;; (_array <type> <len> ...+)


### PR DESCRIPTION
This typo results in an unbound identifier error, which was reported by
Efi on the Racket Discord:

> /usr/local/racket/collects/ffi/unsafe.rkt:1241:15:
> _bytes/nul-teriminated: unbound identifier
>   in: _bytes/nul-teriminated
>   location...:
>    /usr/local/racket/collects/ffi/unsafe.rkt:1241:15

It's been like this since it was added in 62b8ca3.  It looks like it was
meant to be _bytes/nul-terminated instead, so this is just a typo fix.