### PR TITLE
Chez Scheme: add reductions for bitwise operations in cptypes

### DIFF
--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -1399,6 +1399,47 @@
     '(lambda (x) (unless (fixnum? x) (when (real? x) x))))
 )
 
+(mat bitwise
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (fixnum? x) (bitwise-and x 7)))
+    '(lambda (x) (when (fixnum? x) (fxand x 7))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (fixnum? x) (bitwise-ior x 7)))
+    '(lambda (x) (when (fixnum? x) (fxior x 7))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (fixnum? x) (bitwise-xor x 7)))
+    '(lambda (x) (when (fixnum? x) (fxxor x 7))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (fixnum? x) (bitwise-not x)))
+    '(lambda (x) (when (fixnum? x) (fxnot x))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (fixnum? (bitwise-and x 7)))
+    '(lambda (x) (bitwise-and x 7) #t))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x) (fixnum? (bitwise-and x -7)))
+         '(lambda (x) (bitwise-and x -7) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (fixnum? (bitwise-ior x -7)))
+    '(lambda (x) (bitwise-ior x -7) #t))
+  (not (cptypes-equivalent-expansion?
+         '(lambda (x) (fixnum? (bitwise-ior x 7)))
+         '(lambda (x) (bitwise-ior x 7) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (f x) (when (fixnum? x) (bitwise-and (f) x)))
+    '(lambda (f x) (when (fixnum? x)
+                     (let ([y (f)])
+                       (if (#2%fixnum? y) ;the specialization uses #2%fixnum?
+                           (fxand y x)
+                           (bitwise-and y x))))))
+  (cptypes-equivalent-expansion?
+    '(lambda (f x) (when (fixnum? x) (bitwise-and x (f))))
+    '(lambda (f x) (when (fixnum? x)
+                     (let ([y (f)])
+                       (if (#2%fixnum? y) ;the specialization uses #2%fixnum?
+                           (fxand x y)
+                           (bitwise-and x y))))))
+)
+
 (mat cptypes-unreachable
   (cptypes-equivalent-expansion?
    '(lambda (x) (if (pair? x) (car x) (#3%assert-unreachable)))

--- a/racket/src/ChezScheme/mats/cptypes.ms
+++ b/racket/src/ChezScheme/mats/cptypes.ms
@@ -556,6 +556,36 @@
                                `(let ()
                                   ,preamble
                                   (lambda (x) (when (,(car t) x) #t)))))
+                        (or (not check-self?)
+                            (cptypes-equivalent-expansion?
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (and (,(car l) x) (,(car t) x)) (,(car l) x))))
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (and (,(car l) x) (,(car t) x)) #t))))
+                            (cptypes-equivalent-expansion?
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (and (,(car t) x) (,(car l) x)) (,(car l) x))))
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (and (,(car t) x) (,(car l) x)) #t))))
+                            (cptypes-equivalent-expansion?
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (or (,(car l) x) (,(car t) x)) (,(car t) x))))
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (or (,(car l) x) (,(car t) x)) #t))))
+                            (cptypes-equivalent-expansion?
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (or (,(car l) x) (,(car t) x)) (,(car t) x))))
+                              `(let ()
+                                 ,preamble
+                                 (lambda (x) (when (or (,(car t) x) (,(car l) x)) #t))))
+                            )
                         (loop (cdr t)))))
              (loop (cdr l))))))
 
