### PR TITLE
make the phrase "core form" searchable in the docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -449,7 +449,7 @@ things:
        identifier (third case in the previous enumeration), and
        parsing continues.}
 
- @item{A core @deftech{syntactic form}, which is parsed as described
+ @item{A core @deftech{syntactic form} (often abbreviated as @deftech{core form}), which is parsed as described
        for each form in @secref["syntax"]. Parsing a core syntactic
        form typically involves recursive parsing of sub-forms, and may
        introduce @tech{bindings} that determine the parsing of


### PR DESCRIPTION
i've heard the phrase "core form" to refer to the core syntactic forms more often than not, but i noticed it isn't searchable in the docs to find what that means. this commit is a suggestion for addressing that