### PR TITLE
Remove extraneous quote

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/ex-kw-args.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/ex-kw-args.scrbl
@@ -88,7 +88,7 @@ Here's an alternative definition that re-uses Racket's @racket[cond] macro:
   (syntax-parse stx
     [(mycond (~optional (~seq #:error-on-fallthrough who:expr))
              clause ...)
-     #'(cond clause ... (~? [else (error 'who "no clause matched")] (~@)))]))
+     #'(cond clause ... (~? [else (error who "no clause matched")] (~@)))]))
 ]
 
 In this version, we optionally insert an @racket[else] clause at the


### PR DESCRIPTION
In section 1.2.2 the usage example for mycond quotes the "who"
argument, 'myfun in this case, as follows:

(mycond #:error-on-fallthrough 'myfun
        [(even? 13) 'blue]
        [(odd? 4) 'red])

So, in the second example in section 1.2.2.1, who should not be quoted.