### PR TITLE
Add boxes to place-message

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change only when
 ;; "racket_version.h" changes:
-(define version "8.4.0.6")
+(define version "8.4.0.7")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -352,10 +352,11 @@ messages:
 
  @item{@tech{paths} (for any platform);}
 
- @item{@tech{pairs}, @tech{lists}, @tech{vectors}, and immutable
+ @item{@tech{pairs}, @tech{lists}, @tech{box}es, @tech{vectors}, and immutable
        @tech{prefab} structures containing message-allowed values,
-       where a mutable vector is automatically replaced by an
-       immutable vector and where @tech{impersonators} of vectors and
+       where a mutable box is automatically replaced by an
+       immutable box, a mutable vector is automatically replaced by an
+       immutable vector and where @tech{impersonators} of boxes, vectors and
        @tech{prefab} structures are copied;}
 
  @item{@tech{hash tables} where mutable hash tables are automatically
@@ -376,9 +377,9 @@ messages:
  @item{values produced by @racket[shared-flvector],
        @racket[make-shared-flvector], @racket[shared-fxvector],
        @racket[make-shared-fxvector], @racket[shared-bytes], and
-       @racket[make-shared-bytes].}
-
-]}
+       @racket[make-shared-bytes].}]
+       
+@history[#:changed "8.4.0.7" @elem{include @racket[boxes].}]}
 
 @deftogether[(
 @defthing[prop:place-location struct-type-property?]

--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -378,7 +378,7 @@ messages:
        @racket[make-shared-flvector], @racket[shared-fxvector],
        @racket[make-shared-fxvector], @racket[shared-bytes], and
        @racket[make-shared-bytes].}]
-       
+
 @history[#:changed "8.4.0.7" @elem{include @racket[boxes].}]}
 
 @deftogether[(

--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -379,7 +379,7 @@ messages:
        @racket[make-shared-fxvector], @racket[shared-bytes], and
        @racket[make-shared-bytes].}]
 
-@history[#:changed "8.4.0.7" @elem{include @racket[boxes].}]}
+@history[#:changed "8.4.0.7" @elem{Include boxes in allowed messages.}]}
 
 @deftogether[(
 @defthing[prop:place-location struct-type-property?]

--- a/pkgs/racket-test-core/tests/racket/place.rktl
+++ b/pkgs/racket-test-core/tests/racket/place.rktl
@@ -54,6 +54,9 @@
     (test #t equal? us (car r2))
     (test #t equal? us2 (cdr r2)))
 
+  (place-channel-put out (make-prefab-struct 'bx (box 1) (box 2)))
+  (test (make-prefab-struct 'bx (box 1) (box 2)) place-channel-get in)
+
   (place-channel-put out (make-prefab-struct 'vec (vector) (vector)))
   (test (make-prefab-struct 'vec (vector) (vector)) place-channel-get in))
 
@@ -99,7 +102,9 @@
                (string->unreadable-symbol "grape"))])
   (test #t place-message-allowed? v)
   (test #t place-message-allowed? (list v))
+  (test #t place-message-allowed? (box v))
   (test #t place-message-allowed? (vector v)))
+(test #t place-message-allowed? (box #f))
 (test #t place-message-allowed? (vector))
 
 (for ([v (list (lambda () 10)
@@ -108,6 +113,7 @@
   (test (not (place-enabled?)) place-message-allowed? (list v))
   (test (not (place-enabled?)) place-message-allowed? (cons 1 v))
   (test (not (place-enabled?)) place-message-allowed? (cons v 1))
+  (test (not (place-enabled?)) place-message-allowed? (box v))
   (test (not (place-enabled?)) place-message-allowed? (vector v)))
 
 (let ()

--- a/racket/collects/racket/place/private/th-place.rkt
+++ b/racket/collects/racket/place/private/th-place.rkt
@@ -138,6 +138,11 @@
         o
         (lambda ()
           (cons (dcw (car o)) (dcw (cdr o)))))]
+      [(box? o)
+       (define new-b (box (unbox o)))
+       (define r (record o new-b))
+       (set-box! new-b (dcw (unbox r)))
+       r]
       [(vector? o)
        (define new-v (make-vector (vector-length o)))
        (vector-copy! new-v 0 o)
@@ -206,6 +211,8 @@
       [(ormap (lambda (x) (x o)) (list number? char? boolean? null? void? string? symbol? keyword? TH-place-channel?
                                        path? bytes? fxvector? flvector? TH-place?)) #t]
       [(pair? o) (and (dcw (car o)) (dcw (cdr o)))]
+      [(box? o)
+       (dcw (unbox o))]
       [(vector? o)
        (for/fold ([nh #t]) ([i (in-vector o)])
         (and nh (dcw i)))]

--- a/racket/src/bc/src/place.c
+++ b/racket/src/bc/src/place.c
@@ -1502,15 +1502,16 @@ static Scheme_Object *places_deep_copy_worker(Scheme_Object *so, Scheme_Hash_Tab
 
 #define DEEP_DO_CDR       1
 #define DEEP_DO_FIN_PAIR  2
-#define DEEP_VEC1         3
-#define DEEP_ST1          4   
-#define DEEP_ST2          5
-#define DEEP_SST1         6
-#define DEEP_SST2         7      
-#define DEEP_HT1          8
-#define DEEP_HT2          9      
-#define DEEP_RETURN      10
-#define DEEP_DONE        11
+#define DEEP_BOX1         3
+#define DEEP_VEC1         4
+#define DEEP_ST1          5
+#define DEEP_ST2          6
+#define DEEP_SST1         7
+#define DEEP_SST2         8
+#define DEEP_HT1          9
+#define DEEP_HT2         10
+#define DEEP_RETURN      11
+#define DEEP_DONE        12
 #define RETURN do { goto DEEP_RETURN_L; } while(0);
 #define ABORT do { goto DEEP_DONE_L; } while(0);
 #define IFS_PUSH(x) inf_push(&inf_stack, x, &inf_stack_depth, &inf_max_depth, gcable)
@@ -1978,6 +1979,7 @@ DEEP_DONE_L:
 
 #undef DEEP_DO_CDR
 #undef DEEP_DO_FIN_PAIR
+#undef DEEP_BOX1
 #undef DEEP_VEC1
 #undef DEEP_ST1
 #undef DEEP_ST2

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -2915,7 +2915,7 @@
                                                  (if or-part_8
                                                    or-part_8
                                                    (let ((or-part_9
-                                                          (if (vector? v_0)
+                                                          (if (box? v_0)
                                                             (if (let ((or-part_9
                                                                        (not
                                                                         direct?2_0)))
@@ -2939,262 +2939,295 @@
                                                                           graph_0
                                                                           v_0
                                                                           #t)))
-                                                                    (call-with-values
-                                                                     (lambda ()
-                                                                       (begin
-                                                                         (check-vector
-                                                                          v_0)
-                                                                         (values
-                                                                          v_0
-                                                                          (unsafe-vector-length
-                                                                           v_0))))
-                                                                     (case-lambda
-                                                                      ((vec_0
-                                                                        len_0)
-                                                                       (begin
-                                                                         #f
-                                                                         (letrec*
-                                                                          ((for-loop_0
-                                                                            (|#%name|
-                                                                             for-loop
-                                                                             (lambda (result_0
-                                                                                      pos_0)
-                                                                               (begin
-                                                                                 (if (unsafe-fx<
-                                                                                      pos_0
-                                                                                      len_0)
-                                                                                   (let ((e_0
-                                                                                          (unsafe-vector-ref
-                                                                                           vec_0
-                                                                                           pos_0)))
-                                                                                     (let ((result_1
-                                                                                            (let ((result_1
-                                                                                                   (loop_0
-                                                                                                    e_0
-                                                                                                    graph_1)))
-                                                                                              (values
-                                                                                               result_1))))
-                                                                                       (if (if (not
-                                                                                                (let ((x_0
-                                                                                                       (list
-                                                                                                        e_0)))
-                                                                                                  (not
-                                                                                                   result_1)))
-                                                                                             #t
-                                                                                             #f)
-                                                                                         (for-loop_0
-                                                                                          result_1
-                                                                                          (unsafe-fx+
-                                                                                           1
-                                                                                           pos_0))
-                                                                                         result_1)))
-                                                                                   result_0))))))
-                                                                          (for-loop_0
-                                                                           #t
-                                                                           0))))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        2
-                                                                        args)))))))
+                                                                    (loop_0
+                                                                     (unbox
+                                                                      v_0)
+                                                                     graph_1))))
                                                               #f)
                                                             #f)))
                                                      (if or-part_9
                                                        or-part_9
                                                        (let ((or-part_10
-                                                              (if (immutable-prefab-struct-key
-                                                                   v_0)
-                                                                (let ((or-part_10
-                                                                       (hash-ref
-                                                                        graph_0
-                                                                        v_0
-                                                                        #f)))
-                                                                  (if or-part_10
-                                                                    or-part_10
-                                                                    (let ((graph_1
-                                                                           (hash-set
-                                                                            graph_0
-                                                                            v_0
-                                                                            #t)))
-                                                                      (call-with-values
-                                                                       (lambda ()
-                                                                         (let ((vec_0
-                                                                                (struct->vector
-                                                                                 v_0)))
+                                                              (if (vector? v_0)
+                                                                (if (let ((or-part_10
+                                                                           (not
+                                                                            direct?2_0)))
+                                                                      (if or-part_10
+                                                                        or-part_10
+                                                                        (if (immutable?
+                                                                             v_0)
+                                                                          (not
+                                                                           (impersonator?
+                                                                            v_0))
+                                                                          #f)))
+                                                                  (let ((or-part_10
+                                                                         (hash-ref
+                                                                          graph_0
+                                                                          v_0
+                                                                          #f)))
+                                                                    (if or-part_10
+                                                                      or-part_10
+                                                                      (let ((graph_1
+                                                                             (hash-set
+                                                                              graph_0
+                                                                              v_0
+                                                                              #t)))
+                                                                        (call-with-values
+                                                                         (lambda ()
                                                                            (begin
                                                                              (check-vector
-                                                                              vec_0)
+                                                                              v_0)
                                                                              (values
-                                                                              vec_0
+                                                                              v_0
                                                                               (unsafe-vector-length
-                                                                               vec_0)))))
-                                                                       (case-lambda
-                                                                        ((vec_0
-                                                                          len_0)
-                                                                         (begin
-                                                                           #f
-                                                                           (letrec*
-                                                                            ((for-loop_0
-                                                                              (|#%name|
-                                                                               for-loop
-                                                                               (lambda (result_0
-                                                                                        pos_0)
-                                                                                 (begin
-                                                                                   (if (unsafe-fx<
-                                                                                        pos_0
-                                                                                        len_0)
-                                                                                     (let ((e_0
-                                                                                            (unsafe-vector-ref
-                                                                                             vec_0
-                                                                                             pos_0)))
-                                                                                       (let ((result_1
-                                                                                              (let ((result_1
-                                                                                                     (loop_0
-                                                                                                      e_0
-                                                                                                      graph_1)))
-                                                                                                (values
-                                                                                                 result_1))))
-                                                                                         (if (if (not
-                                                                                                  (let ((x_0
-                                                                                                         (list
-                                                                                                          e_0)))
-                                                                                                    (not
-                                                                                                     result_1)))
-                                                                                               #t
-                                                                                               #f)
-                                                                                           (for-loop_0
-                                                                                            result_1
-                                                                                            (unsafe-fx+
-                                                                                             1
-                                                                                             pos_0))
-                                                                                           result_1)))
-                                                                                     result_0))))))
-                                                                            (for-loop_0
-                                                                             #t
-                                                                             0))))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args)))))))
+                                                                               v_0))))
+                                                                         (case-lambda
+                                                                          ((vec_0
+                                                                            len_0)
+                                                                           (begin
+                                                                             #f
+                                                                             (letrec*
+                                                                              ((for-loop_0
+                                                                                (|#%name|
+                                                                                 for-loop
+                                                                                 (lambda (result_0
+                                                                                          pos_0)
+                                                                                   (begin
+                                                                                     (if (unsafe-fx<
+                                                                                          pos_0
+                                                                                          len_0)
+                                                                                       (let ((e_0
+                                                                                              (unsafe-vector-ref
+                                                                                               vec_0
+                                                                                               pos_0)))
+                                                                                         (let ((result_1
+                                                                                                (let ((result_1
+                                                                                                       (loop_0
+                                                                                                        e_0
+                                                                                                        graph_1)))
+                                                                                                  (values
+                                                                                                   result_1))))
+                                                                                           (if (if (not
+                                                                                                    (let ((x_0
+                                                                                                           (list
+                                                                                                            e_0)))
+                                                                                                      (not
+                                                                                                       result_1)))
+                                                                                                 #t
+                                                                                                 #f)
+                                                                                             (for-loop_0
+                                                                                              result_1
+                                                                                              (unsafe-fx+
+                                                                                               1
+                                                                                               pos_0))
+                                                                                             result_1)))
+                                                                                       result_0))))))
+                                                                              (for-loop_0
+                                                                               #t
+                                                                               0))))
+                                                                          (args
+                                                                           (raise-binding-result-arity-error
+                                                                            2
+                                                                            args)))))))
+                                                                  #f)
                                                                 #f)))
                                                          (if or-part_10
                                                            or-part_10
                                                            (let ((or-part_11
-                                                                  (if (hash?
+                                                                  (if (immutable-prefab-struct-key
                                                                        v_0)
-                                                                    (if (let ((or-part_11
-                                                                               (not
-                                                                                direct?2_0)))
-                                                                          (if or-part_11
-                                                                            or-part_11
-                                                                            (if (immutable?
-                                                                                 v_0)
-                                                                              (not
-                                                                               (impersonator?
-                                                                                v_0))
-                                                                              #f)))
-                                                                      (let ((or-part_11
-                                                                             (hash-ref
-                                                                              graph_0
-                                                                              v_0
-                                                                              #f)))
-                                                                        (if or-part_11
-                                                                          or-part_11
-                                                                          (let ((graph_1
-                                                                                 (hash-set
-                                                                                  graph_0
-                                                                                  v_0
-                                                                                  #t)))
-                                                                            (begin
-                                                                              (letrec*
-                                                                               ((for-loop_0
-                                                                                 (|#%name|
-                                                                                  for-loop
-                                                                                  (lambda (result_0
-                                                                                           i_0)
-                                                                                    (begin
-                                                                                      (if i_0
-                                                                                        (call-with-values
-                                                                                         (lambda ()
-                                                                                           (hash-iterate-key+value
-                                                                                            v_0
-                                                                                            i_0))
-                                                                                         (case-lambda
-                                                                                          ((k_0
-                                                                                            v_1)
+                                                                    (let ((or-part_11
+                                                                           (hash-ref
+                                                                            graph_0
+                                                                            v_0
+                                                                            #f)))
+                                                                      (if or-part_11
+                                                                        or-part_11
+                                                                        (let ((graph_1
+                                                                               (hash-set
+                                                                                graph_0
+                                                                                v_0
+                                                                                #t)))
+                                                                          (call-with-values
+                                                                           (lambda ()
+                                                                             (let ((vec_0
+                                                                                    (struct->vector
+                                                                                     v_0)))
+                                                                               (begin
+                                                                                 (check-vector
+                                                                                  vec_0)
+                                                                                 (values
+                                                                                  vec_0
+                                                                                  (unsafe-vector-length
+                                                                                   vec_0)))))
+                                                                           (case-lambda
+                                                                            ((vec_0
+                                                                              len_0)
+                                                                             (begin
+                                                                               #f
+                                                                               (letrec*
+                                                                                ((for-loop_0
+                                                                                  (|#%name|
+                                                                                   for-loop
+                                                                                   (lambda (result_0
+                                                                                            pos_0)
+                                                                                     (begin
+                                                                                       (if (unsafe-fx<
+                                                                                            pos_0
+                                                                                            len_0)
+                                                                                         (let ((e_0
+                                                                                                (unsafe-vector-ref
+                                                                                                 vec_0
+                                                                                                 pos_0)))
                                                                                            (let ((result_1
                                                                                                   (let ((result_1
-                                                                                                         (if (loop_0
-                                                                                                              k_0
-                                                                                                              graph_1)
-                                                                                                           (loop_0
-                                                                                                            v_1
-                                                                                                            graph_1)
-                                                                                                           #f)))
+                                                                                                         (loop_0
+                                                                                                          e_0
+                                                                                                          graph_1)))
                                                                                                     (values
                                                                                                      result_1))))
                                                                                              (if (if (not
                                                                                                       (let ((x_0
                                                                                                              (list
-                                                                                                              k_0
-                                                                                                              v_1)))
+                                                                                                              e_0)))
                                                                                                         (not
                                                                                                          result_1)))
                                                                                                    #t
                                                                                                    #f)
                                                                                                (for-loop_0
                                                                                                 result_1
-                                                                                                (hash-iterate-next
-                                                                                                 v_0
-                                                                                                 i_0))
+                                                                                                (unsafe-fx+
+                                                                                                 1
+                                                                                                 pos_0))
                                                                                                result_1)))
-                                                                                          (args
-                                                                                           (raise-binding-result-arity-error
-                                                                                            2
-                                                                                            args))))
-                                                                                        result_0))))))
-                                                                               (for-loop_0
-                                                                                #t
-                                                                                (hash-iterate-first
-                                                                                 v_0)))))))
-                                                                      #f)
+                                                                                         result_0))))))
+                                                                                (for-loop_0
+                                                                                 #t
+                                                                                 0))))
+                                                                            (args
+                                                                             (raise-binding-result-arity-error
+                                                                              2
+                                                                              args)))))))
                                                                     #f)))
                                                              (if or-part_11
                                                                or-part_11
-                                                               (if (not
-                                                                    direct?2_0)
-                                                                 (let ((or-part_12
-                                                                        (cpointer?
-                                                                         v_0)))
-                                                                   (if or-part_12
-                                                                     or-part_12
+                                                               (let ((or-part_12
+                                                                      (if (hash?
+                                                                           v_0)
+                                                                        (if (let ((or-part_12
+                                                                                   (not
+                                                                                    direct?2_0)))
+                                                                              (if or-part_12
+                                                                                or-part_12
+                                                                                (if (immutable?
+                                                                                     v_0)
+                                                                                  (not
+                                                                                   (impersonator?
+                                                                                    v_0))
+                                                                                  #f)))
+                                                                          (let ((or-part_12
+                                                                                 (hash-ref
+                                                                                  graph_0
+                                                                                  v_0
+                                                                                  #f)))
+                                                                            (if or-part_12
+                                                                              or-part_12
+                                                                              (let ((graph_1
+                                                                                     (hash-set
+                                                                                      graph_0
+                                                                                      v_0
+                                                                                      #t)))
+                                                                                (begin
+                                                                                  (letrec*
+                                                                                   ((for-loop_0
+                                                                                     (|#%name|
+                                                                                      for-loop
+                                                                                      (lambda (result_0
+                                                                                               i_0)
+                                                                                        (begin
+                                                                                          (if i_0
+                                                                                            (call-with-values
+                                                                                             (lambda ()
+                                                                                               (hash-iterate-key+value
+                                                                                                v_0
+                                                                                                i_0))
+                                                                                             (case-lambda
+                                                                                              ((k_0
+                                                                                                v_1)
+                                                                                               (let ((result_1
+                                                                                                      (let ((result_1
+                                                                                                             (if (loop_0
+                                                                                                                  k_0
+                                                                                                                  graph_1)
+                                                                                                               (loop_0
+                                                                                                                v_1
+                                                                                                                graph_1)
+                                                                                                               #f)))
+                                                                                                        (values
+                                                                                                         result_1))))
+                                                                                                 (if (if (not
+                                                                                                          (let ((x_0
+                                                                                                                 (list
+                                                                                                                  k_0
+                                                                                                                  v_1)))
+                                                                                                            (not
+                                                                                                             result_1)))
+                                                                                                       #t
+                                                                                                       #f)
+                                                                                                   (for-loop_0
+                                                                                                    result_1
+                                                                                                    (hash-iterate-next
+                                                                                                     v_0
+                                                                                                     i_0))
+                                                                                                   result_1)))
+                                                                                              (args
+                                                                                               (raise-binding-result-arity-error
+                                                                                                2
+                                                                                                args))))
+                                                                                            result_0))))))
+                                                                                   (for-loop_0
+                                                                                    #t
+                                                                                    (hash-iterate-first
+                                                                                     v_0)))))))
+                                                                          #f)
+                                                                        #f)))
+                                                                 (if or-part_12
+                                                                   or-part_12
+                                                                   (if (not
+                                                                        direct?2_0)
                                                                      (let ((or-part_13
-                                                                            (if (let ((or-part_13
-                                                                                       (fxvector?
-                                                                                        v_0)))
-                                                                                  (if or-part_13
-                                                                                    or-part_13
-                                                                                    (let ((or-part_14
-                                                                                           (flvector?
+                                                                            (cpointer?
+                                                                             v_0)))
+                                                                       (if or-part_13
+                                                                         or-part_13
+                                                                         (let ((or-part_14
+                                                                                (if (let ((or-part_14
+                                                                                           (fxvector?
                                                                                             v_0)))
                                                                                       (if or-part_14
                                                                                         or-part_14
-                                                                                        (bytes?
-                                                                                         v_0)))))
-                                                                              (place-shared?
-                                                                               v_0)
-                                                                              #f)))
-                                                                       (if or-part_13
-                                                                         or-part_13
-                                                                         (if (place-message?
-                                                                              v_0)
-                                                                           (if (|#%app|
-                                                                                (place-message-ref
-                                                                                 v_0)
-                                                                                v_0)
-                                                                             #t
-                                                                             #f)
-                                                                           #f)))))
-                                                                 #f))))))))))))))))))))))))))))))
+                                                                                        (let ((or-part_15
+                                                                                               (flvector?
+                                                                                                v_0)))
+                                                                                          (if or-part_15
+                                                                                            or-part_15
+                                                                                            (bytes?
+                                                                                             v_0)))))
+                                                                                  (place-shared?
+                                                                                   v_0)
+                                                                                  #f)))
+                                                                           (if or-part_14
+                                                                             or-part_14
+                                                                             (if (place-message?
+                                                                                  v_0)
+                                                                               (if (|#%app|
+                                                                                    (place-message-ref
+                                                                                     v_0)
+                                                                                    v_0)
+                                                                                 #t
+                                                                                 #f)
+                                                                               #f)))))
+                                                                     #f))))))))))))))))))))))))))))))))
         (loop_0 v4_0 hash2610))))))
 (define place-message-allowed-direct? (lambda (v_0) (allowed?.1 #t v_0)))
 (define 1/place-message-allowed?
@@ -3268,159 +3301,106 @@
                                               (cons
                                                app_0
                                                (loop_0 (cdr v_1)))))))
-                                       (if (vector? v_1)
+                                       (if (box? v_1)
                                          (let ((ph_0 (make-placeholder #f)))
                                            (begin
                                              (hash-set! graph_0 v_1 ph_0)
                                              (maybe-ph_0
                                               ph_0
                                               v_1
-                                              (let ((len_0
-                                                     (vector-length v_1)))
-                                                (begin
-                                                  (if (exact-nonnegative-integer?
-                                                       len_0)
-                                                    (void)
-                                                    (raise-argument-error
-                                                     'for/vector
-                                                     "exact-nonnegative-integer?"
-                                                     len_0))
-                                                  (let ((v_2
-                                                         (make-vector
-                                                          len_0
-                                                          0)))
-                                                    (begin
-                                                      (if (zero? len_0)
-                                                        (void)
-                                                        (call-with-values
-                                                         (lambda ()
-                                                           (begin
-                                                             (check-vector v_1)
-                                                             (values
-                                                              v_1
-                                                              (unsafe-vector-length
-                                                               v_1))))
-                                                         (case-lambda
-                                                          ((vec_0 len_1)
-                                                           (begin
-                                                             #f
-                                                             (letrec*
-                                                              ((for-loop_0
-                                                                (|#%name|
-                                                                 for-loop
-                                                                 (lambda (i_0
-                                                                          pos_0)
-                                                                   (begin
-                                                                     (if (unsafe-fx<
-                                                                          pos_0
-                                                                          len_1)
-                                                                       (let ((e_0
-                                                                              (unsafe-vector-ref
-                                                                               vec_0
-                                                                               pos_0)))
-                                                                         (let ((i_1
-                                                                                (let ((i_1
-                                                                                       (begin
-                                                                                         (unsafe-vector*-set!
-                                                                                          v_2
-                                                                                          i_0
-                                                                                          (loop_0
-                                                                                           e_0))
-                                                                                         (unsafe-fx+
-                                                                                          1
-                                                                                          i_0))))
-                                                                                  (values
-                                                                                   i_1))))
-                                                                           (if (if (not
-                                                                                    (let ((x_0
-                                                                                           (list
-                                                                                            e_0)))
-                                                                                      (unsafe-fx=
-                                                                                       i_1
-                                                                                       len_0)))
-                                                                                 #t
-                                                                                 #f)
-                                                                             (for-loop_0
-                                                                              i_1
-                                                                              (unsafe-fx+
-                                                                               1
-                                                                               pos_0))
-                                                                             i_1)))
-                                                                       i_0))))))
-                                                              (for-loop_0
-                                                               0
-                                                               0))))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))
-                                                      v_2)))))))
-                                         (let ((c1_0
-                                                (immutable-prefab-struct-key
-                                                 v_1)))
-                                           (if c1_0
-                                             (let ((ph_0
-                                                    (make-placeholder #f)))
-                                               (begin
-                                                 (hash-set! graph_0 v_1 ph_0)
-                                                 (maybe-ph_0
-                                                  ph_0
-                                                  v_1
-                                                  (apply
-                                                   make-prefab-struct
-                                                   c1_0
-                                                   (reverse$1
-                                                    (call-with-values
-                                                     (lambda ()
-                                                       (unsafe-normalise-inputs
-                                                        unsafe-vector-length
-                                                        (struct->vector v_1)
-                                                        1
-                                                        #f
-                                                        1))
-                                                     (case-lambda
-                                                      ((v*_0
-                                                        start*_0
-                                                        stop*_0
-                                                        step*_0)
-                                                       (begin
-                                                         #t
-                                                         (letrec*
-                                                          ((for-loop_0
-                                                            (|#%name|
-                                                             for-loop
-                                                             (lambda (fold-var_0
-                                                                      idx_0)
-                                                               (begin
-                                                                 (if (unsafe-fx<
-                                                                      idx_0
-                                                                      stop*_0)
-                                                                   (let ((e_0
-                                                                          (unsafe-vector-ref
-                                                                           v*_0
-                                                                           idx_0)))
-                                                                     (let ((fold-var_1
-                                                                            (let ((fold-var_1
-                                                                                   (cons
-                                                                                    (loop_0
-                                                                                     e_0)
-                                                                                    fold-var_0)))
-                                                                              (values
-                                                                               fold-var_1))))
-                                                                       (for-loop_0
-                                                                        fold-var_1
-                                                                        (unsafe-fx+
-                                                                         idx_0
-                                                                         1))))
-                                                                   fold-var_0))))))
-                                                          (for-loop_0
-                                                           null
-                                                           start*_0))))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        4
-                                                        args)))))))))
-                                             (if (hash? v_1)
+                                              (box (loop_0 (unbox v_1))))))
+                                         (if (vector? v_1)
+                                           (let ((ph_0 (make-placeholder #f)))
+                                             (begin
+                                               (hash-set! graph_0 v_1 ph_0)
+                                               (maybe-ph_0
+                                                ph_0
+                                                v_1
+                                                (let ((len_0
+                                                       (vector-length v_1)))
+                                                  (begin
+                                                    (if (exact-nonnegative-integer?
+                                                         len_0)
+                                                      (void)
+                                                      (raise-argument-error
+                                                       'for/vector
+                                                       "exact-nonnegative-integer?"
+                                                       len_0))
+                                                    (let ((v_2
+                                                           (make-vector
+                                                            len_0
+                                                            0)))
+                                                      (begin
+                                                        (if (zero? len_0)
+                                                          (void)
+                                                          (call-with-values
+                                                           (lambda ()
+                                                             (begin
+                                                               (check-vector
+                                                                v_1)
+                                                               (values
+                                                                v_1
+                                                                (unsafe-vector-length
+                                                                 v_1))))
+                                                           (case-lambda
+                                                            ((vec_0 len_1)
+                                                             (begin
+                                                               #f
+                                                               (letrec*
+                                                                ((for-loop_0
+                                                                  (|#%name|
+                                                                   for-loop
+                                                                   (lambda (i_0
+                                                                            pos_0)
+                                                                     (begin
+                                                                       (if (unsafe-fx<
+                                                                            pos_0
+                                                                            len_1)
+                                                                         (let ((e_0
+                                                                                (unsafe-vector-ref
+                                                                                 vec_0
+                                                                                 pos_0)))
+                                                                           (let ((i_1
+                                                                                  (let ((i_1
+                                                                                         (begin
+                                                                                           (unsafe-vector*-set!
+                                                                                            v_2
+                                                                                            i_0
+                                                                                            (loop_0
+                                                                                             e_0))
+                                                                                           (unsafe-fx+
+                                                                                            1
+                                                                                            i_0))))
+                                                                                    (values
+                                                                                     i_1))))
+                                                                             (if (if (not
+                                                                                      (let ((x_0
+                                                                                             (list
+                                                                                              e_0)))
+                                                                                        (unsafe-fx=
+                                                                                         i_1
+                                                                                         len_0)))
+                                                                                   #t
+                                                                                   #f)
+                                                                               (for-loop_0
+                                                                                i_1
+                                                                                (unsafe-fx+
+                                                                                 1
+                                                                                 pos_0))
+                                                                               i_1)))
+                                                                         i_0))))))
+                                                                (for-loop_0
+                                                                 0
+                                                                 0))))
+                                                            (args
+                                                             (raise-binding-result-arity-error
+                                                              2
+                                                              args)))))
+                                                        v_2)))))))
+                                           (let ((c1_0
+                                                  (immutable-prefab-struct-key
+                                                   v_1)))
+                                             (if c1_0
                                                (let ((ph_0
                                                       (make-placeholder #f)))
                                                  (begin
@@ -3428,62 +3408,72 @@
                                                    (maybe-ph_0
                                                     ph_0
                                                     v_1
-                                                    (if (hash-eq? v_1)
-                                                      (begin
-                                                        (letrec*
-                                                         ((for-loop_0
-                                                           (|#%name|
-                                                            for-loop
-                                                            (lambda (table_0
-                                                                     i_0)
-                                                              (begin
-                                                                (if i_0
-                                                                  (call-with-values
-                                                                   (lambda ()
-                                                                     (hash-iterate-key+value
-                                                                      v_1
-                                                                      i_0))
-                                                                   (case-lambda
-                                                                    ((k_0 v_2)
-                                                                     (let ((table_1
-                                                                            (let ((table_1
-                                                                                   (call-with-values
-                                                                                    (lambda ()
-                                                                                      (let ((app_0
-                                                                                             (loop_0
-                                                                                              k_0)))
-                                                                                        (values
-                                                                                         app_0
-                                                                                         (loop_0
-                                                                                          v_2))))
-                                                                                    (case-lambda
-                                                                                     ((key_0
-                                                                                       val_0)
-                                                                                      (hash-set
-                                                                                       table_0
-                                                                                       key_0
-                                                                                       val_0))
-                                                                                     (args
-                                                                                      (raise-binding-result-arity-error
-                                                                                       2
-                                                                                       args))))))
-                                                                              (values
-                                                                               table_1))))
-                                                                       (for-loop_0
-                                                                        table_1
-                                                                        (hash-iterate-next
-                                                                         v_1
-                                                                         i_0))))
-                                                                    (args
-                                                                     (raise-binding-result-arity-error
-                                                                      2
-                                                                      args))))
-                                                                  table_0))))))
-                                                         (for-loop_0
-                                                          hash2610
-                                                          (hash-iterate-first
-                                                           v_1))))
-                                                      (if (hash-eqv? v_1)
+                                                    (apply
+                                                     make-prefab-struct
+                                                     c1_0
+                                                     (reverse$1
+                                                      (call-with-values
+                                                       (lambda ()
+                                                         (unsafe-normalise-inputs
+                                                          unsafe-vector-length
+                                                          (struct->vector v_1)
+                                                          1
+                                                          #f
+                                                          1))
+                                                       (case-lambda
+                                                        ((v*_0
+                                                          start*_0
+                                                          stop*_0
+                                                          step*_0)
+                                                         (begin
+                                                           #t
+                                                           (letrec*
+                                                            ((for-loop_0
+                                                              (|#%name|
+                                                               for-loop
+                                                               (lambda (fold-var_0
+                                                                        idx_0)
+                                                                 (begin
+                                                                   (if (unsafe-fx<
+                                                                        idx_0
+                                                                        stop*_0)
+                                                                     (let ((e_0
+                                                                            (unsafe-vector-ref
+                                                                             v*_0
+                                                                             idx_0)))
+                                                                       (let ((fold-var_1
+                                                                              (let ((fold-var_1
+                                                                                     (cons
+                                                                                      (loop_0
+                                                                                       e_0)
+                                                                                      fold-var_0)))
+                                                                                (values
+                                                                                 fold-var_1))))
+                                                                         (for-loop_0
+                                                                          fold-var_1
+                                                                          (unsafe-fx+
+                                                                           idx_0
+                                                                           1))))
+                                                                     fold-var_0))))))
+                                                            (for-loop_0
+                                                             null
+                                                             start*_0))))
+                                                        (args
+                                                         (raise-binding-result-arity-error
+                                                          4
+                                                          args)))))))))
+                                               (if (hash? v_1)
+                                                 (let ((ph_0
+                                                        (make-placeholder #f)))
+                                                   (begin
+                                                     (hash-set!
+                                                      graph_0
+                                                      v_1
+                                                      ph_0)
+                                                     (maybe-ph_0
+                                                      ph_0
+                                                      v_1
+                                                      (if (hash-eq? v_1)
                                                         (begin
                                                           (letrec*
                                                            ((for-loop_0
@@ -3536,88 +3526,145 @@
                                                                         args))))
                                                                     table_0))))))
                                                            (for-loop_0
-                                                            hash2589
+                                                            hash2610
                                                             (hash-iterate-first
                                                              v_1))))
-                                                        (begin
-                                                          (letrec*
-                                                           ((for-loop_0
-                                                             (|#%name|
-                                                              for-loop
-                                                              (lambda (table_0
-                                                                       i_0)
-                                                                (begin
-                                                                  (if i_0
-                                                                    (call-with-values
-                                                                     (lambda ()
-                                                                       (hash-iterate-key+value
-                                                                        v_1
-                                                                        i_0))
-                                                                     (case-lambda
-                                                                      ((k_0
-                                                                        v_2)
-                                                                       (let ((table_1
-                                                                              (let ((table_1
-                                                                                     (call-with-values
-                                                                                      (lambda ()
-                                                                                        (let ((app_0
-                                                                                               (loop_0
-                                                                                                k_0)))
-                                                                                          (values
-                                                                                           app_0
-                                                                                           (loop_0
-                                                                                            v_2))))
-                                                                                      (case-lambda
-                                                                                       ((key_0
-                                                                                         val_0)
-                                                                                        (hash-set
-                                                                                         table_0
-                                                                                         key_0
-                                                                                         val_0))
-                                                                                       (args
-                                                                                        (raise-binding-result-arity-error
-                                                                                         2
-                                                                                         args))))))
-                                                                                (values
-                                                                                 table_1))))
-                                                                         (for-loop_0
-                                                                          table_1
-                                                                          (hash-iterate-next
-                                                                           v_1
-                                                                           i_0))))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        2
-                                                                        args))))
-                                                                    table_0))))))
-                                                           (for-loop_0
-                                                            hash2725
-                                                            (hash-iterate-first
-                                                             v_1)))))))))
-                                               (if (cpointer? v_1)
-                                                 (ptr-add v_1 0)
-                                                 (if (if (let ((or-part_0
-                                                                (fxvector?
-                                                                 v_1)))
-                                                           (if or-part_0
-                                                             or-part_0
-                                                             (flvector? v_1)))
-                                                       (place-shared? v_1)
-                                                       #f)
-                                                   v_1
-                                                   (if (place-message? v_1)
-                                                     (let ((make-unmessager_0
+                                                        (if (hash-eqv? v_1)
+                                                          (begin
+                                                            (letrec*
+                                                             ((for-loop_0
+                                                               (|#%name|
+                                                                for-loop
+                                                                (lambda (table_0
+                                                                         i_0)
+                                                                  (begin
+                                                                    (if i_0
+                                                                      (call-with-values
+                                                                       (lambda ()
+                                                                         (hash-iterate-key+value
+                                                                          v_1
+                                                                          i_0))
+                                                                       (case-lambda
+                                                                        ((k_0
+                                                                          v_2)
+                                                                         (let ((table_1
+                                                                                (let ((table_1
+                                                                                       (call-with-values
+                                                                                        (lambda ()
+                                                                                          (let ((app_0
+                                                                                                 (loop_0
+                                                                                                  k_0)))
+                                                                                            (values
+                                                                                             app_0
+                                                                                             (loop_0
+                                                                                              v_2))))
+                                                                                        (case-lambda
+                                                                                         ((key_0
+                                                                                           val_0)
+                                                                                          (hash-set
+                                                                                           table_0
+                                                                                           key_0
+                                                                                           val_0))
+                                                                                         (args
+                                                                                          (raise-binding-result-arity-error
+                                                                                           2
+                                                                                           args))))))
+                                                                                  (values
+                                                                                   table_1))))
+                                                                           (for-loop_0
+                                                                            table_1
+                                                                            (hash-iterate-next
+                                                                             v_1
+                                                                             i_0))))
+                                                                        (args
+                                                                         (raise-binding-result-arity-error
+                                                                          2
+                                                                          args))))
+                                                                      table_0))))))
+                                                             (for-loop_0
+                                                              hash2589
+                                                              (hash-iterate-first
+                                                               v_1))))
+                                                          (begin
+                                                            (letrec*
+                                                             ((for-loop_0
+                                                               (|#%name|
+                                                                for-loop
+                                                                (lambda (table_0
+                                                                         i_0)
+                                                                  (begin
+                                                                    (if i_0
+                                                                      (call-with-values
+                                                                       (lambda ()
+                                                                         (hash-iterate-key+value
+                                                                          v_1
+                                                                          i_0))
+                                                                       (case-lambda
+                                                                        ((k_0
+                                                                          v_2)
+                                                                         (let ((table_1
+                                                                                (let ((table_1
+                                                                                       (call-with-values
+                                                                                        (lambda ()
+                                                                                          (let ((app_0
+                                                                                                 (loop_0
+                                                                                                  k_0)))
+                                                                                            (values
+                                                                                             app_0
+                                                                                             (loop_0
+                                                                                              v_2))))
+                                                                                        (case-lambda
+                                                                                         ((key_0
+                                                                                           val_0)
+                                                                                          (hash-set
+                                                                                           table_0
+                                                                                           key_0
+                                                                                           val_0))
+                                                                                         (args
+                                                                                          (raise-binding-result-arity-error
+                                                                                           2
+                                                                                           args))))))
+                                                                                  (values
+                                                                                   table_1))))
+                                                                           (for-loop_0
+                                                                            table_1
+                                                                            (hash-iterate-next
+                                                                             v_1
+                                                                             i_0))))
+                                                                        (args
+                                                                         (raise-binding-result-arity-error
+                                                                          2
+                                                                          args))))
+                                                                      table_0))))))
+                                                             (for-loop_0
+                                                              hash2725
+                                                              (hash-iterate-first
+                                                               v_1)))))))))
+                                                 (if (cpointer? v_1)
+                                                   (ptr-add v_1 0)
+                                                   (if (if (let ((or-part_0
+                                                                  (fxvector?
+                                                                   v_1)))
+                                                             (if or-part_0
+                                                               or-part_0
+                                                               (flvector?
+                                                                v_1)))
+                                                         (place-shared? v_1)
+                                                         #f)
+                                                     v_1
+                                                     (if (place-message? v_1)
+                                                       (let ((make-unmessager_0
+                                                              (|#%app|
+                                                               (place-message-ref
+                                                                v_1)
+                                                               v_1)))
+                                                         (if make-unmessager_0
+                                                           (message-ized1.1
                                                             (|#%app|
-                                                             (place-message-ref
-                                                              v_1)
-                                                             v_1)))
-                                                       (if make-unmessager_0
-                                                         (message-ized1.1
-                                                          (|#%app|
-                                                           make-unmessager_0))
-                                                         (|#%app| fail_0)))
-                                                     (|#%app|
-                                                      fail_0))))))))))))))))))))
+                                                             make-unmessager_0))
+                                                           (|#%app| fail_0)))
+                                                       (|#%app|
+                                                        fail_0)))))))))))))))))))))
                   (loop_0 v_0))))
             (message-ized1.1 new-v_0)))))))
 (define un-message-ize
@@ -3650,158 +3697,118 @@
                 (if (pair? v_1)
                   (let ((app_0 (loop_0 (car v_1))))
                     (cons app_0 (loop_0 (cdr v_1))))
-                  (if (vector? v_1)
-                    (vector->immutable-vector
-                     (let ((len_0 (vector-length v_1)))
-                       (begin
-                         (if (exact-nonnegative-integer? len_0)
-                           (void)
-                           (raise-argument-error
-                            'for/vector
-                            "exact-nonnegative-integer?"
-                            len_0))
-                         (let ((v_2 (make-vector len_0 0)))
-                           (begin
-                             (if (zero? len_0)
-                               (void)
-                               (call-with-values
-                                (lambda ()
-                                  (begin
-                                    (check-vector v_1)
-                                    (values v_1 (unsafe-vector-length v_1))))
-                                (case-lambda
-                                 ((vec_0 len_1)
-                                  (begin
-                                    #f
-                                    (letrec*
-                                     ((for-loop_0
-                                       (|#%name|
-                                        for-loop
-                                        (lambda (i_0 pos_0)
-                                          (begin
-                                            (if (unsafe-fx< pos_0 len_1)
-                                              (let ((e_0
-                                                     (unsafe-vector-ref
-                                                      vec_0
-                                                      pos_0)))
-                                                (let ((i_1
-                                                       (let ((i_1
-                                                              (begin
-                                                                (unsafe-vector*-set!
-                                                                 v_2
-                                                                 i_0
-                                                                 (loop_0 e_0))
-                                                                (unsafe-fx+
-                                                                 1
-                                                                 i_0))))
-                                                         (values i_1))))
-                                                  (if (if (not
-                                                           (let ((x_0
-                                                                  (list e_0)))
-                                                             (unsafe-fx=
-                                                              i_1
-                                                              len_0)))
-                                                        #t
-                                                        #f)
-                                                    (for-loop_0
-                                                     i_1
-                                                     (unsafe-fx+ 1 pos_0))
-                                                    i_1)))
-                                              i_0))))))
-                                     (for-loop_0 0 0))))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args)))))
-                             v_2)))))
-                    (let ((c3_0 (immutable-prefab-struct-key v_1)))
-                      (if c3_0
-                        (apply
-                         make-prefab-struct
-                         c3_0
-                         (reverse$1
-                          (call-with-values
-                           (lambda ()
-                             (unsafe-normalise-inputs
-                              unsafe-vector-length
-                              (struct->vector v_1)
-                              1
-                              #f
-                              1))
-                           (case-lambda
-                            ((v*_0 start*_0 stop*_0 step*_0)
+                  (if (box? v_1)
+                    (box-immutable (loop_0 (unbox v_1)))
+                    (if (vector? v_1)
+                      (vector->immutable-vector
+                       (let ((len_0 (vector-length v_1)))
+                         (begin
+                           (if (exact-nonnegative-integer? len_0)
+                             (void)
+                             (raise-argument-error
+                              'for/vector
+                              "exact-nonnegative-integer?"
+                              len_0))
+                           (let ((v_2 (make-vector len_0 0)))
                              (begin
-                               #t
-                               (letrec*
-                                ((for-loop_0
-                                  (|#%name|
-                                   for-loop
-                                   (lambda (fold-var_0 idx_0)
-                                     (begin
-                                       (if (unsafe-fx< idx_0 stop*_0)
-                                         (let ((e_0
-                                                (unsafe-vector-ref
-                                                 v*_0
-                                                 idx_0)))
-                                           (let ((fold-var_1
-                                                  (let ((fold-var_1
-                                                         (cons
-                                                          (loop_0 e_0)
-                                                          fold-var_0)))
-                                                    (values fold-var_1))))
-                                             (for-loop_0
-                                              fold-var_1
-                                              (unsafe-fx+ idx_0 1))))
-                                         fold-var_0))))))
-                                (for-loop_0 null start*_0))))
-                            (args
-                             (raise-binding-result-arity-error 4 args))))))
-                        (if (hash? v_1)
-                          (if (hash-eq? v_1)
-                            (begin
-                              (letrec*
-                               ((for-loop_0
-                                 (|#%name|
-                                  for-loop
-                                  (lambda (table_0 i_0)
+                               (if (zero? len_0)
+                                 (void)
+                                 (call-with-values
+                                  (lambda ()
                                     (begin
-                                      (if i_0
-                                        (call-with-values
-                                         (lambda ()
-                                           (hash-iterate-key+value v_1 i_0))
-                                         (case-lambda
-                                          ((k_0 v_2)
-                                           (let ((table_1
-                                                  (let ((table_1
-                                                         (call-with-values
-                                                          (lambda ()
-                                                            (let ((app_0
+                                      (check-vector v_1)
+                                      (values v_1 (unsafe-vector-length v_1))))
+                                  (case-lambda
+                                   ((vec_0 len_1)
+                                    (begin
+                                      #f
+                                      (letrec*
+                                       ((for-loop_0
+                                         (|#%name|
+                                          for-loop
+                                          (lambda (i_0 pos_0)
+                                            (begin
+                                              (if (unsafe-fx< pos_0 len_1)
+                                                (let ((e_0
+                                                       (unsafe-vector-ref
+                                                        vec_0
+                                                        pos_0)))
+                                                  (let ((i_1
+                                                         (let ((i_1
+                                                                (begin
+                                                                  (unsafe-vector*-set!
+                                                                   v_2
+                                                                   i_0
                                                                    (loop_0
-                                                                    k_0)))
-                                                              (values
-                                                               app_0
-                                                               (loop_0 v_2))))
-                                                          (case-lambda
-                                                           ((key_0 val_0)
-                                                            (hash-set
-                                                             table_0
-                                                             key_0
-                                                             val_0))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args))))))
-                                                    (values table_1))))
-                                             (for-loop_0
-                                              table_1
-                                              (hash-iterate-next v_1 i_0))))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
-                                        table_0))))))
-                               (for-loop_0
-                                hash2610
-                                (hash-iterate-first v_1))))
-                            (if (hash-eqv? v_1)
+                                                                    e_0))
+                                                                  (unsafe-fx+
+                                                                   1
+                                                                   i_0))))
+                                                           (values i_1))))
+                                                    (if (if (not
+                                                             (let ((x_0
+                                                                    (list
+                                                                     e_0)))
+                                                               (unsafe-fx=
+                                                                i_1
+                                                                len_0)))
+                                                          #t
+                                                          #f)
+                                                      (for-loop_0
+                                                       i_1
+                                                       (unsafe-fx+ 1 pos_0))
+                                                      i_1)))
+                                                i_0))))))
+                                       (for-loop_0 0 0))))
+                                   (args
+                                    (raise-binding-result-arity-error
+                                     2
+                                     args)))))
+                               v_2)))))
+                      (let ((c3_0 (immutable-prefab-struct-key v_1)))
+                        (if c3_0
+                          (apply
+                           make-prefab-struct
+                           c3_0
+                           (reverse$1
+                            (call-with-values
+                             (lambda ()
+                               (unsafe-normalise-inputs
+                                unsafe-vector-length
+                                (struct->vector v_1)
+                                1
+                                #f
+                                1))
+                             (case-lambda
+                              ((v*_0 start*_0 stop*_0 step*_0)
+                               (begin
+                                 #t
+                                 (letrec*
+                                  ((for-loop_0
+                                    (|#%name|
+                                     for-loop
+                                     (lambda (fold-var_0 idx_0)
+                                       (begin
+                                         (if (unsafe-fx< idx_0 stop*_0)
+                                           (let ((e_0
+                                                  (unsafe-vector-ref
+                                                   v*_0
+                                                   idx_0)))
+                                             (let ((fold-var_1
+                                                    (let ((fold-var_1
+                                                           (cons
+                                                            (loop_0 e_0)
+                                                            fold-var_0)))
+                                                      (values fold-var_1))))
+                                               (for-loop_0
+                                                fold-var_1
+                                                (unsafe-fx+ idx_0 1))))
+                                           fold-var_0))))))
+                                  (for-loop_0 null start*_0))))
+                              (args
+                               (raise-binding-result-arity-error 4 args))))))
+                          (if (hash? v_1)
+                            (if (hash-eq? v_1)
                               (begin
                                 (letrec*
                                  ((for-loop_0
@@ -3846,61 +3853,116 @@
                                               args))))
                                           table_0))))))
                                  (for-loop_0
-                                  hash2589
+                                  hash2610
                                   (hash-iterate-first v_1))))
-                              (begin
-                                (letrec*
-                                 ((for-loop_0
-                                   (|#%name|
-                                    for-loop
-                                    (lambda (table_0 i_0)
-                                      (begin
-                                        (if i_0
-                                          (call-with-values
-                                           (lambda ()
-                                             (hash-iterate-key+value v_1 i_0))
-                                           (case-lambda
-                                            ((k_0 v_2)
-                                             (let ((table_1
-                                                    (let ((table_1
-                                                           (call-with-values
-                                                            (lambda ()
-                                                              (let ((app_0
-                                                                     (loop_0
-                                                                      k_0)))
-                                                                (values
-                                                                 app_0
-                                                                 (loop_0
-                                                                  v_2))))
-                                                            (case-lambda
-                                                             ((key_0 val_0)
-                                                              (hash-set
-                                                               table_0
-                                                               key_0
-                                                               val_0))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args))))))
-                                                      (values table_1))))
-                                               (for-loop_0
-                                                table_1
-                                                (hash-iterate-next v_1 i_0))))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
-                                          table_0))))))
-                                 (for-loop_0
-                                  hash2725
-                                  (hash-iterate-first v_1))))))
-                          (if (if (cpointer? v_1)
-                                (if v_1 (not (bytes? v_1)) #f)
-                                #f)
-                            (ptr-add v_1 0)
-                            (if (message-ized? v_1)
-                              (|#%app| (message-ized-unmessage v_1))
-                              v_1)))))))))))))
+                              (if (hash-eqv? v_1)
+                                (begin
+                                  (letrec*
+                                   ((for-loop_0
+                                     (|#%name|
+                                      for-loop
+                                      (lambda (table_0 i_0)
+                                        (begin
+                                          (if i_0
+                                            (call-with-values
+                                             (lambda ()
+                                               (hash-iterate-key+value
+                                                v_1
+                                                i_0))
+                                             (case-lambda
+                                              ((k_0 v_2)
+                                               (let ((table_1
+                                                      (let ((table_1
+                                                             (call-with-values
+                                                              (lambda ()
+                                                                (let ((app_0
+                                                                       (loop_0
+                                                                        k_0)))
+                                                                  (values
+                                                                   app_0
+                                                                   (loop_0
+                                                                    v_2))))
+                                                              (case-lambda
+                                                               ((key_0 val_0)
+                                                                (hash-set
+                                                                 table_0
+                                                                 key_0
+                                                                 val_0))
+                                                               (args
+                                                                (raise-binding-result-arity-error
+                                                                 2
+                                                                 args))))))
+                                                        (values table_1))))
+                                                 (for-loop_0
+                                                  table_1
+                                                  (hash-iterate-next
+                                                   v_1
+                                                   i_0))))
+                                              (args
+                                               (raise-binding-result-arity-error
+                                                2
+                                                args))))
+                                            table_0))))))
+                                   (for-loop_0
+                                    hash2589
+                                    (hash-iterate-first v_1))))
+                                (begin
+                                  (letrec*
+                                   ((for-loop_0
+                                     (|#%name|
+                                      for-loop
+                                      (lambda (table_0 i_0)
+                                        (begin
+                                          (if i_0
+                                            (call-with-values
+                                             (lambda ()
+                                               (hash-iterate-key+value
+                                                v_1
+                                                i_0))
+                                             (case-lambda
+                                              ((k_0 v_2)
+                                               (let ((table_1
+                                                      (let ((table_1
+                                                             (call-with-values
+                                                              (lambda ()
+                                                                (let ((app_0
+                                                                       (loop_0
+                                                                        k_0)))
+                                                                  (values
+                                                                   app_0
+                                                                   (loop_0
+                                                                    v_2))))
+                                                              (case-lambda
+                                                               ((key_0 val_0)
+                                                                (hash-set
+                                                                 table_0
+                                                                 key_0
+                                                                 val_0))
+                                                               (args
+                                                                (raise-binding-result-arity-error
+                                                                 2
+                                                                 args))))))
+                                                        (values table_1))))
+                                                 (for-loop_0
+                                                  table_1
+                                                  (hash-iterate-next
+                                                   v_1
+                                                   i_0))))
+                                              (args
+                                               (raise-binding-result-arity-error
+                                                2
+                                                args))))
+                                            table_0))))))
+                                   (for-loop_0
+                                    hash2725
+                                    (hash-iterate-first v_1))))))
+                            (if (if (cpointer? v_1)
+                                  (if v_1 (not (bytes? v_1)) #f)
+                                  #f)
+                              (ptr-add v_1 0)
+                              (if (message-ized? v_1)
+                                (|#%app| (message-ized-unmessage v_1))
+                                v_1))))))))))))))
        (loop_0 v_0)))))
 (define finish_2216
   (make-struct-type-install-properties

--- a/racket/src/thread/place-message.rkt
+++ b/racket/src/thread/place-message.rkt
@@ -264,6 +264,11 @@
   (test #t (place-message-allowed? (make-prefab-struct 'bx (box #f) (box #f))))
   (test #f (place-message-allowed-direct? (make-prefab-struct 'bx (box #f) (box #f))))
 
+  (struct unallowed
+    (a b))
+  (test #f (place-message-allowed? (unallowed 1 2)))
+  (test #f (place-message-allowed? (box (unallowed 1 2))))
+  
   (define stateful-cyclic (make-reader-graph
                            (let ([ph (make-placeholder #f)]
                                  [ph2 (make-placeholder #f)]
@@ -271,6 +276,7 @@
                              (define (as ph v) (placeholder-set! ph v) v)
                              (as ph2 (vector (as ph (cons ph (string-copy "apple")))
                                              (box (box 2))
+                                             (box (vector "string" (box 'symbol)))
                                              ph2
                                              (as ph3 (hasheq 'a 1 'b ph3))
                                              '#s(pre 4 5)))
@@ -282,7 +288,7 @@
                                                        (raise-argument-error #f
                                                                              "test-error"
                                                                              stateful-cyclic)))))
-  
+
   (define ext (external 'x))
   (test #t (place-message-allowed? ext))
   (test #f (place-message-allowed-direct? ext))

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 4
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 6
+#define MZSCHEME_VERSION_W 7
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
These changes are designed to add `box`es to `place-message`s, treating boxes in that context in the same way `vector`s are treated. That is, boxes are allowed, and mutable boxes are automatically converted to immutable boxes.

This follows a short conversation on discourse:

[https://racket.discourse.group/t/vectors-boxes-and-places/648](https://racket.discourse.group/t/vectors-boxes-and-places/648)