@@ -1313,12 +1343,6 @@
     '(lambda (p) (define x (get-u8 p)) (unless (fixnum? x) (eq? x (eof-object))))
     '(lambda (p) (define x (get-u8 p)) (unless (fixnum? x) #t)))
   (cptypes-equivalent-expansion?
-    '(lambda (x) (when (or (fixnum? x) (bignum? x)) (or (fixnum? x) (bignum? x))))
-    '(lambda (x) (when (or (fixnum? x) (bignum? x)) #t)))
-  (cptypes-equivalent-expansion?
-    '(lambda (x) (when (or (fixnum? x) (bignum? x)) (or (bignum? x) (fixnum? x))))
-    '(lambda (x) (when (or (fixnum? x) (bignum? x)) #t)))
-  (cptypes-equivalent-expansion?
     '(lambda (x) (unless (char? x) (char? x)))
     '(lambda (x) (unless (char? x) #f)))
   (cptypes-equivalent-expansion?
@@ -1342,6 +1366,37 @@
   (cptypes-equivalent-expansion?
     '(lambda (x) (when (eq? x #\A) (unless (char? x) 1)))
     '(lambda (x) (when (eq? x #\A) (unless (char? x) 2))))
+)
+
+(mat exact-integer
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (or (fixnum? x) (bignum? x)) (or (fixnum? x) (bignum? x))))
+    '(lambda (x) (when (or (fixnum? x) (bignum? x)) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (or (fixnum? x) (bignum? x)) (or (bignum? x) (fixnum? x))))
+    '(lambda (x) (when (or (fixnum? x) (bignum? x)) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (or (fixnum? x) (eq? x 7)) (fixnum? x)))
+    '(lambda (x) (when (or (fixnum? x) (eq? x 7)) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (or (eq? x 7) (fixnum? x)) (fixnum? x)))
+    '(lambda (x) (when (or (eq? x 7) (fixnum? x)) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (and (fixnum? x) (eq? x 7)) (eq? x 7)))
+    '(lambda (x) (when (and (fixnum? x) (eq? x 7)) #t)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (and (eq? x 7) (fixnum? x)) (eq? x 7)))
+    '(lambda (x) (when (and (eq? x 7) (fixnum? x)) #t)))
+  ; check that non-fixnum? is not lost
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (unless (fixnum? x) (unless (fixnum? x) x)))
+    '(lambda (x) (unless (fixnum? x) x)))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (when (real? x) (unless (fixnum? x) (unless (fixnum? x) x))))
+    '(lambda (x) (when (real? x) (unless (fixnum? x) x))))
+  (cptypes-equivalent-expansion?
+    '(lambda (x) (unless (fixnum? x) (when (real? x) (unless (fixnum? x) x))))
+    '(lambda (x) (unless (fixnum? x) (when (real? x) x))))
 )
 
 (mat cptypes-unreachable

--- a/racket/src/ChezScheme/s/cptypes.ss
+++ b/racket/src/ChezScheme/s/cptypes.ss
@@ -43,7 +43,7 @@ Notes:
 
 
  - predicate: They may be:
-              * a symbol to indicate the type, like 'vector 'pair 'number
+              * a symbol to indicate the type, like 'vector 'pair 'flonum
                 (there are a few fake values, in particular 'bottom is used to
                  signal that there is an error)
               * a nanopass-quoted value that is okay-to-copy?, like
@@ -407,7 +407,7 @@ Notes:
     ; looks like an union of the fxmaps.
     ; [missing 'ptr] _and_ 'vector -> 'vector
     ; 'box _and_ 'vector -> 'bottom
-    ; 'number _and_ 'exact-integer -> 'exact-integer
+    ; 'number _and_ 'flonum -> 'flonum
     (define (pred-env-intersect/base types from base)
       (cond
         [(or (eq? types bottom-fxmap)
@@ -437,7 +437,7 @@ Notes:
     ; looks like an intersection of the fxmaps.
     ; [missing 'ptr] _or_ 'vector -> [missing 'ptr]
     ; 'box _or_ 'boolean -> [missing 'ptr]
-    ; 'number _or_ 'exact-integer -> 'number
+    ; 'number _or_ 'flonum -> 'number
     ; *Internals auxilary function. Does not check bottom-fxmap.*
     (define ($pred-env-union/from from base types new-base)
       ; Calculate the union of types and from, and intersect it with new-base
@@ -1120,24 +1120,24 @@ Notes:
       (define-specialize 2 atan
         [(n) (let ([r (get-type n)])
                (cond
-                 [(predicate-disjoint? r 'number)
+                 [(predicate-disjoint? r number-pred)
                   (values `(call ,preinfo ,pr ,n)
                           'bottom pred-env-bottom #f #f)]
                  [else
                   (values `(call ,preinfo ,pr ,n) ret 
-                          (pred-env-add/ref ntypes n 'number plxc) #f #f)]))]
+                          (pred-env-add/ref ntypes n number-pred plxc) #f #f)]))]
         [(x y) (let ([rx (get-type x)]
                      [ry (get-type y)])
                  (cond
-                   [(or (predicate-disjoint? rx 'real)
-                        (predicate-disjoint? ry 'real))
+                   [(or (predicate-disjoint? rx real-pred)
+                        (predicate-disjoint? ry real-pred))
                     (values `(call ,preinfo ,pr ,x ,y)
                             'bottom pred-env-bottom #f #f)]
                    [else
                     (values `(call ,preinfo ,pr ,x ,y) ret 
                             (pred-env-add/ref (pred-env-add/ref ntypes
-                                                                x 'real  plxc)
-                                              y 'real plxc)
+                                                                x real-pred plxc)
+                                              y real-pred plxc)
                              #f #f)]))])
 
       (define-specialize 2 char-name

--- a/racket/src/ChezScheme/s/primdata.ss
+++ b/racket/src/ChezScheme/s/primdata.ss
@@ -16,10 +16,10 @@
 ;;; r6rs features
 
 (define-symbol-flags* ([libraries (rnrs) (rnrs arithmetic bitwise)] [flags primitive proc])
-  (bitwise-not [sig [(sint) -> (sint)]] [flags arith-op mifoldable discard safeongoodargs])
-  (bitwise-and [sig [(sint ...) -> (sint)]] [flags arith-op partial-folder safeongoodargs])
-  (bitwise-ior [sig [(sint ...) -> (sint)]] [flags arith-op partial-folder safeongoodargs])
-  (bitwise-xor [sig [(sint ...) -> (sint)]] [flags arith-op partial-folder safeongoodargs])
+  (bitwise-not [sig [(sint) -> (sint)]] [flags arith-op mifoldable discard safeongoodargs cptypes2])
+  (bitwise-and [sig [(sint ...) -> (sint)]] [flags arith-op partial-folder safeongoodargs cptypes2])
+  (bitwise-ior [sig [(sint ...) -> (sint)]] [flags arith-op partial-folder safeongoodargs cptypes2])
+  (bitwise-xor [sig [(sint ...) -> (sint)]] [flags arith-op partial-folder safeongoodargs cptypes2])
   (bitwise-if [sig [(sint sint sint) -> (sint)]] [flags arith-op mifoldable discard safeongoodargs])
   (bitwise-bit-count [sig [(sint) -> (sint)]] [flags arith-op mifoldable discard safeongoodargs])
   (bitwise-length [sig [(sint) -> (uint)]] [flags arith-op mifoldable discard safeongoodargs])


### PR DESCRIPTION
### Isolate exact-integers in cptypes lattice

Add an additional field to `pred-or` to store the information about `exact-integer` separately from the other number types. This ensures that when a check `(fixnum? x)` is false, that information is not lost. In particular, in

    (unless (fixnum? x)
      (unless (fixnum? x)
        (something x)))

the second check will be eliminated.

My idea is to add in the future (1 month?) a more fine grained classification of `exact-integers`, so it also helps to keep them in a different part. 

Also, this includes fixes that enable some missed reduction opportunities.

### Add reductions for bitwise operations

 **In particular reduce**

    (bitwise-and <fixnum> <fixnum>)
    ==>
    (#3%fxand <fixnum> <fixnum>)

**Also**

    (bitwise-and (f) <fixnum>)
    ==>
    (let ([x (f)])
      (if (fixnum? x))
          (#3%fxand x <fixnum>)
          (bitwise-and x <fixnum>)))

This is a reduction in the wrong direction, because it makes the code longer instead of shorted, but `rumble` already has a similar trick with a macro. The difference is that the macro can do this with any number of arguments, but my version only does this with one argument to ensure the second pass of `cptypes` does not repeat it, because the types system in `cptypes` can't remember `(not (and (fixnum? x) (fixnum? y)))`.


**Know that the result of**

    (bitwise-and x <positive-fixnum>)
    (bitwise-ior x <negative-fixnum>)

is a `fixnum`. I added a check in optimize.rktl for `bitwise-ior` but this is a new feature that is not implemented in BC. I can add it to BC, but I think it's almost-frozen.