### PR TITLE
Clarify priority order of breaks

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/breaks.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/breaks.scrbl
@@ -14,9 +14,9 @@ or @as-index{@tt{SIGTERM}}; the latter two correspond to hang-up and
 terminate breaks as reflected by @racket[exn:break:hang-up] and
 @racket[exn:break:terminate], respectively. Multiple breaks may be
 collapsed into a single exception, and multiple breaks of different
-kinds may be collapsed to a single ``strongest'' break, where a
-hang-up break is stronger than an interrupt break, and a terminate
-break is stronger than a hang-up break.
+kinds may be collapsed to a single ``strongest'' break, where a 
+terminate break is stronger than a hang-up break which is stronger
+than an interrupt break.
 
 A break exception can only occur in a
 thread while breaks are enabled. When a break is detected and enabled,


### PR DESCRIPTION
The original wording on priority order for break exceptions was confusing as it was of the form "B > C and A > B".  I altered it to "C > B > A" in order to clarify the hierarchy.