### PR TITLE
Chez Scheme: fix reduction of primitives with no arguments

### DIFF
--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -202,6 +202,10 @@
   (cptypes-equivalent-expansion?
     '(lambda (x) (+ (unbox x) (car x)))
     '(lambda (x) (- (unbox x) (car x))))
+  ;Regresion test for primitives with 0 arguments after an error
+  (cptypes-equivalent-expansion?
+    '(lambda () (box (let ([x (error 'who "msg")]) (cons x (random)))))
+    '(lambda () (error 'who "msg")))
   (cptypes-equivalent-expansion?
     '(lambda (x) (vector-set! (box 5) 0 0) 1)
     '(lambda (x) (vector-set! (box 5) 0 0) 2))


### PR DESCRIPTION
The problem was correctly identified by @mflatt  in https://github.com/racket/racket/pull/4103#issuecomment-1000858936 . It would be nice that when `cptypes `has already detected an impossible path and the initial type info is `pred-env-bottom` then the surrounding expression handles it and `fold-primref/next` never is called. But for now `let`, `letrec`, `letrec*`, and perhaps other constructions doesn't ensure this. Moreover it's a very fragile condition, so it's better that `fold-primref/next` handle that correctly, but I prefer not to test it explicitly at the beginning.

There is a second error, because I forgot to wrap the result to ensure the expression is not in tail position. This can be a problem, for example in

    (lambda (x) (list (car x) (something-with-marks (unbox x))))
 
it get transformed to

    (lambda (x) (car x) (something-with-marks (unbox x)))

 ( @mflatt : Is it easy to construct an example? )

Anyway, one possibility is to just call `unwrapped-error` that will transform that into

    (lambda (x) (car x) ($value (something-with-marks (unbox x))))

but I prefer an alternative method to add a (void) at the end

    (lambda (x) (car x) (something-with-marks (unbox x)) (void))

so the old last expression can be reduced or eliminated. 


