### PR TITLE
place: allow `resolved-module-path?` args to `dynamic-place`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -150,7 +150,7 @@ are simulated using @racket[thread].}
 }
 
 
-@defproc[(dynamic-place [module-path (or/c module-path? path?)]
+@defproc[(dynamic-place [module-path (or/c resolved-module-path? module-path? path?)]
                         [start-name symbol?]
                         [#:at location (or/c #f place-location?) #f]
                         [#:named named any/c #f])
@@ -214,7 +214,7 @@ The @racket[dynamic-place] binding is protected in the sense of
                                    value.}]}
 
 
-@defproc[(dynamic-place* [module-path (or/c module-path? path?)]
+@defproc[(dynamic-place* [module-path (or/c resolved-module-path? module-path? path?)]
                          [start-name symbol?]
                          [#:in in (or/c input-port? #f) #f]
                          [#:out out (or/c output-port? #f) (current-output-port)]

--- a/racket/collects/racket/private/place.rkt
+++ b/racket/collects/racket/private/place.rkt
@@ -108,8 +108,10 @@
   ;; Duplicate checks in that are in the primitive `pl-dynamic-place',
   ;; unfortunately, but we want these checks before we start making
   ;; stream-pumping threads, etc.
-  (unless (or (module-path? module-path) (path? module-path))
-    (raise-argument-error who "(or/c module-path? path?)" module-path))
+  (unless (or (resolved-module-path? module-path)
+              (module-path? module-path)
+              (path? module-path))
+    (raise-argument-error who "(or/c resolved-module-path? module-path? path?)" module-path))
   (unless (symbol? function)
     (raise-argument-error who "symbol?" function))
   (unless (or (not in) (input-port? in))


### PR DESCRIPTION
I think this is meant to work and the existing check is incomplete.