### PR TITLE
Fix #4065: also search "package name"

### DIFF
--- a/pkgs/racket-index/scribblings/main/private/search.js
+++ b/pkgs/racket-index/scribblings/main/private/search.js
@@ -413,16 +413,6 @@ function UrlToManual(url) {
 // mostly for context queries.
 
 function CompileTerm(term) {
-  function regularMaker() {
-    var compare_words = CompileWordCompare(term);
-    return function(x) {
-      var r = Compare(term,x[0]);
-      // only bindings can be used for rexact matches
-      if (r >= C_rexact) return (x[3] ? r : C_exact);
-      if (r > C_words3) return r;
-      else return compare_words(x[0]);
-    };
-  }
   var op = ((term.search(/^[NLMHRTQ]:/) == 0) && term.substring(0,1));
   if (op) term = term.substring(2);
   term = term.toLowerCase();
@@ -464,8 +454,15 @@ function CompileTerm(term) {
     };
   /* a case for "Q" is not needed -- same as the default case below */
   default:
+    var compare_words = CompileWordCompare(term);
     return CompileOrTerms([
-      regularMaker(),
+      function(x) {
+        var r = Compare(term,x[0]);
+        // only bindings can be used for rexact matches
+        if (r >= C_rexact) return (x[3] ? r : C_exact);
+        if (r > C_words3) return r;
+        else return compare_words(x[0]);
+      },
       function(x) {
         if (x[1].search(/\/index\.html$/) > 0) {
           return Compare(term,UrlToManual(x[1]));


### PR DESCRIPTION
This PR adjusts searching so that a regular search term `<term>` also
functions like `T:<term>`, which searches the "package name" (it is
actually the manual directory name), except that:

- In `T:<term>`, the term must match exactly. Here, partial match is OK.
- In `T:<term>`, related results (bindings, etc.) are also presented.
  Here, only the "main" result is presented.