### PR TITLE
Place the source location on the inner form in let-syntax

### DIFF
--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -910,6 +910,20 @@
 (error-test #'(let () (define x 0)) exn:begin-possibly-implicit?)
 (error-test #'(let () (struct a ())) exn:begin-possibly-implicit?)
 (error-test #'(cond [#t (define x 0)]) exn:begin-possibly-implicit?)
+(error-test #'(letrec () (define x 0)) exn:begin-possibly-implicit?)
+(error-test #'(let-syntax () (define x 0)) exn:begin-possibly-implicit?)
+(error-test #'(letrec-values () () (define x 0)) exn:begin-possibly-implicit?)
+;; Check that the exceptions have the source location of the use-site.
+(define (exn:srclocs-from-syntax.rktl? x)
+  (and (exn:srclocs? x)
+       (for/and ([srcloc (in-list ((exn:srclocs-accessor x) x))])
+         (regexp-match? #px"syntax.rktl" (srcloc-source srcloc)))))
+(error-test #'(let () (define x 0)) exn:srclocs-from-syntax.rktl?)
+(error-test #'(let () (struct a ())) exn:srclocs-from-syntax.rktl?)
+(error-test #'(cond [#t (define x 0)]) exn:srclocs-from-syntax.rktl?)
+(error-test #'(letrec () (define x 0)) exn:srclocs-from-syntax.rktl?)
+(error-test #'(let-syntax () (define x 0)) exn:srclocs-from-syntax.rktl?)
+(error-test #'(letrec-values () () (define x 0)) exn:srclocs-from-syntax.rktl?)
 
 ;; Weird test: check that `eval` does not wrap its last argument
 ;; in a prompt, which means that `(foo 10)` replaces the continuation

--- a/racket/collects/racket/private/letstx-scheme.rkt
+++ b/racket/collects/racket/private/letstx-scheme.rkt
@@ -32,14 +32,18 @@
 	 (with-syntax ([((tmp ...) ...) 
 			(map
 			 generate-temporaries 
-			 (syntax->list (syntax ((id ...) ...))))])
-	   (syntax/loc stx
-	       (letrec-syntaxes+values ([(tmp ...) expr] ...) ()
-		 (letrec-syntaxes+values ([(id ...) (values
-						     (make-rename-transformer (quote-syntax tmp))
-						     ...)] ...)
-					 ()
-		   body1 body ...))))])))
+                         (syntax->list (syntax ((id ...) ...))))])
+           (with-syntax ([let-syntaxes-body/loc
+                          (syntax/loc stx
+                            (letrec-syntaxes+values ([(id ...)
+                                                      (values
+                                                       (make-rename-transformer (quote-syntax tmp))
+                                                       ...)] ...)
+                                                    ()
+                              body1 body ...))])
+             (syntax/loc stx
+               (letrec-syntaxes+values ([(tmp ...) expr] ...) ()
+                 let-syntaxes-body/loc))))])))
 
   (-define-syntax let-syntax
     (lambda (stx)


### PR DESCRIPTION
Original fix by @sorawee in <https://groups.google.com/g/racket-users/c/KxGI2b3ytPQ/m/fsDTadFjAgAJ>