### PR TITLE
add hash-map/copy and dict-map/copy

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/dicts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/dicts.scrbl
@@ -557,6 +557,32 @@ Supported for any @racket[dict] that implements @racket[dict-iterate-first],
 ]}
 
 
+@defproc[(dict-map/copy [dict dict?]
+                        [proc (any/c any/c . -> . (values any/c any/c))])
+         dict?]{
+
+Applies the procedure @racket[proc] to each element in
+@racket[dict] in an unspecified order, accumulating the results
+into a dict of the same kind.
+The procedure @racket[proc] is called each time with a key
+and its value, and must return a corresponding key and
+value.
+
+Supported for any @racket[dict] that implements
+@racket[dict-iterate-first], @racket[dict-iterate-next],
+@racket[dict-iterate-key], and @racket[dict-iterate-value],
+and either @racket[dict-set] and @racket[dict-clear], or
+@racket[dict-set!], @racket[dict-copy], and
+@racket[dict-clear!].
+
+@examples[
+#:eval dict-eval
+(dict-map/copy #hash((a . "apple") (b . "banana")) (lambda (k v) (values k (string-upcase v))))
+]
+
+@history[#:added "8.5.0.2"]}
+
+
 @defproc[(dict-for-each [dict dict?]
                         [proc (any/c any/c . -> . any)])
          void?]{

--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -570,6 +570,22 @@ with the following order (earlier bullets before later):
 @history[#:changed "6.3" @elem{Added the @racket[try-order?] argument.}
          #:changed "7.1.0.7" @elem{Added guarantees for @racket[try-order?].}]}
 
+@defproc[(hash-map/copy [hash hash?]
+                        [proc (any/c any/c . -> . (values any/c any/c))])
+         hash?]{
+
+Applies the procedure @racket[proc] to each element in
+@racket[hash] in an unspecified order, accumulating the results
+into a new hash of the same kind, with the same key-comparison
+procedure and mutability of @racket[hash].
+
+@examples[
+#:eval the-eval
+(hash-map/copy #hash((a . "apple") (b . "banana")) (lambda (k v) (values k (string-upcase v))))
+]
+
+@history[#:added "8.5.0.2"]}
+
 @defproc[(hash-keys [hash hash?] [try-order? any/c #f])
          (listof any/c)]{
 Returns a list of the keys of @racket[hash] in an unspecified order.

--- a/pkgs/racket-test-core/tests/racket/dict.rktl
+++ b/pkgs/racket-test-core/tests/racket/dict.rktl
@@ -3,7 +3,7 @@
 
 (Section 'dict)
 
-(require scheme/dict)
+(require scheme/dict racket/generic)
 
 ;; Currently relying on the `map' an `for-each' to test `dict-iterate-...',
 ;; and custom hashes to test `prop:dict' use.
@@ -117,6 +117,75 @@
           (try-add d "ONE")
           (try-add d 'one)))))
 
+(define (dict-set/list d kvs)
+  (for/fold ([acc d]) ([kv (in-list kvs)])
+    (dict-set acc (car kv) (cdr kv))))
+
+(define (dict-set!/list d kvs)
+  (for ([kv (in-list kvs)])
+    (dict-set! d (car kv) (cdr kv))))
+
+(define (dict-new d kvs)
+  (cond
+    [(dict-can-functional-set? d)
+     (dict-set/list (dict-clear d) kvs)]
+    [(dict-mutable? d)
+     (define dn (dict-copy d))
+     (dict-clear! dn)
+     (dict-set!/list dn kvs)
+     dn]
+    [else
+     (error 'dict-new "expected a functional or mutable dict, given ~v" d)]))
+
+(define (dict=? a b)
+  (and (for/and ([(k av) (in-dict a)])
+         (and (dict-has-key? b k) (equal? av (dict-ref b k))))
+       (for/and ([(k bv) (in-dict b)])
+         (and (dict-has-key? a k) (equal? (dict-ref a k) bv)))))
+
+(define (test-dict-map/copy d d?)
+  (define (make-dict kvs) (dict-new d kvs))
+  (test "apple" dict-ref (make-dict '((a . "apple") (b . "banana"))) 'a)
+  (test "banana" dict-ref (make-dict '((a . "apple") (b . "banana"))) 'b)
+  (test "go fish" dict-ref (make-dict '((a . "apple") (b . "banana"))) 'c "go fish")
+  (test #t d? (make-dict '()))
+  (test #t d? (make-dict '((a . "apple") (b . "banana"))))
+  (test/compare dict=? (make-dict '()) make-dict '())
+  (test/compare dict=?
+                (make-dict '((a . "apple") (b . "banana")))
+                make-dict
+                '((b . "banana") (a . "apple")))
+  (test/compare dict=?
+                '((a . "apple") (b . "banana"))
+                dict->list
+                (make-dict '((a . "apple") (b . "banana"))))
+  (test/compare dict=?
+                '((a . "APPLE") (b . "BANANA"))
+                dict-map
+                (make-dict '((a . "apple") (b . "banana")))
+                (λ (k v)
+                  (cons k (string-upcase v))))
+  (test/compare dict=?
+                '((a . "APPLE") (b . "BANANA"))
+                dict-map
+                (make-dict '((a . "apple") (b . "banana")))
+                (λ (k v)
+                  (cons k (string-upcase v))))
+  (test #t
+        d?
+        (dict-map/copy
+         (make-dict '((a . "apple") (b . "banana")))
+         (λ (k v)
+           (values k (string-upcase v)))))
+  (test/compare dict=?
+                (make-dict '((a . "APPLE") (b . "BANANA")))
+                dict-map/copy
+                (make-dict '((a . "apple") (b . "banana")))
+                (λ (k v)
+                  (values k (string-upcase v)))))
+
+;; ---------------------------------------------------------
+
 (try-simple (vector 'zero 'one 'two) #t #t #f #f)
 (try-simple #hash((1 . one) (#f . 7)) #f #f #t #t)
 
@@ -133,11 +202,37 @@
 (try-simple '((0 . zero) (1 . one)) #t #f #t #t)
 (try-simple '((1 . one) (0 . zero)) #t #f #t #t)
 
+(test-dict-map/copy '() (listof pair?))
+(test-dict-map/copy (hash) (and/c hash? hash-equal? immutable?))
+(test-dict-map/copy (hasheqv) (and/c hash? hash-eqv? immutable?))
+(test-dict-map/copy (hasheq) (and/c hash? hash-eq? immutable?))
+(test-dict-map/copy (make-hash)
+                      (and/c hash? hash-equal? (not/c immutable?)))
+(test-dict-map/copy (make-hasheqv)
+                      (and/c hash? hash-eqv? (not/c immutable?)))
+(test-dict-map/copy (make-hasheq)
+                      (and/c hash? hash-eq? (not/c immutable?)))
+(test-dict-map/copy (make-weak-hash)
+                      (and/c hash? hash-equal? hash-weak?))
+(test-dict-map/copy (make-weak-hasheqv)
+                      (and/c hash? hash-eqv? hash-weak?))
+(test-dict-map/copy (make-weak-hasheq)
+                      (and/c hash? hash-eq? hash-weak?))
+(test-dict-map/copy (make-ephemeron-hash)
+                      (and/c hash? hash-equal? hash-ephemeron?))
+(test-dict-map/copy (make-ephemeron-hasheqv)
+                      (and/c hash? hash-eqv? hash-ephemeron?))
+(test-dict-map/copy (make-ephemeron-hasheq)
+                      (and/c hash? hash-eq? hash-ephemeron?))
+
 (let ()
   (define (key? x) #t)
   (define (key-code a rec) (rec (format "~a" a)))
   (define (key=? x y rec) (rec (format "~a" x) (format "~a" y)))
   (define-custom-hash-types string-hash #:key? key? key=? key-code)
+
+  (test-dict-map/copy (make-mutable-string-hash) mutable-string-hash?)
+  (test-dict-map/copy (make-immutable-string-hash) immutable-string-hash?)
   
   (try-simple (let ([h (make-mutable-string-hash)])
                 (dict-set! h "1" 'one)
@@ -172,6 +267,126 @@
 (test '((a 1) (b 2) (a 3)) dict-map '((a . 1) (b . 2) (a . 3)) list)
 (test '(a b a) dict-keys '((a . 1) (b . 2) (a . 3)))
 (test '(1 2 3) dict-values '((a . 1) (b . 2) (a . 3)))
+
+(let ()
+  ;; immutable wrapping immutable
+  (define-struct idict (inside)
+    #:methods gen:dict
+    [(define/generic inside-ref dict-ref)
+     (define/generic inside-set dict-set)
+     (define/generic inside-clear dict-clear)
+     (define/generic inside-iterate-first dict-iterate-first)
+     (define/generic inside-iterate-next dict-iterate-next)
+     (define/generic inside-iterate-key dict-iterate-key)
+     (define/generic inside-iterate-value dict-iterate-value)
+     (define (dict-ref dict key
+                       [default (lambda () (error "key not found" key))])
+       (inside-ref (idict-inside dict) key default))
+     (define (dict-set dict key val)
+       (idict (inside-set (idict-inside dict) key val)))
+     (define (dict-clear dict)
+       (idict (inside-clear (idict-inside dict))))
+     (define (dict-iterate-first dict)
+       (inside-iterate-first (idict-inside dict)))
+     (define (dict-iterate-next dict pos)
+       (inside-iterate-next (idict-inside dict) pos))
+     (define (dict-iterate-key dict pos)
+       (inside-iterate-key (idict-inside dict) pos))
+     (define (dict-iterate-value dict pos)
+       (inside-iterate-value (idict-inside dict) pos))])
+
+  ;; mutable wrapping mutable
+  (define-struct mdict (inside)
+    #:methods gen:dict
+    [(define/generic inside-ref dict-ref)
+     (define/generic inside-set! dict-set!)
+     (define/generic inside-copy dict-copy)
+     (define/generic inside-remove! dict-remove!)
+     (define/generic inside-iterate-first dict-iterate-first)
+     (define/generic inside-iterate-next dict-iterate-next)
+     (define/generic inside-iterate-key dict-iterate-key)
+     (define/generic inside-iterate-value dict-iterate-value)
+     (define (dict-ref dict key
+                       [default (lambda () (error "key not found" key))])
+       (inside-ref (mdict-inside dict) key default))
+     (define (dict-set! dict key val)
+       (inside-set! (mdict-inside dict) key val))
+     (define (dict-copy dict)
+       (mdict (inside-copy (mdict-inside dict))))
+     (define (dict-remove! dict key)
+       (inside-remove! (mdict-inside dict) key))
+     (define (dict-iterate-first dict)
+       (inside-iterate-first (mdict-inside dict)))
+     (define (dict-iterate-next dict pos)
+       (inside-iterate-next (mdict-inside dict) pos))
+     (define (dict-iterate-key dict pos)
+       (inside-iterate-key (mdict-inside dict) pos))
+     (define (dict-iterate-value dict pos)
+       (inside-iterate-value (mdict-inside dict) pos))])
+
+  ;; mutable wrapping immutable
+  (define idict-set dict-set)
+  (define idict-remove dict-remove)
+  (define-struct mdicti (inside) #:mutable
+    #:methods gen:dict
+    [(define/generic inside-ref dict-ref)
+     (define/generic inside-iterate-first dict-iterate-first)
+     (define/generic inside-iterate-next dict-iterate-next)
+     (define/generic inside-iterate-key dict-iterate-key)
+     (define/generic inside-iterate-value dict-iterate-value)
+     (define (dict-ref dict key
+                       [default (lambda () (error "key not found" key))])
+       (inside-ref (mdicti-inside dict) key default))
+     (define (dict-set! dict key val)
+       (set-mdicti-inside! dict (idict-set (mdicti-inside dict) key val)))
+     (define (dict-copy dict)
+       (mdicti (mdicti-inside dict)))
+     (define (dict-remove! dict key)
+       (set-mdicti-inside! dict (idict-remove (mdicti-inside dict) key)))
+     (define (dict-iterate-first dict)
+       (inside-iterate-first (mdicti-inside dict)))
+     (define (dict-iterate-next dict pos)
+       (inside-iterate-next (mdicti-inside dict) pos))
+     (define (dict-iterate-key dict pos)
+       (inside-iterate-key (mdicti-inside dict) pos))
+     (define (dict-iterate-value dict pos)
+       (inside-iterate-value (mdicti-inside dict) pos))])
+
+  ;; immutable wrapping mutable by copying state
+  (define mdict-set! dict-set!)
+  (define mdict-copy dict-copy)
+  (define mdict-clear! dict-clear!)
+  (define-struct idictm (inside)
+    #:methods gen:dict
+    [(define/generic inside-ref dict-ref)
+     (define/generic inside-iterate-first dict-iterate-first)
+     (define/generic inside-iterate-next dict-iterate-next)
+     (define/generic inside-iterate-key dict-iterate-key)
+     (define/generic inside-iterate-value dict-iterate-value)
+     (define (dict-ref dict key
+                       [default (lambda () (error "key not found" key))])
+       (inside-ref (idictm-inside dict) key default))
+     (define (dict-set dict key val)
+       (define copy (mdict-copy (idictm-inside dict)))
+       (mdict-set! copy key val)
+       (idictm copy))
+     (define (dict-clear dict)
+       (define copy (mdict-copy (idictm-inside dict)))
+       (mdict-clear! copy)
+       (idictm copy))
+     (define (dict-iterate-first dict)
+       (inside-iterate-first (idictm-inside dict)))
+     (define (dict-iterate-next dict pos)
+       (inside-iterate-next (idictm-inside dict) pos))
+     (define (dict-iterate-key dict pos)
+       (inside-iterate-key (idictm-inside dict) pos))
+     (define (dict-iterate-value dict pos)
+       (inside-iterate-value (idictm-inside dict) pos))])
+
+  (test-dict-map/copy (idict '()) idict?)
+  (test-dict-map/copy (mdict (make-hash)) mdict?)
+  (test-dict-map/copy (mdicti '()) mdicti?)
+  (test-dict-map/copy (idictm (make-hash)) idictm?))
 
 ;; ----------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -723,7 +723,11 @@
 
   (test (void) hash-for-each (hash 'one 1) (proc void))
   (test (void) hash-for-each (hasheq 'one 1) (proc void))
-  (test (void) hash-for-each (hasheqv 'one 1) (proc void)))
+  (test (void) hash-for-each (hasheqv 'one 1) (proc void))
+
+  (test (hash 'one 2) hash-map/copy (hash 'one 1) (proc (lambda (k v) (values k (add1 v)))))
+  (test (hasheq 'one 2) hash-map/copy (hasheq 'one 1) (proc (lambda (k v) (values k (add1 v)))))
+  (test (hasheqv 'one 2) hash-map/copy (hasheqv 'one 1) (proc (lambda (k v) (values k (add1 v))))))
 
 ;; ----------------------------------------
 
@@ -804,6 +808,17 @@
 (test #t hash-equal? (hash-copy-clear (make-ephemeron-hash)))
 (test #t hash-eq? (hash-copy-clear (make-ephemeron-hasheq)))
 (test #t hash-eqv? (hash-copy-clear (make-ephemeron-hasheqv)))
+
+;; ----------------------------------------
+
+(for ([make-hash
+       (in-list
+        (list make-immutable-hash make-immutable-hasheq make-immutable-hasheqv
+              make-hash make-hasheq make-hasheqv
+              make-weak-hash make-weak-hasheq make-weak-hasheqv
+              make-ephemeron-hash make-ephemeron-hasheq make-ephemeron-hasheqv))])
+  (define (10*v k v) (values k (* 10 v)))
+  (test (make-hash '((a . 10) (b . 20))) hash-map/copy (make-hash '((a . 1) (b . 2))) 10*v))
 
 ;; ----------------------------------------
 

--- a/racket/collects/racket/dict.rkt
+++ b/racket/collects/racket/dict.rkt
@@ -245,6 +245,11 @@
  [dict-for-each
   (->i ([d dict?] [proc (d) (-> (dict-key-contract d) (dict-value-contract d) any)])
        [_r void?])]
+ [dict-map/copy
+  (->i ([d dict?]
+        [proc (d) (-> (dict-key-contract d) (dict-value-contract d)
+                      (values (dict-key-contract d) (dict-value-contract d)))])
+       [_r dict?])]
 
  [dict-keys
   (->i ([d dict?])

--- a/racket/collects/racket/private/dict.rkt
+++ b/racket/collects/racket/private/dict.rkt
@@ -291,7 +291,7 @@
     (cdr x)))
 
 (define (fallback-copy d)
-  (unless (dict-implements? d 'dict-clear dict-set!)
+  (unless (dict-implements? d 'dict-clear 'dict-set!)
     (raise-support-error 'dict-copy d))
   (define d2 (dict-clear d))
   (for ([(k v) (in-dict d)])

--- a/racket/collects/racket/private/dict.rkt
+++ b/racket/collects/racket/private/dict.rkt
@@ -265,6 +265,13 @@
       (raise-argument-error 'dict-map "dict?" d))
     (proc (car x) (cdr x))))
 
+(define (assoc-map/copy d proc)
+  (for/list ([x (in-list d)])
+    (unless (pair? x)
+      (raise-argument-error 'dict-map/copy "dict?" d))
+    (define-values [k v] (proc (car x) (cdr x)))
+    (cons k v)))
+
 (define (assoc-for-each d proc)
   (for ([x (in-list d)])
     (unless (pair? x)
@@ -325,6 +332,23 @@
   (for ([(k v) (:in-dict d)])
     (f k v)))
 
+(define (fallback-map/copy d f)
+  (cond
+    [(dict-can-functional-set? d)
+     (for/fold ([acc (dict-clear d)])
+               ([(k1 v1) (:in-dict d)])
+       (define-values [k2 v2] (f k1 v1))
+       (dict-set acc k2 v2))]
+    [(dict-mutable? d)
+     (define acc (dict-copy d))
+     (dict-clear! acc)
+     (for ([(k1 v1) (:in-dict d)])
+       (define-values [k2 v2] (f k1 v1))
+       (dict-set! acc k2 v2))
+     acc]
+    [else
+     (raise-support-error 'dict-map/copy d)]))
+
 (define (fallback-keys d)
   (for/list ([k (:in-dict-keys d)])
     k))
@@ -354,13 +378,14 @@
     (define dict-set*! hash-set*!)
     (define dict-update! hash-update!)
     (define dict-map hash-map)
+    (define dict-map/copy hash-map/copy)
     (define dict-for-each hash-for-each)
     (define dict-keys hash-keys)
     (define dict-values hash-values)
     (define dict->list hash->list)
     (define dict-copy hash-copy)
     (define dict-empty? hash-empty?)
-    (define dict-clear hash-clear)
+    (define dict-clear hash-copy-clear)
     (define dict-clear! hash-clear!)]
    [immutable-hash? immutable-hash?
     (define dict-ref hash-ref)
@@ -375,6 +400,7 @@
     (define dict-set* hash-set*)
     (define dict-update hash-update)
     (define dict-map hash-map)
+    (define dict-map/copy hash-map/copy)
     (define dict-for-each hash-for-each)
     (define dict-keys hash-keys)
     (define dict-values hash-values)
@@ -424,6 +450,7 @@
     (define dict-iterate-value assoc-iterate-value)
     (define dict-has-key? assoc-has-key?)
     (define dict-map assoc-map)
+    (define dict-map/copy assoc-map/copy)
     (define dict-for-each assoc-for-each)
     (define dict-keys assoc-keys)
     (define dict-values assoc-values)
@@ -440,6 +467,7 @@
    (define dict-update fallback-update)
    (define dict-count fallback-count)
    (define dict-map fallback-map)
+   (define dict-map/copy fallback-map/copy)
    (define dict-for-each fallback-for-each)
    (define dict-keys fallback-keys)
    (define dict-values fallback-values)
@@ -466,6 +494,7 @@
   (dict-update! dict key proc [default])
   (dict-update dict key proc [default])
   (dict-map dict proc)
+  (dict-map/copy dict proc)
   (dict-for-each dict proc)
   (dict-keys dict)
   (dict-values dict)
@@ -651,6 +680,7 @@
          dict-update!
          dict-update
          dict-map
+         dict-map/copy
          dict-for-each
          dict-keys
          dict-values

--- a/racket/collects/racket/private/hash.rkt
+++ b/racket/collects/racket/private/hash.rkt
@@ -96,6 +96,8 @@
   (define (hash-map/copy table f)
     (unless (hash? table)
       (raise-argument-error 'hash-map/copy "hash?" table))
+    (unless (and (procedure? f) (procedure-arity-includes? f 2))
+      (raise-argument-error 'hash-map/copy "(procedure-arity-includes/c 2)" f))
     (cond
      [(immutable? table)
       (for/fold ([acc (hash-copy-clear table)])

--- a/racket/collects/racket/private/hash.rkt
+++ b/racket/collects/racket/private/hash.rkt
@@ -93,6 +93,22 @@
        [(hash-eqv? table) (make-hasheqv)]
        [(hash-eq? table) (make-hasheq)])]))
 
+  (define (hash-map/copy table f)
+    (unless (hash? table)
+      (raise-argument-error 'hash-map/copy "hash?" table))
+    (cond
+     [(immutable? table)
+      (for/fold ([acc (hash-copy-clear table)])
+                ([(k1 v1) (in-hash table)])
+        (define-values [k2 v2] (f k1 v1))
+        (hash-set acc k2 v2))]
+     [else
+      (define acc (hash-copy-clear table))
+      (for ([(k1 v1) (in-hash table)])
+        (define-values [k2 v2] (f k1 v1))
+        (hash-set! acc k2 v2))
+      acc]))
+
   (define (hash-empty? table)
     (unless (hash? table)
       (raise-argument-error 'hash-empty? "hash?" table))
@@ -105,4 +121,5 @@
            hash-set*
            hash-set*!
            hash-empty?
-           hash-copy-clear))
+           hash-copy-clear
+           hash-map/copy))

--- a/racket/collects/racket/private/hash.rkt
+++ b/racket/collects/racket/private/hash.rkt
@@ -99,7 +99,7 @@
     (cond
      [(immutable? table)
       (for/fold ([acc (hash-copy-clear table)])
-                ([(k1 v1) (in-hash table)])
+                ([(k1 v1) (in-immutable-hash table)])
         (define-values [k2 v2] (f k1 v1))
         (hash-set acc k2 v2))]
      [else

--- a/racket/collects/syntax/strip-context.rkt
+++ b/racket/collects/syntax/strip-context.rkt
@@ -26,17 +26,8 @@
                 k
                 (replace-context ctx (struct->list e))))]
    [(hash? e)
-    (cond
-      [(hash-eq? e)
-       (for/hasheq ([(k v) (in-hash e)])
-         (values (replace-context ctx k)
-                 (replace-context ctx v)))]
-      [(hash-eqv? e)
-       (for/hasheqv ([(k v) (in-hash e)])
-         (values (replace-context ctx k)
-                 (replace-context ctx v)))]
-      [else
-       (for/hash ([(k v) (in-hash e)])
-         (values (replace-context ctx k)
-                 (replace-context ctx v)))])]
+    (hash-map/copy e
+                   (lambda (k v)
+                     (values (replace-context ctx k)
+                             (replace-context ctx v))))]
    [else e]))

--- a/racket/src/expander/compile/correlated-linklet.rkt
+++ b/racket/src/expander/compile/correlated-linklet.rkt
@@ -90,16 +90,9 @@
             (hash-set (or ht '#hasheq()) k p)
             ht)))]
     [(hash? v)
-     (cond
-       [(hash-eq? v)
-        (for/hasheq ([(key value) (in-hash v)])
-          (values (->faslable key) (->faslable value)))]
-       [(hash-eqv? v)
-        (for/hasheqv ([(key value) (in-hash v)])
-          (values (->faslable key) (->faslable value)))]
-       [else
-        (for/hash ([(key value) (in-hash v)])
-          (values (->faslable key) (->faslable value)))])]
+     (hash-map/copy v
+                    (lambda (key value)
+                      (values (->faslable key) (->faslable value))))]
     [(correlated-linklet? v)
      (faslable-correlated-linklet (->faslable (correlated-linklet-expr v))
                                   (->faslable (correlated-linklet-name v)))]
@@ -133,16 +126,9 @@
            (correlated-property c k p))
          c)]
     [(hash? v)
-     (cond
-       [(hash-eq? v)
-        (for/hasheq ([(key value) (in-hash v)])
-          (values (faslable-> key) (faslable-> value)))]
-       [(hash-eqv? v)
-        (for/hasheqv ([(key value) (in-hash v)])
-          (values (faslable-> key) (faslable-> value)))]
-       [else
-        (for/hash ([(key value) (in-hash v)])
-          (values (faslable-> key) (faslable-> value)))])]
+     (hash-map/copy v
+                    (lambda (key value)
+                      (values (faslable-> key) (faslable-> value))))]
     [(faslable-correlated-linklet? v)
      (make-correlated-linklet (faslable-> (faslable-correlated-linklet-expr v))
                               (faslable-> (faslable-correlated-linklet-name v)))]

--- a/racket/src/expander/syntax/datum-map.rkt
+++ b/racket/src/expander/syntax/datum-map.rkt
@@ -85,19 +85,10 @@
                      (for/list ([e (in-vector (struct->vector s) 1)])
                        (loop #f e seen)))))]
      [(and (hash? s) (immutable? s))
-      (cond
-       [(hash-eq? s)
-        (f #f
-           (for/hasheq ([(k v) (in-hash s)])
-             (values k (loop #f v seen))))]
-       [(hash-eqv? s)
-        (f #f
-           (for/hasheqv ([(k v) (in-hash s)])
-             (values k (loop #f v seen))))]
-       [else
-        (f #f
-           (for/hash ([(k v) (in-hash s)])
-             (values k (loop #f v seen))))])]
+      (f #f
+         (hash-map/copy s
+                        (lambda (k v)
+                          (values k (loop #f v seen)))))]
      [else (f #f s)])))
 
 (define (datum-has-elements? d)

--- a/racket/src/thread/place-message.rkt
+++ b/racket/src/thread/place-message.rkt
@@ -158,16 +158,9 @@
             (maybe-ph
              ph
              v
-             (cond
-               [(hash-eq? v)
-                (for/hasheq ([(k v) (in-hash v)])
-                  (values (loop k) (loop v)))]
-               [(hash-eqv? v)
-                (for/hasheqv ([(k v) (in-hash v)])
-                  (values (loop k) (loop v)))]
-               [else
-                (for/hash ([(k v) (in-hash v)])
-                  (values (loop k) (loop v)))]))]
+             (hash-map/copy v
+                            (lambda (k v)
+                              (values (loop k) (loop v)))))]
            [(cpointer? v)
             (ptr-add v 0)]
            [(and (or (fxvector? v)
@@ -216,16 +209,9 @@
                    (for/list ([e (in-vector (struct->vector v) 1)])
                      (loop e))))]
       [(hash? v)
-       (cond
-         [(hash-eq? v)
-          (for/hasheq ([(k v) (in-hash v)])
-            (values (loop k) (loop v)))]
-         [(hash-eqv? v)
-          (for/hasheqv ([(k v) (in-hash v)])
-            (values (loop k) (loop v)))]
-         [else
-          (for/hash ([(k v) (in-hash v)])
-            (values (loop k) (loop v)))])]
+       (hash-map/copy v
+                      (lambda (k v)
+                        (values (loop k) (loop v))))]
       [(and (cpointer? v)
             v ; not #f
             (not (bytes? v)))


### PR DESCRIPTION
So that it can be used instead of enumerating variants of hash tables.