### PR TITLE
Fix typos

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/distributed.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/distributed.scrbl
@@ -20,7 +20,7 @@
 The @racketmodname[racket/place/distributed] library provides support for
 distributed programming.
 
-The example bellow demonstrates how to launch a remote racket node instance,
+The example below demonstrates how to launch a remote racket node instance,
 launch remote places on the new remote node instance, and start an
 event loop that monitors the remote node instance.
 

--- a/pkgs/racket-doc/scribblings/guide/performance.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/performance.scrbl
@@ -573,15 +573,13 @@ argument instead.
 
 @section[#:tag "Reachability and Garbage Collection"]{Reachability and Garbage Collection}
 
-In general, Racket re-uses the storage for a value when the
-garbage collector can prove that the object is unreachable from
-any other (reachable) value. Reachability is a low-level, 
-abstraction breaking concept (and thus one must understand many
-details of the runtime system's implementation to accurately predict
-when values are reachable from each other),
-but generally speaking one value is reachable from a second one when 
-there is some operation to recover the original value from the second
-one.
+In general, Racket re-uses the storage for a value when the garbage
+collector can prove that the object is unreachable from any other
+(reachable) value. Reachability is a low-level, abstraction-breaking
+concept, and thus it requires detailed knowledge of the runtime system
+to predict exactly when values are reachable from each other. But
+generally one value is reachable from a second one when there is some
+operation to recover the original value from the second one.
 
 To help programmers understand when an object is no longer reachable and its
 storage can be reused,

--- a/pkgs/racket-doc/scribblings/guide/performance.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/performance.scrbl
@@ -577,8 +577,8 @@ In general, Racket re-uses the storage for a value when the
 garbage collector can prove that the object is unreachable from
 any other (reachable) value. Reachability is a low-level, 
 abstraction breaking concept (and thus one must understand many
-details of the runtime system's implementation to accurate predicate
-precisely when values are reachable from each other),
+details of the runtime system's implementation to accurately predict
+when values are reachable from each other),
 but generally speaking one value is reachable from a second one when 
 there is some operation to recover the original value from the second
 one.


### PR DESCRIPTION
In `performance.scrbl`, that's how I understand the sentence. Please
change it if something else is meant.