### PR TITLE
Add module-level contract to make-limited-input-port

### DIFF
--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -723,6 +723,11 @@
       (test 1 peek-bytes-avail!* b 1 #f s)
       (test 2 read-bytes-avail!* b s))))
 
+;; module-level contract violation check
+(err/rt-test (make-limited-input-port (open-input-bytes #"_") 1.0)
+             exn:fail:contract?)
+
+
 ;; Make sure that blocking on a limited input port doesn't
 ;; block in the case of a peek after available bytes:
 (let ()

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -41,13 +41,14 @@
          copy-port
          input-port-append
          convert-stream
-         make-limited-input-port
          reencode-input-port
          reencode-output-port
          dup-input-port
          dup-output-port
 
          (contract-out
+           [make-limited-input-port ((input-port? exact-nonnegative-integer?) (any/c)
+                                     . ->* . input-port?)]
            [read-bytes-avail!-evt (mutable-bytes? input-port-with-progress-evts?
                                    . -> . evt?)]
            [peek-bytes-avail!-evt (mutable-bytes? exact-nonnegative-integer? evt?/false


### PR DESCRIPTION
First PR, so I'm probably missing something. Just point me to the materials I missed and I'll update accordingly (Case in point: How do you all define tests for module-level contracts?)

Consider:

```racket
(define in (make-limited-input-port (open-input-bytes #"_") 1.0))
(read-byte in)
```

`make-limited-input-port` does not fail, and returns a useless input port. The contract for `read-bytes-avail!*` raises a violation when a read actually occurs. At that point one might not have the right party to blame.