### PR TITLE
[json]: improve `write-json`.

### DIFF
--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -82,7 +82,7 @@ the @rfc for more information about JSON.
   the range of @tt{U+10000} and above are encoded as two @tt{\uHHHH}
   escapes, see Section 2.5 of the @|rfc|.
 
-  If @racket[format?] is given as @racket[#f], then @racket[indent] is
+  If @racket[format?] is given as @racket[#t], then @racket[indent] is
   used to format JSON.
 
 @examples[#:eval ev

--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -67,7 +67,9 @@ the @rfc for more information about JSON.
 
 @defproc[(write-json [x jsexpr?] [out output-port? (current-output-port)]
                      [#:null jsnull any/c (json-null)]
-                     [#:encode encode (or/c 'control 'all) 'control])
+                     [#:encode encode (or/c 'control 'all) 'control]
+                     [#:format? format? boolean? #f]
+                     [#:indent indent string? "\t"])
          any]{
   Writes the @racket[x] @tech{jsexpr}, encoded as JSON, to the
   @racket[out] output port.
@@ -80,18 +82,38 @@ the @rfc for more information about JSON.
   the range of @tt{U+10000} and above are encoded as two @tt{\uHHHH}
   escapes, see Section 2.5 of the @|rfc|.
 
+  If @racket[format?] is given as @racket[#f], then @racket[indent] is
+  used to format JSON.
+
 @examples[#:eval ev
   (with-output-to-string
     (λ () (write-json #hasheq((waffle . (1 2 3))))))
   (with-output-to-string
     (λ () (write-json #hasheq((와플 . (1 2 3)))
                       #:encode 'all)))
+  (write-string
+   (with-output-to-string
+     (λ () (write-json #hasheq((waffle . (1 2 3))
+                               (와플 . (1 2 3)))))))
+  (write-string
+   (with-output-to-string
+     (λ () (write-json #hasheq((waffle . (1 2 3))
+                               (와플 . (1 2 3)))
+                       #:format? #t))))
+  (write-string
+   (with-output-to-string
+     (λ () (write-json #hasheq((waffle . (1 2 3))
+                               (와플 . (1 2 3)))
+                       #:format? #t
+                       #:indent "  "))))
 ]
 }
 
 @defproc[(jsexpr->string [x jsexpr?]
                          [#:null jsnull any/c (json-null)]
-                         [#:encode encode (or/c 'control 'all) 'control])
+                         [#:encode encode (or/c 'control 'all) 'control]
+                         [#:format? format? boolean? #f]
+                         [#:indent indent string? "\t"])
          string?]{
   Generates a JSON source string for the @tech{jsexpr} @racket[x].
 
@@ -102,7 +124,9 @@ the @rfc for more information about JSON.
 
 @defproc[(jsexpr->bytes [x jsexpr?]
                         [#:null jsnull any/c (json-null)]
-                        [#:encode encode (or/c 'control 'all) 'control])
+                        [#:encode encode (or/c 'control 'all) 'control]
+                        [#:format? format? boolean? #f]
+                        [#:indent indent string? "\t"])
          bytes?]{
   Generates a JSON source byte string for the @tech{jsexpr} @racket[x].
   (The byte string is encoded in UTF-8.)
@@ -124,8 +148,8 @@ the @rfc for more information about JSON.
   characters in the port so that a second call can retrieve the
   remaining JSON input(s). If the JSON inputs aren't delimited per se
   (true, false, null), they  must be separated by whitespace from the
-  following JSON input. 
-  
+  following JSON input.
+
 
 @examples[#:eval ev
   (with-input-from-string

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -55,8 +55,8 @@
           )))
 
 (define (print-tests)
-  (for ([x (list 0 1 -1 12345 0.0 1.0 #t #f (λ(n) n) "" "abc" "abc\n\\"
-                 '() '(1 2 3) (λ(n) `(1 "2" (3) #t #f ,n)) '((((()))))
+  (for ([x (list 0 1 -1 12345 0.0 1.0 #t #f (λ (n) n) "" "abc" "abc\n\\"
+                 '() '(1 2 3) (λ (n) `(1 "2" (3) #t #f ,n)) '((((()))))
                  '#hasheq()
                  '#hasheq([x . 1])
                  '#hasheq([x . 1] [y . 2])
@@ -67,17 +67,18 @@
                  "\b" "\n" "\r" "\f" "\t"         ; same escapes in both
                  "\a" "\v" "\e"                   ; does not use racket escapes
                  )])
-    (define (N x null) (if (procedure? x) (x null) x))
+    (define (N0 x null) (if (procedure? x) (x null) x))
+    (define (N1 x null) (N0 (if (integer? x) (inexact->exact x) x) null))
     (test
      ;; default
-     (string->jsexpr (jsexpr->string (N x 'null)))
-     => (N x 'null)
+     (string->jsexpr (jsexpr->string (N0 x 'null)))
+     => (N1 x 'null)
      ;; different null
-     (string->jsexpr (jsexpr->string (N x #\null) #:null #\null) #:null #\null)
-     => (N x #\null)
+     (string->jsexpr (jsexpr->string (N0 x #\null) #:null #\null) #:null #\null)
+     => (N1 x #\null)
      ;; encode all non-ascii
-     (string->jsexpr (jsexpr->string (N x 'null) #:encode 'all))
-     => (N x 'null)))
+     (string->jsexpr (jsexpr->string (N0 x 'null) #:encode 'all))
+     => (N1 x 'null)))
   ;; also test some specific expected encodings
   (test (jsexpr->string "\0\1\2\3") => "\"\\u0000\\u0001\\u0002\\u0003\""
         (jsexpr->string "\b\n\r\f\t\\\"") => "\"\\b\\n\\r\\f\\t\\\\\\\"\""
@@ -88,7 +89,7 @@
         ;; and that the same holds for keys
         (jsexpr->string (string->jsexpr "{\"\U0010FFFF\":\"\U0010FFFF\"}"))
           => "{\"\U0010FFFF\":\"\U0010FFFF\"}"
-	(jsexpr->string #hash[(a . 1) (b . 2)]) => "{\"a\":1,\"b\":2}"
+        (jsexpr->string #hash[(a . 1) (b . 2)]) => "{\"a\":1,\"b\":2}"
         (jsexpr->string (string->jsexpr "{\"\U0010FFFF\":\"\U0010FFFF\"}")
                         #:encode 'all)
           => "{\"\\udbff\\udfff\":\"\\udbff\\udfff\"}"

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -130,7 +130,8 @@
     (write-string (regexp-replace* rx-to-encode str escape) o)
     (write-bytes #"\"" o))
   (let loop ([x x])
-    (cond [(or (exact-integer? x) (inexact-rational? x)) (write x o)]
+    (cond [(integer? x) (write (inexact->exact x) o)]
+          [(inexact-rational? x) (write x o)]
           [(eq? x #f)     (write-bytes #"false" o)]
           [(eq? x #t)     (write-bytes #"true" o)]
           [(eq? x jsnull) (write-bytes #"null" o)]

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -166,6 +166,8 @@
            (define first? #t)
            (define (write-hash-kv layer)
              (λ (k v)
+               (unless (symbol? k)
+                 (raise-type-error who "legal JSON key value" k))
                (if first? (set! first? #f) (write-bytes #"," o))
                (format/write-newline)
                (format/write-indent layer)

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -175,7 +175,7 @@
                (write-bytes #":" o)
                (format/write-whitespace)
                (loop v layer)))
-           (format/write-newline)
+           (when (> layer 0) (format/write-newline))
            (format/write-indent layer)
            (write-bytes #"{" o)
            (hash-for-each x (write-hash-kv (add1 layer))


### PR DESCRIPTION
This PR makes the following changes to `write-json`:
1. Add `#:format?` and `#:indent` to `write-json`.
````racket
Welcome to Racket v8.5 [cs].
> (require json)
> (displayln
     (with-output-to-string
       (λ () (write-json #hasheq((waffle . (1 2 3))
                                 (와플 . (1 2 3)))))))
{"waffle":[1,2,3],"와플":[1,2,3]}
> (displayln
     (with-output-to-string
       (λ () (write-json #hasheq((waffle . (1 2 3))
                                 (와플 . (1 2 3)))
                         #:format? #t))))
{
	"waffle": [1, 2, 3],
	"와플": [1, 2, 3]
}
> (displayln
     (with-output-to-string
       (λ () (write-json #hasheq((waffle . (1 2 3))
                                 (와플 . (1 2 3)))
                         #:format? #t
                         #:indent "  "))))
{
  "waffle": [1, 2, 3],
  "와플": [1, 2, 3]
}
````

2. Avoid generating JSON strings containing `inexact-integer`.

Before:
```racket
Welcome to Racket v8.5 [cs].
> (require json)
> (jsexpr->string 1)
"1"
> (jsexpr->string 1.)
"1.0"
```
After:
```racket
Welcome to Racket v8.5 [cs].
> (require json)
> (jsexpr->string 1)
"1"
> (jsexpr->string 1.)
"1"
```
