### PR TITLE
racket/src/cs/c/Makefile.in: add LDFLAGS to starter@NOT_MINGW@

### DIFF
--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -441,7 +441,7 @@ boot.o: $(srcdir)/boot.c $(srcdir)/../../rktio/rktio.inc $(srcdir)/boot.h
 	$(CC) $(CFLAGS) -c -o boot.o $(srcdir)/boot.c
 
 starter@NOT_MINGW@: $(srcdir)/../../start/ustart.c $(srcdir)/../../start/self_exe.inc
-	$(CC) $(CFLAGS) -o starter $(srcdir)/../../start/ustart.c
+	$(CC) $(CFLAGS) $(LDFLAGS) -o starter $(srcdir)/../../start/ustart.c
 
 
 repack-install-libs:


### PR DESCRIPTION
Signed-off-by: Maciej Barć <xgqt@riseup.net>

Noticed in: https://bugs.gentoo.org/749729
