### PR TITLE
Fix build guide when returning to normal

### DIFF
--- a/build.md
+++ b/build.md
@@ -807,7 +807,7 @@ Some information that might improve your experience:
 * If you’re done and want to go back to the normal installation for
   <_pkg-name_>, use
 
-    `raco pkg update --catalog <pkg-name>`
+    `raco pkg update --lookup <pkg-name>`
 
 * See Developing Packages with Git for more information about how
   packages are meant to work as Git repositories.

--- a/pkgs/racket-build-guide/contribute.scrbl
+++ b/pkgs/racket-build-guide/contribute.scrbl
@@ -140,7 +140,7 @@ Some information that might improve your experience:
  @item{If you're done and want to go back to the normal installation
        for @nonterm{pkg-name}, use
 
-        @commandline{raco pkg update @DFlag{catalog} @nonterm{pkg-name}}}
+        @commandline{raco pkg update @DFlag{lookup} @nonterm{pkg-name}}}
 
  @item{See @secref["git-workflow" #:doc '(lib
        "pkg/scribblings/pkg.scrbl")] for more information about how


### PR DESCRIPTION
This fixes a small error in the build guide. Instead of `--catalog`, `--lookup` should be used to return to the default installation of a package.