### PR TITLE
Tightening XML numeric entity constraints

### DIFF
--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -110,7 +110,7 @@ Represents an attribute within an element.}
  If @racket[(permissive-xexprs)] is @racket[#t], then equivalent to @racket[any/c], otherwise equivalent to @racket[(make-none/c 'permissive)]}
 
 @defproc[(valid-char? [x any/c]) boolean?]{
- Returns true if @racket[x] is an exact-nonnegative-integer whose character interpretation under UTF-8 is from the set ([#x9] | [#xA] | [#xD] | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]), which matches the behaviour of libxml2.
+ Returns true if @racket[x] is an exact-nonnegative-integer whose character interpretation under UTF-8 is from the set ([#x0-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]), in accordance with section 2.2 of the XML 1.1 spec relaxed to include \#x0.
 }
 
 @defstruct[(entity source) ([text (or/c symbol? valid-char?)])]{

--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -110,7 +110,7 @@ Represents an attribute within an element.}
  If @racket[(permissive-xexprs)] is @racket[#t], then equivalent to @racket[any/c], otherwise equivalent to @racket[(make-none/c 'permissive)]}
 
 @defproc[(valid-char? [x any/c]) boolean?]{
- Returns true if @racket[x] is an exact-nonnegative-integer whose character interpretation under UTF-8 is from the set ([#x1-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]), in accordance with section 2.2 of the XML 1.1 spec.
+ Returns true if @racket[x] is an exact-nonnegative-integer whose character interpretation under UTF-8 is from the set ([#x9] | [#xA] | [#xD] | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]), which matches the behaviour of libxml2.
 }
 
 @defstruct[(entity source) ([text (or/c symbol? valid-char?)])]{

--- a/racket/collects/xml/private/core.rkt
+++ b/racket/collects/xml/private/core.rkt
@@ -24,10 +24,9 @@
 ; Cdata = (make-cdata Location Location String)
 (define-struct (cdata source) (string) #:transparent)
 
-; Set compatible with libxml2
+; Section 2.2 of XML 1.1, relaxed (#x0 is valid)
 (define (valid-char? i)
   (and (exact-nonnegative-integer? i)
-       (or (<= #x20     i #xD7FF)
+       (or (<= #x0     i #xD7FF)
            (<= #xE000  i #xFFFD)
-           (<= #x10000 i #x10FFFF)
-	   (= #x9 i) (= #xA i) (= #xD i))))
+           (<= #x10000 i #x10FFFF))))

--- a/racket/collects/xml/private/core.rkt
+++ b/racket/collects/xml/private/core.rkt
@@ -24,10 +24,10 @@
 ; Cdata = (make-cdata Location Location String)
 (define-struct (cdata source) (string) #:transparent)
 
-; Section 2.2 of XML 1.1
-; (XML 1.0 is slightly different and more restrictive)
+; Set compatible with libxml2
 (define (valid-char? i)
   (and (exact-nonnegative-integer? i)
-       (or (<= #x1     i #xD7FF)
+       (or (<= #x20     i #xD7FF)
            (<= #xE000  i #xFFFD)
-           (<= #x10000 i #x10FFFF))))
+           (<= #x10000 i #x10FFFF)
+	   (= #x9 i) (= #xA i) (= #xD i))))


### PR DESCRIPTION
As per #1636 , this matches `libxml2`'s behaviour.

The set of valid characters becomes
`\#x9 | #xA | #xD | [#x20-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`
instead of
`[#x1-#xD7FF] | [#xE000-#xFFFD] | [#x10000-#x10FFFF]`.

More information may be found in https://groups.google.com/g/racket-users/c/GKytlPKVx2o/m/RWgswlm1AgAJ