### PR TITLE
hash-map/copy: add optional kind argument, update schemified

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -518,10 +518,24 @@ performed in constant time.  If @racket[hash] is a @tech{chaperone},
 then each key is removed one-by-one using @racket[hash-remove].}
 
 
-@defproc[(hash-copy-clear [hash hash?]) hash?]{
+@defproc[(hash-copy-clear
+          [hash hash?]
+          [#:kind kind (or/c #f 'immutable 'mutable 'weak 'ephemeron) #f])
+         hash?]{
 
 Produces an empty @tech{hash table} with the same key-comparison
-procedure and mutability of @racket[hash].}
+procedure as @racket[hash], with either the given @racket[kind]
+or the same kind as the given @racket[hash].
+
+If @racket[kind] is not supplied or @racket[#f], produces a hash
+table of the same kind and mutability as the given @racket[hash].
+If @racket[kind] is @racket['immutable], @racket['mutable],
+@racket['weak], or @racket['ephemeron], produces a table that's
+immutable, mutable with strongly-held keys, mutable with
+weakly-held keys, or mutable with ephemeron-held keys
+respectively.
+
+@history[#:changed "8.5.0.2" @elem{Added the @racket[kind] argument.}]}
 
 
 
@@ -570,35 +584,34 @@ with the following order (earlier bullets before later):
 @history[#:changed "6.3" @elem{Added the @racket[try-order?] argument.}
          #:changed "7.1.0.7" @elem{Added guarantees for @racket[try-order?].}]}
 
-@defproc[(hash-map/copy [hash hash?]
-                        [proc (any/c any/c . -> . (values any/c any/c))])
+@defproc[(hash-map/copy
+          [hash hash?]
+          [proc (any/c any/c . -> . (values any/c any/c))]
+          [#:kind kind (or/c #f 'immutable 'mutable 'weak 'ephemeron) #f])
          hash?]{
 
 Applies the procedure @racket[proc] to each element in
 @racket[hash] in an unspecified order, accumulating the results
-into a new hash of the same kind, with the same key-comparison
-procedure and mutability of @racket[hash].
+into a new hash with the same key-comparison procedure as
+@racket[hash], with either the given @racket[kind] or the same
+kind as the given @racket[hash].
+
+If @racket[kind] is not supplied or @racket[#f], produces a hash
+table of the same kind and mutability as the given @racket[hash].
+If @racket[kind] is @racket['immutable], @racket['mutable],
+@racket['weak], or @racket['ephemeron], produces a table that's
+immutable, mutable with strongly-held keys, mutable with
+weakly-held keys, or mutable with ephemeron-held keys
+respectively.
 
 @examples[
 #:eval the-eval
-(hash-map/copy #hash((a . "apple") (b . "banana")) (lambda (k v) (values k (string-upcase v))))
-]
-
-@history[#:added "8.5.0.2"]}
-
-@defproc[(hash-map/freeze [hash hash?]
-                          [proc (any/c any/c . -> . (values any/c any/c))])
-         (and/c hash? immutable?)]{
-
-Applies the procedure @racket[proc] to each element in
-@racket[hash] in an unspecified order, accumulating the results
-into a new immutable hash with the same key-comparison procedure
-as @racket[hash].
-
-@examples[
-#:eval the-eval
+(hash-map/copy #hash((a . "apple") (b . "banana"))
+               (lambda (k v) (values k (string-upcase v))))
 (define frozen-capital
-  (hash-map/freeze (make-hash '((a . "apple") (b . "banana"))) (lambda (k v) (values k (string-upcase v)))))
+  (hash-map/copy (make-hash '((a . "apple") (b . "banana")))
+                 (lambda (k v) (values k (string-upcase v)))
+                 #:kind 'immutable))
 frozen-capital
 (immutable? frozen-capital)
 ]

--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -586,6 +586,25 @@ procedure and mutability of @racket[hash].
 
 @history[#:added "8.5.0.2"]}
 
+@defproc[(hash-map/freeze [hash hash?]
+                          [proc (any/c any/c . -> . (values any/c any/c))])
+         (and/c hash? immutable?)]{
+
+Applies the procedure @racket[proc] to each element in
+@racket[hash] in an unspecified order, accumulating the results
+into a new immutable hash with the same key-comparison procedure
+as @racket[hash].
+
+@examples[
+#:eval the-eval
+(define frozen-capital
+  (hash-map/freeze (make-hash '((a . "apple") (b . "banana"))) (lambda (k v) (values k (string-upcase v)))))
+frozen-capital
+(immutable? frozen-capital)
+]
+
+@history[#:added "8.5.0.2"]}
+
 @defproc[(hash-keys [hash hash?] [try-order? any/c #f])
          (listof any/c)]{
 Returns a list of the keys of @racket[hash] in an unspecified order.

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -727,7 +727,20 @@
 
   (test (hash 'one 2) hash-map/copy (hash 'one 1) (proc (lambda (k v) (values k (add1 v)))))
   (test (hasheq 'one 2) hash-map/copy (hasheq 'one 1) (proc (lambda (k v) (values k (add1 v)))))
-  (test (hasheqv 'one 2) hash-map/copy (hasheqv 'one 1) (proc (lambda (k v) (values k (add1 v))))))
+  (test (hasheqv 'one 2) hash-map/copy (hasheqv 'one 1) (proc (lambda (k v) (values k (add1 v)))))
+
+  (test (hash 'one 2)
+        hash-map/freeze
+        (make-hash '((one . 1)))
+        (proc (lambda (k v) (values k (add1 v)))))
+  (test (hasheq 'one 2)
+        hash-map/freeze
+        (make-hasheq '((one . 1)))
+        (proc (lambda (k v) (values k (add1 v)))))
+  (test (hasheqv 'one 2)
+        hash-map/freeze
+        (make-hasheqv '((one . 1)))
+        (proc (lambda (k v) (values k (add1 v))))))
 
 ;; ----------------------------------------
 
@@ -811,14 +824,18 @@
 
 ;; ----------------------------------------
 
-(for ([make-hash
+(for ([make-immutable-hash
+       (in-cycle
+        (list make-immutable-hash make-immutable-hasheq make-immutable-hasheqv))]
+      [make-hash
        (in-list
         (list make-immutable-hash make-immutable-hasheq make-immutable-hasheqv
               make-hash make-hasheq make-hasheqv
               make-weak-hash make-weak-hasheq make-weak-hasheqv
               make-ephemeron-hash make-ephemeron-hasheq make-ephemeron-hasheqv))])
   (define (10*v k v) (values k (* 10 v)))
-  (test (make-hash '((a . 10) (b . 20))) hash-map/copy (make-hash '((a . 1) (b . 2))) 10*v))
+  (test (make-hash '((a . 10) (b . 20))) hash-map/copy (make-hash '((a . 1) (b . 2))) 10*v)
+  (test (make-immutable-hash '((a . 10) (b . 20))) hash-map/freeze (make-hash '((a . 1) (b . 2))) 10*v))
 
 ;; ----------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -730,17 +730,20 @@
   (test (hasheqv 'one 2) hash-map/copy (hasheqv 'one 1) (proc (lambda (k v) (values k (add1 v)))))
 
   (test (hash 'one 2)
-        hash-map/freeze
+        hash-map/copy
         (make-hash '((one . 1)))
-        (proc (lambda (k v) (values k (add1 v)))))
+        (proc (lambda (k v) (values k (add1 v))))
+        #:kind 'immutable)
   (test (hasheq 'one 2)
-        hash-map/freeze
+        hash-map/copy
         (make-hasheq '((one . 1)))
-        (proc (lambda (k v) (values k (add1 v)))))
+        (proc (lambda (k v) (values k (add1 v))))
+        #:kind 'immutable)
   (test (hasheqv 'one 2)
-        hash-map/freeze
+        hash-map/copy
         (make-hasheqv '((one . 1)))
-        (proc (lambda (k v) (values k (add1 v))))))
+        (proc (lambda (k v) (values k (add1 v))))
+        #:kind 'immutable))
 
 ;; ----------------------------------------
 
@@ -835,7 +838,11 @@
               make-ephemeron-hash make-ephemeron-hasheq make-ephemeron-hasheqv))])
   (define (10*v k v) (values k (* 10 v)))
   (test (make-hash '((a . 10) (b . 20))) hash-map/copy (make-hash '((a . 1) (b . 2))) 10*v)
-  (test (make-immutable-hash '((a . 10) (b . 20))) hash-map/freeze (make-hash '((a . 1) (b . 2))) 10*v))
+  (test (make-immutable-hash '((a . 10) (b . 20)))
+        hash-map/copy
+        (make-hash '((a . 1) (b . 2)))
+        10*v
+        #:kind 'immutable))
 
 ;; ----------------------------------------
 

--- a/racket/collects/racket/private/hash.rkt
+++ b/racket/collects/racket/private/hash.rkt
@@ -111,6 +111,24 @@
         (hash-set! acc k2 v2))
       acc]))
 
+  (define (hash-freeze-clear table)
+    (unless (hash? table)
+      (raise-argument-error 'hash-freeze-clear "hash?" table))
+    (cond
+     [(hash-equal? table) (hash)]
+     [(hash-eqv? table) (hasheqv)]
+     [(hash-eq? table) (hasheq)]))
+
+  (define (hash-map/freeze table f)
+    (unless (hash? table)
+      (raise-argument-error 'hash-map/freeze "hash?" table))
+    (unless (and (procedure? f) (procedure-arity-includes? f 2))
+      (raise-argument-error 'hash-map/freeze "(procedure-arity-includes/c 2)" f))
+    (for/fold ([acc (hash-freeze-clear table)])
+              ([(k1 v1) (in-hash table)])
+      (define-values [k2 v2] (f k1 v1))
+      (hash-set acc k2 v2)))
+
   (define (hash-empty? table)
     (unless (hash? table)
       (raise-argument-error 'hash-empty? "hash?" table))
@@ -124,4 +142,5 @@
            hash-set*!
            hash-empty?
            hash-copy-clear
-           hash-map/copy))
+           hash-map/copy
+           hash-map/freeze))

--- a/racket/collects/racket/private/hash.rkt
+++ b/racket/collects/racket/private/hash.rkt
@@ -68,21 +68,26 @@
                 (lambda (x k v)
                   (hash-set! table k v))))
 
-  (define (hash-copy-clear table)
+  (define (hash-copy-clear table #:kind [kind #f])
     (unless (hash? table)
       (raise-argument-error 'hash-copy-clear "hash?" table))
+    (unless (memq kind '(#f immutable mutable weak ephemeron))
+      (raise-argument-error
+       'hash-copy-clear
+       "(or/c #f 'immutable 'mutable 'weak 'ephemeron)"
+       kind))
     (cond
-     [(immutable? table)
+     [(if kind (eq? 'immutable kind) (immutable? table))
       (cond
        [(hash-equal? table) (hash)]
        [(hash-eqv? table) (hasheqv)]
        [(hash-eq? table) (hasheq)])]
-     [(hash-weak? table)
+     [(if kind (eq? 'weak kind) (hash-weak? table))
       (cond
        [(hash-equal? table) (make-weak-hash)]
        [(hash-eqv? table) (make-weak-hasheqv)]
        [(hash-eq? table) (make-weak-hasheq)])]
-     [(hash-ephemeron? table)
+     [(if kind (eq? 'ephemeron kind) (hash-ephemeron? table))
       (cond
         [(hash-equal? table) (make-ephemeron-hash)]
         [(hash-eqv? table) (make-ephemeron-hasheqv)]
@@ -93,41 +98,28 @@
        [(hash-eqv? table) (make-hasheqv)]
        [(hash-eq? table) (make-hasheq)])]))
 
-  (define (hash-map/copy table f)
+  (define (hash-map/copy table f #:kind [kind #f])
     (unless (hash? table)
       (raise-argument-error 'hash-map/copy "hash?" table))
     (unless (and (procedure? f) (procedure-arity-includes? f 2))
       (raise-argument-error 'hash-map/copy "(procedure-arity-includes/c 2)" f))
+    (unless (memq kind '(#f immutable mutable weak ephemeron))
+      (raise-argument-error
+       'hash-map/copy
+       "(or/c #f 'immutable 'mutable 'weak 'ephemeron)"
+       kind))
+    (define acc (hash-copy-clear table #:kind kind))
     (cond
-     [(immutable? table)
-      (for/fold ([acc (hash-copy-clear table)])
-                ([(k1 v1) (in-immutable-hash table)])
+     [(immutable? acc)
+      (for/fold ([acc acc])
+                ([(k1 v1) (in-hash table)])
         (define-values [k2 v2] (f k1 v1))
         (hash-set acc k2 v2))]
      [else
-      (define acc (hash-copy-clear table))
       (for ([(k1 v1) (in-hash table)])
         (define-values [k2 v2] (f k1 v1))
         (hash-set! acc k2 v2))
       acc]))
-
-  (define (hash-freeze-clear table)
-    (unless (hash? table)
-      (raise-argument-error 'hash-freeze-clear "hash?" table))
-    (cond
-     [(hash-equal? table) (hash)]
-     [(hash-eqv? table) (hasheqv)]
-     [(hash-eq? table) (hasheq)]))
-
-  (define (hash-map/freeze table f)
-    (unless (hash? table)
-      (raise-argument-error 'hash-map/freeze "hash?" table))
-    (unless (and (procedure? f) (procedure-arity-includes? f 2))
-      (raise-argument-error 'hash-map/freeze "(procedure-arity-includes/c 2)" f))
-    (for/fold ([acc (hash-freeze-clear table)])
-              ([(k1 v1) (in-hash table)])
-      (define-values [k2 v2] (f k1 v1))
-      (hash-set acc k2 v2)))
 
   (define (hash-empty? table)
     (unless (hash? table)
@@ -142,5 +134,4 @@
            hash-set*!
            hash-empty?
            hash-copy-clear
-           hash-map/copy
-           hash-map/freeze))
+           hash-map/copy))

--- a/racket/collects/syntax/strip-context.rkt
+++ b/racket/collects/syntax/strip-context.rkt
@@ -26,8 +26,9 @@
                 k
                 (replace-context ctx (struct->list e))))]
    [(hash? e)
-    (hash-map/freeze e
-                     (lambda (k v)
-                       (values (replace-context ctx k)
-                               (replace-context ctx v))))]
+    (hash-map/copy e
+                   (lambda (k v)
+                     (values (replace-context ctx k)
+                             (replace-context ctx v)))
+                   #:kind 'immutable)]
    [else e]))

--- a/racket/collects/syntax/strip-context.rkt
+++ b/racket/collects/syntax/strip-context.rkt
@@ -26,8 +26,8 @@
                 k
                 (replace-context ctx (struct->list e))))]
    [(hash? e)
-    (hash-map/copy e
-                   (lambda (k v)
-                     (values (replace-context ctx k)
-                             (replace-context ctx v))))]
+    (hash-map/freeze e
+                     (lambda (k v)
+                       (values (replace-context ctx k)
+                               (replace-context ctx v))))]
    [else e]))

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -892,57 +892,134 @@
            (void)
            (raise-argument-error 'hash-keys "hash?" 0 h_0 try-order?_0))
          (hash-keys_0 h_0 try-order?_0)))))))
-(define hash-freeze-clear
-  (lambda (table_0)
-    (begin
-      (if (hash? table_0)
-        (void)
-        (raise-argument-error 'hash-freeze-clear "hash?" table_0))
-      (if (hash-equal? table_0)
-        (hash)
-        (if (hash-eqv? table_0)
-          (hasheqv)
-          (if (hash-eq? table_0) (hasheq) (void)))))))
-(define hash-map/freeze
-  (lambda (table_0 f_0)
-    (begin
-      (if (hash? table_0)
-        (void)
-        (raise-argument-error 'hash-map/freeze "hash?" table_0))
-      (if (if (procedure? f_0) (procedure-arity-includes? f_0 2) #f)
-        (void)
-        (raise-argument-error
-         'hash-map/freeze
-         "(procedure-arity-includes/c 2)"
-         f_0))
-      (begin
-        (letrec*
-         ((for-loop_0
-           (|#%name|
-            for-loop
-            (lambda (acc_0 i_0)
-              (begin
-                (if i_0
-                  (call-with-values
-                   (lambda () (hash-iterate-key+value table_0 i_0))
-                   (case-lambda
-                    ((k1_0 v1_0)
-                     (let ((acc_1
-                            (let ((acc_1
-                                   (call-with-values
-                                    (lambda () (|#%app| f_0 k1_0 v1_0))
-                                    (case-lambda
-                                     ((k2_0 v2_0) (hash-set acc_0 k2_0 v2_0))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args))))))
-                              (values acc_1))))
-                       (for-loop_0 acc_1 (hash-iterate-next table_0 i_0))))
-                    (args (raise-binding-result-arity-error 2 args))))
-                  acc_0))))))
-         (let ((app_0 (hash-freeze-clear table_0)))
-           (for-loop_0 app_0 (hash-iterate-first table_0))))))))
+(define hash-copy-clear.1
+  (|#%name|
+   hash-copy-clear
+   (lambda (kind1_0 table3_0)
+     (begin
+       (begin
+         (if (hash? table3_0)
+           (void)
+           (raise-argument-error 'hash-copy-clear "hash?" table3_0))
+         (if (memq kind1_0 '(#f immutable mutable weak ephemeron))
+           (void)
+           (raise-argument-error
+            'hash-copy-clear
+            "(or/c #f 'immutable 'mutable 'weak 'ephemeron)"
+            kind1_0))
+         (if (if kind1_0 (eq? 'immutable kind1_0) (immutable? table3_0))
+           (if (hash-equal? table3_0)
+             (hash)
+             (if (hash-eqv? table3_0)
+               (hasheqv)
+               (if (hash-eq? table3_0) (hasheq) (void))))
+           (if (if kind1_0 (eq? 'weak kind1_0) (hash-weak? table3_0))
+             (if (hash-equal? table3_0)
+               (make-weak-hash)
+               (if (hash-eqv? table3_0)
+                 (make-weak-hasheqv)
+                 (if (hash-eq? table3_0) (make-weak-hasheq) (void))))
+             (if (if kind1_0
+                   (eq? 'ephemeron kind1_0)
+                   (hash-ephemeron? table3_0))
+               (if (hash-equal? table3_0)
+                 (make-ephemeron-hash)
+                 (if (hash-eqv? table3_0)
+                   (make-ephemeron-hasheqv)
+                   (if (hash-eq? table3_0) (make-ephemeron-hasheq) (void))))
+               (if (hash-equal? table3_0)
+                 (make-hash)
+                 (if (hash-eqv? table3_0)
+                   (make-hasheqv)
+                   (if (hash-eq? table3_0) (make-hasheq) (void))))))))))))
+(define hash-map/copy.1
+  (|#%name|
+   hash-map/copy
+   (lambda (kind5_0 table7_0 f8_0)
+     (begin
+       (begin
+         (if (hash? table7_0)
+           (void)
+           (raise-argument-error 'hash-map/copy "hash?" table7_0))
+         (begin
+           (if (if (procedure? f8_0) (procedure-arity-includes? f8_0 2) #f)
+             (void)
+             (raise-argument-error
+              'hash-map/copy
+              "(procedure-arity-includes/c 2)"
+              f8_0))
+           (begin
+             (if (memq kind5_0 '(#f immutable mutable weak ephemeron))
+               (void)
+               (raise-argument-error
+                'hash-map/copy
+                "(or/c #f 'immutable 'mutable 'weak 'ephemeron)"
+                kind5_0))
+             (let ((acc_0 (hash-copy-clear.1 kind5_0 table7_0)))
+               (if (immutable? acc_0)
+                 (begin
+                   (letrec*
+                    ((for-loop_0
+                      (|#%name|
+                       for-loop
+                       (lambda (acc_1 i_0)
+                         (begin
+                           (if i_0
+                             (call-with-values
+                              (lambda () (hash-iterate-key+value table7_0 i_0))
+                              (case-lambda
+                               ((k1_0 v1_0)
+                                (let ((acc_2
+                                       (let ((acc_2
+                                              (call-with-values
+                                               (lambda ()
+                                                 (|#%app| f8_0 k1_0 v1_0))
+                                               (case-lambda
+                                                ((k2_0 v2_0)
+                                                 (hash-set acc_1 k2_0 v2_0))
+                                                (args
+                                                 (raise-binding-result-arity-error
+                                                  2
+                                                  args))))))
+                                         (values acc_2))))
+                                  (for-loop_0
+                                   acc_2
+                                   (hash-iterate-next table7_0 i_0))))
+                               (args
+                                (raise-binding-result-arity-error 2 args))))
+                             acc_1))))))
+                    (for-loop_0 acc_0 (hash-iterate-first table7_0))))
+                 (begin
+                   (begin
+                     (letrec*
+                      ((for-loop_0
+                        (|#%name|
+                         for-loop
+                         (lambda (i_0)
+                           (begin
+                             (if i_0
+                               (call-with-values
+                                (lambda ()
+                                  (hash-iterate-key+value table7_0 i_0))
+                                (case-lambda
+                                 ((k1_0 v1_0)
+                                  (begin
+                                    (call-with-values
+                                     (lambda () (|#%app| f8_0 k1_0 v1_0))
+                                     (case-lambda
+                                      ((k2_0 v2_0) (hash-set! acc_0 k2_0 v2_0))
+                                      (args
+                                       (raise-binding-result-arity-error
+                                        2
+                                        args))))
+                                    (for-loop_0
+                                     (hash-iterate-next table7_0 i_0))))
+                                 (args
+                                  (raise-binding-result-arity-error 2 args))))
+                               (values)))))))
+                      (for-loop_0 (hash-iterate-first table7_0))))
+                   (void)
+                   acc_0))))))))))
 (define hash-empty?
   (lambda (table_0)
     (begin
@@ -3522,14 +3599,19 @@
                                                      (maybe-ph_0
                                                       ph_0
                                                       v_1
-                                                      (hash-map/freeze
-                                                       v_1
-                                                       (lambda (k_0 v_2)
-                                                         (let ((app_0
-                                                                (loop_0 k_0)))
-                                                           (values
-                                                            app_0
-                                                            (loop_0 v_2))))))))
+                                                      (let ((temp12_0
+                                                             (lambda (k_0 v_2)
+                                                               (let ((app_0
+                                                                      (loop_0
+                                                                       k_0)))
+                                                                 (values
+                                                                  app_0
+                                                                  (loop_0
+                                                                   v_2))))))
+                                                        (hash-map/copy.1
+                                                         'immutable
+                                                         v_1
+                                                         temp12_0)))))
                                                  (if (cpointer? v_1)
                                                    (ptr-add v_1 0)
                                                    (if (if (let ((or-part_0
@@ -3698,11 +3780,11 @@
                               (args
                                (raise-binding-result-arity-error 4 args))))))
                           (if (hash? v_1)
-                            (hash-map/freeze
-                             v_1
-                             (lambda (k_0 v_2)
-                               (let ((app_0 (loop_0 k_0)))
-                                 (values app_0 (loop_0 v_2)))))
+                            (let ((temp15_0
+                                   (lambda (k_0 v_2)
+                                     (let ((app_0 (loop_0 k_0)))
+                                       (values app_0 (loop_0 v_2))))))
+                              (hash-map/copy.1 'immutable v_1 temp15_0))
                             (if (if (cpointer? v_1)
                                   (if v_1 (not (bytes? v_1)) #f)
                                   #f)

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -160,8 +160,6 @@
                 (1/would-be-future would-be-future)
                 (1/wrap-evt wrap-evt)))
 (define hash2610 (hasheq))
-(define hash2589 (hasheqv))
-(define hash2725 (hash))
 (define select-handler/no-breaks
   (lambda (e_0 bpz_0 l_0)
     (with-continuation-mark*
@@ -894,6 +892,57 @@
            (void)
            (raise-argument-error 'hash-keys "hash?" 0 h_0 try-order?_0))
          (hash-keys_0 h_0 try-order?_0)))))))
+(define hash-freeze-clear
+  (lambda (table_0)
+    (begin
+      (if (hash? table_0)
+        (void)
+        (raise-argument-error 'hash-freeze-clear "hash?" table_0))
+      (if (hash-equal? table_0)
+        (hash)
+        (if (hash-eqv? table_0)
+          (hasheqv)
+          (if (hash-eq? table_0) (hasheq) (void)))))))
+(define hash-map/freeze
+  (lambda (table_0 f_0)
+    (begin
+      (if (hash? table_0)
+        (void)
+        (raise-argument-error 'hash-map/freeze "hash?" table_0))
+      (if (if (procedure? f_0) (procedure-arity-includes? f_0 2) #f)
+        (void)
+        (raise-argument-error
+         'hash-map/freeze
+         "(procedure-arity-includes/c 2)"
+         f_0))
+      (begin
+        (letrec*
+         ((for-loop_0
+           (|#%name|
+            for-loop
+            (lambda (acc_0 i_0)
+              (begin
+                (if i_0
+                  (call-with-values
+                   (lambda () (hash-iterate-key+value table_0 i_0))
+                   (case-lambda
+                    ((k1_0 v1_0)
+                     (let ((acc_1
+                            (let ((acc_1
+                                   (call-with-values
+                                    (lambda () (|#%app| f_0 k1_0 v1_0))
+                                    (case-lambda
+                                     ((k2_0 v2_0) (hash-set acc_0 k2_0 v2_0))
+                                     (args
+                                      (raise-binding-result-arity-error
+                                       2
+                                       args))))))
+                              (values acc_1))))
+                       (for-loop_0 acc_1 (hash-iterate-next table_0 i_0))))
+                    (args (raise-binding-result-arity-error 2 args))))
+                  acc_0))))))
+         (let ((app_0 (hash-freeze-clear table_0)))
+           (for-loop_0 app_0 (hash-iterate-first table_0))))))))
 (define hash-empty?
   (lambda (table_0)
     (begin
@@ -3473,173 +3522,14 @@
                                                      (maybe-ph_0
                                                       ph_0
                                                       v_1
-                                                      (if (hash-eq? v_1)
-                                                        (begin
-                                                          (letrec*
-                                                           ((for-loop_0
-                                                             (|#%name|
-                                                              for-loop
-                                                              (lambda (table_0
-                                                                       i_0)
-                                                                (begin
-                                                                  (if i_0
-                                                                    (call-with-values
-                                                                     (lambda ()
-                                                                       (hash-iterate-key+value
-                                                                        v_1
-                                                                        i_0))
-                                                                     (case-lambda
-                                                                      ((k_0
-                                                                        v_2)
-                                                                       (let ((table_1
-                                                                              (let ((table_1
-                                                                                     (call-with-values
-                                                                                      (lambda ()
-                                                                                        (let ((app_0
-                                                                                               (loop_0
-                                                                                                k_0)))
-                                                                                          (values
-                                                                                           app_0
-                                                                                           (loop_0
-                                                                                            v_2))))
-                                                                                      (case-lambda
-                                                                                       ((key_0
-                                                                                         val_0)
-                                                                                        (hash-set
-                                                                                         table_0
-                                                                                         key_0
-                                                                                         val_0))
-                                                                                       (args
-                                                                                        (raise-binding-result-arity-error
-                                                                                         2
-                                                                                         args))))))
-                                                                                (values
-                                                                                 table_1))))
-                                                                         (for-loop_0
-                                                                          table_1
-                                                                          (hash-iterate-next
-                                                                           v_1
-                                                                           i_0))))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        2
-                                                                        args))))
-                                                                    table_0))))))
-                                                           (for-loop_0
-                                                            hash2610
-                                                            (hash-iterate-first
-                                                             v_1))))
-                                                        (if (hash-eqv? v_1)
-                                                          (begin
-                                                            (letrec*
-                                                             ((for-loop_0
-                                                               (|#%name|
-                                                                for-loop
-                                                                (lambda (table_0
-                                                                         i_0)
-                                                                  (begin
-                                                                    (if i_0
-                                                                      (call-with-values
-                                                                       (lambda ()
-                                                                         (hash-iterate-key+value
-                                                                          v_1
-                                                                          i_0))
-                                                                       (case-lambda
-                                                                        ((k_0
-                                                                          v_2)
-                                                                         (let ((table_1
-                                                                                (let ((table_1
-                                                                                       (call-with-values
-                                                                                        (lambda ()
-                                                                                          (let ((app_0
-                                                                                                 (loop_0
-                                                                                                  k_0)))
-                                                                                            (values
-                                                                                             app_0
-                                                                                             (loop_0
-                                                                                              v_2))))
-                                                                                        (case-lambda
-                                                                                         ((key_0
-                                                                                           val_0)
-                                                                                          (hash-set
-                                                                                           table_0
-                                                                                           key_0
-                                                                                           val_0))
-                                                                                         (args
-                                                                                          (raise-binding-result-arity-error
-                                                                                           2
-                                                                                           args))))))
-                                                                                  (values
-                                                                                   table_1))))
-                                                                           (for-loop_0
-                                                                            table_1
-                                                                            (hash-iterate-next
-                                                                             v_1
-                                                                             i_0))))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args))))
-                                                                      table_0))))))
-                                                             (for-loop_0
-                                                              hash2589
-                                                              (hash-iterate-first
-                                                               v_1))))
-                                                          (begin
-                                                            (letrec*
-                                                             ((for-loop_0
-                                                               (|#%name|
-                                                                for-loop
-                                                                (lambda (table_0
-                                                                         i_0)
-                                                                  (begin
-                                                                    (if i_0
-                                                                      (call-with-values
-                                                                       (lambda ()
-                                                                         (hash-iterate-key+value
-                                                                          v_1
-                                                                          i_0))
-                                                                       (case-lambda
-                                                                        ((k_0
-                                                                          v_2)
-                                                                         (let ((table_1
-                                                                                (let ((table_1
-                                                                                       (call-with-values
-                                                                                        (lambda ()
-                                                                                          (let ((app_0
-                                                                                                 (loop_0
-                                                                                                  k_0)))
-                                                                                            (values
-                                                                                             app_0
-                                                                                             (loop_0
-                                                                                              v_2))))
-                                                                                        (case-lambda
-                                                                                         ((key_0
-                                                                                           val_0)
-                                                                                          (hash-set
-                                                                                           table_0
-                                                                                           key_0
-                                                                                           val_0))
-                                                                                         (args
-                                                                                          (raise-binding-result-arity-error
-                                                                                           2
-                                                                                           args))))))
-                                                                                  (values
-                                                                                   table_1))))
-                                                                           (for-loop_0
-                                                                            table_1
-                                                                            (hash-iterate-next
-                                                                             v_1
-                                                                             i_0))))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args))))
-                                                                      table_0))))))
-                                                             (for-loop_0
-                                                              hash2725
-                                                              (hash-iterate-first
-                                                               v_1)))))))))
+                                                      (hash-map/freeze
+                                                       v_1
+                                                       (lambda (k_0 v_2)
+                                                         (let ((app_0
+                                                                (loop_0 k_0)))
+                                                           (values
+                                                            app_0
+                                                            (loop_0 v_2))))))))
                                                  (if (cpointer? v_1)
                                                    (ptr-add v_1 0)
                                                    (if (if (let ((or-part_0
@@ -3808,154 +3698,11 @@
                               (args
                                (raise-binding-result-arity-error 4 args))))))
                           (if (hash? v_1)
-                            (if (hash-eq? v_1)
-                              (begin
-                                (letrec*
-                                 ((for-loop_0
-                                   (|#%name|
-                                    for-loop
-                                    (lambda (table_0 i_0)
-                                      (begin
-                                        (if i_0
-                                          (call-with-values
-                                           (lambda ()
-                                             (hash-iterate-key+value v_1 i_0))
-                                           (case-lambda
-                                            ((k_0 v_2)
-                                             (let ((table_1
-                                                    (let ((table_1
-                                                           (call-with-values
-                                                            (lambda ()
-                                                              (let ((app_0
-                                                                     (loop_0
-                                                                      k_0)))
-                                                                (values
-                                                                 app_0
-                                                                 (loop_0
-                                                                  v_2))))
-                                                            (case-lambda
-                                                             ((key_0 val_0)
-                                                              (hash-set
-                                                               table_0
-                                                               key_0
-                                                               val_0))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args))))))
-                                                      (values table_1))))
-                                               (for-loop_0
-                                                table_1
-                                                (hash-iterate-next v_1 i_0))))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
-                                          table_0))))))
-                                 (for-loop_0
-                                  hash2610
-                                  (hash-iterate-first v_1))))
-                              (if (hash-eqv? v_1)
-                                (begin
-                                  (letrec*
-                                   ((for-loop_0
-                                     (|#%name|
-                                      for-loop
-                                      (lambda (table_0 i_0)
-                                        (begin
-                                          (if i_0
-                                            (call-with-values
-                                             (lambda ()
-                                               (hash-iterate-key+value
-                                                v_1
-                                                i_0))
-                                             (case-lambda
-                                              ((k_0 v_2)
-                                               (let ((table_1
-                                                      (let ((table_1
-                                                             (call-with-values
-                                                              (lambda ()
-                                                                (let ((app_0
-                                                                       (loop_0
-                                                                        k_0)))
-                                                                  (values
-                                                                   app_0
-                                                                   (loop_0
-                                                                    v_2))))
-                                                              (case-lambda
-                                                               ((key_0 val_0)
-                                                                (hash-set
-                                                                 table_0
-                                                                 key_0
-                                                                 val_0))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args))))))
-                                                        (values table_1))))
-                                                 (for-loop_0
-                                                  table_1
-                                                  (hash-iterate-next
-                                                   v_1
-                                                   i_0))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
-                                            table_0))))))
-                                   (for-loop_0
-                                    hash2589
-                                    (hash-iterate-first v_1))))
-                                (begin
-                                  (letrec*
-                                   ((for-loop_0
-                                     (|#%name|
-                                      for-loop
-                                      (lambda (table_0 i_0)
-                                        (begin
-                                          (if i_0
-                                            (call-with-values
-                                             (lambda ()
-                                               (hash-iterate-key+value
-                                                v_1
-                                                i_0))
-                                             (case-lambda
-                                              ((k_0 v_2)
-                                               (let ((table_1
-                                                      (let ((table_1
-                                                             (call-with-values
-                                                              (lambda ()
-                                                                (let ((app_0
-                                                                       (loop_0
-                                                                        k_0)))
-                                                                  (values
-                                                                   app_0
-                                                                   (loop_0
-                                                                    v_2))))
-                                                              (case-lambda
-                                                               ((key_0 val_0)
-                                                                (hash-set
-                                                                 table_0
-                                                                 key_0
-                                                                 val_0))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args))))))
-                                                        (values table_1))))
-                                                 (for-loop_0
-                                                  table_1
-                                                  (hash-iterate-next
-                                                   v_1
-                                                   i_0))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
-                                            table_0))))))
-                                   (for-loop_0
-                                    hash2725
-                                    (hash-iterate-first v_1))))))
+                            (hash-map/freeze
+                             v_1
+                             (lambda (k_0 v_2)
+                               (let ((app_0 (loop_0 k_0)))
+                                 (values app_0 (loop_0 v_2)))))
                             (if (if (cpointer? v_1)
                                   (if v_1 (not (bytes? v_1)) #f)
                                   #f)

--- a/racket/src/expander/compile/correlated-linklet.rkt
+++ b/racket/src/expander/compile/correlated-linklet.rkt
@@ -90,9 +90,10 @@
             (hash-set (or ht '#hasheq()) k p)
             ht)))]
     [(hash? v)
-     (hash-map/freeze v
-                      (lambda (key value)
-                        (values (->faslable key) (->faslable value))))]
+     (hash-map/copy v
+                    (lambda (key value)
+                      (values (->faslable key) (->faslable value)))
+                    #:kind 'immutable)]
     [(correlated-linklet? v)
      (faslable-correlated-linklet (->faslable (correlated-linklet-expr v))
                                   (->faslable (correlated-linklet-name v)))]
@@ -126,9 +127,10 @@
            (correlated-property c k p))
          c)]
     [(hash? v)
-     (hash-map/freeze v
-                      (lambda (key value)
-                        (values (faslable-> key) (faslable-> value))))]
+     (hash-map/copy v
+                    (lambda (key value)
+                      (values (faslable-> key) (faslable-> value)))
+                    #:kind 'immutable)]
     [(faslable-correlated-linklet? v)
      (make-correlated-linklet (faslable-> (faslable-correlated-linklet-expr v))
                               (faslable-> (faslable-correlated-linklet-name v)))]

--- a/racket/src/expander/compile/correlated-linklet.rkt
+++ b/racket/src/expander/compile/correlated-linklet.rkt
@@ -90,9 +90,9 @@
             (hash-set (or ht '#hasheq()) k p)
             ht)))]
     [(hash? v)
-     (hash-map/copy v
-                    (lambda (key value)
-                      (values (->faslable key) (->faslable value))))]
+     (hash-map/freeze v
+                      (lambda (key value)
+                        (values (->faslable key) (->faslable value))))]
     [(correlated-linklet? v)
      (faslable-correlated-linklet (->faslable (correlated-linklet-expr v))
                                   (->faslable (correlated-linklet-name v)))]
@@ -126,9 +126,9 @@
            (correlated-property c k p))
          c)]
     [(hash? v)
-     (hash-map/copy v
-                    (lambda (key value)
-                      (values (faslable-> key) (faslable-> value))))]
+     (hash-map/freeze v
+                      (lambda (key value)
+                        (values (faslable-> key) (faslable-> value))))]
     [(faslable-correlated-linklet? v)
      (make-correlated-linklet (faslable-> (faslable-correlated-linklet-expr v))
                               (faslable-> (faslable-correlated-linklet-name v)))]

--- a/racket/src/expander/syntax/datum-map.rkt
+++ b/racket/src/expander/syntax/datum-map.rkt
@@ -86,9 +86,9 @@
                        (loop #f e seen)))))]
      [(and (hash? s) (immutable? s))
       (f #f
-         (hash-map/copy s
-                        (lambda (k v)
-                          (values k (loop #f v seen)))))]
+         (hash-map/freeze s
+                          (lambda (k v)
+                            (values k (loop #f v seen)))))]
      [else (f #f s)])))
 
 (define (datum-has-elements? d)

--- a/racket/src/expander/syntax/datum-map.rkt
+++ b/racket/src/expander/syntax/datum-map.rkt
@@ -86,9 +86,10 @@
                        (loop #f e seen)))))]
      [(and (hash? s) (immutable? s))
       (f #f
-         (hash-map/freeze s
-                          (lambda (k v)
-                            (values k (loop #f v seen)))))]
+         (hash-map/copy s
+                        (lambda (k v)
+                          (values k (loop #f v seen)))
+                        #:kind 'immutable))]
      [else (f #f s)])))
 
 (define (datum-has-elements? d)

--- a/racket/src/thread/place-message.rkt
+++ b/racket/src/thread/place-message.rkt
@@ -158,9 +158,10 @@
             (maybe-ph
              ph
              v
-             (hash-map/freeze v
-                              (lambda (k v)
-                                (values (loop k) (loop v)))))]
+             (hash-map/copy v
+                            (lambda (k v)
+                              (values (loop k) (loop v)))
+                            #:kind 'immutable))]
            [(cpointer? v)
             (ptr-add v 0)]
            [(and (or (fxvector? v)
@@ -209,9 +210,10 @@
                    (for/list ([e (in-vector (struct->vector v) 1)])
                      (loop e))))]
       [(hash? v)
-       (hash-map/freeze v
-                        (lambda (k v)
-                          (values (loop k) (loop v))))]
+       (hash-map/copy v
+                      (lambda (k v)
+                        (values (loop k) (loop v)))
+                      #:kind 'immutable)]
       [(and (cpointer? v)
             v ; not #f
             (not (bytes? v)))

--- a/racket/src/thread/place-message.rkt
+++ b/racket/src/thread/place-message.rkt
@@ -158,9 +158,9 @@
             (maybe-ph
              ph
              v
-             (hash-map/copy v
-                            (lambda (k v)
-                              (values (loop k) (loop v)))))]
+             (hash-map/freeze v
+                              (lambda (k v)
+                                (values (loop k) (loop v)))))]
            [(cpointer? v)
             (ptr-add v 0)]
            [(and (or (fxvector? v)
@@ -209,9 +209,9 @@
                    (for/list ([e (in-vector (struct->vector v) 1)])
                      (loop e))))]
       [(hash? v)
-       (hash-map/copy v
-                      (lambda (k v)
-                        (values (loop k) (loop v))))]
+       (hash-map/freeze v
+                        (lambda (k v)
+                          (values (loop k) (loop v))))]
       [(and (cpointer? v)
             v ; not #f
             (not (bytes? v)))


### PR DESCRIPTION
To fix a mistake I made in my #4240, this adds an optional `kind` argument to `hash-map/copy`, because some uses of `hash-map/copy` need to produce immutable versions. In particular, the messages for places in "thread.scm" need to use `#:kind 'immutable` with `hash-map/copy` because they are meant to convert to immutable hashes.