### PR TITLE
Fix 'peek in edge cases, add test

### DIFF
--- a/pkgs/racket-test/tests/xml/test.rkt
+++ b/pkgs/racket-test/tests/xml/test.rkt
@@ -672,6 +672,21 @@ XML
 </foo>
 XML
                          )
+       ;; Ensure 'peek works on empty tags when empty-tag-shorthand is a list of symbols
+       ;; in which the empty tag does not appear
+       (parameterize ([empty-tag-shorthand '(p)])
+         (test-indentation 'peek el #<<XML
+<foo>
+  <a></a>
+  <b>1</b>
+  <c>12</c>
+  <d>&sym;</d>
+  <span>&quot;blah&quot;</span>
+  <e>&#42;</e>
+</foo>
+XML
+                         ))
+
        (test-indentation 'scan el #<<XML
 <foo>
   <a />

--- a/racket/collects/xml/private/writer.rkt
+++ b/racket/collects/xml/private/writer.rkt
@@ -131,7 +131,7 @@
         (display " />" out)
         (let ([dent-kids (case dent
                            [(peek)
-                            (if (whitespace-sensitive? (car content))
+                            (if (or (null? content) (whitespace-sensitive? (car content)))
                                 'none
                                 dent)]
                            [(scan)


### PR DESCRIPTION
Fixes a bug in the new indentation feature in the `xml` module, which you can reproduce in the latest snapshot like so:

```racket
#lang racket/base

(require xml)

(define test-xexpr '(a))

(display-xml/content (xexpr->xml test-xexpr) #:indentation 'scan)
(display-xml/content (xexpr->xml test-xexpr) #:indentation 'peek)
```

which will result in:

```
<a>
</a>
<a car: contract violation
  expected: pair?
  given: '()
```

The exception happens when the `empty-tag-shorthand` parameter is set to a list of symbols (which is the default setting) and you give `display-content/xml` an empty element whose tag symbol is not included in that list.

It seems the existing tests did not catch this because, at the relevant point in `test.rkt`, `empty-tag-parameter` is set to `'always` rather than to the default list of symbols.

Fixed by adding a short-circuit check before the offending `car`. At that point it’s deciding whether or not to indent child elements, but when there are none it doesn’t matter what setting is chosen.