### PR TITLE
Fix fixnum/wraparound tests

### DIFF
--- a/pkgs/racket-test-core/tests/racket/fixnum.rktl
+++ b/pkgs/racket-test-core/tests/racket/fixnum.rktl
@@ -28,9 +28,9 @@
     (unless (fixnum? x) (raise-argument-error 'wraparound "fixnum?" x))
     (unless (fixnum? y) (raise-argument-error 'wraparound "fixnum?" y))
     (define v (op x y))
-    (if (zero? (bitwise-and v (add1 (greatext-fixnum))))
-        (bitwise-ior v (- -1 (greatest-fixnum)))
-        (bitwise-and v (greatest-fixnum)))))
+    (if (zero? (bitwise-and v (add1 (greatest-fixnum))))
+        (bitwise-and v (greatest-fixnum))
+        (bitwise-ior v (least-fixnum)))))
 
 (define (lshift x y)
   (unless (<= 0 y (integer-length (greatest-fixnum)))


### PR DESCRIPTION
Fix a typo in a variable. This was causing an error, but it was call inside an error handler that calls an escape continuation claiming success, so the error was ignored.

https://github.com/racket/racket/blob/d5794de89bb7e44e46621c9fd2385ebb20313f41/pkgs/racket-test-core/tests/racket/fixnum.rktl#L102

Also, it's necessary also swap the code used to complete the bits of the result in case of a wraparound. 