### PR TITLE
Fix hash chaperone error messages

### DIFF
--- a/pkgs/racket-test-core/tests/racket/chaperone.rktl
+++ b/pkgs/racket-test-core/tests/racket/chaperone.rktl
@@ -2438,6 +2438,30 @@
 
 ;; ----------------------------------------
 
+;; Check chaparone violation message:
+
+(let ()
+  (define h
+    (chaperone-hash (make-hash '((a . 0)))
+                    (λ (h k) (values k (λ (h k v) (add1 v))))
+                    (λ (h k v) (values k (add1 v)))
+                    (λ (h k) k)
+                    (λ (h k) k)))
+  (err/rt-test (hash-ref h 'a)
+               exn:fail:contract?
+               (string-append
+                "hash-ref: non-chaperone result; received a value that is not a chaperone of the original value\n"
+                "  original: 0\n"
+                "  received: 1"))
+  (err/rt-test (hash-set! h 'a 5)
+               exn:fail:contract?
+               (string-append
+                "hash-set!: non-chaperone result; received a value that is not a chaperone of the original value\n"
+                "  original: 5\n"
+                "  received: 6")))
+
+;; ----------------------------------------
+
 ;; Check broken key impersonator:
 
 (let ([check

--- a/pkgs/racket-test-core/tests/racket/chaperone.rktl
+++ b/pkgs/racket-test-core/tests/racket/chaperone.rktl
@@ -2450,13 +2450,13 @@
   (err/rt-test (hash-ref h 'a)
                exn:fail:contract?
                (string-append
-                "hash-ref: non-chaperone result; received a value that is not a chaperone of the original value\n"
+                "hash-ref: non-chaperone result;\n? received a [a-z]* that is not a chaperone of the original [a-z]*\n"
                 "  original: 0\n"
                 "  received: 1"))
   (err/rt-test (hash-set! h 'a 5)
                exn:fail:contract?
                (string-append
-                "hash-set!: non-chaperone result; received a value that is not a chaperone of the original value\n"
+                "hash-set!: non-chaperone result;\n? received a [a-z]* that is not a chaperone of the original [a-z]*\n"
                 "  original: 5\n"
                 "  received: 6")))
 

--- a/racket/src/cs/rumble/hash.ss
+++ b/racket/src/cs/rumble/hash.ss
@@ -1078,10 +1078,10 @@
                 ;; In `set` mode, `new-v-or-wrap` is a replacement value.
                 (when chaperone?
                   (unless (or (not chaperone?) (chaperone-of? new-k k))
-                    (raise-chaperone-error who "key" new-k k))
+                    (raise-chaperone-error who "key" k new-k))
                   (when set?
                     (unless (or (not chaperone?) (chaperone-of? new-v-or-wrap v))
-                      (raise-chaperone-error who "value" new-v-or-wrap v))))
+                      (raise-chaperone-error who "value" v new-v-or-wrap))))
                 ;; Recur...
                 (let ([r (loop next-ht get-k new-k (if set? new-v-or-wrap none))])
                   ;; In `ref` mode, `r` is the result value (hash-ref) or key (hash-ref-key).
@@ -1100,7 +1100,7 @@
                     (let ([new-r (new-v-or-wrap next-ht new-k r)])
                       (when chaperone?
                         (unless (chaperone-of? new-r r)
-                          (raise-chaperone-error who what-r new-r r)))
+                          (raise-chaperone-error who what-r r new-r)))
                       new-r)]))]
                [args
                 (raise-arguments-error who
@@ -1132,7 +1132,7 @@
     (let* ([k (get-k k)]
            [new-k (|#%app| (hash-procs-equal-key procs) next-ht k)])
       (unless (or (not chaperone?) (chaperone-of? new-k k))
-        (raise-chaperone-error who "key" new-k k))
+        (raise-chaperone-error who "key" k new-k))
       new-k)))
 
 (define (impersonate-hash-clear ht mutable?)
@@ -1239,7 +1239,7 @@
         (let* ([k (loop ht)]
                [new-k (|#%app| (hash-procs-key procs) ht k)])
           (unless (chaperone-of? new-k k)
-            (raise-chaperone-error who "key" new-k k))
+            (raise-chaperone-error who "key" k new-k))
           new-k))]
      [(impersonator? ht)
       (loop (impersonator-next ht))]

--- a/racket/src/cs/rumble/impersonator.ss
+++ b/racket/src/cs/rumble/impersonator.ss
@@ -14,13 +14,15 @@
       (impersonator-val v)
       v))
 
-(define (raise-chaperone-error who what e e2)
+;; different arg order: (chaperone-of? new  orig)
+;; vs. (raise-chaperone-error who what orig new)
+(define (raise-chaperone-error who what orig naya)
   (raise-arguments-error
    who
    (string-append "non-chaperone result; received a" (if (equal? what "argument") "n" "") " " what
                   " that is not a chaperone of the original " what)
-   "original" e
-   "received" e2))
+   "original" orig
+   "received" naya))
 
 (define (hash-ref2 ht key1 key2 default)
   (let ([ht/val (intmap-ref ht key1 #f)])


### PR DESCRIPTION
`raise-chaperone-error` takes `orig`, then `new`