### PR TITLE
cs: don't mix-hash-code for impersonator case

### DIFF
--- a/racket/src/cs/rumble/hash-code.ss
+++ b/racket/src/cs/rumble/hash-code.ss
@@ -178,7 +178,7 @@
      ;; If an impersonator wraps a value where `equal?` hashing is
      ;; `eq?` hashing, such as for a procedure, then make sure
      ;; we discard the impersonator wrapper.
-     (equal-hash-loop (impersonator-val x) burn (mix-hash-code hc))]
+     (equal-hash-loop (impersonator-val x) burn hc)]
     [else (values (fx+/wraparound hc (eq-hash-code x)) burn)]))
 
 (define (equal-secondary-hash-loop x burn hc) ; hc should be 0 or already mixed


### PR DESCRIPTION
In the `impersonator?` case of `equal-hash-loop`, don't use `mix-hash-code` on that recursive call.

Impersonators of the same object can be `equal?` to that object and each other, their hash codes should also be equal without mixing getting in the way.