### PR TITLE
match: add #:context for better syntax error message

### DIFF
--- a/pkgs/racket-test/tests/match/match-exn-tests.rkt
+++ b/pkgs/racket-test/tests/match/match-exn-tests.rkt
@@ -1,5 +1,7 @@
 (module match-tests mzscheme
-  (require mzlib/match rackunit)
+  (require mzlib/match
+           rackunit
+           syntax/macro-testing)
   (provide match-exn-tests)
 
   (define simple-fail-tests
@@ -63,8 +65,18 @@
        (check-exn #rx"match-define-values: no matching clause for \\(6 7\\)"
                   (lambda () (match-define-values (3 x) (values 6 7)) x)))))
 
+  (define exn-message-tests-3
+    (test-suite "Empty clause"
+      (test-case "match"
+        (check-exn #rx"match: expected more terms starting with any term"
+                   (lambda () (convert-syntax-error (match 1 [])))))
+      (test-case "match*"
+        (check-exn #rx"match\\*: expected more terms starting with any term"
+                   (lambda () (convert-syntax-error (match* 1 [])))))))
+
   (define match-exn-tests
     (test-suite "Tests for exceptions raised by match.rkt"
                 simple-fail-tests
                 exn-message-tests-1
-                exn-message-tests-2)))
+                exn-message-tests-2
+                exn-message-tests-3)))

--- a/racket/collects/racket/match/gen-match.rkt
+++ b/racket/collects/racket/match/gen-match.rkt
@@ -14,6 +14,7 @@
     (pattern [p . rhs]
              #:with res (syntax/loc this-syntax [(p) . rhs])))
   (syntax-parse clauses
+    #:context stx
     [(c:cl ...)
      (go parse stx (quasisyntax/loc expr (#,expr))
          #'(c.res ...))]))
@@ -23,6 +24,7 @@
 (define (go parse stx es clauses)
   (with-disappeared-uses
     (syntax-parse clauses
+      #:context stx
       [([pats . rhs] ...)
        (unless (syntax->list es)
          (raise-syntax-error 'match* "expected a sequence of expressions to match" es))


### PR DESCRIPTION
Fixes #4034