### PR TITLE
Fix rerequire reload on changed dependencies

### DIFF
--- a/pkgs/racket-test/tests/racket/rerequire.rkt
+++ b/pkgs/racket-test/tests/racket/rerequire.rkt
@@ -1,46 +1,150 @@
-#lang racket
-(require racket/file
-         racket/rerequire)
+#lang racket/base
+(require (for-syntax racket/base)
+         racket/file
+         racket/rerequire
+         compiler/cm
+         compiler/compilation-path
+         rackunit)
 
-(define dir (make-temporary-file "rereq-~a" 'directory))
+(use-compiled-file-check 'modify-seconds) ; in case it isn't
 
-(display-to-file
- (string-append
-  "#lang racket/base\n"
-  "(module inner racket/base\n"
-  "  (require \"two.rkt\")\n"
-  "  (provide proc))\n"
-  "(module more-inner racket/base\n"
-  "  (require (submod \"..\" inner))\n"
-  "  (provide proc))\n"
-  "(require 'more-inner)\n"
-  "(provide proc)")
- (build-path dir "one.rkt")
- #:exists 'replace)
 
-(define (change-required-file path proc-value)
-  (display-to-file
-   (string-append
-    "#lang racket/base\n"
-    "(module other racket/base)\n"
-    "(provide proc)\n"
-    (format "(define (proc) ~v)" proc-value))
-   (build-path dir path)
-   #:exists 'replace)
-  (sleep 1) ; to make sure mod time changes so rerequire notices it
-  (file-or-directory-modify-seconds
-   (build-path dir path)
-   (current-seconds)))
+(define (member/compiled path changed-paths)
+  (member (get-compilation-bytecode-file path) changed-paths))
 
-;; create "two.rkt" with `proc` function that evaluates to "foo"
-(change-required-file "two.rkt" "foo")
-;; even though "two.rkt" is inside a submodule, rerequire will transitively load it the first time
-(unless (member (build-path dir "two.rkt")
-                (dynamic-rerequire (build-path dir "one.rkt")))
-  (error "failed on round"))
-;; change "two.rkt"
-(change-required-file "two.rkt" "zam")
-;; this will error: rerequire should transitively reload "two.rkt", but doesn't
-(when (empty? (dynamic-rerequire (build-path dir "one.rkt")
-                                 #:verbosity 'none))
-  (error "failed on second round"))
+
+(define (compile-file path)
+  (parameterize ([current-namespace (make-base-empty-namespace)] ;; omits deps otherwise???
+                 [compile-enforce-module-constants #f])          ;; no reloading allowed otherwise
+    (managed-compile-zo path)))
+
+(define-syntax (do-test stx)
+  (syntax-case stx ()
+    [(_ name zero-src? one-src? two-src/1? two-src/2? initial-value updated-value)
+     (syntax/loc stx
+       (test-case
+        name
+        (define dir0 (make-temporary-file "rereq-~a" 'directory))
+        (define dir1 (make-temporary-file "rereq-~a" 'directory))
+        (define dir2 (make-temporary-file "rereq-~a" 'directory))
+        (define zero-path (build-path dir0 "zero.rkt"))
+        (define one-path (build-path dir1 "one.rkt"))
+        (define two-path (build-path dir2 "two.rkt"))
+   
+        (define (create-zero)
+          (display-to-file
+           (string-append
+            "#lang racket/base\n"
+            (format "(require (file ~v))"
+                    (path->string (build-path dir1 "one.rkt")))
+            "(provide proc)")
+           zero-path
+           #:exists 'replace))
+
+
+        (define (create-one)
+          (display-to-file
+           (string-append
+            "#lang racket/base\n"
+            "(module inner racket/base\n"
+            (format "  (require (file ~v))\n"
+                    (path->string two-path))
+            "  (provide proc))\n"
+            "(module more-inner racket/base\n"
+            "  (require (submod \"..\" inner))\n"
+            "  (provide proc))\n"
+            "(require 'more-inner)\n"
+            "(provide proc)")
+           one-path
+           #:exists 'replace))
+
+
+        (define (delete-extra-files dirpath filepath)
+          (for ([file (in-list
+                       (find-files (lambda (fpath)
+                                     (and (not (equal? fpath filepath))
+                                          (eq? 'file (file-or-directory-type fpath))))
+                                   dirpath))])
+            (delete-file file)))
+
+        (define (change-required-file proc-value)
+          (display-to-file
+           (string-append
+            "#lang racket/base\n"
+            "(module other racket/base)\n"
+            "(provide proc)\n"
+            (format "(define (proc) ~v)" proc-value))
+           two-path
+           #:exists 'replace)
+          (sleep 1) ; to make sure mod time changes so rerequire notices it
+          (file-or-directory-modify-seconds
+           two-path
+           (current-seconds)))
+
+        
+
+        (define (make-check-loaded-files two?)
+          (lambda (list-of-paths)
+            (and
+             (if zero-src?
+                 (member zero-path list-of-paths)
+                 (member/compiled zero-path list-of-paths))
+             (if one-src?
+                 (member one-path list-of-paths)
+                 (member/compiled one-path list-of-paths))
+             (if two?
+                 (member two-path list-of-paths)
+                 (member/compiled two-path list-of-paths)))))
+
+
+        (define check-loaded-files/initial (make-check-loaded-files two-src/1?))
+        (define check-loaded-files/updated (make-check-loaded-files two-src/2?))
+        ;; create files, compile them as need be
+        (create-zero)
+        (create-one)
+        (change-required-file initial-value)
+        (if zero-src?
+            (if one-src?
+                (if two-src/1? (void) (compile-file two-path))
+                (compile-file one-path))
+            (compile-file zero-path))
+       (when (and one-src? (not zero-src?)) ; compiling zero made compiled files, delete them
+          (delete-extra-files dir1 one-path))
+        (when (and two-src/1? (or (not zero-src?)
+                                  (not one-src?)))
+          (delete-extra-files dir2 two-path))
+       
+        (define loaded-files (dynamic-rerequire zero-path #:verbosity 'none))
+        (define initial-value/actual ((dynamic-require zero-path 'proc)))
+
+        (check-pred check-loaded-files/initial loaded-files "first rerequire loaded wrong modules")
+        (check-equal? initial-value/actual initial-value "first rerequire loaded incorrect proc")
+        
+        (change-required-file updated-value)
+        (unless two-src/2?
+          (compile-file two-path))
+        (define reloaded-files (dynamic-rerequire zero-path #:verbosity 'none))
+        (define updated-value/actual ((dynamic-require zero-path 'proc)))
+        (check-pred check-loaded-files/updated reloaded-files "second rerequire reloaded wrong modules")
+        (check-equal? updated-value/actual updated-value "second rerequire loaded incorrect proc")))]))
+        
+
+(do-test "all source" #t #t #t #t "foo" "zam")
+(do-test "two compiled for reload" #t #t #t #f "foo" "zam")
+(do-test "two compiled for initial" #t #t #f #t "foo" "zam")
+(do-test "two compiled" #t #t #f #f "foo" "zam")
+
+(do-test "one compiled" #t #f #t #t "foo" "zam")
+(do-test "one compiled, two compiled for reload" #t #f #t #f "foo" "zam")
+(do-test "one compiled, two compiled for initial" #t #f #f #t "foo" "zam")
+(do-test "one compiled, two compiled" #t #f #f #f "foo" "zam")
+
+(do-test "zero compiled" #f #t #t #t "foo" "zam")
+(do-test "zero compiled, two compiled for reload" #f #t #t #f "foo" "zam")
+(do-test "zero compiled, two compiled for initial" #f #t #f #t "foo" "zam")
+(do-test "zero compiled, two compiled" #f #t #f #f "foo" "zam")
+
+(do-test "zero compiled, one compiled" #f #f #t #t "foo" "zam")
+(do-test "zero compiled, one compiled, two compiled for reload" #f #f #t #f "foo" "zam")
+(do-test "zero compiled, one compiled, two compiled for initial" #f #f #f #t "foo" "zam")
+(do-test "all compiled" #f #f #f #f "foo" "zam")

--- a/racket/collects/racket/rerequire.rkt
+++ b/racket/collects/racket/rerequire.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require syntax/modcode
+         syntax/modresolve
          racket/path)
 
 (provide dynamic-rerequire)
@@ -98,12 +99,19 @@
                   (values -inf.0 path)))
             (values -inf.0 path)))))
 
+(define (make-resolved-module-path/modresolve path-or-submod)
+  (make-resolved-module-path
+   (if (pair? path-or-submod)
+       (cdr path-or-submod)
+       path-or-submod)))
+
 (define (check-latest mod verbosity path-collector)
   (define mpi (module-path-index-join mod #f))
   (define done (make-hash))
   (let loop ([mpi mpi] [wrt-mpi #f] [wrt-path #f])
     (define reloaded? #f)
-    (define rpath (module-path-index-resolve mpi))
+    (define rpath (make-resolved-module-path/modresolve
+                   (resolve-module-path-index mpi wrt-path)))
     (define name (resolved-module-path-name rpath))
     (define path (if (pair? name)
                      (let ([path (car name)])


### PR DESCRIPTION
Fix for #3925 (maybe #971)

mflatt pointed me to `resolve-module-path-index` being needed to rebase the module-path-index attached to the exports of  .zo files (which is always relative to themselves)

