### PR TITLE
Use monotonic time for timeouts and delays

### DIFF
--- a/pkgs/compiler-test/tests/compiler/zo-test.rkt
+++ b/pkgs/compiler-test/tests/compiler/zo-test.rkt
@@ -158,9 +158,10 @@ exec racket -t "$0" -- -s -t 60 -v -R $*
 (define timing-thread
   (thread
    (λ ()
-     (sync 
-      (alarm-evt (+ (current-inexact-milliseconds)
-                    (* 1000 (time-limit)))))
+     (sync
+      (alarm-evt (+ (current-inexact-monotonic-milliseconds)
+                    (* 1000 (time-limit)))
+                 #t))
      (stop!))))
 
 (define server-thread

--- a/pkgs/net-lib/net/dns.rkt
+++ b/pkgs/net-lib/net/dns.rkt
@@ -195,8 +195,9 @@
           (udp-send-to udp nameserver 53 (list->bytes query))
           (sync (handle-evt (udp-receive!-evt udp s)
                             (lambda (r) (bytes->list (subbytes s 0 (car r)))))
-                (handle-evt (alarm-evt (+ (current-inexact-milliseconds)
-                                          timeout))
+                (handle-evt (alarm-evt (+ (current-inexact-monotonic-milliseconds)
+                                          timeout)
+                                       #t)
                             (lambda (v) (retry (* timeout 2)))))))
       (lambda () (udp-close udp))))
 

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/common/auto.rkt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/common/auto.rkt
@@ -675,9 +675,9 @@ exec racket -qu "$0" ${1+"$@"}
           (rprintf "[~a ~a ~s #f]\n" (hash-ref names impl impl) bm '(#f #f #f))
           (begin
             ((impl-setup i) bm)
-            (let ([start (current-inexact-milliseconds)])
+            (let ([start (current-inexact-monotonic-milliseconds)])
               ((impl-make i) bm)
-              (let ([end (current-inexact-milliseconds)])
+              (let ([end (current-inexact-monotonic-milliseconds)])
                 (let loop ([n num-iterations])
                   (unless (zero? n)
                     (let ([out (open-output-bytes)])

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/rx/auto.rkt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/rx/auto.rkt
@@ -17,12 +17,12 @@ exec racket -qu "$0" ${1+"$@"}
     (define byte-pregexp byte-regexp))
 
   (define (test-mz input rx iterations)
-    (let ([start (current-inexact-milliseconds)])
+    (let ([start (current-inexact-monotonic-milliseconds)])
       (let loop ([n iterations])
 	(unless (zero? n)
 	  (regexp-match-positions rx input)
 	  (loop (sub1 n))))
-      (- (current-inexact-milliseconds) start)))
+      (- (current-inexact-monotonic-milliseconds) start)))
 
   (define (test-racket input rx iterations)
     (test-mz input (byte-pregexp rx) iterations))
@@ -83,12 +83,12 @@ exec racket -qu "$0" ${1+"$@"}
     (let ([pcregexp (dynamic-require "pcre.rkt" 'pcregexp)]
 	  [pcregexp-match (dynamic-require "pcre.rkt" 'pcregexp-match)])
       (let ([rx (pcregexp rx)])
-	(let ([start (current-inexact-milliseconds)])
+	(let ([start (current-inexact-monotonic-milliseconds)])
 	  (let loop ([n iterations])
 	    (unless (zero? n)
 	      (pcregexp-match rx input)
 	      (loop (sub1 n))))
-	  (- (current-inexact-milliseconds) start)))))
+	  (- (current-inexact-monotonic-milliseconds) start)))))
 
   (define (random-letters n)
     (parameterize ([current-pseudo-random-generator (make-pseudo-random-generator)])

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/auto.rkt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/auto.rkt
@@ -169,15 +169,15 @@ exec racket -qu "$0" ${1+"$@"}
           (rprintf "[~a ~a ~s #f]\n" impl bm '(#f #f #f))
           (begin
             ((impl-setup i) bm)
-            (let ([start (current-inexact-milliseconds)])
+            (let ([start (current-inexact-monotonic-milliseconds)])
               ((impl-make i) bm)
-              (let ([end (current-inexact-milliseconds)])
+              (let ([end (current-inexact-monotonic-milliseconds)])
                 (let loop ([n num-iterations])
                   (unless (zero? n)
                     (let ([out (open-output-bytes)])
                       (unless (parameterize ([current-output-port out]
                                              [current-error-port out])
-                                ((impl-run i) 
+                                ((impl-run i)
                                  (if (symbol? bm)
                                    (format "~a" bm)
                                    bm)))

--- a/pkgs/racket-doc/scribblings/foreign/schedule.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/schedule.scrbl
@@ -83,9 +83,12 @@ available.}
                                               [msecs flonum?])
          void?]{
 
-Causes the Racket process will wake up and resume polling at the point
-when @racket[(current-inexact-milliseconds)] starts returning a value
-that is @racket[msecs] or greater.}
+Causes the Racket process to wake up and resume polling at the point
+when @racket[(current-inexact-monotonic-milliseconds)] starts returning
+a value that is @racket[msecs] or greater.}
+
+@history[#:changed "8.3.0.9" @elem{@racket[unsafe-poll-ctx-milliseconds-wakeup] previously used
+                                   @racket[current-inexact-milliseconds].}]
 
 @defproc[(unsafe-set-sleep-in-thread! [foreground-sleep (-> any/c)]
                                       [fd fixnum?])

--- a/pkgs/racket-doc/scribblings/reference/evts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/evts.scrbl
@@ -307,13 +307,15 @@ with timeouts that have not yet expired. The system-idle event's
 ]}
 
 
-@defproc[(alarm-evt [msecs real?]) evt?]{
+@defproc[(alarm-evt [msecs real?] [monotonic? boolean? #f]) evt?]{
 
 Returns a @tech{synchronizable event} that is not @tech{ready for synchronization} when
-@racket[(current-inexact-milliseconds)] would return a value that is
+@racket[(_milliseconds)] would return a value that is
 less than @racket[msecs], and it is @tech{ready for synchronization} when
-@racket[(current-inexact-milliseconds)] would return a value that is
-more than @racket[msecs]. @ResultItself{alarm event}.
+@racket[(_milliseconds)] would return a value that is
+more than @racket[msecs]. The value of @racket[_milliseconds] is
+@racket[current-inexact-milliseconds] when @racket[monotonic?] is @racket[#f],
+or @racket[current-inexact-monotonic-milliseconds] otherwise. @ResultItself{alarm event}.
 
 @examples[#:eval evt-eval
   (define alarm (alarm-evt (+ (current-inexact-milliseconds) 100)))

--- a/pkgs/racket-test-core/tests/racket/portlib.rktl
+++ b/pkgs/racket-test-core/tests/racket/portlib.rktl
@@ -985,7 +985,7 @@
      (object-name p)
      (lambda (bstr)
        (if (zero? (random 2))
-           (wrap-evt (alarm-evt (+ (current-inexact-milliseconds) 5))
+           (wrap-evt (alarm-evt (+ (current-inexact-monotonic-milliseconds) 5) #t)
                      (lambda (v) 0))
            (read-bytes-avail! bstr p)))
      #f
@@ -1327,7 +1327,7 @@
     (define PORT 5999)
 
     (define (make-alarm-e)
-      (alarm-evt (+ (current-inexact-milliseconds) 5)))
+      (alarm-evt (+ (current-inexact-monotonic-milliseconds) 5) #t))
 
     (define ((connection-handler in out with-alarm?))
       (let loop ((alarm-e (make-alarm-e))

--- a/pkgs/racket-test-core/tests/racket/sync.rktl
+++ b/pkgs/racket-test-core/tests/racket/sync.rktl
@@ -155,6 +155,16 @@
   (test 'ok sync/timeout 100
         (wrap-evt
          (alarm-evt (+ (current-inexact-milliseconds) 50))
+         (lambda (x) 'ok)))
+
+  (test #f sync/timeout 0.1 (alarm-evt (+ (current-inexact-monotonic-milliseconds) 200) #t))
+  (test 'ok sync/timeout 0.1
+        (wrap-evt
+         (alarm-evt (+ (current-inexact-monotonic-milliseconds) 50) #t)
+         (lambda (x) 'ok)))
+  (test 'ok sync/timeout 100
+        (wrap-evt
+         (alarm-evt (+ (current-inexact-monotonic-milliseconds) 50) #t)
          (lambda (x) 'ok))))
 
 ;; ----------------------------------------
@@ -1085,7 +1095,7 @@
                               (set! counter (sub1 counter))
                               (when wakeups
                                 ;; Cancel any sleep:
-                                (unsafe-poll-ctx-milliseconds-wakeup wakeups (current-inexact-milliseconds)))
+                                (unsafe-poll-ctx-milliseconds-wakeup wakeups (current-inexact-monotonic-milliseconds)))
                               (values #f self)]))))
   (test #t sync (p)))
 
@@ -1598,7 +1608,7 @@
       (test val values got)))
 
   (try values 'ok-channel)
-  (try (lambda (c) (choice-evt c (alarm-evt (+ 10000 (current-inexact-milliseconds)))))
+  (try (lambda (c) (choice-evt c (alarm-evt (+ 10000 (current-inexact-monotonic-milliseconds)) #t)))
        'ok-channel+alarm))
 
 ;; ----------------------------------------

--- a/pkgs/racket-test-core/tests/racket/will.rktl
+++ b/pkgs/racket-test-core/tests/racket/will.rktl
@@ -496,9 +496,9 @@
     (define ITERS 5)
     (define msecs
       (/ (for/fold ([t 0]) ([i (in-range ITERS)])
-           (define start (current-inexact-milliseconds))
+           (define start (current-inexact-monotonic-milliseconds))
            (collect-garbage)
-           (+ t (- (current-inexact-milliseconds) start)))
+           (+ t (- (current-inexact-monotonic-milliseconds) start)))
          ITERS))
     ;; Keep `key` and `es` live:
     (if (zero? (random 1))

--- a/pkgs/racket-test/tests/racket/place-thread-sleep.rkt
+++ b/pkgs/racket-test/tests/racket/place-thread-sleep.rkt
@@ -15,7 +15,7 @@
          (define th (thread (lambda ()
                               (let loop ()
                                 (loop)))))
-         (sync (alarm-evt (+ 100 (current-inexact-milliseconds))))
+         (sync (alarm-evt (+ 100 (current-inexact-monotonic-milliseconds)) #t))
          (thread-suspend th)
          (printf "fib...\n")
          (fib 30) ; takes long enough to exhaust quantum

--- a/pkgs/racket-test/tests/racket/stress/datum-to-syntax.rkt
+++ b/pkgs/racket-test/tests/racket/stress/datum-to-syntax.rkt
@@ -6,14 +6,14 @@
              'x)))
 
 
-(let ([now (current-inexact-milliseconds)])
+(let ([now (current-inexact-monotonic-milliseconds)])
   (let loop ([l l])
     (define v (syntax-e l))
     (cond
       [(null? v) 'done]
       [else
        (loop (datum->syntax #f (cdr v)))]))
-  (define t (- (current-inexact-milliseconds) now))
+  (define t (- (current-inexact-monotonic-milliseconds) now))
   (unless (t . < . 1000.0)
     (error 'datum->syntax-stress "took too long: ~a" t)))
 

--- a/pkgs/sandbox-lib/racket/sandbox.rkt
+++ b/pkgs/sandbox-lib/racket/sandbox.rkt
@@ -472,8 +472,9 @@
     (make-custodian me))
   (define timeout-evt
     (handle-evt
-     (alarm-evt (+ (current-inexact-milliseconds)
-                   (* 1000 secs)))
+     (alarm-evt (+ (current-inexact-monotonic-milliseconds)
+                   (* 1000 secs))
+                #t)
      (λ (a) #f)))
 
   (define results null)

--- a/racket/collects/ffi/unsafe/try-atomic.rkt
+++ b/racket/collects/ffi/unsafe/try-atomic.rkt
@@ -61,11 +61,11 @@
 
 (define (can-try-atomic?) (and (freezer-box) (not (in-try-atomic?))))
 
-(define (try-atomic thunk default 
+(define (try-atomic thunk default
                     #:should-give-up? [should-give-up?
-                                       (let ([now (current-inexact-milliseconds)])
+                                       (let ([now (current-inexact-monotonic-milliseconds)])
                                          (lambda ()
-                                           ((current-inexact-milliseconds) . > . (+ now 200))))]
+                                           ((current-inexact-monotonic-milliseconds) . > . (+ now 200))))]
                     #:keep-in-order? [keep-in-order? #t])
   (let ([b (freezer-box)])
     (cond

--- a/racket/collects/syntax/parse/private/opt.rkt
+++ b/racket/collects/syntax/parse/private/opt.rkt
@@ -70,12 +70,12 @@
 ;; ----
 
 (define (optimize-matrix0 rows)
-  (define now (current-inexact-milliseconds))
+  (define now (current-inexact-monotonic-milliseconds))
   (when (and (> (length rows) 1))
     (log-syntax-parse-debug "OPT matrix (~s rows)\n~a" (length rows)
                             (pretty-format (matrix->sexpr rows) #:mode 'print)))
   (define result (optimize-matrix rows))
-  (define then (current-inexact-milliseconds))
+  (define then (current-inexact-monotonic-milliseconds))
   (when (and (> (length rows) 1))
     (cond [(= (length result) (length rows))
            (log-syntax-parse-debug "OPT FAILED (~s ms)" (floor (- then now)))]

--- a/racket/src/bc/src/sema.c
+++ b/racket/src/bc/src/sema.c
@@ -1,4 +1,5 @@
 #include "schpriv.h"
+#include "schrktio.h"
 
 #ifndef NO_SCHEME_THREADS
 
@@ -52,6 +53,7 @@ static void register_traversers(void);
 typedef struct {
   Scheme_Object so;
   double sleep_end;
+  int is_monotonic;
 } Scheme_Alarm;
 
 /* For object-sync: */
@@ -176,7 +178,7 @@ void scheme_init_sema(Scheme_Startup_Env *env)
   scheme_addto_prim_instance("alarm-evt", 
 			     scheme_make_prim_w_arity(make_alarm,
 						      "alarm-evt",
-						      1, 1), 
+						      1, 2),
 			     env);
 
   scheme_addto_prim_instance("system-idle-evt", 
@@ -1400,6 +1402,7 @@ static Scheme_Object *make_alarm(int argc, Scheme_Object **argv)
 {
   Scheme_Alarm *a;
   double sleep_end;
+  int is_monotonic = 0;
 
   if (!SCHEME_REALP(argv[0])) {
     scheme_wrong_contract("alarm-evt", "real?", 0, argc, argv);
@@ -1407,9 +1410,14 @@ static Scheme_Object *make_alarm(int argc, Scheme_Object **argv)
 
   sleep_end = scheme_get_val_as_double(argv[0]);
 
+  if((argc > 1) && SCHEME_TRUEP(argv[1])) {
+    is_monotonic = 1;
+  }
+
   a = MALLOC_ONE_TAGGED(Scheme_Alarm);
   a->so.type = scheme_alarm_type;
   a->sleep_end = sleep_end;
+  a->is_monotonic = is_monotonic;
 
   return (Scheme_Object *)a;
 }
@@ -1418,11 +1426,17 @@ static int alarm_ready(Scheme_Object *_a, Scheme_Schedule_Info *sinfo)
 {
   Scheme_Alarm *a = (Scheme_Alarm *)_a;
 
-  if (!sinfo->sleep_end
-      || (sinfo->sleep_end > a->sleep_end))
-    sinfo->sleep_end = a->sleep_end;
+  double sleep_end_monotonic = a->sleep_end;
+  if(!a->is_monotonic) {
+    sleep_end_monotonic = rktio_get_inexact_monotonic_milliseconds(scheme_rktio)
+                          + a->sleep_end - scheme_get_inexact_milliseconds();
+  }
 
-  if (a->sleep_end <= scheme_get_inexact_milliseconds())
+  if (!sinfo->sleep_end
+      || (sinfo->sleep_end > sleep_end_monotonic))
+    sinfo->sleep_end = sleep_end_monotonic;
+
+  if (sleep_end_monotonic <= rktio_get_inexact_monotonic_milliseconds(scheme_rktio))
     return 1;
 
   return 0;

--- a/racket/src/bc/src/thread.c
+++ b/racket/src/bc/src/thread.c
@@ -4231,7 +4231,7 @@ static int check_sleep(int need_activity, int sleep_now)
 	double d;
 	double t;
 
-	d = (p_time - scheme_get_inexact_milliseconds());
+	d = (p_time - rktio_get_inexact_monotonic_milliseconds(scheme_rktio));
 
 	t = (d / 1000);
 	if (t <= 0) {
@@ -4307,7 +4307,7 @@ void scheme_check_threads(void)
 {
   double start, now;
 
-  start = scheme_get_inexact_milliseconds();
+  start = rktio_get_inexact_monotonic_milliseconds(scheme_rktio);
   
   while (1) {
     scheme_current_thread->suspend_break++;
@@ -4317,7 +4317,7 @@ void scheme_check_threads(void)
     if (check_sleep(have_activity, 0))
       break;
 
-    now = scheme_get_inexact_milliseconds();
+    now = rktio_get_inexact_monotonic_milliseconds(scheme_rktio);
     if (((now - start) * 1000) > MZ_THREAD_QUANTUM_USEC)
       break;
   }
@@ -4754,7 +4754,7 @@ static void find_next_thread(Scheme_Thread **return_arg) {
         }
       } else if (next->block_descriptor == SLEEP_BLOCKED) {
         if (!msecs)
-          msecs = scheme_get_inexact_milliseconds();
+          msecs = rktio_get_inexact_monotonic_milliseconds(scheme_rktio);
         if (next->sleep_end <= msecs)
           break;
       } else
@@ -4878,7 +4878,7 @@ void scheme_thread_block(float sleep_time)
     scheme_wake_up();
 
   if (sleep_time > 0) {
-    sleep_end = scheme_get_inexact_milliseconds();
+    sleep_end = rktio_get_inexact_monotonic_milliseconds(scheme_rktio);
     sleep_end += (sleep_time * 1000.0);
   } else
     sleep_end = 0;
@@ -5061,7 +5061,7 @@ void scheme_thread_block(float sleep_time)
 #endif
   
   if (sleep_end > 0) {
-    if (sleep_end > scheme_get_inexact_milliseconds()) {
+    if (sleep_end > rktio_get_inexact_monotonic_milliseconds(scheme_rktio)) {
       /* Still have time to sleep if necessary, but make sure we're
 	 not ready (because maybe that's why we were swapped back in!) */
       if (p->block_descriptor == GENERIC_BLOCKED) {
@@ -5121,7 +5121,7 @@ int scheme_block_until(Scheme_Ready_Fun _f, Scheme_Needs_Wakeup_Fun fdf,
   if (!delay)
     sleep_end = 0.0;
   else {
-    sleep_end = scheme_get_inexact_milliseconds();
+    sleep_end = rktio_get_inexact_monotonic_milliseconds(scheme_rktio);
     sleep_end += (delay * 1000.0);    
   }
 
@@ -5137,7 +5137,7 @@ int scheme_block_until(Scheme_Ready_Fun _f, Scheme_Needs_Wakeup_Fun fdf,
       scheme_current_thread->ran_some = 1;
     } else {
       if (now_sleep_end) {
-	delay = (float)(now_sleep_end - scheme_get_inexact_milliseconds());
+	delay = (float)(now_sleep_end - rktio_get_inexact_monotonic_milliseconds(scheme_rktio));
 	delay /= 1000.0;
 	if (delay <= 0)
 	  delay = (float)0.00001;
@@ -6772,7 +6772,7 @@ int scheme_syncing_ready(Syncing *syncing, Scheme_Schedule_Info *sinfo, int can_
   }
 
   if (syncing->timeout >= 0.0) {
-    if (syncing->sleep_end <= scheme_get_inexact_milliseconds())
+    if (syncing->sleep_end <= rktio_get_inexact_monotonic_milliseconds(scheme_rktio))
       result = 1;
   } else if (all_semas && can_suspend) {
     /* Try to block in a GCable way: */
@@ -7256,7 +7256,7 @@ static Scheme_Object *do_sync(const char *name, int argc, Scheme_Object *argv[],
 	return NULL;
       }
       
-      start_time = scheme_get_inexact_milliseconds();
+      start_time = rktio_get_inexact_monotonic_milliseconds(scheme_rktio);
     } else
       start_time = 0;
   } else {

--- a/racket/src/cs/demo/thread.ss
+++ b/racket/src/cs/demo/thread.ss
@@ -92,31 +92,31 @@
      (check 'ok (sync (nack-guard-evt (lambda (n) (set! nack n) (make-semaphore))) ok-evt))
      (unless nack (loop)))
    (check (void) (sync/timeout 0 nack))
-   
+
    (semaphore-post s)
    (check #f (sync/timeout 0 ch (channel-put-evt ch 'oops)))
    (check sp (sync/timeout #f ch (channel-put-evt ch 'oops) sp))
 
-   (define now1 (current-inexact-milliseconds))
+   (define now1 (current-inexact-monotonic-milliseconds))
    (sleep 0.1)
-   (check #t (>= (current-inexact-milliseconds) (+ now1 0.1)))
+   (check #t (>= (current-inexact-monotonic-milliseconds) (+ now1 0.1)))
 
-   (define now2 (current-inexact-milliseconds))
+   (define now2 (current-inexact-monotonic-milliseconds))
    (define ts (thread (lambda () (sleep 0.1))))
    (check ts (sync ts))
-   (check #t (>= (current-inexact-milliseconds) (+ now2 0.1)))
+   (check #t (>= (current-inexact-monotonic-milliseconds) (+ now2 0.1)))
 
    (define v 0)
    (thread (lambda () (set! v (add1 v))))
    (sync (system-idle-evt))
    (check 1 v)
-   
+
    (define tinf (thread (lambda () (let loop () (loop)))))
    (break-thread tinf)
    (check tinf (sync tinf))
    (printf "[That break was from a thread, and it's expected]\n")
 
-   (define now3 (current-inexact-milliseconds))
+   (define now3 (current-inexact-monotonic-milliseconds))
    (define tdelay (with-continuation-mark
                       break-enabled-key
                     (make-thread-cell #f #t)
@@ -131,7 +131,7 @@
    (break-thread tdelay)
    (check tdelay (sync tdelay))
    (printf "[That break was from a thread, and it's expected]\n")
-   (check #t (>= (current-inexact-milliseconds) (+ now3 0.1)))
+   (check #t (>= (current-inexact-monotonic-milliseconds) (+ now3 0.1)))
 
    (define got-here? #f)
    (define break-self (thread (lambda ()
@@ -268,14 +268,14 @@
    #;
    (let ([t1 (thread (lambda () (let loop () (loop))))]
          [t2 (thread (lambda () (let loop ()
-                             (define n (current-inexact-milliseconds))
+                             (define n (current-inexact-monotonic-milliseconds))
                              (sleep)
-                             (fprintf (current-error-port) "~a\n" (- (current-inexact-milliseconds) n))
+                             (fprintf (current-error-port) "~a\n" (- (current-inexact-monotonic-milliseconds) n))
                              (loop))))])
      (sleep 0.5)
      (break-thread t1)
      (break-thread t2))
-   
+
    (time
     (let ([s1 (make-semaphore)]
           [s2 (make-semaphore)])

--- a/racket/src/cs/primitive/kernel.ss
+++ b/racket/src/cs/primitive/kernel.ss
@@ -18,7 +18,7 @@
   [absolute-path? (known-procedure/no-prompt 2)]
   [acos (known-procedure/folding 2)]
   [add1 (known-procedure/folding 2)]
-  [alarm-evt (known-procedure/no-prompt 2)]
+  [alarm-evt (known-procedure/no-prompt 6)]
   [always-evt (known-authentic)]
   [andmap (known-procedure -4)]
   [angle (known-procedure/folding 2)]

--- a/racket/src/cs/schemified/io.scm
+++ b/racket/src/cs/schemified/io.scm
@@ -3629,7 +3629,7 @@
     (begin
       (unsafe-place-local-set! cell.1$10 sleep_0)
       (unsafe-place-local-set! cell.2$3 fd_0))))
-(define effect_2807
+(define effect_2319
   (begin
     (void
      (|#%app|
@@ -3661,7 +3661,9 @@
                    (let ((sleep-secs_0
                           (if timeout-at_0
                             (/
-                             (- timeout-at_0 (current-inexact-milliseconds))
+                             (-
+                              timeout-at_0
+                              (current-inexact-monotonic-milliseconds))
                              1000.0)
                             #f)))
                      (begin
@@ -36042,7 +36044,7 @@
    #f
    2
    3))
-(define effect_2319 (finish_3124 struct:connect-progress))
+(define effect_2320 (finish_3124 struct:connect-progress))
 (define connect-progress1.1
   (|#%name|
    connect-progress
@@ -39237,7 +39239,7 @@
                         (if vals_1
                           (sandman-poll-ctx-merge-timeout
                            poll-ctx_0
-                           (current-inexact-milliseconds))
+                           (current-inexact-monotonic-milliseconds))
                           (void))
                         (values #f self_0)))
                      (args (raise-binding-result-arity-error 2 args))))

--- a/racket/src/expander/common/performance.rkt
+++ b/racket/src/expander/common/performance.rkt
@@ -81,14 +81,14 @@
                                                              (cdr enclosing-path)
                                                              null)))))
                                        path)
-                                   (current-inexact-milliseconds)
+                                   (current-inexact-monotonic-milliseconds)
                                    (current-memory-use 'cumulative)
                                    0.0
                                    0)
                            region-stack)))
 
 (define (end-performance-region)
-  (define now (current-inexact-milliseconds))
+  (define now (current-inexact-monotonic-milliseconds))
   (define now-memory (current-memory-use 'cumulative))
   (define r (car region-stack))
   (set! region-stack (cdr region-stack))

--- a/racket/src/io/sandman/main.rkt
+++ b/racket/src/io/sandman/main.rkt
@@ -73,7 +73,7 @@
            [else
             (fd-adders ps)]))
        (define sleep-secs (and timeout-at
-                               (/ (- timeout-at (current-inexact-milliseconds)) 1000.0)))
+                               (/ (- timeout-at (current-inexact-monotonic-milliseconds)) 1000.0)))
        (unless (and sleep-secs (sleep-secs . <= . 0.0))
          (cond
            [background-sleep

--- a/racket/src/io/unsafe/schedule.rkt
+++ b/racket/src/io/unsafe/schedule.rkt
@@ -28,7 +28,7 @@
                     ;; that the event will be polled again; we do not
                     ;; select the event now. That rule accommodates
                     ;; the old Racket scheduler.
-                    (sandman-poll-ctx-merge-timeout poll-ctx (current-inexact-milliseconds)))
+                    (sandman-poll-ctx-merge-timeout poll-ctx (current-inexact-monotonic-milliseconds)))
                   (values #f self)]
                  [else
                   (values #f evt)])]))))

--- a/racket/src/regexp/demo.rkt
+++ b/racket/src/regexp/demo.rkt
@@ -165,21 +165,21 @@
 ;; ----------------------------------------
 
 (define (check rx in N [M (max 1 (quotient N 10))])
-  (define c-start (current-inexact-milliseconds))
+  (define c-start (current-inexact-monotonic-milliseconds))
   (define orig-rx
     (if (bytes? rx)
         (for/fold ([r #f]) ([i (in-range M)])
           (byte-pregexp rx))
         (for/fold ([r #f]) ([i (in-range M)])
           (pregexp rx))))
-  (define c-after-orig (current-inexact-milliseconds))
+  (define c-after-orig (current-inexact-monotonic-milliseconds))
   (define new-rx
     (if (bytes? rx)
         (for/fold ([r #f]) ([i (in-range M)])
           (rx:byte-pregexp rx))
         (for/fold ([r #f]) ([i (in-range M)])
           (rx:pregexp rx))))
-  (define c-after-new (current-inexact-milliseconds))
+  (define c-after-new (current-inexact-monotonic-milliseconds))
 
   (define orig-v (regexp-match orig-rx in))
   (define new-v (rx:regexp-match new-rx in))
@@ -188,14 +188,14 @@
            "failed\n  pattern: ~s\n  input: ~s\n  expected: ~s\n  got: ~s"
            rx in orig-v new-v))
 
-  (define start (current-inexact-milliseconds))
+  (define start (current-inexact-monotonic-milliseconds))
   (for/fold ([r #f]) ([i (in-range N)])
     (regexp-match? orig-rx in))
-  (define after-orig (current-inexact-milliseconds))
+  (define after-orig (current-inexact-monotonic-milliseconds))
   (for/fold ([r #f]) ([i (in-range N)])
     (rx:regexp-match? new-rx in))
-  (define after-new (current-inexact-milliseconds))
-  
+  (define after-new (current-inexact-monotonic-milliseconds))
+
   (define orig-c-msec (- c-after-orig c-start))
   (define new-c-msec (- c-after-new c-after-orig))
   (define orig-msec (- after-orig start))

--- a/racket/src/thread/alarm.rkt
+++ b/racket/src/thread/alarm.rkt
@@ -5,18 +5,23 @@
 
 (provide (rename-out [create-alarm-evt alarm-evt]))
 
-(struct alarm-evt (msecs)
+(struct alarm-evt (msecs monotonic)
   #:property
   prop:evt
   (poller (lambda (e ctx)
             (define msecs (alarm-evt-msecs e))
-            (if ((current-inexact-milliseconds) . >= . msecs)
+            (define monotonic? (alarm-evt-monotonic e))
+            (define current-ms (if monotonic? current-inexact-monotonic-milliseconds current-inexact-milliseconds))
+            (if ((current-ms) . >= . msecs)
                 (values (list e) #f)
                 (begin
                   (schedule-info-add-timeout-at! (poll-ctx-sched-info ctx)
-                                                 msecs)
+                                                 (if monotonic?
+                                                     msecs
+                                                     (+ (current-inexact-monotonic-milliseconds)
+                                                        (- msecs (current-inexact-milliseconds)))))
                   (values #f e))))))
 
-(define/who (create-alarm-evt msecs)
+(define/who (create-alarm-evt msecs [monotonic? #f])
   (check who real? msecs)
-  (alarm-evt msecs))
+  (alarm-evt msecs monotonic?))

--- a/racket/src/thread/demo.rkt
+++ b/racket/src/thread/demo.rkt
@@ -139,15 +139,15 @@
    (check-chaperone-channel (lambda (ch v) (sync (channel-put-evt ch v))))
 
    ;; Check sleeping in main thread
-   (define now1 (current-inexact-milliseconds))
+   (define now1 (current-inexact-monotonic-milliseconds))
    (sleep 0.1)
-   (check #t ((current-inexact-milliseconds) . >= . (+ now1 0.1)))
+   (check #t ((current-inexact-monotonic-milliseconds) . >= . (+ now1 0.1)))
 
    ;; Check sleeping in other thread
-   (define now2 (current-inexact-milliseconds))
+   (define now2 (current-inexact-monotonic-milliseconds))
    (define ts (thread (lambda () (sleep 0.1))))
    (check ts (sync ts))
-   (check #t ((current-inexact-milliseconds) . >= . (+ now2 0.1)))
+   (check #t ((current-inexact-monotonic-milliseconds) . >= . (+ now2 0.1)))
 
    ;; Check `alarm-evt`
    (define now2+ (current-inexact-milliseconds))
@@ -225,7 +225,7 @@
      (report-expected-break)
 
      ;; Check that a break exception is delayed if disabled
-     (define now3 (current-inexact-milliseconds))
+     (define now3 (current-inexact-monotonic-milliseconds))
      (define tdelay (with-continuation-mark
                         break-enabled-key
                       (make-thread-cell #f)
@@ -241,7 +241,7 @@
      (check tdelay (sync tdelay))
      (report-expected-break)
      (unless kill?
-       (check #t ((current-inexact-milliseconds) . >= . (+ now3 0.1))))
+       (check #t ((current-inexact-monotonic-milliseconds) . >= . (+ now3 0.1))))
 
      ;; Check that a semaphore wait can be abandoned
      (define tstuck (thread (lambda () (semaphore-wait (make-semaphore)))))

--- a/racket/src/thread/sandman.rkt
+++ b/racket/src/thread/sandman.rkt
@@ -108,13 +108,13 @@
   (sandman
    ;; sleep
    (lambda (timeout-at)
-     (host:sleep (max 0.0 (/ (- (or timeout-at (distant-future)) (current-inexact-milliseconds)) 1000.0))))
+     (host:sleep (max 0.0 (/ (- (or timeout-at (distant-future)) (current-inexact-monotonic-milliseconds)) 1000.0))))
 
    ;; poll
    (lambda (wakeup)
      (unless (tree-empty? sleeping-threads)
        (define-values (timeout-at threads) (tree-min sleeping-threads))
-       (when (timeout-at . <= . (current-inexact-milliseconds))
+       (when (timeout-at . <= . (current-inexact-monotonic-milliseconds))
          (unless (null? threads)
            (for ([t (in-hash-keys threads)])
              (wakeup t))))))
@@ -174,5 +174,5 @@
 
 ;; Compute an approximation to infinity:
 (define (distant-future)
-  (+ (current-inexact-milliseconds)
+  (+ (current-inexact-monotonic-milliseconds)
      (* 1000.0 60 60 24 365)))

--- a/racket/src/thread/sync.rkt
+++ b/racket/src/thread/sync.rkt
@@ -129,12 +129,12 @@
           ;; callbacks, then the loop can suspend the current thread
           (define timeout-at
             (and timeout
-                 (+ (* timeout 1000) (current-inexact-milliseconds))))
+                 (+ (* timeout 1000) (current-inexact-monotonic-milliseconds))))
           (let loop ([did-work? #t] [polled-all? #f])
             (cond
               [(and polled-all?
                     timeout
-                    (timeout-at . <= . (current-inexact-milliseconds)))
+                    (timeout-at . <= . (current-inexact-monotonic-milliseconds)))
                (start-atomic)
                (cond
                  [(syncing-selected s)

--- a/racket/src/thread/thread.rkt
+++ b/racket/src/thread/thread.rkt
@@ -733,7 +733,7 @@
      (thread-yield #f)]
     [else
      (define until-msecs (+ (* secs 1000.0)
-                            (current-inexact-milliseconds)))
+                            (current-inexact-monotonic-milliseconds)))
      (let loop ()
        ((thread-deschedule! (current-thread)
                             until-msecs


### PR DESCRIPTION
I noticed random crashes when starting a Racket service at boot on a Raspberry Pi. These crashes were happening just after NTP set the system clock (Raspberry Pi has no RTC). The root cause is that many routines used to generate delays or timeouts use `current-inexact-milliseconds`. This can cause a lengthy hang when the system clock moves back, or premature timeout and shortened delays when the system clock moves forward.

This PR:

- Attempts to replace `current-inexact-milliseconds` with `current-inexact-monotonic-milliseconds` in all locations I could find that seem to really want monotonic milliseconds.
- Adds an optional second argument to `alarm-evt` for using monotonic milliseconds (defaults to UTC milliseconds).
- Changes the already-documented API of `unsafe-poll-ctx-milliseconds-wakeup` to use monotonic milliseconds.

Marking this WIP until tests pass and someone who knows the Racket runtime better than me takes a look. I'm not very confident these changes are safe or that breaking the API of `unsafe-poll-ctx-milliseconds-wakeup` is acceptable.