### PR TITLE
Add random generation to `set/c`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sets.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sets.scrbl
@@ -277,6 +277,8 @@ named by the @racket[sym]s.
  @racket[lazy?] is @racket[#f], and @racket[kind] is @racket['immutable].
  The result will be a @tech{chaperone contract} when @racket[elem/c] is a
  @tech{chaperone contract}.
+
+ @history[#:changed "8.3.0.9" @elem{Added support for random generation.}]
 }
 
 @section{Generic Set Interface}

--- a/racket/collects/racket/HISTORY.txt
+++ b/racket/collects/racket/HISTORY.txt
@@ -1,3 +1,7 @@
+Version 8.4, January 2022
+Change `set/c` to support random generation
+Other bug repairs and other changes noted in the documentation
+
 Version 8.3, October 2021
 Expander: remove syntax arming and disarming in favor of a simpler
  system of protected syntax operations


### PR DESCRIPTION
Adds support for random generation and exercising `set/c` by piggybacking off the generator for `listof`.