### PR TITLE
Fix spelling in source documentation

### DIFF
--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -244,7 +244,7 @@ Detailed instructions:
     documentation.
 
     For a `--prefix` build, unless `--enable-sharezo` is specified,
-    "compiled" directories containin ".zo" files are moved from
+    "compiled" directories containing ".zo" files are moved from
     "share" to "lib" as the last step of installation. (The
     "config.rktd" file is updated so that `current-compile-file-roots`
     is initialized to find the relocated ".zo" files.) For Racket BC,
@@ -388,7 +388,7 @@ Some less commonly needed `configure` flags are for Racket BC:
 
  * `--enable-cify` or `--disable-cify` if the JIT availability on the
     target platform is different than the build platform; use
-    `--enable-cify` if the JIT is not abailable on the target
+    `--enable-cify` if the JIT is not available on the target
     platform.
 
 
@@ -529,7 +529,7 @@ Sources for the Racket CS implementation
 
  * "io" --- I/O
 
-    This layer uses the "racketio" library to access OS facilties.
+    This layer uses the "racketio" library to access OS facilities.
 
  * "regexp" --- regexp matcher
 
@@ -543,11 +543,11 @@ Sources for the Racket BC implementation
 
    This implementation can build from "scratch" with a C compiler, but
    first by building a CGC variant of Racket to transform the C
-   sourses to build a (normal) 3m variant.
+   sources to build a (normal) 3m variant.
 
  * "mzcom" --- MzCOM executable (for Windows)
 
- * "mysink" --- `ffi/unsafe/com` helper DLL (for Windows)
+ * "myssink" --- `ffi/unsafe/com` helper DLL (for Windows)
 
  * "cify" --- a Racket-to-C compiler
 
@@ -596,7 +596,7 @@ Sources shared by both Racket implementations
 
  * "setup-go.rkt" --- helper script
 
-   The "setup-go.rkt" script is a bootstrapping too that is used by
+   The "setup-go.rkt" script is a bootstrapping tool that is used by
    parts of the build that need to run Racket programs in the process
    of building Racket.
 

--- a/racket/src/cs/README.txt
+++ b/racket/src/cs/README.txt
@@ -17,7 +17,7 @@ directory is organized into two layers:
 
 The Racket source distribution includes already-bootstrapped files to
 build Racket CS. Some of those files are checked into the Racket Git
-rrepository, and the rest are in a sibling "pb" repository that that
+repository, and the rest are in a sibling "pb" repository that that
 Racket repository's top-level makefile checks out.
 
 Building Racket CS from original sources requires an existing Racket
@@ -42,7 +42,7 @@ build:
  * Racket is needed to generate the files in the "schemified"
    directory from the sources in sibling directories like "../io". The
    Racket version must be practically the same as the current Racket
-   verson, although it can be the Racket BC implementation (instead of
+   version, although it can be the Racket BC implementation (instead of
    the Racket CS implementation).
 
    Unlike Chez Scheme boot files, the files generated in "schemified"
@@ -272,12 +272,12 @@ Files in this directory:
          Racket) of the thread and event subsystem.
 
  schemified/*.scm (generated) - A conversion from a ".rktl" file to be
-         `included`d into an ".sls" library.
+         `include`d into an ".sls" library.
 
  ../build/so-rktio/rktio.rktl (generated) and
  ../../lib/librktio.{so,dylib,dll} (generated) - Created when building
          the "io" layer, the "rktio.rktl" file contains FFI descriptions
-         that are `included` by "io.sls" and "librktio.{so,dylib,dll}"
+         that are `include`d by "io.sls" and "librktio.{so,dylib,dll}"
          is the shared library that implements rktio.
 
          CAUTION: The makefile here doesn't track dependencies for
@@ -489,8 +489,8 @@ Inlining Expectations
 
 Chez Scheme will inline small Rumble functions as long as the inlined
 function body refers only to primitives and other identifiers that are
-explicitly defined in the Rumble library body. The "explicily defined"
-part can be tricky, particularly since inling will consider the
+explicitly defined in the Rumble library body. The "explicitly defined"
+part can be tricky, particularly since inlining will consider the
 function body after other inlining is already applied. For example,
 given
 
@@ -570,7 +570,7 @@ from that layer, but any provided name also needs to be added to
 (a hash table) that the expander layer uses to create primitive
 modules like `#%kernel`. The entries in "primitive" files use the
 constructors defined in "../schemify/known.rkt" to describe
-primitives; note that most of the numebrs you see are arity masks in
+primitives; note that most of the numbers you see are arity masks in
 the sense of `procedure-arity-mask`.
 
 For some additions to rktio with corresponding changes to the io


### PR DESCRIPTION
This fixes various small typos in a few source docs that I noticed recently while reading through them.