### PR TITLE
Add a global search notice to local doc

### DIFF
--- a/pkgs/racket-index/scribblings/main/private/notice.rkt
+++ b/pkgs/racket-index/scribblings/main/private/notice.rkt
@@ -1,0 +1,28 @@
+#lang at-exp racket/base
+
+(provide global-notice local-notice)
+
+(require scribble/base
+         scribble/core
+         scribble/html-properties)
+
+(define global-notice
+  @para[#:style (style #f (list (attributes (list (cons 'class "plt_global_only")))))]{
+    You are searching all available Racket packages,
+    including those that you may not have installed locally.
+    Therefore, you may need to install a package to use the results shown below.
+    @hyperlink["http://docs.racket-lang.org/pkg/getting-started.html"]{Getting Started with Packages}
+    guides you through this process.
+    If you want to re-run your search with local results only,
+    press F1 in DrRacket or run @tt{raco docs} on the command line.
+  })
+
+(define local-notice
+  @para[#:style (style #f (list (attributes (list (cons 'class "plt_local_only")))))]{
+    You are searching only your locally installed Racket packages.
+    More results may be available by using the
+    @hyperlink["http://docs.racket-lang.org/search/"]{global search}
+    that inspects all available packages.
+    @elem[#:style (style #f (list (attributes (list (cons 'id "redo_search_global")))))]{
+      You may wish to repeat your search globally.
+    }})

--- a/pkgs/racket-index/scribblings/main/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/search.scrbl
@@ -4,13 +4,13 @@
           scribble/html-properties
           "private/utils.rkt"
           "private/make-search.rkt"
+          "private/notice.rkt"
           "config.rkt")
 
 @main-page['search #t]
 
-@para[#:style (style #f (list (attributes (list (cons 'class "plt_global_only")))))]{You are searching all available Racket packages, including those that you may not have installed locally. Therefore, you may need to install a package to use the results shown below. @hyperlink["http://docs.racket-lang.org/pkg/getting-started.html"]{Getting Started with Packages} guides you through this process. If you want to re-run your search with local results only, press F1 in DrRacket or run @tt{raco docs} on the command line.}
-
-@para[#:style (style #f (list (attributes (list (cons 'class "plt_local_only")))))]{You are searching only your locally installed Racket packages. More results may be available by using the @hyperlink["http://docs.racket-lang.org/search/"]{global search} that inspects all available packages. @elem[#:style (style #f (list (attributes (list (cons 'id "redo_search_global")))))]{You may wish to repeat your search globally.}}
+@global-notice
+@local-notice
 
 @make-search[#f]
 

--- a/pkgs/racket-index/scribblings/main/user/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/user/search.scrbl
@@ -1,8 +1,14 @@
 #lang scribble/doc
-@(require "../private/utils.rkt" "../private/make-search.rkt")
+@(require scribble/base
+          scribble/core
+          scribble/html-properties
+          "../private/utils.rkt"
+          "../private/make-search.rkt")
 
 @main-page['search #f
                    ;; "racket.css" needs to be installed for search results:
                    #:force-racket-css? #t]
+
+@para[#:style (style #f (list (attributes (list (cons 'class "plt_local_only")))))]{You are searching only your locally installed Racket packages. More results may be available by using the @hyperlink["http://docs.racket-lang.org/search/"]{global search} that inspects all available packages. @elem[#:style (style #f (list (attributes (list (cons 'id "redo_search_global")))))]{You may wish to repeat your search globally.}}
 
 @make-search[#t]

--- a/pkgs/racket-index/scribblings/main/user/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/user/search.scrbl
@@ -3,12 +3,13 @@
           scribble/core
           scribble/html-properties
           "../private/utils.rkt"
-          "../private/make-search.rkt")
+          "../private/make-search.rkt"
+          "../private/notice.rkt")
 
 @main-page['search #f
                    ;; "racket.css" needs to be installed for search results:
                    #:force-racket-css? #t]
 
-@para[#:style (style #f (list (attributes (list (cons 'class "plt_local_only")))))]{You are searching only your locally installed Racket packages. More results may be available by using the @hyperlink["http://docs.racket-lang.org/search/"]{global search} that inspects all available packages. @elem[#:style (style #f (list (attributes (list (cons 'id "redo_search_global")))))]{You may wish to repeat your search globally.}}
+@local-notice
 
 @make-search[#t]


### PR DESCRIPTION
This PR adds a notice to local docs that search results are local.
It also fixes a JS error about the missing `redo_search_global`.