### PR TITLE
Cptypes: Specialize min, max, =, >, ...

### DIFF
--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -3016,14 +3016,13 @@
   (test-use-unsafe-fxbinary 'fxior 'unsafe-fxior)
   (test-use-unsafe-fxbinary 'fxxor 'unsafe-fxxor)
 
-  (unless (eq? 'chez-scheme (system-type 'vm)) ; cptypes doesn't currently convert to fixnum ops
-    (test-use-unsafe-fxbinary '= 'unsafe-fx=)
-    (test-use-unsafe-fxbinary '< 'unsafe-fx<)
-    (test-use-unsafe-fxbinary '> 'unsafe-fx>)
-    (test-use-unsafe-fxbinary '<= 'unsafe-fx<=)
-    (test-use-unsafe-fxbinary '>= 'unsafe-fx>=)
-    (test-use-unsafe-fxbinary 'min 'unsafe-fxmin)
-    (test-use-unsafe-fxbinary 'max 'unsafe-fxmax))
+  (test-use-unsafe-fxbinary '= 'unsafe-fx=)
+  (test-use-unsafe-fxbinary '< 'unsafe-fx<)
+  (test-use-unsafe-fxbinary '> 'unsafe-fx>)
+  (test-use-unsafe-fxbinary '<= 'unsafe-fx<=)
+  (test-use-unsafe-fxbinary '>= 'unsafe-fx>=)
+  (test-use-unsafe-fxbinary 'min 'unsafe-fxmin)
+  (test-use-unsafe-fxbinary 'max 'unsafe-fxmax)
 
   (test-use-unsafe-fxbinary 'fx= 'unsafe-fx=)
   (test-use-unsafe-fxbinary 'fx< 'unsafe-fx<)

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -216,6 +216,9 @@
   (cptypes-equivalent-expansion?
     '(lambda (x) (when (and (fixnum? x) (zero? x)) x))
     '(lambda (x) (when (and (fixnum? x) (zero? x)) 0)))
+  (cptypes/once-equivalent-expansion?
+    '(lambda (x) (when (fixnum? x) (zero? x) 7))
+    '(lambda (x) (when (fixnum? x) 7)))
   (cptypes-equivalent-expansion?
     '(lambda (x f) (when (list-assuming-immutable? x) (f x) (list-assuming-immutable? x)))
     '(lambda (x f) (when (list-assuming-immutable? x) (f x) #t)))

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -196,6 +196,13 @@
     '(lambda (x) (vector-set! x 0 0) (set-box! x 0) 1)
     '(lambda (x) (vector-set! x 0 0) (set-box! x 0) 2))
   (cptypes-equivalent-expansion?
+    '(lambda (x) (vector-set! x x x) 1)
+    '(lambda (x) (vector-set! x x x) 2))
+  ;This test may fail because the subexpressions may be reordered
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (+ (unbox x) (car x)))
+    '(lambda (x) (- (unbox x) (car x))))
+  (cptypes-equivalent-expansion?
     '(lambda (x) (vector-set! (box 5) 0 0) 1)
     '(lambda (x) (vector-set! (box 5) 0 0) 2))
   (cptypes-equivalent-expansion?

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -406,6 +406,33 @@
        (if (if t (unbox b) #f) #f (box? b))))
 )
 
+(mat cptypes-type-specialize-numbers
+  (cptypes-equivalent-expansion?
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (= x y)))
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (#3%fx= x y))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (= x y)))
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (#3%fl= x y))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (> x y)))
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (#3%fx> x y))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (> x y)))
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (#3%fl> x y))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (max x y)))
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (#3%fxmax x y))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (max x y)))
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (#3%flmax x y))))
+  (cptypes/once-equivalent-expansion?
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (fixnum? (max x y))))
+    '(lambda (x y) (when (and (fixnum? x) (fixnum? y)) (#3%fxmax x y) #t)))
+  (cptypes/once-equivalent-expansion?
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (flonum? (max x y))))
+    '(lambda (x y) (when (and (flonum? x) (flonum? y)) (#3%flmax x y) #t)))
+)
+
 (mat cptype-directly-applied-case-lambda
   (equal?
     (parameterize ([enable-type-recovery #t]

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -877,6 +877,39 @@ Notes:
                                      e2 r1 plxc))
                                #f)]))])
 
+      (let ()
+        (define-syntax define-specialize/fxfl
+          (syntax-rules ()
+            [(_ lev prim fxprim flprim)
+             (define-specialize/fxfl lev prim fxprim flprim #t)]
+            [(_ lev prim fxprim flprim boolean?)
+             (define-specialize lev prim
+               ; Arity is checked before calling this handle.
+               [e* (let ([r* (get-type e*)])
+                     (cond
+                       [(andmap (lambda (r) (predicate-implies? r 'fixnum)) r*)
+                        (let ([pr (lookup-primref 3 'fxprim)])
+                          (values `(call ,preinfo ,pr ,e* (... ...))
+                                  (if boolean? 'boolean 'fixnum)
+                                  ntypes #f #f))]
+                       [(andmap (lambda (r) (predicate-implies? r 'flonum)) r*)
+                        (let ([pr (lookup-primref 3 'flprim)])
+                          (values `(call ,preinfo ,pr ,e* (... ...))
+                                  (if boolean? 'boolean 'flonum)
+                                  ntypes #f #f))]
+                       [else
+                        (values `(call ,preinfo ,pr ,e* (... ...))
+                                ret ntypes #f #f)]))])]))
+
+        (define-specialize/fxfl 2 (< r6rs:<) fx< fl<)
+        (define-specialize/fxfl 2 (<= r6rs:<=) fx<= fl<=)
+        (define-specialize/fxfl 2 (= r6rs:=) fx= fl=)
+        (define-specialize/fxfl 2 (> r6rs:>) fx> fl>)
+        (define-specialize/fxfl 2 (>= r6rs:>=) fx>= fl>=)
+        (define-specialize/fxfl 2 min fxmin flmin #f)
+        (define-specialize/fxfl 2 max fxmax flmax #f)
+      )
+
       (define-specialize 2 list
         [() (values null-rec null-rec ntypes #f #f)] ; should have been reduced by cp0
         [e* (values `(call ,preinfo ,pr ,e* ...) 'pair ntypes #f #f)])

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -1527,7 +1527,7 @@ Notes:
          [else
           (let-values ([(e2 ret types t-types f-types)
                         (Expr e2 ctxt types plxc)])
-            (values (make-seq/no-drop ctxt e1 e2) ret types t-types f-types))])]
+            (values (make-seq ctxt e1 e2) ret types t-types f-types))])]
       [(if ,[Expr/fix-tf-types : e1 'test types plxc -> e1 ret1 types1 t-types1 f-types1] ,e2 ,e3)
        (cond
          [(predicate-implies? ret1 'bottom) ;check bottom first

--- a/racket/src/ChezScheme/s/primdata.ss
+++ b/racket/src/ChezScheme/s/primdata.ss
@@ -196,11 +196,11 @@
   (inexact? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2 ieee r5rs])
   (inexact [sig [(number) -> (inexact-number)]] [flags arith-op mifoldable discard safeongoodargs])
   (exact [sig [(number) -> (exact-number)]] [flags arith-op mifoldable discard]) ; no safeongoodargs because it fails with +inf.0
-  ((r6rs: <) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])   ; restricted to 2+ arguments
-  ((r6rs: <=) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])  ; restricted to 2+ arguments
-  ((r6rs: =) [sig [(number number number ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])   ; restricted to 2+ arguments
-  ((r6rs: >) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])   ; restricted to 2+ arguments
-  ((r6rs: >=) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])  ; restricted to 2+ arguments
+  ((r6rs: <) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs cptypes2])         ; restricted to 2+ arguments
+  ((r6rs: <=) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs cptypes2])        ; restricted to 2+ arguments
+  ((r6rs: =) [sig [(number number number ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs cptypes2])   ; restricted to 2+ arguments
+  ((r6rs: >) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs cptypes2])         ; restricted to 2+ arguments
+  ((r6rs: >=) [sig [(real real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs cptypes2])        ; restricted to 2+ arguments
   (zero? [sig [(number) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2 ieee r5rs])
   (positive? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
   (negative? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs ieee r5rs])
@@ -209,8 +209,8 @@
   (finite? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])
   (infinite? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])
   (nan? [sig [(real) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])
-  (max [sig [(real real ...) -> (real)]] [flags arith-op mifoldable discard safeongoodargs ieee r5rs])
-  (min [sig [(real real ...) -> (real)]] [flags arith-op mifoldable discard safeongoodargs ieee r5rs])
+  (max [sig [(real real ...) -> (real)]] [flags arith-op mifoldable discard safeongoodargs ieee r5rs cptypes2])
+  (min [sig [(real real ...) -> (real)]] [flags arith-op mifoldable discard safeongoodargs ieee r5rs cptypes2])
   (+ [sig [(number ...) -> (number)]] [flags arith-op partial-folder safeongoodargs ieee r5rs])
   (* [sig [(number ...) -> (number)]] [flags arith-op partial-folder safeongoodargs ieee r5rs])
   (- [sig [(number number ...) -> (number)]] [flags arith-op partial-folder safeongoodargs ieee r5rs])
@@ -1126,11 +1126,11 @@
 )
 
 (define-symbol-flags* ([libraries] [flags primitive proc])
-  (< [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])           ; not restricted to 2+ arguments
-  (<= [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])          ; not restricted to 2+ arguments
-  (= [sig [(number number ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])           ; not restricted to 2+ arguments
-  (> [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])           ; not restricted to 2+ arguments
-  (>= [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs])          ; not restricted to 2+ arguments
+  (< [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2])           ; not restricted to 2+ arguments
+  (<= [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2])          ; not restricted to 2+ arguments
+  (= [sig [(number number ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2])       ; not restricted to 2+ arguments
+  (> [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2])           ; not restricted to 2+ arguments
+  (>= [sig [(real real ...) -> (boolean)]] [flags pure mifoldable discard safeongoodargs cptypes2])          ; not restricted to 2+ arguments
   (-1+ [sig [(number) -> (number)]] [flags arith-op mifoldable discard safeongoodargs])
   (1+ [sig [(number) -> (number)]] [flags arith-op mifoldable discard safeongoodargs])
   (1- [sig [(number) -> (number)]] [flags arith-op mifoldable discard safeongoodargs])


### PR DESCRIPTION
**ChezScheme: check again if first part of seq is omitable:**

This is not 100% necessary and it's one of the commits where the explanation is longer than the change. 

For example in 

    (lambda (x) (when (fixnum? x) (zero? x) 'banana)))

`cp0` does not remove `(zero? x)` because it can raise an error. `cptypes` assumes that all the the first part of a `sequence` has a side effect, because otherwise it would have been removed. But `cptypes` can prove that it will not raise an error and transform it into the unsafe version, but `cptypes`will not check if it has side effects after the reduction. In the second run, `cp0` will notice that it can be removed, so the final result is 

        (lambda (x) (when (fixnum? x) 'banana)))

With this change, after analyzing (and reducing) `(zero? x)`, `cptypes` will check if it's possible to remove it using a shallow check (`drop`) that has a small amount of fuel to avoid quadratic behavior.

This second change is most of the times wasteful, but not very expensive. The advantage is that it can remove some expressions in a single run, and is more similar to the handling of other constructions.

When I wrote the code (1 year ago?) I preferred to avoid this second check, but now I like it. (I'm not sure what I'll think next year.)

---

**ChezScheme: specialize = and max**

This add a specialization in `cptypes` for some primitives that never raise errors when all the arguments are `fixnum?` or `flonums?`, for example `min`, `max`, `=`, `>`, ... , so

    (lambda (x) (when (fixnum? x) (min x 7)))

is reduced to

    (lambda (x) (when (fixnum? x) (#3%fxmin x 7)))

In particular, this re-enable some of the tests in optimize.rktl,