### PR TITLE
Add missing docs for equal-always related list/hash ops

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/for.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/for.scrbl
@@ -222,20 +222,25 @@ mutate a shared vector.}
 @defform[(for/hash (for-clause ...) body-or-break ... body)]
 @defform[(for/hasheq (for-clause ...) body-or-break ... body)]
 @defform[(for/hasheqv (for-clause ...) body-or-break ... body)]
+@defform[(for/hashalw (for-clause ...) body-or-break ... body)]
 )]{
 
 Like @racket[for/list], but the result is an immutable @tech{hash
 table}; @racket[for/hash] creates a table using @racket[equal?] to
 distinguish keys, @racket[for/hasheq] produces a table using
-@racket[eq?], and @racket[for/hasheqv] produces a table using
-@racket[eqv?]. The last expression in the @racket[body]s must return
+@racket[eq?], @racket[for/hasheqv] produces a table using
+@racket[eqv?], and @racket[for/hashalw] produces a table using
+@racket[equal-always?].
+The last expression in the @racket[body]s must return
 two values: a key and a value to extend the hash table accumulated by
 the iteration.
 
 @examples[
 (for/hash ([i '(1 2 3)])
   (values i (number->string i)))
-]}
+]
+
+@history[#:changed "8.5.0.3" @elem{Added the @racket[for/hashalw] form.}]}
 
 
 @defform[(for/and (for-clause ...) body-or-break ... body)]{ Iterates like
@@ -584,6 +589,7 @@ nested.
 @defform[(for*/hash (for-clause ...) body-or-break ... body)]
 @defform[(for*/hasheq (for-clause ...) body-or-break ... body)]
 @defform[(for*/hasheqv (for-clause ...) body-or-break ... body)]
+@defform[(for*/hashalw (for-clause ...) body-or-break ... body)]
 @defform[(for*/and (for-clause ...) body-or-break ... body)]
 @defform[(for*/or (for-clause ...) body-or-break ... body)]
 @defform[(for*/sum (for-clause ...) body-or-break ... body)]
@@ -606,7 +612,8 @@ Like @racket[for/list], etc., but with the implicit nesting of
   (list i j))
 ]
 
-@history[#:changed "7.3.0.3" @elem{Added the @racket[for*/foldr] form.}]}
+@history[#:changed "7.3.0.3" @elem{Added the @racket[for*/foldr] form.}
+         #:changed "8.5.0.3" @elem{Added the @racket[for*/hashalw] form.}]}
 
 @;------------------------------------------------------------------------
 @section{Deriving New Iteration Forms}

--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -518,7 +518,10 @@ Returns @racket[(remove v lst equal-always?)].
   (remw 2 (list 1 2 3 4 5))
   (remw '(2) (list '(1) '(2) '(3)))
   (remw "2" (list "1" "2" "3"))
-  (remw #\c (list #\a #\b #\c))]
+  (remw #\c (list #\a #\b #\c))
+  (define b1 (box 5))
+  (define b2 (box 5))
+  (remw b2 (list 0 b1 1 b2 2))]
 
 @history[#:added "8.5.0.3"]}
 
@@ -561,7 +564,10 @@ Returns @racket[(remove* v-lst lst eqv?)].
 Returns @racket[(remove* v-lst lst equal-always?)].
 
 @mz-examples[
-  (remw* (list 1 2) (list 1 2 3 2 4 5 2))]
+  (remw* (list 1 2) (list 1 2 3 2 4 5 2))
+  (define b1 (box 5))
+  (define b2 (box 5))
+  (remw* (list b2) (list 0 b1 1 b2 2 b2 3))]
 
 @history[#:added "8.5.0.3"]}
 
@@ -648,7 +654,10 @@ Like @racket[member], but finds an element using @racket[equal-always?].
 
 @mz-examples[
   (memw 2 (list 1 2 3 4))
-  (memw 9 (list 1 2 3 4))]
+  (memw 9 (list 1 2 3 4))
+  (define b1 (box 5))
+  (define b2 (box 5))
+  (memw b2 (list 0 b1 1 b2 2))]
 
 @history[#:added "8.5.0.3"]}
 
@@ -727,7 +736,10 @@ then @racket[lst] must be a list of pairs (and not a cyclic list).
 Like @racket[assoc], but finds an element using @racket[equal-always?].
 
 @mz-examples[
-  (assw 3 (list (list 1 2) (list 3 4) (list 5 6)))]
+  (assw 3 (list (list 1 2) (list 3 4) (list 5 6)))
+  (define b1 (box 0))
+  (define b2 (box 0))
+  (assw b2 (list (cons b1 1) (cons b2 2)))]
 
 @history[#:added "8.5.0.3"]}
 

--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -1676,3 +1676,11 @@ for use with @racket[make-reader-graph].}
 
 Like @racket[make-immutable-hasheqv], but produces a @tech{hash placeholder}
 for use with @racket[make-reader-graph].}
+
+@defproc[(make-hashalw-placeholder [assocs (listof pair?)])
+         hash-placeholder?]{
+
+Like @racket[make-immutable-hashalw], but produces a @tech{hash placeholder}
+for use with @racket[make-reader-graph].
+
+@history[#:added "8.5.0.3"]}

--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -509,6 +509,20 @@ Returns @racket[(remove v lst eqv?)].
   (remv #\c (list #\a #\b #\c))]}
 
 
+@defproc[(remw [v any/c] [lst list?])
+         list?]{
+
+Returns @racket[(remove v lst equal-always?)].
+
+@mz-examples[
+  (remw 2 (list 1 2 3 4 5))
+  (remw '(2) (list '(1) '(2) '(3)))
+  (remw "2" (list "1" "2" "3"))
+  (remw #\c (list #\a #\b #\c))]
+
+@history[#:added "8.5.0.3"]}
+
+
 @defproc[(remove* [v-lst list?] [lst list?] [proc procedure? equal?])
          list?]{
 
@@ -539,6 +553,17 @@ Returns @racket[(remove* v-lst lst eqv?)].
 
 @mz-examples[
   (remv* (list 1 2) (list 1 2 3 2 4 5 2))]}
+
+
+@defproc[(remw* [v-lst list?] [lst list?])
+         list?]{
+
+Returns @racket[(remove* v-lst lst equal-always?)].
+
+@mz-examples[
+  (remw* (list 1 2) (list 1 2 3 2 4 5 2))]
+
+@history[#:added "8.5.0.3"]}
 
 
 @defproc[(sort [lst list?] [less-than? (any/c any/c . -> . any/c)]
@@ -616,6 +641,18 @@ non-list.
   (member 'b '(a b . etc))]}
 
 
+@defproc[(memw [v any/c] [lst (or/c list? any/c)])
+         (or/c #f list? any/c)]{
+
+Like @racket[member], but finds an element using @racket[equal-always?].
+
+@mz-examples[
+  (memw 2 (list 1 2 3 4))
+  (memw 9 (list 1 2 3 4))]
+
+@history[#:added "8.5.0.3"]}
+
+
 @defproc[(memv [v any/c] [lst (or/c list? any/c)])
          (or/c #f list? any/c)]{
 
@@ -682,6 +719,17 @@ then @racket[lst] must be a list of pairs (and not a cyclic list).
   (assoc 3.5
          (list (list 1 2) (list 3 4) (list 5 6))
          (lambda (a b) (< (abs (- a b)) 1)))]}
+
+
+@defproc[(assw [v any/c] [lst (or/c (listof pair?) any/c)])
+         (or/c pair? #f)]{
+
+Like @racket[assoc], but finds an element using @racket[equal-always?].
+
+@mz-examples[
+  (assw 3 (list (list 1 2) (list 3 4) (list 5 6)))]
+
+@history[#:added "8.5.0.3"]}
 
 
 @defproc[(assv [v any/c] [lst (or/c (listof pair?) any/c)])


### PR DESCRIPTION
Thanks to @samth for pointing out these missing docs from Typed Racket `test-docs-complete`.