### PR TITLE
Add checks to placeholder-set! and placeholder-get

### DIFF
--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -384,6 +384,11 @@
 (test '(1/2) assv '1/2 '(((a)) (1/2) ((c))))
 (test '(1/2) assoc '1/2 '(((a)) (1/2) ((c))))
 
+(arity-test placeholder-set! 2 2)
+(err/rt-test (placeholder-set! #f #f))
+(arity-test placeholder-get 1 1)
+(err/rt-test (placeholder-get #f))
+
 (test #f immutable? (cons 1 null))
 (test #f immutable? (list 1))
 (test #f immutable? (list 1 2))

--- a/racket/src/cs/rumble/graph.ss
+++ b/racket/src/cs/rumble/graph.ss
@@ -9,10 +9,12 @@
   (parent hash-placeholder)
   (fields))
 
-(define (placeholder-set! ph datum)
+(define/who (placeholder-set! ph datum)
+  (check who placeholder? ph)
   (set-placeholder-val! ph datum))
 
-(define (placeholder-get ph)
+(define/who (placeholder-get ph)
+  (check who placeholder? ph)
   (placeholder-val ph))
 
 (define/who (make-hash-placeholder alst)


### PR DESCRIPTION
These two functions did not check that their argument was actually a placeholder.