### PR TITLE
file/glob: fixes for Windows

### DIFF
--- a/pkgs/racket-doc/file/scribblings/glob.scrbl
+++ b/pkgs/racket-doc/file/scribblings/glob.scrbl
@@ -37,6 +37,8 @@ a set of path strings using the following @deftech[#:key "glob-wildcard"]{wildca
 }
 ]
 
+@margin-note{On Windows, wildcards cannot be escaped because @tt{\} is a path separator.}
+
 By default, wildcards will not match files or directories whose name begins
 with a period (aka "dotfiles").  To override, set the parameter
 @racket[glob-capture-dotfiles?] to a non-@racket[#f] value or supply a similar


### PR DESCRIPTION
- disallow escapes because \ is a path separator
- output correct path separators
- change expectations for some tests (/ vs. C:\ etc.)

fixes #4000 