### PR TITLE
json: Parse large exponents without getting stuck

### DIFF
--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -115,6 +115,15 @@
         (string->jsexpr @T{-10.34e-3}) => -1.034e-2
         (string->jsexpr @T{-10.34e-03}) => -1.034e-2
         (string->jsexpr @T{-10.34e+31}) => -1.034e32
+        (string->jsexpr @T{ 1e9999999999999999    }) => +inf.0 ; breaks contract
+        (string->jsexpr @T{ 1.0e9999999999999999  }) => +inf.0
+        (string->jsexpr @T{-1e9999999999999999    }) => -inf.0
+        (string->jsexpr @T{-1.0e9999999999999999  }) => -inf.0
+        (string->jsexpr @T{ 1e-9999999999999999   }) =>  0.0
+        (string->jsexpr @T{-1e-9999999999999999   }) => -0.0
+        (string->jsexpr @T{ 0e9999999999999999    }) => 0.0
+        (string->jsexpr @T{ 0e-9999999999999999   }) => 0.0
+        (string->jsexpr @T{ 0.001e310 }) => 1.0e307
         (string->jsexpr @T{ true  }) => #t
         (string->jsexpr @T{ false }) => #f
         (string->jsexpr @T{ null  }) => 'null

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -124,6 +124,7 @@
         (string->jsexpr @T{ 0e9999999999999999    }) => 0.0
         (string->jsexpr @T{ 0e-9999999999999999   }) => 0.0
         (string->jsexpr @T{ 0.001e310 }) => 1.0e307
+        (string->jsexpr @T{ 100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000e-402 }) => 1e-292
         (string->jsexpr @T{ true  }) => #t
         (string->jsexpr @T{ false }) => #f
         (string->jsexpr @T{ null  }) => 'null

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -361,12 +361,16 @@
     ;; evaluate n * 10^exp to inexact? without passing large arguments to expt
     ;; assumes n is an integer
     (define (safe-exponential->inexact n exp)
+      (define result-exp
+        (if (= n 0)
+            exp
+            (+ (log (abs n) 10) exp)))
       (cond
-        [(< exp -309)
+        [(< result-exp -400)
          (cond
            [(>= n 0) 0.0]
            [else -0.0])]
-        [(> exp 309)
+        [(> result-exp 400)
          (cond
            [(= n 0) 0.0]
            [(> n 0) +inf.0]


### PR DESCRIPTION
Before this patch, all JSON-parsing forms in the `json` module get stuck on numbers with large exponents:

```
(require json racket/sandbox)
(with-limits 10 #f (string->jsexpr "1e99999999999999"))
; with-limit: out of time
```

Memory consumption appears to grow slowly. This is bad when parsing JSON from untrusted sources, e.g. as a web server might do.

The underlying cause is evaluation of `(expt 10 exp)` where `exp` is an unbounded value read from the input. Since the JSON parser coerces all exponent-containing numbers to `inexact?`, the result will have bounded exponent magnitude or will be +/-infinity. This patch returns +/-infinity or +/- 0 eagerly when the exponent is too big or too small.

It's worth noting that the JSON-parsing forms already break their contract by returning +/-infinity on large enough inputs:

```
(string->jsexpr "1e400")
+inf.0
```

This patch preserves that behaviour.