### PR TITLE
doc: use processor-count from racket/future

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -6,7 +6,7 @@
                      racket/future
                      racket/promise
                      racket/file
-                     racket/place
+                     (except-in racket/place processor-count)
                      compiler/cm
                      compiler/cm-accomplice
                      setup/parallel-build


### PR DESCRIPTION
There's a broken link at https://www.cs.utah.edu/plt/snapshots/current/doc/raco/api_parallel-build.html#%28def._%28%28lib._setup%2Fparallel-build..rkt%29._parallel-compile-files%29%29

The cause seems to be due to how both `racket/future` and `racket/place` provide `processor-count`, so Scribble got confused. It looks like if Scribble is smarter, then this PR wouldn't be necessary. So feel free to not merge the PR if you think it's not the right solution.