### PR TITLE
Add links to useful blog posts in CONTRIBUTING.md

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,6 +1,8 @@
 Contribute to Racket by [submitting a pull request](https://github.com/racket/racket), joining the
 [development mailing list](https://lists.racket-lang.org), or visiting
 the [IRC](https://racket-lang.org/community.html) or [Slack](https://racket-slack.herokuapp.com/) channels.
+A tutorial on writing your first contribution is available at
+[Tutorial: Contributing to Racket](https://blog.racket-lang.org/2017/09/tutorial-contributing-to-racket.html).
 
 By making a contribution, you are agreeing that your contribution is
 licensed under the LGPLv3, Apache 2.0, and MIT licenses. Those
@@ -9,6 +11,7 @@ racket/src/LICENSE-LGPL.txt, racket/src/LICENSE-APACHE.txt, and
 racket/src/LICENSE-MIT.txt.
 
 See the [Racket Build Guide](../build.md) for more guidance on
-contributing.
+contributing. To test your contributions against all third-party packages in the Racket package catalog, see
+[this blog post](https://blog.racket-lang.org/2020/03/running-pkg-build-today.html).
 
 The [Friendly Environment Policy](https://racket-lang.org/friendly.html) contains guidelines on expected behavior within the Racket community.


### PR DESCRIPTION
This change adds links to two Racket blog posts for first-time contributors to see: the tutorial on how to contribute to Racket, and the instructions for testing changes against the entire package catalog.