### PR TITLE
Generalize for(*) macros to work with multiple values

### DIFF
--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -1824,11 +1824,23 @@
     (lambda (x) x)
     (lambda (x) `(,#'begin ,x ,#'(values))))
 
+  ;; rev-append :: list?, list? -> list?
+  (define (rev-append xs ys)
+    (if (null? xs)
+        ys
+        (rev-append (cdr xs) (cons (car xs) ys))))
+
   (define-for-variants (for/list for*/list)
     ([fold-var null])
     (lambda (x) `(,#'alt-reverse ,x))
     (lambda (x) x)
-    (lambda (x) `(,#'cons ,x ,#'fold-var)))
+    (lambda (x)
+      #`(call-with-values
+         (λ () #,x)
+         (case-lambda
+           [() fold-var]
+           [(e) (cons e fold-var)]
+           [xs (rev-append xs fold-var)]))))
 
   (define (grow-vector vec)
     (define n (vector-length vec))


### PR DESCRIPTION
**NOTE**: this is a draft PR for discussion. Please do not merge.

This PR allows each iteration of `for(*)/list` to accumulate more or less than one element. Other `for(*)` macros, like `for/hash` and `for/vector` could also be generalized in the same way.

This PR is in the same spirit as #2483 (which is right now still unmerged), but this PR generalizes the existing macros rather than creating entirely new set of macros.

The PR is backward compatible for `#lang racket`, and there is no performance
degradation. Existing uses of `for/list`, which produces only one value in
the body, will generate the same code (compared to before the PR) after
CP0 performs inlining.

The PR requires Typed Racket to be updated, however.

To be done: writing tests, adjusting docs, generalizing other `for` macros.