### PR TITLE
define-ffi-definer: support variables, c-id from run-time expr

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/define.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/define.scrbl
@@ -16,12 +16,15 @@ Binds @racket[define-id] as a definition form to extract bindings from
 the library produced by @racket[ffi-lib-expr]. The syntax of
 @racket[define-id] is
 
-@specform/subs[(define-id id type-expr
+@specform/subs[#:literals (unquote)
+               (define-id id type-expr
                  bind-option ...)
                ([bind-option (code:line #:c-id c-id)
+                             (code:line #:c-id (@#,(racket unquote) c-id-expr))
                              (code:line #:wrap wrap-expr)
                              (code:line #:make-fail make-fail-expr)
-                             (code:line #:fail fail-expr)])]
+                             (code:line #:fail fail-expr)
+                             (code:line #:variable)])]
 
 A @racket[define-id] form binds @racket[id] by extracting a binding
 with the name @racket[_c-id] from the library produced by
@@ -52,6 +55,15 @@ The other options support further wrapping and configuration:
       underscores or camel case.
       Several conventions are provided by
       @racketmodname[ffi/unsafe/define/conventions].}
+
+ @item{If the @racket[#:c-id] argument has the form
+       @racket[(@#,(racket unquote) _c-id-expr)], then the foreign
+       name is the result of evaluating @racket[_c-id-expr]. In this
+       case, the @racket[#:make-c-id] argument is ignored.}
+
+ @item{If the @racket[#:variable] keyword is given, then
+       @racket[make-c-parameter] is used instead of
+       @racket[get-ffi-obj] to get the foreign value.}
 ]
 
 If @racket[provide-id] is provided to @racket[define-ffi-definer], then
@@ -89,9 +101,13 @@ error immediately. If @racket[define-gtk] is instead defined with
 ]
 
 then if @tt{gtk_rc_parse} is not found in @racket[gtk-lib], an error
-is reported only when @racket[gtk_rc_parse] is called.}
+is reported only when @racket[gtk_rc_parse] is called.
 
-@history[#:changed "6.9.0.5" @elem{Added @racket[#:make-c-id] parameter.}]
+@history[#:changed "6.9.0.5" @elem{Added @racket[#:make-c-id] parameter.}
+         #:changed "8.4.0.5" @elem{Added @racket[#:variable] option.
+                                   Added @racket[unquote] variant of
+                                   @racket[#:c-id] argument.}]}
+
 
 @defproc[(make-not-available [name symbol?]) procedure?]{
 

--- a/pkgs/racket-doc/scribblings/foreign/libs.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/libs.scrbl
@@ -174,7 +174,7 @@ Keep in mind that @racket[get-ffi-obj] is an unsafe procedure; see
 
 If the name is not found, and @racket[failure-thunk] is provided, it is
 used to produce a return value.  For example, a failure thunk can be
-provided to report a specific error if an name is not found:
+provided to report a specific error if a name is not found:
 
 @racketblock[
 (define foo
@@ -203,7 +203,8 @@ interface, including Racket callbacks.}
 
 @defproc[(make-c-parameter [objname (or/c string? bytes? symbol?)]
                            [lib (or/c ffi-lib? path-string? #f)]
-                           [type ctype?])
+                           [type ctype?]
+                           [failure-thunk (or/c (-> any) #f) #f])
          (and/c (-> any)
                 (any/c -> void?))]{
 
@@ -216,7 +217,9 @@ code interact through a library value.  Although
 @racket[make-c-parameter] can be used with any time, it is not
 recommended to use this for foreign functions, since each reference
 through the parameter will construct the low-level interface before the
-actual call.}
+actual call.
+
+@history[#:changed "8.4.0.5" @elem{Added @racket[failure-thunk] argument.}]}
 
 
 @defform[(define-c id lib-expr type-expr)]{

--- a/pkgs/racket-test-core/tests/racket/foreign-test.rktl
+++ b/pkgs/racket-test-core/tests/racket/foreign-test.rktl
@@ -1621,6 +1621,29 @@
     (saved-errno 5)
     (test 5 saved-errno)))
 
+(let ()
+  (define-ffi-definer define-test-lib test-lib)
+
+  (define-test-lib g1 _int #:variable)
+  (define-test-lib curry_ret_int_int (_fun _int -> _int))
+
+  (g1 12)
+  (test 25 curry_ret_int_int 13)
+  (test 12 g1)
+
+  (define-test-lib g2 _int #:variable)
+  (define-test-lib ho_return (_fun _int -> _int))
+  (define update-g2-fun-name 'ho)
+  (define-test-lib update-g2 (_fun (_fun _int -> _int) _int -> _void)
+    #:c-id ,update-g2-fun-name)
+  (g2 20)
+  (test (void) update-g2 (lambda (n) (* n 3)) 15)
+  (test 45 g2)
+  (test 48 ho_return 3)
+
+  (define-test-lib no_such_var _int #:variable #:fail (lambda () #f))
+  (test #f values no_such_var))
+
 ;; ----------------------------------------
 ;; Make sure `_union` can deal with various things
 ;; that create a large structure

--- a/racket/collects/ffi/unsafe/define.rkt
+++ b/racket/collects/ffi/unsafe/define.rkt
@@ -44,14 +44,16 @@
                                         define-form  ;; Identifier
                                         default-make-fail ;; Identifier
                                         make-c-id)  ;; Identifier/#'#f
-    ;; do-make-c-id : Identifier -> Identifier
-    (define (do-make-c-id id)
-      (cond [(identifier? make-c-id)
-             (define result ((syntax-local-value make-c-id) id))
-             (unless (identifier? result)
-               (raise-syntax-error #f "invalid make-c-id result" make-c-id))
-             result]
-            [else id]))
+    (define-syntax-class c-id-spec #:attributes (c-id-expr)
+      #:literals (unquote)
+      (pattern (unquote c-id-expr:expr))
+      (pattern c-id:id
+               #:with c-id-expr (cond [(identifier? make-c-id)
+                                       (define result ((syntax-local-value make-c-id) #'c-id))
+                                       (unless (identifier? result)
+                                         (raise-syntax-error #f "invalid make-c-id result" make-c-id))
+                                       #`(quote #,result)]
+                                      [else #'(quote c-id)])))
     (with-syntax ([the-ffi-lib  the-ffi-lib]
                   [provide      provide-form]
                   [define-form  define-form]
@@ -59,22 +61,23 @@
       (lambda (stx)
         (syntax-parse stx
           [(_ s-id:id type:expr
-              (~seq (~or (~optional (~seq #:c-id c-id:id)
-                                    #:defaults ([c-id (do-make-c-id #'s-id)])
+              (~seq (~or (~optional (~seq #:c-id c-id)
                                     #:name "#:c-id keyword")
                          (~optional (~seq #:wrap wrapper:expr)
                                     #:defaults ([wrapper #'values])
                                     #:name "#:wrap keyword")
                          (~optional (~or (~seq #:make-fail make-fail:expr)
                                          (~seq #:fail fail:expr))
-                                    #:defaults ([make-fail #'default-make-fail])))
+                                    #:defaults ([make-fail #'default-make-fail]))
+                         (~optional (~seq (~and #:variable var-kw))
+                                    #:name "#:variable keyword"))
                     ...))
-           (with-syntax ([fail (if (attribute fail)
-                                   #'fail
-                                   #'(make-fail 's-id))])
+           #:with :c-id-spec #'(~? c-id s-id)
+           (with-syntax ([fail #'(~? fail (make-fail 's-id))]
+                         [get (if (attribute var-kw) #'make-c-parameter #'get-ffi-obj)])
              (with-syntax ([def (syntax/loc stx
                                   (define-form s-id
-                                    (wrapper (get-ffi-obj 'c-id the-ffi-lib type fail))))])
+                                    (wrapper (get c-id-expr the-ffi-lib type fail))))])
                (if (syntax-e #'provide)
                    (syntax/loc stx
                      (begin


### PR DESCRIPTION
If `define-foreign` is defined with `define-ffi-definer`, then it can define variables (backed by `make-c-parameter`) as follows:

    (define-foreign counter _int #:variable)

And it can calculate the foreign object name at run time as follows:

    (define-foreign close (_fun _socket -> _int)
      #:c-id ,(if win? 'closesocket 'close))
