### PR TITLE
reference: Be more explicit about the weakness of interned literals

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/reader.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/reader.scrbl
@@ -53,6 +53,15 @@ necessarily produce an interned value at the receiving
 @tech{place}. See also @racket[datum-intern-literal] and
 @racket[datum->syntax].
 
+Note that @tech{interned} values are only weakly held by the reader's
+internal table, so they may be @tech[#:key "garbage collection"]{garbage
+collected} if they are no longer otherwise @tech{reachable}. This weakness
+can never affect the result of an @racket[eq?], @racket[eqv?], or
+@racket[equal?] test, but an interned value may disappear when placed into
+a weak box (see @secref["weakbox"]), used as the key in a weak @tech{hash
+table} (see @secref["hashtables"]), or used as an ephemeron key (see
+@secref["ephemerons"]).
+
 @;------------------------------------------------------------------------
 @section[#:tag "default-readtable-dispatch"]{Delimiters and Dispatch}
 

--- a/pkgs/racket-doc/scribblings/reference/symbols.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/symbols.scrbl
@@ -33,7 +33,7 @@ in the result of functions like @racket[identifier-binding].
 Interned and unreadable symbols are only weakly held by the internal
 symbol table. This weakness can never affect the result of an
 @racket[eq?], @racket[eqv?], or @racket[equal?] test, but a symbol may
-disappear when placed into a weak box (see @secref["weakbox"]) used as
+disappear when placed into a weak box (see @secref["weakbox"]), used as
 the key in a weak @tech{hash table} (see @secref["hashtables"]), or
 used as an ephemeron key (see @secref["ephemerons"]).
 


### PR DESCRIPTION
Similar verbiage is already included in the section on symbols, but I was not able to find it when I went looking for it because I was looking at the documentation for “interned”, and including it here makes it more explicit that the weakness applies to all types of interned values.