### PR TITLE
Add examples of potentially "missing" stat data

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/filesystem.scrbl
@@ -570,7 +570,10 @@ precision) and in another environment @racket[1234567891000000000] (seconds
 precision).
 
 Values that aren't available for a platform/filesystem combination may be set
-to @racket[0].
+to @racket[0]. For example, this applies to the @racket['user-id] and
+@racket['group-id] keys on Windows. Also, Posix platforms provide the status
+change timestamp, but not the creation timestamp; for Windows it's the
+opposite.
 
 If @racket[as-link?] is @racket[#f] and @racket[path] isn't accessible,
 the @exnraise[exn:fail:filesystem]. This exception is also raised if


### PR DESCRIPTION
See
https://racket.discourse.group/t/get-creation-date-from-a-file-function-missing/487
for some context.

I hope the grammar is correct. :-)

Is it sufficiently clear from the wording that there may be more situations where values are set to 0?