### PR TITLE
cs: tpb build fixes

### DIFF
--- a/racket/src/ChezScheme/c/atomic.h
+++ b/racket/src/ChezScheme/c/atomic.h
@@ -97,7 +97,7 @@ FORCEINLINE int S_cas_any_fence(int load_acquire, volatile void *addr, void *old
 # define CAS_LOAD_ACQUIRE(a, old, new) S_cas_any_fence(1, a, old, new)
 # define CAS_STORE_RELEASE(a, old, new) S_cas_any_fence(0, a, old, new)
 #elif (__GNUC__ >= 5) || defined(__clang__)
-# define CAS_ANY_FENCE(a, old, new) __sync_bool_compare_and_swap(a, old, new)
+# define CAS_ANY_FENCE(a, old, new) __sync_bool_compare_and_swap((uptr *)a, (uptr)old, (uptr)new)
 #elif defined(_MSC_VER)
 # if ptr_bits == 64
 #  define CAS_ANY_FENCE(a, old, new) (_InterlockedCompareExchange64((__int64 *)(a), (__int64)(new), (__int64)(old)) == (__int64)(old))

--- a/racket/src/ChezScheme/rktboot/make-boot.rkt
+++ b/racket/src/ChezScheme/rktboot/make-boot.rkt
@@ -41,6 +41,13 @@
   (printf "~a\n" msg)
   (flush-output))
 
+(define target-arch
+  (case target-machine
+    [("pb32" "tpb" "tpb32")
+     (begin0 'pb
+       (status (format "Target arch for ~a machine is pb" target-machine)))]
+    [else (string->symbol target-machine)]))
+
 (define sources-date
   (for/fold ([d 0]) ([dir (in-list (list here-dir
                                          nano-dir
@@ -255,7 +262,7 @@
               [(constant-case architecture [else e ...])
                (loop #`(begin e ...))]
               [(constant-case architecture [(arch ...) e ...] . _)
-               (memq (string->symbol target-machine) (syntax->datum #'(arch ...)))
+               (memq target-arch (syntax->datum #'(arch ...)))
                (loop #`(begin e ...))]
               [(constant-case architecture _ . clauses)
                (loop #`(constant-case architecture . clauses))]

--- a/racket/src/cfg-cs
+++ b/racket/src/cfg-cs
@@ -2272,6 +2272,9 @@ if test "${enable_racket}" = "auto" ; then
 fi
 RUN_LOCAL_RACKET="local/cs/c/racketcs"
 CONFIGURE_LOCAL_RACKET=--enable-cs
+if test "${enable_pb}" = "yes" ; then
+  CONFIGURE_LOCAL_RACKET="${CONFIGURE_LOCAL_RACKET} --enable-pb"
+fi
 LOCAL_RACKET_TARGET=cs
 
 # If BC is the default, then we rely on BC configure-parent

--- a/racket/src/cs/c/configure-parent.ac
+++ b/racket/src/cs/c/configure-parent.ac
@@ -30,6 +30,9 @@ if test "${enable_racket}" = "auto" ; then
 fi
 RUN_LOCAL_RACKET="local/cs/c/racketcs"
 CONFIGURE_LOCAL_RACKET=--enable-cs
+if test "${enable_pb}" = "yes" ; then
+  CONFIGURE_LOCAL_RACKET="${CONFIGURE_LOCAL_RACKET} --enable-pb"
+fi
 LOCAL_RACKET_TARGET=cs
 
 # If BC is the default, then we rely on BC configure-parent


### PR DESCRIPTION
These are fixes for some problems I encountered while trying out https://github.com/racket/racket/commit/4480e643daa5ec13c4d41c4e002223d86c1fa645 on my x86-64 MBP. There may be better approaches to each of these, in which case you should feel free to ignore this PR!

With these changes in place, I can configure a build with

```
$ ../configure --enable-pb --enable-racket=auto
```

and end up with

```
$ ./cs/c/racketcs -l racket/base -i
Welcome to Racket v8.4.0.4 [cs].
> (system-type 'vm)
'chez-scheme
> (system-type 'arch)
'pb
> (require racket/future)
> (futures-enabled?)
#t
```