### PR TITLE
Allow showing arbitrary pass results.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/compiler.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/compiler.scrbl
@@ -119,6 +119,11 @@ forms or adjust the way forms are displayed:
          form after transformation by Chez Scheme's front-end
          optimizer}
 
+   @item{@envvar-indexed{PLT_LINKLET_SHOW_PASSES} --- show the
+         intermediate form of a schemified linklet after the specified
+         passes (listed space-separated) in Chez Scheme's internal
+         representation}
+
    @item{@envvar-indexed{PLT_LINKLET_SHOW_ASSEMBLY} --- show the
          compiled form of a schemified linklet in Chez Scheme's
          abstraction of machine instructions}


### PR DESCRIPTION
Here's an example of the output:

```
$ PLT_LINKLET_SHOW_PASSES="cpnanopass np-recognize-let" racket -e 1
;; linklet ---------------------
(linklet
  ((.top-level-bind! .top-level-require!)
    (.mpi-vector .syntax-literals)
    (.namespace .phase .self .inspector .bulk-binding-registry
      .set-transformer!))
  ()
  1)
;; schemified ---------------------
(lambda (instance-variable-reference .top-level-bind!1
         .top-level-require!2 .mpi-vector3 .syntax-literals4
         .namespace5 .phase6 .self7 .inspector8
         .bulk-binding-registry9 .set-transformer!10)
  1)
;; cpnanopass np-recognize-let ---------------------
output of cpnanopass:
(case-lambda
  [clause
   ()
   0
   (case-lambda
     [clause
      (#{instance-variable-reference n4kgr6aybd814a9h7f37s1lxn-0} #{\x2E;top-level-bind!1 n4kgr6aybd814a9h7f37s1lxn-1}
        #{\x2E;top-level-require!2 n4kgr6aybd814a9h7f37s1lxn-2}
        #{\x2E;mpi-vector3 n4kgr6aybd814a9h7f37s1lxn-3}
        #{\x2E;syntax-literals4 n4kgr6aybd814a9h7f37s1lxn-4}
        #{\x2E;namespace5 n4kgr6aybd814a9h7f37s1lxn-5}
        #{\x2E;phase6 n4kgr6aybd814a9h7f37s1lxn-6}
        #{\x2E;self7 n4kgr6aybd814a9h7f37s1lxn-7}
        #{\x2E;inspector8 n4kgr6aybd814a9h7f37s1lxn-8}
        #{\x2E;bulk-binding-registry9 n4kgr6aybd814a9h7f37s1lxn-9}
        #{\x2E;set-transformer!10 n4kgr6aybd814a9h7f37s1lxn-10})
      11
      '1])])
output of np-recognize-let:
(case-lambda
  [clause
   ()
   0
   (case-lambda
     [clause
      (#{instance-variable-reference n4kgr6aybd814a9h7f37s1lxn-0} #{\x2E;top-level-bind!1 n4kgr6aybd814a9h7f37s1lxn-1}
        #{\x2E;top-level-require!2 n4kgr6aybd814a9h7f37s1lxn-2}
        #{\x2E;mpi-vector3 n4kgr6aybd814a9h7f37s1lxn-3}
        #{\x2E;syntax-literals4 n4kgr6aybd814a9h7f37s1lxn-4}
        #{\x2E;namespace5 n4kgr6aybd814a9h7f37s1lxn-5}
        #{\x2E;phase6 n4kgr6aybd814a9h7f37s1lxn-6}
        #{\x2E;self7 n4kgr6aybd814a9h7f37s1lxn-7}
        #{\x2E;inspector8 n4kgr6aybd814a9h7f37s1lxn-8}
        #{\x2E;bulk-binding-registry9 n4kgr6aybd814a9h7f37s1lxn-9}
        #{\x2E;set-transformer!10 n4kgr6aybd814a9h7f37s1lxn-10})
      11
      '1])])
;; compiled ---------------------
done
```