### PR TITLE
Add #:groups, #:group-sep and #:decimal-sep keywords to ~r

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/format.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/format.scrbl
@@ -231,7 +231,10 @@ marker is @racket["..."].
                 (or/c #f string? (-> exact-integer? string?))
                 #f]
                [#:min-width min-width exact-positive-integer? 1]
-               [#:pad-string pad-string non-empty-string? " "])
+               [#:pad-string pad-string non-empty-string? " "]
+               [#:groups groups (listof exact-positive-integer?) '()]
+               [#:group-sep group-sep string? ""]
+               [#:decimal-sep decimal-sep string? "."])
          string?]{
 
 Converts the rational number @racket[x] to a string in either
@@ -281,6 +284,26 @@ decimal point are used, and the decimal point is never dropped.
 (~r 50 #:precision 2)
 (~r 50 #:precision '(= 2))
 (~r 50 #:precision '(= 0))
+]}
+
+@item{@racket[decimal-sep] specifies what decimal separator is printed.
+
+@examples[#:eval the-eval
+(~r 123.456)
+(~r 123.456 #:decimal-sep ",")
+]}
+
+@item{@racket[groups] controls how digits of the integral part of the number 
+   are separated into groups.
+   Rightmost numbers of @racket[groups] are used to group rightmost digits of the integral part.
+   The leftmost number of @racket[groups] is used repeatedly to group leftmost digits.
+   @racket[group-sep] specifies which separator to use between digit groups.
+       
+
+   @examples[#:eval the-eval
+(~r 1234567890 #:groups '(3) #:group-sep ",")
+(~r 1234567890 #:groups '(3 2) #:group-sep ",")
+(~r 1234567890 #:groups '(1 3 2) #:group-sep "_")
 ]}
 
 @item{@racket[min-width] --- if @racket[x] would normally be printed
@@ -402,6 +425,8 @@ the resulting string is appended to the significand:
 ]}
 
 ]
+@history[#:changed "8.5.0.3"
+         @elem{Added @racket[#:groups], @racket[#:groups-sep] and @racket[#:decimal-sep].}]
 }
 
 @; ----------------------------------------

--- a/pkgs/racket-doc/scribblings/reference/format.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/format.scrbl
@@ -232,7 +232,7 @@ marker is @racket["..."].
                 #f]
                [#:min-width min-width exact-positive-integer? 1]
                [#:pad-string pad-string non-empty-string? " "]
-               [#:groups groups (listof exact-positive-integer?) '()]
+               [#:groups groups (non-empty-listof exact-positive-integer?) '(3)]
                [#:group-sep group-sep string? ""]
                [#:decimal-sep decimal-sep string? "."])
          string?]{
@@ -426,7 +426,7 @@ the resulting string is appended to the significand:
 
 ]
 @history[#:changed "8.5.0.3"
-         @elem{Added @racket[#:groups], @racket[#:groups-sep] and @racket[#:decimal-sep].}]
+         @elem{Added @racket[#:groups], @racket[#:group-sep] and @racket[#:decimal-sep].}]
 }
 
 @; ----------------------------------------

--- a/pkgs/racket-doc/scribblings/reference/format.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/format.scrbl
@@ -297,7 +297,7 @@ decimal point are used, and the decimal point is never dropped.
    are separated into groups.
    Rightmost numbers of @racket[groups] are used to group rightmost digits of the integral part.
    The leftmost number of @racket[groups] is used repeatedly to group leftmost digits.
-   @racket[group-sep] specifies which separator to use between digit groups.
+   The @racket[group-sep] argument specifies which separator to use between digit groups.
        
 
    @examples[#:eval the-eval
@@ -425,7 +425,7 @@ the resulting string is appended to the significand:
 ]}
 
 ]
-@history[#:changed "8.5.0.3"
+@history[#:changed "8.5.0.5"
          @elem{Added @racket[#:groups], @racket[#:group-sep] and @racket[#:decimal-sep].}]
 }
 

--- a/pkgs/racket-test/tests/racket/format.rkt
+++ b/pkgs/racket-test/tests/racket/format.rkt
@@ -321,6 +321,15 @@
 (tc (~r #:notation 'exponential 0 #:precision '(= 4))
     "0.0000e+00")
 
+(tc (~r 123456789.123)
+    "123456789.123")
+(tc (~r 1023456789.123 #:groups '(3) #:group-sep "," #:decimal-sep ".")
+    "1,023,456,789.123")
+(tc (~r 21231234567890 #:groups '(4 2 3) #:group-sep "_")
+    "2_1231_2345_67_890")
+(tc (~r 1234567890.123 #:groups '(3 2) #:group-sep "**" #:decimal-sep "::")
+    "12**345**678**90::123")
+
 ;; some random testing for exponential notation
 ;;  - only positive numbers
 ;;  - limited number of digits, exponent range

--- a/racket/collects/racket/format.rkt
+++ b/racket/collects/racket/format.rkt
@@ -69,7 +69,7 @@
            #:format-exponent (or/c #f string? (-> exact-integer? string?))
            #:min-width exact-positive-integer?
            #:pad-string padding/c
-           #:groups (listof exact-positive-integer?)
+           #:groups (non-empty-listof exact-positive-integer?)
            #:group-sep string?
            #:decimal-sep string?)
           string?)])
@@ -197,7 +197,7 @@
             #:format-exponent [exp-format-exponent #f]
             #:min-width [pad-digits-to 1]
             #:pad-string [digits-padding " "]
-            #:groups [groups '()]
+            #:groups [groups '(3)]
             #:group-sep [group-sep ""]
             #:decimal-sep [decimal-sep "."])
   (let ([notation (if (procedure? notation) (notation N) notation)])

--- a/racket/collects/racket/format.rkt
+++ b/racket/collects/racket/format.rkt
@@ -464,7 +464,7 @@
 
 (define (number->string*/whole-positional N base upper? groups group-sep)
   (if (zero? N)
-    "0"
+    (string #\0)
     (let ([Nstr (number->string* N base upper?)])
       (if (string=? group-sep "")
         Nstr
@@ -477,14 +477,12 @@
   (let ([s (number->string* N base upper?)])
     (string-append (make-string (max 0 (- precision (string-length s))) #\0) s)))
 
-(define A-10 (- (char->integer #\A) 10))
-(define a-10 (- (char->integer #\a) 10))
-(define char0 (char->integer #\0))
-
 ;; Allow base up to 36!
 (define (get-digit d upper?)
-  (cond [(< d 10) (integer->char (+ d char0))]
-        [else (integer->char (+ d (if upper? A-10 a-10)))]))
+  (cond [(< d 10) (integer->char (+ d (char->integer #\0)))]
+        [else (integer->char (+ d (if upper?
+                                    (- (char->integer #\A) 10)
+                                    (- (char->integer #\a) 10))))]))
 
 ;; round* : nonnegative-real -> nonnegative-integer (preserving exactness)
 ;; Implements "round half up" rounding (thus this library formats using

--- a/racket/collects/racket/format.rkt
+++ b/racket/collects/racket/format.rkt
@@ -455,7 +455,7 @@
                (string-upcase s)
                s))]
         [(zero? N)
-         (string #\0)]
+         "0"]
         [else
          (let loop ([N N] [digits null])
            (cond [(zero? N) (apply string digits)]
@@ -464,19 +464,14 @@
 
 (define (number->string*/whole-positional N base upper? groups group-sep)
   (if (zero? N)
-    (string #\0)    
-    (let loop ([N N] [digits null])
-      (cond
-        [(zero? N)
-         (apply string
-                (if (string=? group-sep "")
-                  digits
-                  (separate-groups (reverse digits)
-                                   (reverse groups)
-                                   (string->list group-sep))))]
-        [else
-         (let-values ([(q r) (quotient/remainder N base)])
-           (loop q (cons (get-digit r upper?) digits)))]))))
+    "0"
+    (let ([Nstr (number->string* N base upper?)])
+      (if (string=? group-sep "")
+        Nstr
+        (apply string
+               (separate-groups (reverse (string->list Nstr))
+                                (reverse groups)
+                                (string->list group-sep)))))))
 
 (define (number->fraction-string N base upper? precision)
   (let ([s (number->string* N base upper?)])


### PR DESCRIPTION
It can be difficult to read very large integers, and I often find myself grouping digits with my finger or mouse pointer on the screen. I figured it would be smarter to tackle the problem at the core. Digits can be grouped not only 3 by 3, but also more generally by groups of varying sizes (for example the Indian system groups the first 2 digits, then groups digits 3 by 3).

Additionally, this PR also introduces the `#:decimal-sep` option to `~r`, because not all languages or conventions use `.` as a decimal separator and it makes sense to allow for changing the decimal separator if the group separator can be changed too.

This PR does _not_ group digits after the decimal separator, because i) default floats have only small precision that don't require much grouping (by contrast to integers) ii) because I don't really have a use case for it myself and iii) because it took me long enough already to getting around to finish this small PR.