### PR TITLE
Add define/with-datum

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/datum.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/datum.scrbl
@@ -1,7 +1,8 @@
 #lang scribble/manual
 @(require "common.rkt"
           scribble/eval
-          (for-label racket/base 
+          (for-label racket/base
+                     racket/syntax
                      syntax/datum
                      syntax/parse))
 
@@ -107,6 +108,20 @@ Analogous to @racket[with-syntax], but for @racket[datum-case] and
   (datum ((a b) ...)))
 ]}
 
+@defform[(define/with-datum pattern datum-expr)]{
+
+The definition form of @racket[with-datum]. Analogous to
+@racket[define/with-syntax], but for @racket[datum-case] and @racket[datum].
+
+@examples[
+#:eval datum-eval
+ (define/with-datum ((x y) ...)
+   '((a 1) (b 2) (c 3)))
+ (datum ((x ...)
+         (y ...)))
+]
+
+@history[#:added "8.2.0.8"]}
 
 @deftogether[(
 @defform[(quasidatum template)]

--- a/pkgs/racket-test/tests/syntax/racket-syntax.rkt
+++ b/pkgs/racket-test/tests/syntax/racket-syntax.rkt
@@ -45,6 +45,11 @@
                  (define/with-syntax (n ...) #'(1 2 3))
                  #'(0 n ...)))
               '(0 1 2 3))
+(check-equal? (syntax->datum
+               (let ()
+                 (define/with-syntax (0 (m n ...) ...) #'(0 (1 2) (3 4 5) (6)))
+                 #'(0 m ... (n ... $) ...)))
+              '(0 1 3 6 (2 $) (4 5 $) ($)))
 
 ;; ----
 

--- a/racket/collects/racket/syntax.rkt
+++ b/racket/collects/racket/syntax.rkt
@@ -28,14 +28,13 @@
                                       stx
                                       #'pattern
                                       '())]
-            [depthmap (for/list ([x pvar-env])
+            [depthmap (for/list ([x (in-list pvar-env)])
                         (let loop ([x x] [d 0])
                           (if (pair? x)
                               (loop (car x) (add1 d))
                               (cons x d))))]
             [pvars (map car depthmap)]
-            [depths (map cdr depthmap)]
-            [mark (make-syntax-introducer)])
+            [depths (map cdr depthmap)])
        (with-syntax ([(pvar ...) pvars]
                      [(depth ...) depths]
                      [(valvar ...) (generate-temporaries pvars)])

--- a/racket/collects/syntax/datum.rkt
+++ b/racket/collects/syntax/datum.rkt
@@ -1,5 +1,45 @@
-(module datum '#%kernel
-  (#%require racket/private/stxcase-scheme
-             racket/private/qqstx)
-  (#%provide datum datum-case with-datum
-             quasidatum undatum undatum-splicing))
+#lang racket/base
+
+(require racket/private/stxcase-scheme
+         racket/private/qqstx
+         (for-syntax racket/base
+                     racket/private/sc))
+
+(provide datum datum-case with-datum define/with-datum
+         quasidatum undatum undatum-splicing)
+
+(define-syntax (define/with-datum stx)
+  (syntax-case stx ()
+    [(define/with-datum pattern rhs)
+     (let ()
+       (define pvar-env
+         (get-match-vars #'define/with-datum
+                         stx
+                         #'pattern
+                         '()))
+       (define-values (pvars depths)
+         (for/lists (pvars depths)
+                    ([x (in-list pvar-env)])
+           (let loop ([x x] [depth 0])
+             (cond
+               [(pair? x) (loop (car x) (add1 depth))]
+               [else      (values x depth)]))))
+       (with-syntax ([(pvar ...) pvars]
+                     [(depth ...) depths]
+                     [(valvar ...) (generate-temporaries pvars)])
+         #'(begin (define-values (valvar ...)
+                    (with-datum ([pattern rhs])
+                      (values (pvar-value pvar) ...)))
+                  (define-syntax pvar
+                    (make-s-exp-mapping 'depth (quote-syntax valvar)))
+                  ...)))]))
+
+;; auxiliary macro
+(define-syntax (pvar-value stx)
+  (syntax-case stx ()
+    [(_ pvar)
+     (identifier? #'pvar)
+     (let ([mapping (syntax-local-value #'pvar)])
+       (unless (s-exp-pattern-variable? mapping)
+         (raise-syntax-error #f "not a datum pattern variable" #'pvar))
+       (s-exp-mapping-valvar mapping))]))


### PR DESCRIPTION
Add `define/with-datum`, the definition form of `with-datum`. Modified from the implementation of `define/with-syntax` in `racket/syntax`.