### PR TITLE
string: empty string optimization on string-join

### DIFF
--- a/pkgs/racket-test-core/tests/racket/string.rktl
+++ b/pkgs/racket-test-core/tests/racket/string.rktl
@@ -392,6 +392,15 @@
   (test "x y z" string-join '("x" "y" "z") " ")
   (test "x,y,z" string-join '("x" "y" "z") ",")
   (test "x, y and z" string-join '("x" "y" "z") ", " #:before-last " and ")
+
+  ;; test empty string optimization
+  (test "xyz" string-join '("x" "y" "z") "")
+  (test "xyz" string-join '("x" "y" "z") "" #:before-last "")
+  (test "xy and z" string-join '("x" "y" "z") "" #:before-last " and ")
+  (test "xy" string-join '("x" "y") "")
+  (test "xy" string-join '("x" "y") "" #:before-last "")
+  (test "x and y" string-join '("x" "y") "" #:before-last " and ")
+
   (for ([strs+res
          (in-list '((("x" "y" "z") "x, y and z")
                     (("x" "y")     "x and y")

--- a/racket/collects/racket/string.rkt
+++ b/racket/collects/racket/string.rkt
@@ -38,9 +38,21 @@
     (raise-argument-error 'string-join "string?" sep))
   (unless (or (string? after-last) (eq? after-last none))
     (raise-argument-error 'string-join "string?" after-last))
-  (let* ([r (if (or (null? strs) (null? (cdr strs)))
-              strs
-              (add-between strs sep #:before-last before-last))]
+
+  (let* ([r (cond
+              [(or (null? strs) (null? (cdr strs))) strs]
+              ;; below here, strs definitely has at least two elements
+              [(equal? sep "")
+               (cond
+                 [(equal? before-last "") strs]
+                 [else
+                  (define rev-strs (reverse strs))
+                  (define rev-assembled
+                    (cons (car rev-strs)
+                          (cons before-last
+                                (cdr rev-strs))))
+                  (reverse rev-assembled)])]
+              [else (add-between strs sep #:before-last before-last)])]
          [r (if (eq? after-last   none) r (append r (list after-last)))]
          [r (if (eq? before-first none) r (cons before-first r))])
     (apply string-append r)))


### PR DESCRIPTION
The pattern `(string-join xs "")` is widespread (from Python),
so we can special-case it, improving its performance significantly.

With `(define xs (make-list 10000000 "a"))`

Before the PR:

- `(string-join xs "")`: cpu time: 3158 real time: 3361 gc time: 2342
- `(string-append* xs)`: cpu time: 668 real time: 681 gc time: 427

After the PR:

- `(string-join xs "")`: cpu time: 720 real time: 748 gc time: 432
- `(string-join xs "" #:before-last " ")`: cpu time: 1083 real time: 1119 gc time: 727
- `(string-append* xs)`: cpu time: 662 real time: 682 gc time: 409