### PR TITLE
Optimize hash union

### DIFF
--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -64,6 +64,13 @@
 (test #hash([four . 4] [three . 3] [one . 1] [two . 2])
       hash-union #hash([one . 1] [two . 1]) #hash([three . 3] [four . 4] [two . 1])
       #:combine +)
+(test #hash([1 . 1] [2 . 2] [3 . 3] [4 . 4])
+      hash-union #hash([1 . 1]) #hasheq([2 . 2] [3 . 3]) #hasheq([4 . 4]))
+(test #hasheq([1 . 1] [2 . 2] [3 . 3] [4 . 4])
+      hash-union #hasheq([1 . 1]) #hash([2 . 2] [3 . 3]) #hash([4 . 4]))
+(test #hash([1 . -2] [2 . 2])
+      hash-union #hash([1 . 1] [2 . 2]) #hash([1 . 3])
+      #:combine -)
 
 (test #hash((a . 5) (b . 7))
       hash-intersect #hash((a . 1) (b . 2) (c . 3)) #hash((a . 4) (b . 5))

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -17,10 +17,11 @@
                           (lambda (k x y) (combine x y))
                           (hash-duplicate-error 'hash-union))]
          one . rest)
+  (define one-empty (hash-clear one))
   (for/fold ([one one]) ([two (in-list rest)])
     (cond
       [(and (< (hash-count one) (hash-count two))
-            (equal? (hash-clear one) (hash-clear two)))
+            (equal? one-empty (hash-clear two)))
        (merge two one (λ (k a b) (combine/key k b a)))]
       [else (merge one two combine/key)])))
 

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -4,6 +4,12 @@
 (define ((hash-duplicate-error name) key value1 value2)
   (error name "duplicate values for key ~e: ~e and ~e" key value1 value2))
 
+(define (merge one two combine/key)
+  (for/fold ([one one]) ([(k v) (in-hash two)])
+    (hash-set one k (if (hash-has-key? one k)
+                        (combine/key k (hash-ref one k) v)
+                        v))))
+
 (define (hash-union
          #:combine [combine #f]
          #:combine/key [combine/key
@@ -11,10 +17,12 @@
                           (lambda (k x y) (combine x y))
                           (hash-duplicate-error 'hash-union))]
          one . rest)
-  (for*/fold ([one one]) ([two (in-list rest)] [(k v) (in-hash two)])
-    (hash-set one k (if (hash-has-key? one k)
-                        (combine/key k (hash-ref one k) v)
-                        v))))
+  (for/fold ([one one]) ([two (in-list rest)])
+    (cond
+      [(and (< (hash-count one) (hash-count two))
+            (equal? (hash-clear one) (hash-clear two)))
+       (merge two one (λ (k a b) (combine/key k b a)))]
+      [else (merge one two combine/key)])))
 
 (define (hash-union!
          #:combine [combine #f]


### PR DESCRIPTION
Use a larger hash table as the main table whenever it's safe to do so,
so that we do not need to iterate on large tables.

A more aggressive optimization is to find the largest hash table and use it as the main hash table. However, by doing so, the order of `combine/key` invocations would be different from the current one, which would be a breaking change if `combine/key` is effectful. 

Here's a benchmark result, based on @rmculpepper's code for `hash-intersect`:

```
#lang racket/base

;; the current one in racket/hash
(define (hash-union
         #:combine [combine #f]
         #:combine/key [combine/key
                        (if combine
                            (lambda (k x y) (combine x y))
                            (error 'hash-union))]
         one . rest)
  (for*/fold ([one one]) ([two (in-list rest)] [(k v) (in-hash two)])
    (hash-set one k (if (hash-has-key? one k)
                        (combine/key k (hash-ref one k) v)
                        v))))

(define (merge one two combine/key)
  (for/fold ([one one]) ([(k v) (in-hash two)])
    (hash-set one k (if (hash-has-key? one k)
                        (combine/key k (hash-ref one k) v)
                        v))))

;; this PR
(define (hash-union*
         #:combine [combine #f]
         #:combine/key [combine/key
                        (if combine
                            (lambda (k x y) (combine x y))
                            (error 'hash-union))]
         one . rest)
  (for/fold ([one one]) ([two (in-list rest)])
    (cond
      [(and (< (hash-count one) (hash-count two))
            (equal? (hash-clear one) (hash-clear two)))
       (merge two one (λ (k a b) (combine/key k b a)))]
      [else (merge one two combine/key)])))

(define (combine/key k v1 v2) (+ v1 v2))

;; ----------------------------------------
;; Benchmarking

(for ([N1 (in-list '(20 100 1000))])
  (printf "==== N = ~a ====\n" N1)
  (define N2 (sqrt N1))
  (define N3 (/ N1 2))
  (define ITERS #e1e4)

  (define h1 (for/hash ([i (in-range N1)]) (values i i)))
  (define h2 (for/hash ([i (in-range N2)]) (values (* i i) i)))
  (define h3 (for/hash ([i (in-range N3)]) (values (+ i i 1) i)))

  (define-syntax-rule (benchmark expr)
    (let-values ([(vs cpu real gc)
                  (time-apply (lambda ()
                                (for ([k (in-range ITERS)])
                                  expr))
                              null)])
      (printf "run ~.s : ~s\n" (quote expr) real)))

  (printf "\n** Perm 1\n")
  (benchmark (hash-union h1 h2 h3 #:combine/key combine/key))
  (benchmark (hash-union* h1 h2 h3 #:combine/key combine/key))

  (printf "\n** Perm 2\n")
  (benchmark (hash-union h1 h3 h2 #:combine/key combine/key))
  (benchmark (hash-union* h1 h3 h2 #:combine/key combine/key))

  (printf "\n** Perm 3\n")
  (benchmark (hash-union h2 h1 h3 #:combine/key combine/key))
  (benchmark (hash-union* h2 h1 h3 #:combine/key combine/key))

  (printf "\n** Perm 4\n")
  (benchmark (hash-union h2 h3 h1 #:combine/key combine/key))
  (benchmark (hash-union* h2 h3 h1 #:combine/key combine/key))

  (printf "\n** Perm 5\n")
  (benchmark (hash-union h3 h1 h2 #:combine/key combine/key))
  (benchmark (hash-union* h3 h1 h2 #:combine/key combine/key))

  (printf "\n** Perm 6\n")
  (benchmark (hash-union h3 h2 h1 #:combine/key combine/key))
  (benchmark (hash-union* h3 h2 h1 #:combine/key combine/key))
  (void))
```

which results in:

```
==== N = 20 ====

** Perm 1
run (hash-union h1 h2 h3 #:combine/key combine/key) : 52
run (hash-union* h1 h2 h3 #:combine/key combine/key) : 51

** Perm 2
run (hash-union h1 h3 h2 #:combine/key combine/key) : 50
run (hash-union* h1 h3 h2 #:combine/key combine/key) : 50

** Perm 3
run (hash-union h2 h1 h3 #:combine/key combine/key) : 78
run (hash-union* h2 h1 h3 #:combine/key combine/key) : 55

** Perm 4
run (hash-union h2 h3 h1 #:combine/key combine/key) : 115
run (hash-union* h2 h3 h1 #:combine/key combine/key) : 79

** Perm 5
run (hash-union h3 h1 h2 #:combine/key combine/key) : 72
run (hash-union* h3 h1 h2 #:combine/key combine/key) : 55

** Perm 6
run (hash-union h3 h2 h1 #:combine/key combine/key) : 73
run (hash-union* h3 h2 h1 #:combine/key combine/key) : 58
==== N = 100 ====

** Perm 1
run (hash-union h1 h2 h3 #:combine/key combine/key) : 211
run (hash-union* h1 h2 h3 #:combine/key combine/key) : 247

** Perm 2
run (hash-union h1 h3 h2 #:combine/key combine/key) : 249
run (hash-union* h1 h3 h2 #:combine/key combine/key) : 204

** Perm 3
run (hash-union h2 h1 h3 #:combine/key combine/key) : 479
run (hash-union* h2 h1 h3 #:combine/key combine/key) : 254

** Perm 4
run (hash-union h2 h3 h1 #:combine/key combine/key) : 559
run (hash-union* h2 h3 h1 #:combine/key combine/key) : 263

** Perm 5
run (hash-union h3 h1 h2 #:combine/key combine/key) : 371
run (hash-union* h3 h1 h2 #:combine/key combine/key) : 248

** Perm 6
run (hash-union h3 h2 h1 #:combine/key combine/key) : 436
run (hash-union* h3 h2 h1 #:combine/key combine/key) : 270
==== N = 1000 ====

** Perm 1
run (hash-union h1 h2 h3 #:combine/key combine/key) : 2200
run (hash-union* h1 h2 h3 #:combine/key combine/key) : 2206

** Perm 2
run (hash-union h1 h3 h2 #:combine/key combine/key) : 2142
run (hash-union* h1 h3 h2 #:combine/key combine/key) : 2183

** Perm 3
run (hash-union h2 h1 h3 #:combine/key combine/key) : 5293
run (hash-union* h2 h1 h3 #:combine/key combine/key) : 2203

** Perm 4
run (hash-union h2 h3 h1 #:combine/key combine/key) : 5163
run (hash-union* h2 h3 h1 #:combine/key combine/key) : 2339

** Perm 5
run (hash-union h3 h1 h2 #:combine/key combine/key) : 3989
run (hash-union* h3 h1 h2 #:combine/key combine/key) : 2289

** Perm 6
run (hash-union h3 h2 h1 #:combine/key combine/key) : 3687
run (hash-union* h3 h2 h1 #:combine/key combine/key) : 2313
```