### PR TITLE
doc: fix incorrect usage of syntax-case

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
@@ -1397,8 +1397,9 @@ Often used in combination with @racket[expand-import].
    (lambda (stx)
      (syntax-case stx ()
        [(_ path)
-        (printf "Importing: ~a~n" #'path)
-        (expand-import #'path)]))))
+        (begin
+          (printf "Importing: ~a~n" #'path)
+          (expand-import #'path))]))))
 
 (require (printing racket/match))
 ]}


### PR DESCRIPTION
printf call here is definitely not meant to be a guard.
Wraps them in begin so that there is only one form.