### PR TITLE
Avoid excess dependencies in `syntax/parse/lib/function-header`.

### DIFF
--- a/racket/collects/racket/match/define-forms.rkt
+++ b/racket/collects/racket/match/define-forms.rkt
@@ -198,5 +198,5 @@
          [(_ ?header:function-header ?clause ...)
           (quasisyntax
            (define ?header
-             (match*/derived (?? ?header.params) #,stx
+             (match*/derived (~? ?header.params) #,stx
                ?clause ...)))])))))

--- a/racket/collects/racket/match/define-forms.rkt
+++ b/racket/collects/racket/match/define-forms.rkt
@@ -4,7 +4,6 @@
                      racket/syntax
                      (only-in racket/list append* remove-duplicates)
                      syntax/parse/pre
-                     syntax/parse/experimental/template
                      racket/lazy-require
                      syntax/parse/lib/function-header))
 
@@ -197,7 +196,7 @@
      (define-syntax (define/match stx)
        (syntax-parse stx
          [(_ ?header:function-header ?clause ...)
-          (quasitemplate
+          (quasisyntax
            (define ?header
              (match*/derived (?? ?header.params) #,stx
                ?clause ...)))])))))

--- a/racket/collects/syntax/parse/lib/function-header.rkt
+++ b/racket/collects/syntax/parse/lib/function-header.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require "../../parse.rkt"
+(require syntax/parse/pre
          racket/list)
 
 (provide function-header formal formals formals-no-rest)


### PR DESCRIPTION
This causes `racket/match` to no longer depend on `racket/contract`.

cc @rmculpepper