### PR TITLE
Fix typo

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/define.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/define.scrbl
@@ -163,6 +163,6 @@ that converts one identifier to another.
  
  @racketblock[
  (define-ffi-definer define-calib camel-lib
-   #:make-c-id conventon:hyphen->camelcase)
+   #:make-c-id convention:hyphen->camelcase)
  (define-calib camel-case-variable (_fun -> _void))]
 }


### PR DESCRIPTION
`conventon:hyphen->camelcase` to `convention:hyphen->camelcase`