### PR TITLE
match: fix tests

### DIFF
--- a/pkgs/racket-test/tests/match/legacy-match-tests.rkt
+++ b/pkgs/racket-test/tests/match/legacy-match-tests.rkt
@@ -1,26 +1,25 @@
-(module match-tests racket/base
-  (require racket/match rackunit
-           (for-syntax racket/base))
+(module legacy-match-tests mzscheme
+  (require mzlib/match rackunit)
   
-  (provide match-tests)
+  (provide legacy-match-tests)
   
   (define match-expander-tests
     (test-suite
      "Tests for define-match-expander"
      (test-case "Trivial expander"
                      (let ()
-                       (define-match-expander bar
-                         (lambda (x) #'_)
-                         (lambda (stx)
-                           (syntax-case stx ()
-                             [(_ x ...) #'(+ x ...)]
-                             [_
-                              (identifier? stx)
-                              #'+])))
-                       (check = 4 (match 3 [(app add1 x) x])) ; other stuff still works
+                       (define-match-expander bar #f (lambda (x) #'_) +)
+                       (check = 4 (match 3 [(= add1 x) x])) ; other stuff still works
                        (check-true (match 3 [(bar) #t])) ; (bar) matches anything
                        (check = 12 (bar 3 4 5))
                        (check = 12 (apply bar '(3 4 5))))) ; bar works like +     
+     (test-case "Trivial expander w/ keywords"
+                     (let ()
+                       (define-match-expander bar  #:match (lambda (x) #'_) #:expression +)
+                       (check = 4 (match 3 [(= add1 x) x])) ; other stuff still works
+                       (check-true (match 3 [(bar) #t])) ; (bar) matches anything
+                       (check = 12 (bar 3 4 5))
+                       (check = 12 (apply bar '(3 4 5))))) ; bar works like +        
      ))
   
  
@@ -30,47 +29,39 @@
      "Some Simple Tests"
      (test-case "Trivial"
                      (check = 3 (match 3 [x x])))
-     (test-case "app pattern"
-                     (check = 4 (match 3 [(app add1 y) y])))
+     (test-case "= pattern"
+                     (check = 4 (match 3 [(= add1 y) y])))
      (test-case "struct patterns"
                      (let ()
                        (define-struct point (x y))
                        (define (origin? pt)
                          (match pt
-                           ((struct point (0 0)) #t)
+                           (($ point 0 0) #t)
                            (_ #f)))
                        (check-true (origin? (make-point 0 0)))
                        (check-false (origin? (make-point 1 1)))))
-     (test-case "empty hash-table pattern bug"
-       (check-equal? (match #hash((1 . 2))
-                       [(hash-table) "empty"]
-                       [_ "non-empty"])
-                     "non-empty")
-       (check-equal? (match #hash()
-                       [(hash-table) "empty"]
-                       [_ "non-empty"])
-                     "empty"))
+
      ))
   
   (define nonlinear-tests
     (test-suite 
      "Non-linear patterns"
      (test-case "Very simple"
-                     (check = 3 (match '(3 3) [(list a a) a])))
+                     (check = 3 (match '(3 3) [(a a) a])))
      (test-case "Fails"
-                     (check-exn exn:misc:match? (lambda () (match '(3 4) [(list a a) a]))))
+                     (check-exn exn:misc:match? (lambda () (match '(3 4) [(a a) a]))))
      (test-case "Use parameter"
                      (parameterize ([match-equality-test eq?])
-                       (check = 5 (match '((3) (3)) [(list a a) a] [_ 5]))))
+                       (check = 5 (match '((3) (3)) [(a a) a] [_ 5]))))
      (test-case "Uses equal?"
-                     (check equal? '(3) (match '((3) (3)) [(list a a) a] [_ 5])))))
+                     (check equal? '(3) (match '((3) (3)) [(a a) a] [_ 5])))))
     
   
   (define doc-tests
     (test-suite 
      "Tests from Help Desk Documentation"
      (test-case "match-let"
-                     (check = 6 (match-let ([(list x y z) (list 1 2 3)]) (+ x y z))))
+                     (check = 6 (match-let ([(x y z) (list 1 2 3)]) (+ x y z))))
      #;
      (test-case "set! pattern"
                      (let ()
@@ -90,9 +81,9 @@
                             (make-Var s)]
                            [(? number? n)
                             (make-Const n)]
-                           [(list 'lambda (and args (list (? symbol?) ...) (not (? repeats?))) body)
+                           [('lambda (and args ((? symbol?) ...) (not (? repeats?))) body)
                             (make-Lam args (parse body))]
-                           [(list f args ...)
+                           [(f args ...)
                             (make-App
                              (parse f)
                              (map parse args))]
@@ -105,21 +96,21 @@
                        
                        (define unparse
                          (match-lambda
-                           [(struct Var (s)) s]
-                           [(struct Const (n)) n]
-                           [(struct Lam (args body)) `(lambda ,args ,(unparse body))]
-                           [(struct App (f args)) `(,(unparse f) ,@(map unparse args))]))
+                           [($ Var s) s]
+                           [($ Const n) n]
+                           [($ Lam args body) `(lambda ,args ,(unparse body))]
+                           [($ App f args) `(,(unparse f) ,@(map unparse args))]))
                        
                        (check equal? '(lambda (x y) x) (unparse (parse '(lambda (x y) x))))))
      
      (test-case "counter : match-define"
                      (let ()
-                       (match-define (list inc value reset)
-                         (let ([val 0])
-                           (list
-                            (lambda () (set! val (add1 val)))
-                            (lambda () val)
-                            (lambda () (set! val 0)))))
+                       (match-define (inc value reset)
+                                     (let ([val 0])
+                                       (list
+                                        (lambda () (set! val (add1 val)))
+                                        (lambda () val)
+                                        (lambda () (set! val 0)))))
                        (inc)
                        (inc)
                        (check =  2 (value))
@@ -130,7 +121,7 @@
 
      ))
 
-  (define match-tests
+  (define legacy-match-tests
     (test-suite "Tests for match.rkt"
                      doc-tests
                      simple-tests

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -2,6 +2,7 @@
 
 (require (for-syntax scheme/base)
          "match-tests.rkt" "match-exn-tests.rkt" "other-plt-tests.rkt" "other-tests.rkt"
+         "legacy-match-tests.rkt"
          "examples.rkt"
          rackunit rackunit/text-ui
          (only-in racket/base local-require))
@@ -445,6 +446,7 @@
                             plt-match-tests
                             match-tests
                             match-exn-tests
+                            legacy-match-tests
                             new-tests
                             ;; from bruce
                             other-tests 

--- a/pkgs/racket-test/tests/match/match-exn-tests.rkt
+++ b/pkgs/racket-test/tests/match/match-exn-tests.rkt
@@ -1,5 +1,5 @@
-(module match-tests mzscheme
-  (require mzlib/match
+(module match-exn-tests racket/base
+  (require racket/match
            rackunit
            syntax/macro-testing)
   (provide match-exn-tests)


### PR DESCRIPTION
Many tests are meant to test the current, modern `match` form,
but it is actually testing the legacy `match` form.
It just happens that these tests are valid for both `match` forms,
and deceptively produce the same matching behaviors.

This PR does the following:

1. Move `match-tests.rkt` to `legacy-match-tests.rkt` and remove
all (one) modern `match` test from the file.
The modern test is introduced in
https://github.com/racket/racket/commit/393582492203608a579a062b3fcece0ad4e18e88

2. Copy `legacy-match-tests.rkt` to `match-tests.rkt` and port these
tests to use the modern `match`. Also, restore the modern test introduced in
https://github.com/racket/racket/commit/393582492203608a579a062b3fcece0ad4e18e88

3. Make `match-exn-tests.rkt` test modern `match`.
This test file is introduced in
https://github.com/racket/racket/commit/026d368a38560b474e13633fdb75aae5b3c3384b
and it is meant to test the modern `match`.