### PR TITLE
Fix `chaperone-hash` wrapper proc for `hash-ref-key`

### DIFF
--- a/pkgs/racket-test-core/tests/racket/chaperone.rktl
+++ b/pkgs/racket-test-core/tests/racket/chaperone.rktl
@@ -3791,5 +3791,19 @@
   (test #t integer? (equal-hash-code (chaperone-struct (b 0) b-x (lambda (b v) v)))))
 
 ;; ----------------------------------------
+;; regression test to make sure hash-ref-key
+;; wrapper proc is called with correct key
+
+(let ()
+  (define orig-key "foo")
+  (define new-key (string-copy orig-key))
+  (define ht
+    (chaperone-hash (hash orig-key 42)
+                    (lambda (h k) (values k (lambda (h k v) v)))
+                    (lambda (h k v) (values k v))
+                    (lambda (h k) k) (lambda (h k) k)))
+  (test orig-key hash-ref-key ht new-key))
+
+;; ----------------------------------------
 
 (report-errs)

--- a/racket/src/cs/rumble/hash.ss
+++ b/racket/src/cs/rumble/hash.ss
@@ -1024,8 +1024,8 @@
                             (lambda (procs ht k none-v)
                               (let-values ([(new-k _) (|#%app| (hash-procs-ref procs) ht k)])
                                 (values new-k
-                                        (lambda (ht k none-v)
-                                          (|#%app| (hash-procs-key procs) ht k)))))
+                                        (lambda (ht given-k actual-k)
+                                          (|#%app| (hash-procs-key procs) ht actual-k)))))
                             hash-procs-ref
                             ht k none))
 


### PR DESCRIPTION
The wrapper proc for `hash-ref-key` was not provided with the correct key. Instead of the key extracted from the table, it was provided with the input key. Here's an example of how this issue manifests in the contract library:

```rkt
(define/contract (foo ht k)
  (-> (hash/c string? integer?) string? any)
  (hash-ref-key ht k))

(foo (make-hash '(["hello" . 42]))
     (string-copy "hello"))
```

Gives the following error:
```
hash-ref-key: non-chaperone result; received a key that is not a chaperone of the original key
  original: "hello"
  received: "hello"
```

I think this was a bug introduced in CS.