### PR TITLE
Use default branch for GitHub package sources

### DIFF
--- a/pkgs/racket-test/tests/pkg/tests-network.rkt
+++ b/pkgs/racket-test/tests/pkg/tests-network.rkt
@@ -96,4 +96,8 @@
 
  (try-git-repo-using-default-branch
   "remote/git with default branch"
-  "https://github.com/racket/test-pkg-2.git"))
+  "https://github.com/racket/test-pkg-2.git")
+
+ (try-git-repo-using-default-branch
+  "remote/github with default branch"
+  "git://github.com/racket/test-pkg-2"))

--- a/racket/collects/pkg/private/repo-path.rkt
+++ b/racket/collects/pkg/private/repo-path.rkt
@@ -26,7 +26,7 @@
       (let* ([paths (map path/param-path (url-path/no-slash pkg-url))])
         (list* (car paths)
                (regexp-replace* #rx"[.]git$" (cadr paths) "")
-               (or (url-fragment pkg-url) "master")
+               (or (url-fragment pkg-url) 'head)
                (extract-git-path pkg-url)))))
 
 (define (extract-git-path pkg-url)


### PR DESCRIPTION
Commit cff766ab84dcc5d9dc969930611e0b8c150bfaf6 changed **Git** package sources to use the default branch (instead of assuming `master` explicitly), but the more specialised **GitHub** code path was missed at the time. This fixes the GitHub path as well.

As with Git package sources at the time of the previous commit above, this is technically a backward-incompatible change to the interpretation of GitHub package sources, but explicit branch specification continues to work the same. For the foreseeable future, to support recent versions, packages in a branch other than `master` will still need to be specified using the branch name, such as including `#main` at the end of the package source. Eventually, relevant versions of Racket will support the new default.

Related to https://github.com/racket/racket/issues/3672
Related to https://github.com/racket/pkg-index/issues/32