### PR TITLE
Quote $PSScriptRoot in msvcprep.ps1

### DIFF
--- a/racket/src/worksp/msvcprep.ps1
+++ b/racket/src/worksp/msvcprep.ps1
@@ -19,7 +19,7 @@
     * https://stackoverflow.com/a/2124759/144981
 #>
 
-$command = "echo off & " + $PSScriptRoot + "\msvcprep.bat " + $Args[0] + " & set"
+$command = "echo off & `"" + $PSScriptRoot + "`"\msvcprep.bat " + $Args[0] + " & set"
 cmd /c $command |
   ForEach {
       if ($_ -match "=") {


### PR DESCRIPTION
This allows the script to work correctly when the path to it contains whitespace.