### PR TITLE
BC: fix tests for custom equal+hash

### DIFF
--- a/racket/src/bc/src/hash.c
+++ b/racket/src/bc/src/hash.c
@@ -1344,6 +1344,23 @@ static Scheme_Object *hash_recur(int argc, Scheme_Object **argv, Scheme_Object *
   return scheme_make_integer(v);
 }
 
+static Scheme_Object *hash_always_recur(int argc, Scheme_Object **argv, Scheme_Object *prim)
+{
+  intptr_t v;
+  Hash_Info *hi;
+
+  hi = (Hash_Info *)SCHEME_PRIM_CLOSURE_ELS(prim)[0];
+  hi->depth += 2;
+  hi->insp = NULL; /* in case recursive call is `parameterize'd */
+  hi->mode = EQUAL_MODE_EQUAL_ALWAYS;
+
+  v = to_signed_hash(equal_hash_key(argv[0], 0, hi));
+
+  hi->insp = NULL;
+  
+  return scheme_make_integer(v);
+}
+
 static Scheme_Object *hash_k(void)
 {
   Scheme_Thread *p = scheme_current_thread;
@@ -1765,10 +1782,17 @@ static uintptr_t equal_hash_key(Scheme_Object *o, uintptr_t k, Hash_Info *hi)
         } else {
           hi2 = (Hash_Info *)scheme_malloc(sizeof(Hash_Info));
           a[0] = (Scheme_Object *)hi2;
-          recur = scheme_make_prim_closure_w_arity(hash_recur,
-                                                   1, a,
-                                                   "equal-hash-code/recur",
-                                                   1, 1);
+          if (hi->mode == EQUAL_MODE_EQUAL_ALWAYS) {
+            recur = scheme_make_prim_closure_w_arity(hash_always_recur,
+                                                     1, a,
+                                                     "equal-always-hash-code/recur",
+                                                     1, 1);
+          } else {
+            recur = scheme_make_prim_closure_w_arity(hash_recur,
+                                                     1, a,
+                                                     "equal-hash-code/recur",
+                                                     1, 1);
+          }
           hi->recur = recur;
         }
         memcpy(hi2, hi, sizeof(Hash_Info));
@@ -2148,6 +2172,20 @@ static Scheme_Object *hash2_recur(int argc, Scheme_Object **argv, Scheme_Object 
   return scheme_make_integer(v);
 }
 
+static Scheme_Object *hash2_always_recur(int argc, Scheme_Object **argv, Scheme_Object *prim)
+{
+  intptr_t v;
+  Hash_Info *hi;
+
+  hi = (Hash_Info *)SCHEME_PRIM_CLOSURE_ELS(prim)[0];
+  hi->depth += 2;
+  hi->mode = EQUAL_MODE_EQUAL_ALWAYS;
+
+  v = to_signed_hash(equal_hash_key2(argv[0], hi));
+  
+  return scheme_make_integer(v);
+}
+
 static Scheme_Object *hash2_k(void)
 {
   Scheme_Thread *p = scheme_current_thread;
@@ -2375,10 +2413,17 @@ static uintptr_t equal_hash_key2(Scheme_Object *o, Hash_Info *hi)
         } else {
           hi2 = (Hash_Info *)scheme_malloc(sizeof(Hash_Info));
           a[0] = (Scheme_Object *)hi2;
-          recur = scheme_make_prim_closure_w_arity(hash2_recur,
-                                                   1, a,
-                                                   "equal-secondary-hash-code/recur",
-                                                   1, 1);
+          if (hi->mode == EQUAL_MODE_EQUAL_ALWAYS) {
+            recur = scheme_make_prim_closure_w_arity(hash2_always_recur,
+                                                     1, a,
+                                                     "equal-always-secondary-hash-code/recur",
+                                                     1, 1);
+          } else {
+            recur = scheme_make_prim_closure_w_arity(hash2_recur,
+                                                     1, a,
+                                                     "equal-secondary-hash-code/recur",
+                                                     1, 1);
+          }
           hi->recur = recur;
         }
         memcpy(hi2, hi, sizeof(Hash_Info));


### PR DESCRIPTION
Fix tests for custom `equal+hash`, and fix the recur argument to `hash-proc` and `hash2-proc` in `equal-always?` mode.