### PR TITLE
compiler: fix relative-base paths

### DIFF
--- a/racket/collects/compiler/distribute.rkt
+++ b/racket/collects/compiler/distribute.rkt
@@ -143,7 +143,7 @@
                (lambda (sub-dir type relative-dir)
                  (cond
                   [relative-base
-                   (if (string? relative-base) (string->path relative-base) relative-base)]
+                   (build-path relative-base relative-dir)]
                   [(not executables?)
                    (build-path dest-dir relative-dir)]
                   [sub-dir


### PR DESCRIPTION
Without this change, all runtime paths resolve to the relative base itself rather than to a path based on it (meaning `raco ctool` with the `--runtime-access` flag produces `.zo`s with embedded runtime paths that all refer to the same path). 