### PR TITLE
Fix resolv.conf parsing in dns-find-nameserver

### DIFF
--- a/pkgs/net-lib/net/dns.rkt
+++ b/pkgs/net-lib/net/dns.rkt
@@ -398,7 +398,7 @@
              (define line (read-line))
              (or (and (string? line)
                       (let ([m (regexp-match
-                                #rx"nameserver[ \t]+([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)"
+                                #rx"^[^#]*nameserver[ \t]+([0-9]+[.][0-9]+[.][0-9]+[.][0-9]+)"
                                 line)])
                         (and m (cadr m))))
                  (and (not (eof-object? line))


### PR DESCRIPTION
Make sure nameserver line does not have a hash character (comment)