### PR TITLE
racket/src/Makefile.in: Add LICENSE.txt to COPYING.

### DIFF
--- a/racket/src/Makefile.in
+++ b/racket/src/Makefile.in
@@ -37,7 +37,8 @@ COPYING = "$(srcdir)/LICENSE-libscheme.txt" \
           "$(srcdir)/LICENSE-MIT.txt" \
           "$(srcdir)/LICENSE-APACHE.txt" \
           "$(srcdir)/LICENSE-LGPL.txt" \
-          "$(srcdir)/LICENSE-GPL.txt"
+          "$(srcdir)/LICENSE-GPL.txt" \
+          "$(srcdir)/LICENSE.txt"
 
 all:
 	$(MAKE) @MAIN_MAKE_TARGET@


### PR DESCRIPTION
With this change, `racket/src/LICENSE.txt`, which describes
the license for Racket as a whole, will be copied by `make install`
along with files like `racket/src/LICENSE-APACHE.txt` that give
the texts of specific licenses.