### PR TITLE
Zuo: Use SHA-256.

### DIFF
--- a/racket/src/ChezScheme/build.zuo
+++ b/racket/src/ChezScheme/build.zuo
@@ -399,7 +399,7 @@
                 `[:target ,dest (,src)
                           ,(lambda (dest token)
                              (define orig-sha1-file (~a dest ".orig-hash"))
-                             (define src-hash (file-sha1 src token))
+                             (define src-hash (file-sha256 src token))
                              (unless (and (file-exists? dest)
                                           (file-exists? orig-sha1-file)
                                           (equal? src-hash

--- a/racket/src/LICENSE.txt
+++ b/racket/src/LICENSE.txt
@@ -35,8 +35,8 @@ which you must comply. Some of them are listed below.
 The following are used in all Racket executables:
 
 * mbed TLS. Code from mbed TLS can be found in
-  rktio/rktio_sha2.c. mbed TLS is licensed under the Apache
-  v2.0 License.
+  rktio/rktio_sha2.c and zuo/zuo.c. mbed TLS is licensed under the
+  Apache v2.0 License.
 
 The following are used only in the Racket BC executable:
 

--- a/racket/src/lib.zuo
+++ b/racket/src/lib.zuo
@@ -156,7 +156,7 @@
                        ;; writing the hash of every file to "stamp-file" means that
                        ;; we expect any change to effect the way that the compiled
                        ;; file runs:
-                       (fd-write out (file-sha1 path token)))
+                       (fd-write out (file-sha256 path token)))
                      paths)
                     (fd-close out))))))
 

--- a/racket/src/rktio/rktio_sha2.c
+++ b/racket/src/rktio/rktio_sha2.c
@@ -24,6 +24,7 @@
  *  http://csrc.nist.gov/publications/fips/fips180-2/fips180-2.pdf
  */
 /* Adjusted by Matthew Flatt for rktio */
+/* This code is also used in "zuo.c".  */
 
 #include "rktio.h"
 

--- a/racket/src/zuo/LICENSE.txt
+++ b/racket/src/zuo/LICENSE.txt
@@ -8,3 +8,6 @@ See the files
 and
   https://github.com/racket/racket/blob/master/racket/src/LICENSE-MIT.txt
 for the full text of the licenses.
+
+The SHA-256 implementation is from mbed TLS. mbed TLS is licensed
+under the Apache v2.0 License.

--- a/racket/src/zuo/lib/zuo/build.zuo
+++ b/racket/src/zuo/lib/zuo/build.zuo
@@ -19,9 +19,10 @@
          rule?
          phony-rule?
 
-         sha1?
-         file-sha1
-         no-sha1
+         sha256?
+         file-sha256
+         no-sha256
+         sha256-length
 
          build
          build/command-line
@@ -43,7 +44,7 @@
 ;; Targets and rules
 
 ;; A token represents a build in progress, used by a target's `get-rule` or `build`
-;; function to make recursive call or get SHA-1s (possibly cached)
+;; function to make recursive call or get SHA-256s (possibly cached)
 (struct token (target      ; the target that received this token
                ch          ; a channel to access the build state
                seen        ; to detect dependency cycles
@@ -58,8 +59,8 @@
 
 ;; A rule is a result from `get-rule`:
 (struct rule (deps        ; list of targets
-              build       ; (-> any), called when deps SHA-1s different than recorded
-              sha1))      ; #f => computed via `file-sha1`
+              build       ; (-> any), called when deps SHA-256s different than recorded
+              sha256))      ; #f => computed via `file-sha256`
 
 ;; A phony target returns a phony-rule, instead:
 (struct phony-rule (deps
@@ -68,16 +69,16 @@
 ;; During a target's `get-rule` or `build`, calls to `build/dep`
 ;; trigger recording of additional dependencies
 
-(define no-sha1 "")
-(define phony-sha1 (string->uninterned-symbol "x")) ; internal use
-(define (sha1? s)
+(define no-sha256 "")
+(define phony-sha256 (string->uninterned-symbol "x")) ; internal use
+(define (sha256? s)
   (or (and (string? s)
-           (or (= (string-length s) 40)
-               (string=? s no-sha1)
-               ;; also allow a concatenation of SHA-1s for multi-file targets
-               (and (>= (string-length s) 40)
-                    (= 0 (modulo (string-length s) 40)))))
-      (eq? s phony-sha1)))
+           (or (= (string-length s) sha256-length)
+               (string=? s no-sha256)
+               ;; also allow a concatenation of SHA-256s for multi-file targets
+               (and (>= (string-length s) sha256-length)
+                    (= 0 (modulo (string-length s) sha256-length)))))
+      (eq? s phony-sha256)))
 
 ;; public constructor
 (define make-target
@@ -100,16 +101,16 @@
 ;; public constructor
 (define make-rule
   (let ([rule
-         (lambda (deps [build #f] [sha1 #f])
+         (lambda (deps [build #f] [sha256 #f])
            (let ([norm-deps (and (list? deps) (map coerce-to-target deps))])
              (unless (and norm-deps (andmap target? norm-deps))
                (arg-error 'rule "list of targets" deps))
              (unless (or (not build)
                          (procedure? build))
                (arg-error 'rule "procedure or #f" build))
-             (unless (or (not sha1) (sha1? sha1))
-               (arg-error 'rule "sha1 or #f" sha1))
-             (rule norm-deps build sha1)))])
+             (unless (or (not sha256) (sha256? sha256))
+               (arg-error 'rule "sha256 or #f" sha256))
+             (rule norm-deps build sha256)))])
     rule))
 
 ;; An input-file target has no dependencies
@@ -139,12 +140,12 @@
             t))
       (coerce-to-target t)))
 
-;; An input-data target supplies its SHA-1 up front
+;; An input-data target supplies its SHA-256 up front
 (define (input-data-target name v)
   (unless (symbol? name) (arg-error 'input-data-target "symbol" name))
   (target (symbol->key name)
           name
-          (lambda (path token) (make-rule '() #f (string-sha1 (~s v))))
+          (lambda (path token) (make-rule '() #f (string-sha256 (~s v))))
           'input
           (hash)))
 
@@ -167,8 +168,8 @@
     (rule (phony-rule-deps r)
           (lambda ()
             ((phony-rule-build r))
-            phony-sha1)
-          phony-sha1)))
+            phony-sha256)
+          phony-sha256)))
 
 (define (target-path t)
   (unless (target? t) (arg-error 'target-path "target" t))
@@ -192,23 +193,23 @@
 
 ;; When a target is built, the build result is recorded as
 ;;
-;;   (list sha1 (list dep-sym-or-path-rel-to-target sha1) ..)
+;;   (list sha256 (list dep-sym-or-path-rel-to-target sha256) ...)
 ;;
 ;; This result is in the `target-state` field of a build state, while
 ;; `db` holds the same-shaped information from the previous build.
 ;;
 ;; The `time-cache` field of a build state is a shortcut for getting
-;; input-file SHA-1s on the assumption that a SHA-1 recorded last time
+;; input-file SHA-256s on the assumption that a SHA-256 recorded last time
 ;; is still right if the file's timestamp hasn't changed.
 
-;; Where the contracts below say "dep-sha1s", that's a hash table
-;; mapping a dependency's key to a SHA-1.
+;; Where the contracts below say "dep-sha256s", that's a hash table
+;; mapping a dependency's key to a SHA-256.
 
 (struct build-state (ch            ; channel to hold the state while target is running
-                     target-state  ; key -> (cons sha1 dep-sha1s) | 'pending | channel
-                     target-accum  ; key -> dep-sha1s
-                     db            ; key -> (cons sha1 dep-sha1s) | #t [for db file itself]
-                     time-cache    ; key -> (cons timestamp sha1)
+                     target-state  ; key -> (cons sha256 dep-sha256s) | 'pending | channel
+                     target-accum  ; key -> dep-sha256s
+                     db            ; key -> (cons sha256 dep-sha256s) | #t [for db file itself]
+                     time-cache    ; key -> (cons timestamp sha256)
                      saw-targets   ; key -> target [to detect multiple for same output]
                      resource-ch   ; channel with available resources enqueued
                      log?          ; logging enabled?
@@ -314,9 +315,9 @@
     [(eq? (target-kind t) 'input)
      ;; no dependencies, not need for a thread to build, etc.
      (define r ((target-get-rule t) (target-name t) #f))
-     (define sha1 (or (rule-sha1 r) (file-sha1/state (target-path t) state)))
-     (when (equal? sha1 no-sha1) ((rule-build r)))
-     (update-target-state state t (list sha1))]
+     (define sha256 (or (rule-sha256 r) (file-sha256/state (target-path t) state)))
+     (when (equal? sha256 no-sha256) ((rule-build r)))
+     (update-target-state state t (list sha256))]
     [else (build-unbuilt t state seen top?)]))
 
 ;; Starts a build for a specific target
@@ -336,10 +337,10 @@
 
   ;; get previously recorded result, possibly loading from a file
   ;; that is cached in the build state
-  (define loaded-state (load-sha1s state t path))
+  (define loaded-state (load-sha256s state t path))
   (define prev-ts (previous-target-state loaded-state (target-key t)))
-  (define prev-sha1 (car prev-ts))
-  (define prev-dep-sha1s/raw-symbols (cdr prev-ts))
+  (define prev-sha256 (car prev-ts))
+  (define prev-dep-sha256s/raw-symbols (cdr prev-ts))
 
   ;; record a channel as the start's current build state
   (define result-ch (channel))
@@ -357,23 +358,23 @@
   (unless (rule? r)
     (error "build: target result is not a rule" r))
   (define deps (rule-deps r))
-  (define sha1 (or (rule-sha1 r) (if (pair? co-outputs)
-                                     (files-sha1 (cons path co-outputs) tok)
-                                     (file-sha1 path tok))))
+  (define sha256 (or (rule-sha256 r) (if (pair? co-outputs)
+                                         (files-sha256 (cons path co-outputs) tok)
+                                         (file-sha256 path tok))))
   (define to-build (rule-build r))
-  (define build-to-sha1? (and (rule-sha1 r) #t))
+  (define build-to-sha256? (and (rule-sha256 r) #t))
 
   ;; if we recorded any data targets, we need to fix up the keys
-  (define prev-dep-sha1s (foldl (lambda (dep-key dep-sha1s)
-                                  (cond
-                                    [(symbol-key? dep-key)
-                                     (let ([actual-key (translate-key dep-key deps t)])
-                                       (hash-set (hash-remove dep-sha1s dep-key)
-                                                 actual-key
-                                                 (hash-ref dep-sha1s dep-key)))]
-                                    [else dep-sha1s]))
-                                prev-dep-sha1s/raw-symbols
-                                (hash-keys prev-dep-sha1s/raw-symbols)))
+  (define prev-dep-sha256s (foldl (lambda (dep-key dep-sha256s)
+                                    (cond
+                                      [(symbol-key? dep-key)
+                                       (let ([actual-key (translate-key dep-key deps t)])
+                                         (hash-set (hash-remove dep-sha256s dep-key)
+                                                   actual-key
+                                                   (hash-ref dep-sha256s dep-key)))]
+                                      [else dep-sha256s]))
+                                  prev-dep-sha256s/raw-symbols
+                                  (hash-keys prev-dep-sha256s/raw-symbols)))
 
   (define rule-state (get-state (token-ch tok) "rule"))
 
@@ -386,14 +387,14 @@
            rule-state
            deps))
 
-  ;; extract results, assemble in a hash table: <rel-path> -> <sha1>
-  (define dep-reported-sha1s
-    (foldl (lambda (dep dep-sha1s)
-             (add-dependent-target-state dep dep-sha1s new-state))
+  ;; extract results, assemble in a hash table: <rel-path> -> <sha256>
+  (define dep-reported-sha256s
+    (foldl (lambda (dep dep-sha256s)
+             (add-dependent-target-state dep dep-sha256s new-state))
            (hash)
            deps))
-  (define dep-sha1s
-    (cdr (merge-target-accumulated new-state t (cons #f dep-reported-sha1s))))
+  (define dep-sha256s
+    (cdr (merge-target-accumulated new-state t (cons #f dep-reported-sha256s))))
 
   ;; calling the build step for `t` might generate more dependencies, but those
   ;; extra dependencies are supposed to be determined only by the ones declared
@@ -402,69 +403,69 @@
   ;; then we can assume that the extra dependencies generated previously are still
   ;; the extra dependencies this time
   (define same-so-far?
-    (and (log-changed (and (equal? sha1 prev-sha1) (not (equal? sha1 no-sha1))) path state)
+    (and (log-changed (and (equal? sha256 prev-sha256) (not (equal? sha256 no-sha256))) path state)
          (andmap (lambda (dep-key)
-                   (log-changed (equal? (hash-ref dep-sha1s dep-key)
-                                        (hash-ref prev-dep-sha1s dep-key #f))
+                   (log-changed (equal? (hash-ref dep-sha256s dep-key)
+                                        (hash-ref prev-dep-sha256s dep-key #f))
                                 dep-key
                                 state))
-                 (hash-keys dep-sha1s))))
+                 (hash-keys dep-sha256s))))
 
   (define more-deps
     (if same-so-far?
-        (foldl (lambda (dep-key more-sha1s)
+        (foldl (lambda (dep-key more-sha256s)
                  ;; currently, we assume that any additional dependencies
                  ;; added in the build phase were and would be inputs
-                 (if (or (hash-ref dep-sha1s dep-key #f)
+                 (if (or (hash-ref dep-sha256s dep-key #f)
                          (symbol-key? dep-key))
-                     more-sha1s
+                     more-sha256s
                      (cons (input-file-target (symbol->string dep-key))
-                           more-sha1s)))
+                           more-sha256s)))
                '()
-               (hash-keys prev-dep-sha1s))
+               (hash-keys prev-dep-sha256s))
         '()))
   (for-each (make-fetch-dep new-state new-seen dep-top?) more-deps)
   (define newer-state
     (foldl (lambda (dep state) (do-build dep state new-seen dep-top?))
            new-state
            more-deps))
-  (define all-dep-sha1s
-    (foldl (lambda (dep dep-sha1s)
-             (add-dependent-target-state dep dep-sha1s newer-state))
-           dep-sha1s
+  (define all-dep-sha256s
+    (foldl (lambda (dep dep-sha256s)
+             (add-dependent-target-state dep dep-sha256s newer-state))
+           dep-sha256s
            more-deps))
 
   ;; compare to recorded result, and rebuild if different
   (cond
     [(and same-so-far?
           (andmap (lambda (dep-key)
-                    (log-changed (equal? (hash-ref all-dep-sha1s dep-key #f)
-                                         (hash-ref prev-dep-sha1s dep-key #f))
+                    (log-changed (equal? (hash-ref all-dep-sha256s dep-key #f)
+                                         (hash-ref prev-dep-sha256s dep-key #f))
                                  dep-key
                                  state))
-                  (hash-keys all-dep-sha1s)))
+                  (hash-keys all-dep-sha256s)))
      ;; no need to rebuild
      (when path-handle (cleanable-cancel path-handle))
      (when (and (or alert-top? (hash-ref (target-options t) 'noisy? #f))
-                (equal? prev-sha1 sha1)
-                (not (equal? sha1 phony-sha1)))
+                (equal? prev-sha256 sha256)
+                (not (equal? sha256 phony-sha256)))
        (alert (~a (target-name t) " is up to date")))
-     (define done-state (update-target-state newer-state t (cons sha1 all-dep-sha1s)))
+     (define done-state (update-target-state newer-state t (cons sha256 all-dep-sha256s)))
      (channel-put result-ch 'done)
      done-state]
     [else
      (unless to-build
        (error "build: out-of-date target has no build procedure" (target-name t)))
      (define (build-one finish)
-       (let* ([maybe-sha1 (to-build)] ; build!
-              [sha1 (if build-to-sha1?
-                        maybe-sha1
-                        (if (pair? co-outputs)
-                            (files-sha1 (cons path co-outputs) tok)
-                            (file-sha1 path tok)))])
-         (unless (sha1? sha1)
-           (error "build: target-build result is not a sha1" sha1))
-         (when (equal? sha1 no-sha1)
+       (let* ([maybe-sha256 (to-build)] ; build!
+              [sha256 (if build-to-sha256?
+                          maybe-sha256
+                          (if (pair? co-outputs)
+                              (files-sha256 (cons path co-outputs) tok)
+                              (file-sha256 path tok)))])
+         (unless (sha256? sha256)
+           (error "build: target-build result is not a sha256" sha256))
+         (when (equal? sha256 no-sha256)
            (error "rule for target did not create it" (if (pair? co-outputs)
                                                           (cons path co-outputs)
                                                           path)))
@@ -472,11 +473,11 @@
          (finish
           (lambda (state)
             ;; record result:
-            (let* ([ts (if (eq? sha1 phony-sha1)
-                           (cons no-sha1 (hash))
-                           (cons sha1 dep-sha1s))]
+            (let* ([ts (if (eq? sha256 phony-sha256)
+                           (cons no-sha256 (hash))
+                           (cons sha256 dep-sha256s))]
                    [ts (merge-target-accumulated state t ts)]
-                   [state (update-target-state/record-sha1s state t ts co-outputs)])
+                   [state (update-target-state/record-sha256s state t ts co-outputs)])
               (channel-put result-ch 'done)
               state)))))
      (let ([state-ch (build-state-ch newer-state)])
@@ -681,25 +682,25 @@
 (define (target-state state t)
   (hash-ref (build-state-target-state state) (target-key t) #f))
 
-(define (add-dependent-target-state dep dep-sha1s state)
+(define (add-dependent-target-state dep dep-sha256s state)
   (define ts (target-state state dep))
-  (define sha1 (car ts))
-  (hash-set dep-sha1s (target-key dep) (if (eq? sha1 phony-sha1) no-sha1 sha1)))
+  (define sha256 (car ts))
+  (hash-set dep-sha256s (target-key dep) (if (eq? sha256 phony-sha256) no-sha256 sha256)))
 
 (define (record-target-accumulated state for-t t)
   (let* ([accum-key (target-key for-t)]
-         [dep-sha1s (hash-ref (build-state-target-accum state) accum-key (hash))]
-         [dep-sha1s (add-dependent-target-state t dep-sha1s state)])
-    (build-state-set-target-accum state (hash-set (build-state-target-accum state) accum-key dep-sha1s))))
+         [dep-sha256s (hash-ref (build-state-target-accum state) accum-key (hash))]
+         [dep-sha256s (add-dependent-target-state t dep-sha256s state)])
+    (build-state-set-target-accum state (hash-set (build-state-target-accum state) accum-key dep-sha256s))))
 
 (define (merge-target-accumulated state t ts)
-  (let ([more-dep-sha1s (hash-ref (build-state-target-accum state) (target-key t) #f)])
-    (if more-dep-sha1s
+  (let ([more-dep-sha256s (hash-ref (build-state-target-accum state) (target-key t) #f)])
+    (if more-dep-sha256s
         (cons (car ts)
-              (foldl (lambda (dep-key dep-sha1s)
-                       (hash-set dep-sha1s dep-key (hash-ref more-dep-sha1s dep-key)))
+              (foldl (lambda (dep-key dep-sha256s)
+                       (hash-set dep-sha256s dep-key (hash-ref more-dep-sha256s dep-key)))
                      (cdr ts)
-                     (hash-keys more-dep-sha1s)))
+                     (hash-keys more-dep-sha256s)))
         ts)))
 
 (define (update-target-state state t ts)
@@ -708,19 +709,19 @@
                                           (target-key t)
                                           ts)))
 
-(define (update-target-state/record-sha1s state t ts co-outputs)
+(define (update-target-state/record-sha256s state t ts co-outputs)
   (unless (eq? 'phony (target-kind t))
-    (db-record-target-sha1s (target-db-dir t) (target-name t) ts co-outputs))
+    (db-record-target-sha256s (target-db-dir t) (target-name t) ts co-outputs))
   (update-target-state state t ts))
 
-(define (load-sha1s state t path)
+(define (load-sha256s state t path)
   (cond
     [(symbol? path) state]
     [else
-     (define db+tc (db-load-sha1s (target-db-dir t)
-                                  path
-                                  (build-state-db state)
-                                  (build-state-time-cache state)))
+     (define db+tc (db-load-sha256s (target-db-dir t)
+                                    path
+                                    (build-state-db state)
+                                    (build-state-time-cache state)))
      (if db+tc
          (let ([state (build-state-set-db state (car db+tc))])
            (build-state-set-time-cache state (cdr db+tc)))
@@ -728,7 +729,7 @@
 
 (define (previous-target-state state key)
   (or (hash-ref (build-state-db state) key #f)
-      (cons no-sha1 (hash))))
+      (cons no-sha256 (hash))))
 
 (define (ensure-consistent state t)
   (let* ([saw (build-state-saw-targets state)]
@@ -743,22 +744,22 @@
       [else
        (build-state-set-saw-targets state (hash-set saw (target-key t) t))])))
 
-(define (file-sha1 path token)
-  (unless (path-string? path) (arg-error 'file-sha1 "path string" path))
-  (unless (or (not token) (token? token)) (error 'file-sha1 "build-token" token))
-  (let ([state (and token (get-state (token-ch token) "sha1"))])
-    (when state (put-state (token-ch token) state "sha1"))
-    (file-sha1/state path state)))
+(define (file-sha256 path token)
+  (unless (path-string? path) (arg-error 'file-sha256 "path string" path))
+  (unless (or (not token) (token? token)) (error 'file-sha256 "build-token" token))
+  (let ([state (and token (get-state (token-ch token) "sha256"))])
+    (when state (put-state (token-ch token) state "sha256"))
+    (file-sha256/state path state)))
 
-(define (files-sha1 paths token)
-  (let ([sha1s (map (lambda (path) (file-sha1 path token)) paths)])
-    (if (ormap (lambda (s) (string=? s no-sha1)) sha1s)
-        no-sha1
-        (apply ~a sha1s))))
+(define (files-sha256 paths token)
+  (let ([sha256s (map (lambda (path) (file-sha256 path token)) paths)])
+    (if (ormap (lambda (s) (string=? s no-sha256)) sha256s)
+        no-sha256
+        (apply ~a sha256s))))
 
-(define (file-sha1/state path state)
-  (or (file-sha1/cached path (and state (build-state-time-cache state)))
-      no-sha1))
+(define (file-sha256/state path state)
+  (or (file-sha256/cached path (and state (build-state-time-cache state)))
+      no-sha256))
 
 ;; translate a data key as loaded from a previous-run to a key as
 ;; instantiated for this run

--- a/racket/src/zuo/lib/zuo/private/build-db.zuo
+++ b/racket/src/zuo/lib/zuo/private/build-db.zuo
@@ -5,7 +5,7 @@
 ;; directory, the goal here is to be able to load information for all
 ;; the targets at once.
 
-;; A timestamp-based SHA-1 cache for input files is stored in
+;; A timestamp-based SHA-256 cache for input files is stored in
 ;; "_zuo_tc.db" alongside "_zuo.db" --- in the directory of a target
 ;; that depends on the input files, not in the input file's directory
 ;; (which is likely to be in the source tree). An input used by
@@ -19,14 +19,16 @@
 ;; format of each file is a top-level sequence of
 ;;   (<rel-path> . <info>)
 ;; For "_zuo.db", it's more specifically
-;;   (<rel-path> <sha1> (<dep-rel-path> <sha1>) ...)
+;;   (<rel-path> <sha256> (<dep-rel-path> <sha256>) ...)
 ;; For "_zuo_tc.db", it's
-;;   (<rel-path> (<time-secs> . <time-msec>) <sha1>)
+;;   (<rel-path> (<time-secs> . <time-msec>) <sha256>)
 
-(provide db-record-target-sha1s
-         db-load-sha1s
+(provide db-record-target-sha256s
+         db-load-sha256s
 
-         file-sha1/cached
+         sha256-length
+
+         file-sha256/cached
          path->absolute-path
          dir-part
 
@@ -34,7 +36,9 @@
          symbol-key?
          symbol-key->symbol)
 
-;; for serialization and deserialization of dep-sha1s tables
+(define sha256-length 64)
+
+;; for serialization and deserialization of dep-sha256s tables
 (define (hash->list ht db-dir)
   (map (lambda (k) (list (serialize-key k db-dir) (hash-ref ht k)))
        (hash-keys ht)))
@@ -79,12 +83,12 @@
   (k rel-target-path db-dir db-path tc-path))
 
 ;; Records the result of a build of `name`, mainly storing the
-;; SHA-1 and dep SHA-1s in "_zuo.db", but also recording a timestamp
-;; plus SHA-1 for dependencies in "_zuo_tc.db".
+;; SHA-256 and dep SHA-256s in "_zuo.db", but also recording a timestamp
+;; plus SHA-256 for dependencies in "_zuo_tc.db".
 ;; All relative file names are stored relative to `db-dir`, which
 ;; defaults to the directory of target-path. On entry, `target-path`
 ;; and keys in `ts` are relative to the current directory.
-(define (db-record-target-sha1s maybe-db-dir target-path ts co-outputs)
+(define (db-record-target-sha256s maybe-db-dir target-path ts co-outputs)
   (db-paths
    maybe-db-dir target-path
    (lambda (rel-target-path db-dir db-path tc-path)
@@ -92,8 +96,8 @@
        (if (file-exists? db-path)
            (string-read (file->string db-path) 0 db-path)
            '()))
-     (define dep-sha1s-l (hash->list (cdr ts) db-dir))
-     (define new-db-content (reassoc (list* rel-target-path (car ts) dep-sha1s-l) db-content))
+     (define dep-sha256s-l (hash->list (cdr ts) db-dir))
+     (define new-db-content (reassoc (list* rel-target-path (car ts) dep-sha256s-l) db-content))
      (update-file db-path new-db-content)
      (unless (ormap (lambda (p) (string=? (car p) "SOURCE_DATE_EPOCH")) (hash-ref (runtime-env) 'env))
        (define tc-content
@@ -110,19 +114,19 @@
                                                       (build-path db-dir dep-name)
                                                       dep-name)))
                      (cond
-                       [time (reassoc (list dep-name time (substring (cadr dep) 0 40)) tc-content)]
+                       [time (reassoc (list dep-name time (substring (cadr dep) 0 sha256-length)) tc-content)]
                        [else tc-content])]))
                 tc-content
                 (if (pair? co-outputs)
-                    (append (split-sha1s rel-target-path co-outputs (car ts) db-dir)
-                            dep-sha1s-l)
-                    (cons (list rel-target-path (car ts)) dep-sha1s-l))))
+                    (append (split-sha256s rel-target-path co-outputs (car ts) db-dir)
+                            dep-sha256s-l)
+                    (cons (list rel-target-path (car ts)) dep-sha256s-l))))
        (update-file tc-path new-tc-content)))))
 
 ;; Loads previous-build information for `abs-path`, as well as cached
-;; SHA-1s for things that might be dependencies; loading needs to
+;; SHA-256s for things that might be dependencies; loading needs to
 ;; happen only once per directory that has a (non-input) build target
-(define (db-load-sha1s maybe-db-dir target-path db tc)
+(define (db-load-sha256s maybe-db-dir target-path db tc)
   (db-paths
    maybe-db-dir target-path
    (lambda (name db-dir db-path tc-path)
@@ -159,8 +163,8 @@
         (define new-tc (read-in tc-path tc (lambda (v) v)))
         (cons new-db new-tc)]))))
 
-;; Helpers to get an input file's SHA-1, possibly cached
-(define (file-sha1/cached path time-cache)
+;; Helpers to get an input file's SHA-256, possibly cached
+(define (file-sha256/cached path time-cache)
   (let ([timestamp (file-timestamp path)])
     (and timestamp
          (let ([cached (and time-cache
@@ -168,15 +172,17 @@
                                       (string->symbol path)
                                       #f))])
            (if (and cached
-                    (equal? (car cached) timestamp))
+                    (equal? (car cached) timestamp)
+                    ;; might be a stale SHA-1 rather than an SHA-256
+                    (= sha256-length (string-length (cadr cached))))
                (cadr cached)
-               (string-sha1 (file->string path)))))))
+               (string-sha256 (file->string path)))))))
 
-;; Split "sha1", which should have a sha1 for each of `rel-target-path`
-;; and each element of `co-outputs`, into a list of sha1s
-(define (split-sha1s rel-target-path co-outputs sha1 db-dir)
-  (cons (list rel-target-path (substring sha1 0 40))
-        (let loop ([co-outputs co-outputs] [start 40])
+;; Split "sha256", which should have a sha256 for each of `rel-target-path`
+;; and each element of `co-outputs`, into a list of sha256s
+(define (split-sha256s rel-target-path co-outputs sha256 db-dir)
+  (cons (list rel-target-path (substring sha256 0 sha256-length))
+        (let loop ([co-outputs co-outputs] [start sha256-length])
           (cond
             [(null? co-outputs) '()]
             [else
@@ -184,8 +190,8 @@
                (cons (list (if (relative-path? co-output)
                                (find-relative-path db-dir co-output)
                                co-output)
-                           (substring sha1 start (+ start 40)))
-                     (loop (cdr co-outputs) (+ start 40))))]))))
+                           (substring sha256 start (+ start sha256-length)))
+                     (loop (cdr co-outputs) (+ start sha256-length))))]))))
 
 ;; Atomic write by write-to-temporary-and-move
 (define (update-file path new-content)

--- a/racket/src/zuo/local/image.zuo
+++ b/racket/src/zuo/local/image.zuo
@@ -44,7 +44,7 @@
 
 (define (image-target cmd)
   (target
-   (hash-ref cmd 'output) ; the output file; `target` uses SHA-1 on this
+   (hash-ref cmd 'output) ; the output file; `target` uses SHA-256 on this
    (lambda (path token)
      ;; when a target is demanded, we report dependencies and more via `rule`
      (rule

--- a/racket/src/zuo/tests/string.zuo
+++ b/racket/src/zuo/tests/string.zuo
@@ -89,7 +89,7 @@
       (unless (= j (string-length s)) (j-loop (+ j 1))))
     (unless (= i (string-length s)) (i-loop (+ i 1)))))
 
-(check (string-sha1 "hello\n") "f572d396fae9206628714fb2ce00f72e94f2258f")
+(check (string-sha256 "hello\n") "5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03")
 
 (check (string->integer "10") 10)
 (check (string->integer "-10") -10)

--- a/racket/src/zuo/zuo-doc/fake-zuo.rkt
+++ b/racket/src/zuo/zuo-doc/fake-zuo.rkt
@@ -104,7 +104,7 @@
     string->uninterned-symbol
     symbol->string
     string
-    string-sha1
+    string-sha256
     char
     string-split string-join string-trim
     string-tree?
@@ -210,9 +210,10 @@
     token?
     rule?
     phony-rule?
-    sha1?
-    file-sha1
-    no-sha1
+    sha256?
+    file-sha256
+    no-sha256
+    sha256-length
     build
     build/command-line
     build/command-line*

--- a/racket/src/zuo/zuo-doc/lang-zuo-kernel.scrbl
+++ b/racket/src/zuo/zuo-doc/lang-zuo-kernel.scrbl
@@ -77,7 +77,7 @@ in @racketmodname[zuo/kernel] (and the values originate there):
   bitwise-and bitwise-ior bitwise-xor bitwise-not
 
   string? string-length string-ref string-u32-ref substring string
-  string=? string-ci=? string-sha1 string-split
+  string=? string-ci=? string-sha256 string-split
 
   symbol? symbol->string string->symbol string->uninterned-symbol
   

--- a/racket/src/zuo/zuo-doc/lang-zuo.scrbl
+++ b/racket/src/zuo/zuo-doc/lang-zuo.scrbl
@@ -440,9 +440,11 @@ endianness.}
 Tries to parse @racket[str] as an integer returning @racket[#f] if
 that fails.}
 
-@defproc[(string-sha1 [str string?]) string?]{
+@defproc[(string-sha256 [str string?]) string?]{
 
-Returns the SHA-1 hash of @racket[str] as a 40-digit hexadecimal string.}
+Returns the SHA-256 hash of @racket[str] as a 64-digit hexadecimal string.
+
+See also @racket[file-sha256] and @racket[sha256-length].}
 
 @defform[(char str)]{
 

--- a/racket/src/zuo/zuo-doc/overview.scrbl
+++ b/racket/src/zuo/zuo-doc/overview.scrbl
@@ -13,7 +13,7 @@ While @racket[@#,hash-lang[] @#,racketmodname[zuo/base]] accesses a
 base language, the primary intended use of Zuo is with
 @racket[@#,hash-lang[] @#,racketmodname[zuo]], which includes the
 @racketmodname[zuo/build] library for using @seclink["zuo-build"]{Zuo
-as a @tt{make} replacement}.
+as a @exec{make} replacement}.
 
 The name ``Zuo'' is derived from the Chinese word for ``make.''
 


### PR DESCRIPTION
This PR changes Zuo to use SHA-256 rather than SHA-1. It avoids adding any new C code by moving the implementation from `rktio_sha2.c` into `zuo.c`, then using Zuo to generate `rktio_sha2.c`.

Currently, this is a just a proof-of-concept: if it seems like a useful thing to do, some cleanup will be needed. In particular, I have not renamed `string-sha1`, `file-sha1`, `sha1?`, or `no-sha1`, just changed the implementations to actually deal with SHA-256.

(Some projects transitioning from SHA-1 to SHA-256 have also changed to avoid mentioning the hash algorithm in API names, to ease a transition some day from SHA-256 to something else. Personally, I think `string-sha256` is good enough, given that `hash` means something else in Racket/Zuo and SHA-256 seems likely to be viable for a long time.)

I don't know of any currently-existing problem with SHA-1 as used by Zuo, but SHA-256 seems like a better choice as a basis for something new.