### PR TITLE
struct: raise a syntax error on an illegal use of the transformer binding

### DIFF
--- a/pkgs/racket-test-core/tests/racket/struct.rktl
+++ b/pkgs/racket-test-core/tests/racket/struct.rktl
@@ -491,6 +491,11 @@
 
 (struct-syntax-test 'define-struct)
 
+;; test using the transformer binding incorrectly
+(syntax-test #'(let ()
+                 (define-struct a ())
+                 (a . b)))
+
 (syntax-test #'(define-struct a (b c) #:transparent #:inspector #f))
 (syntax-test #'(define-struct a (b c) #:transparent #:prefab))
 (syntax-test #'(define-struct a (b c) #:prefab #:guard 10))

--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -89,7 +89,7 @@
                          'constructor-for
                          (syntax-local-introduce #'self))
         alias-of (syntax-local-introduce #'self))]
-      [_ (transfer-srcloc orig stx)]))
+      [_ (raise-syntax-error #f "bad syntax" stx)]))
   
   (define-values-for-syntax (make-self-ctor-struct-info)
     (letrec-values ([(struct: make- ? ref set!)

--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -88,8 +88,7 @@
         (syntax-property (transfer-srcloc orig #'self)
                          'constructor-for
                          (syntax-local-introduce #'self))
-        alias-of (syntax-local-introduce #'self))]
-      [_ (raise-syntax-error #f "bad syntax" stx)]))
+        alias-of (syntax-local-introduce #'self))]))
   
   (define-values-for-syntax (make-self-ctor-struct-info)
     (letrec-values ([(struct: make- ? ref set!)


### PR DESCRIPTION
The program:

```
(define-struct a ())
(a . 1)
```

currently results in:

```
#<procedure:a>
```

which is unreasonable. This PR makes the above program raise a syntax error.