### PR TITLE
pkg/new: update GHA template to allow failures on `current`

### DIFF
--- a/racket/collects/pkg/private/new.rkt
+++ b/racket/collects/pkg/private/new.rkt
@@ -135,13 +135,18 @@ jobs:
   build:
     name: "Build on Racket '${{ matrix.racket-version }}' (${{ matrix.racket-variant }})"
     runs-on: ubuntu-latest
+    continue-on-error: ${{ matrix.experimental || false }}
     strategy:
+      fail-fast: false
       matrix:
         racket-version: ["stable", "current"]
         racket-variant: ["BC", "CS"]
+        include:
+          - racket-version: current
+            experimental: true
     steps:
       - uses: actions/checkout@v2
-      - uses: Bogdanp/setup-racket@v0.12
+      - uses: Bogdanp/setup-racket@v1.7
         with:
           architecture: x64
           distribution: full


### PR DESCRIPTION
This makes it so that CI failures against Racket snapshots don't fail the whole build. Turning `fail-fast` off also makes it so that individual failures don't eagerly fail the whole build. Some additional context [here](https://racket.slack.com/archives/C06V96CKX/p1633979783245800?thread_ts=1633976596.240900&cid=C06V96CKX).