### PR TITLE
Add `(require racket/class)` to code example in class guide chapter

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/class.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/class.scrbl
@@ -14,6 +14,8 @@
 
 @margin-note{This chapter is based on a paper @cite["Flatt06"].}
 
+@margin-note{@racket[(require racket/class)] is needed for the @racketmodname[racket/base] form.}
+
 A @racket[class] expression denotes a first-class value,
 just like a @racket[lambda] expression:
 

--- a/pkgs/racket-doc/scribblings/guide/match.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/match.scrbl
@@ -8,6 +8,8 @@
 
 @title[#:tag "match"]{Pattern Matching}
 
+@margin-note{@racket[(require racket/match)] is needed for the @racketmodname[racket/base] form.}
+
 The @racket[match] form supports pattern matching on arbitrary Racket
 values, as opposed to functions like @racket[regexp-match] that
 compare regular expressions to byte and character sequences (see


### PR DESCRIPTION
This guide doesn't mention `racket/class` is not in the `racket/base`, I think this change could help other Racket learners to solve the unbound identifier error.