### PR TITLE
Unify license text

### DIFF
--- a/.github/workflows/scribble_license.yml
+++ b/.github/workflows/scribble_license.yml
@@ -1,0 +1,63 @@
+name: Scribble License Files
+
+on:
+  push:
+    paths:
+      - "LICENSE.txt"
+      - "racket/src/LICENSE.txt"
+      - ".github/workflows/scribble_license.yml"
+      - "pkgs/racket-index/scribblings/main/*"
+  pull_request:
+    paths:
+      - "LICENSE.txt"
+      - "racket/src/LICENSE.txt"
+      - ".github/workflows/scribble_license.yml"
+      - "pkgs/racket-index/scribblings/main/*"
+
+jobs:
+  scribble:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Bogdanp/setup-racket@v1.5
+      with:
+        architecture: 'x64'
+        distribution: 'full'
+        variant: 'CS'
+        version: 'current'
+    - name: Scribble License Files
+      run: raco pkg install --auto -j $(nproc) pkgs/racket-index
+
+  generation-check:
+    runs-on: ubuntu-18.04
+
+    steps:
+    - uses: actions/checkout@v2
+    - uses: Bogdanp/setup-racket@v1.5
+      with:
+        architecture: 'x64'
+        distribution: 'full'
+        variant: 'CS'
+        version: 'current'
+    - name: Move original root LICENSE.txt
+      run: mv LICENSE.txt LICENSE.txt.orig
+    - name: Move original racket/src/LICENSE.txt
+      working-directory: racket/src
+      run: mv LICENSE.txt LICENSE.txt.orig
+    - name: Generate new LICENSE.txt files
+      working-directory: pkgs/racket-index
+      run: make
+    - name: Check differences
+      shell: bash
+      run: |
+        diff LICENSE.txt LICENSE.txt.orig
+        root_status=$?
+        diff racket/src/LICENSE.txt racket/src/LICENSE.txt.orig
+        src_status=$?
+        if [ $root_status -eq 0 ] && [ $src_status -eq 0 ]; then
+            exit 0
+        else
+            echo "License files differ." 1>&2
+            exit 1
+        fi

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,84 +1,185 @@
-Racket is distributed under the MIT license and the Apache version 2.0
-license, at your option. However, the Racket runtime system includes
+Racket is distributed under the MIT license and the Apache License,
+version 2.0, at your option. However, the Racket runtime system includes
 components distributed under other licenses. In short:
 
-  * The Racket CS runtime system embeds Chez Scheme, which is
-    distributed under the Apache version 2.0 license. This runtime
-    system is built from code in racket/src/cs and
-    racket/src/ChezScheme.
+* The Racket CS runtime system embeds Chez Scheme, which is distributed
+  under the Apache License, version 2.0. This runtime system is built
+  from code in "racket/src/cs" and "racket/src/ChezScheme".
 
-  * The Racket BC runtime system includes code distributed under the
-    GNU Lesser General Public License, version 3. This runtime system
-    is built from code in racket/src/bc.
+* The Racket BC runtime system includes code distributed under the GNU
+  Lesser General Public License, either version 3 of the license, or (at
+  your option) any later version. This runtime system is built from code
+  in "racket/src/bc".
 
-Except for Windows executables that are created with the "embed DLLs"
+Except for Windows executables that are created with the “embed DLLs”
 option, the runtime system remains separate as a shared library or
-additional executable, which means that it is dynamically linked and
-can be replaced with a modified variant by users.
+additional executable, which means that it is dynamically linked and can
+be replaced with a modified variant by users.
 
-See the file racket/src/LICENSE-LGPL.txt for the full text of the GNU
-Lesser General Public License.
+See the file "racket/src/LICENSE-APACHE.txt" for the full text of the
+Apache License, version 2.0.
 
-See the file racket/src/LICENSE-APACHE.txt for the full text of the
-Apache version 2.0 license.
+See the file "racket/src/LICENSE-MIT.txt" for the full text of the MIT
+license.
 
-See the file racket/src/LICENSE-MIT.txt for the full text of the
-MIT license.
+See the file "racket/src/LICENSE-LGPL.txt" for the full text of the GNU
+Lesser General Public License, version 3.
 
-Additionally, the default mode of building Racket will install other
-packages, which are distributed under their own license. In the
-default mode, all of those packages are distributed under the licenses
-listed above.
+The source code of Racket is available at
+https://github.com/racket/racket and
+https://download.racket-lang.org/releases.
 
-There may also be other licenses for code within this repository with
-which you must comply. Some of them are listed below.
+The Racket runtime system includes or extends several components which
+have their own licenses.
 
 The following are used in all Racket executables:
 
-* mbed TLS. Code from mbed TLS can be found in
-  racket/src/rktio/rktio_sha2.c. mbed TLS is licensed under the Apache
-  v2.0 License.
+* SHA-224 and SHA-256 implementation from Mbed TLS
+  Copyright © 2006–2015, ARM Limited, All Rights Reserved
+  Mbed TLS is licensed under the Apache License, version 2.0.
+  Code from Mbed TLS can be found in "racket/src/rktio/rktio_sha2.c" and
+  "racket/src/zuo/zuo.c".
 
-The following are used only in the Racket BC executable:
+* ZLib
+  Copyright © 1995–2022 Jean-loup Gailly and Mark Adler
+  Zlib is distributed under a liberal license: see https://zlib.net.
+  Code translated from earlier versions of Zlib can be found in
+  "racket/collects/file/{gzip,gunzip}.rkt". Racket CS executables also
+  use Zlib via Chez Scheme: a copy of Zlib can be found in
+  "racket/src/ChezScheme/zlib". Additionally, on some platforms, Zlib is
+  packaged with the support libraries for racket/draw.
 
-* libscheme. Code from libscheme can be found in racket/src/racket.
-  See the file racket/src/LICENSE-libscheme.txt.
+* Terminal support from Chez Scheme
+  Both Racket BC and Racket CS use primitive terminal support code from
+  Chez Scheme’s expression editor, which is based on a command-line
+  editor for Scheme developed from 1989 through 1994 by C. David Boyer.
+  This code can be found in "racket/src/ChezScheme/c/expeditor.c". The
+  expression editor, like the rest of Chez Scheme, is licensed under the
+  Apache License, version 2.0.
 
-* GNU Lightning. Code from GNU Lightning can be found in
-  racket/src/racket/src. GNU Lightning is distributed under the GNU
-  Lesser General Public License version 3.
+The following are used in all Racket executables for Windows:
 
-* GMP. Code from GMP can be found in racket/src/racket/src. The
-  version of GMP used is distributed under the GNU Lesser General
-  Public License version 3.
+* MemoryModule
+  Copyright © 2004–2015 by Joachim Bauch / mail@joachim-bauch.de
+  https://www.joachim-bauch.de
+  MemoryModule is licensed under the Mozilla Public License, version
+  2.0: see https://www.mozilla.org/en-US/MPL/2.0/ for the full text of
+  the license. Code from MemoryModule can be found in
+  "racket/src/start/MemoryModule.{c,h}".
 
-* zlib. Code translated from earlier versions of zlib can be found in
-  racket/racket/collects/file/{gzip,gunzip}.rkt. Zlib is distributed
-  under a liberal license, see http://zlib.net/.
+The following are used only in Racket BC executables:
 
-* libffi. Code from libffi can be found in racket/src/foreign/libffi.
-  See racket/src/foreign/libffi/LICENSE.
+* libscheme
+  Copyright © 1994 Brent Benson
+  All rights reserved.
+  See the file "racket/src/LICENSE-libscheme.txt" for the full text of
+  the libscheme license. Code from libscheme can be found in
+  "racket/src/bc/src".
 
-* libunwind. Code from libunwind can be found in
-  racket/src/racket/src/unwind.
+* GNU Lightning
+  Copyright © 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2011 Free
+  Software Foundation, Inc.
+  GNU Lightning is distributed under the GNU Lesser General Public
+  License, version 3, or (at your option) any later version.
+  A fork of GNU Lightning can be found in "racket/src/bc/src/lightning".
 
-* random.c. Code from random.c from FreeBSD 2.2 found in
-  racket/src/racket/src/random.inc.
+* GNU MP Library
+  Copyright © 1991, 1992, 1993, 1994, 1996, 1999, 2000, 2007 Free
+  Software Foundation, Inc.
+  GMP is distributed under the GNU Lesser General Public License,
+  version 3, or (at your option) any later version.
+  Code from GMP can be found in "racket/src/bc/src/gmp".
 
-* install. Code from install can be found in racket/src/lt/install-sh
-  and is distributed under the MIT license.
+* libunwind
+  Copyright © 2003–2005 Hewlett-Packard Development Company, L.P.
+  libunwind is distributed under the MIT license.
+  Code from libunwind can be found in "racket/src/bc/src/unwind".
 
-* MemoryModule. Code from MemoryModule can be found in
-  racket/src/start/MemoryModule.c. MemoryModule is distributed under
-  the MPL v2.0.
+* libffi
+  Copyright © 1996–2019 Anthony Green, Red Hat, Inc and others.
+  libffi is distributed under the MIT license.
+  A copy of libffi can be found in "racket/src/bc/foreign/libffi".
 
-The following are used only in benchmarks, and are not part of the
-standard Racket distribution:
+* random.inc
+  Based on "random.c" from FreeBSD 2.2.
+  Copyright © 1983, 1993 The Regents of the University of California.
+  This code is distributed under a three-clause BSD license.
+  Code from FreeBSD 2.2 can be found in "racket/src/bc/src/random.inc".
 
-* psyntax. Code from psyntax can be found in
-  pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax.sch
-  and is distributed under the Apache v2.0 License.
+In addition to the Racket runtime system, the default mode of building
+Racket will install some packages, which are distributed under their own
+licenses.
 
-* SCM. Code from SCM can be found in
-  pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/pidigits1.rkt
-  SCM is available under the LGPL.
+The Racket code for all packages in the main Racket distribution is
+primarily under the MIT license and the Apache License, version 2.0, at
+your option, but some packages contain Racket code under other
+permissive licenses.
+
+Some components of Racket are implemented using additional shared
+libraries. For some platforms and installation modes (especially for
+Windows and Mac OS), these libraries are distributed in
+platform-specific Racket packages; in other cases, they may be included
+with the operating system or installable via the system’s package
+manager. In all cases, these libraries are dynamically loaded and can be
+replaced with modified variants by users. In particular:
+
+* Even the “minimal Racket” distribution may include shared libraries
+  for OpenSSL, SQLite, and/or Editline, depending on the platform.
+
+  The Windows distribution also includes GNU libiconv, which is
+  distributed under the GNU Lesser General Public License, either
+  version 3 of the license, or (at your option) any later version. See
+  the byte converter documentation for further details.
+
+* The Racket Drawing Toolkit is implemented using Cairo, Pango,
+  HarfBuzz, FriBidi, FreeType, FontConfig, and Glib. Some of these
+  libraries are distributed under the GNU Lesser General Public License:
+  see the applicable platform-specific Racket packages for details.
+
+* The Racket Graphical Interface Toolkit is primarily implemented using
+  racket/draw and the native GUI framework for each platform, but can be
+  configured to always use GTK, instead.  On Mac OS, racket/gui also
+  uses the libraries MMTabBarView and/or PSMTabBarControl, which are
+  distributed under a three-clause BSD license.
+
+* The math/bigfloat library uses GNU MP and MPFR, which are distributed
+  under the GNU Lesser General Public License, either version 3 of the
+  license, or (at your option) any later version.
+
+* Files generated by Scribble’s LaTeX renderer use LaTeX packages with
+  various licenses, such as the LaTeX Project Public License. Some of
+  these are distributed with the Racket package "scribble-lib"; others
+  may be installed as part of your TeX distribution.
+
+For further details about the licenses for these libraries, see the
+"LICENSE.txt" files included with the applicable platform-specific
+packages.
+
+Similarly, your Racket distribution or installation may have been
+configured with additional packages, including third-party packages,
+which could use other licenses: see the documentation or "LICENSE.txt"
+file included with each package for information about the applicable
+licenses.
+
+The Racket source distribution also includes build scripts generated by
+GNU Autoconf which are under various licenses, including the GNU General
+Public License with Autoconf exception; however, these files are not
+installed with Racket.
+
+Finally, this Git repository also contains (in the "racket-benchmarks"
+package) the following benchmarks based third-party code which are not
+part of the standard Racket distribution:
+
+* psyntax (Portable implementation of syntax-case)
+  By R. Kent Dybvig, Oscar Waddell, Bob Hieb, and Carl Bruggeman
+  psyntax was extracted from Chez Scheme, which is distributed under the
+  Apache License, version 2.0; see also the file header for the original
+  permissive license. Code from psyntax can be found in
+  "pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax.sch".
+
+* SCM
+  Copyright (C) 1991, 1993, 1994, 1995 Free Software Foundation, Inc.
+  SCM is distributed under the GNU Lesser General Public License,
+  version 3, or (at your option) any later version.
+  Code from SCM can be found in
+  "pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/pidigits1.rkt".

--- a/pkgs/racket-benchmarks/info.rkt
+++ b/pkgs/racket-benchmarks/info.rkt
@@ -1,4 +1,5 @@
 #lang info
+;; SPDX-License-Identifier: (Apache-2.0 OR MIT)
 
 (define collection 'multi)
 
@@ -17,4 +18,8 @@
 (define pkg-authors '(eli jay mflatt robby samth stamourv))
 
 (define license
-  '(Apache-2.0 OR MIT))
+  '((Apache-2.0 OR MIT)
+    AND
+    (Apache-2.0 ; psyntax : tests/racket/benchmarks/common/psyntax.sch (see file for original license)
+     AND
+     LGPL-3.0-or-later))) ; SCM : tests/racket/benchmarks/shootout/pidigits1.rkt

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax.sch
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax.sch
@@ -1,3 +1,20 @@
+;;; Portable implementation of syntax-case
+;;; Extracted from Chez Scheme Version 7.3 (Feb 26, 2007)
+;;; Authors: R. Kent Dybvig, Oscar Waddell, Bob Hieb, Carl Bruggeman
+
+;;; Copyright (c) 1992-2002 Cadence Research Systems
+;;; Permission to copy this software, in whole or in part, to use this
+;;; software for any lawful purpose, and to redistribute this software
+;;; is granted subject to the restriction that all copies made of this
+;;; software must include this copyright notice in full.  This software
+;;; is provided AS IS, with NO WARRANTY, EITHER EXPRESS OR IMPLIED,
+;;; INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY
+;;; OR FITNESS FOR ANY PARTICULAR PURPOSE.  IN NO EVENT SHALL THE
+;;; AUTHORS BE LIABLE FOR CONSEQUENTIAL OR INCIDENTAL DAMAGES OF ANY
+;;; NATURE WHATSOEVER.
+
+;; Later, Chez Scheme was released under the Apache-2.0 license.
+
 ;; smashed into benchmark form by Matthew
 
 ;;; psyntax.pp

--- a/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/pidigits1.rkt
+++ b/pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/pidigits1.rkt
@@ -1,4 +1,6 @@
 #lang racket/base
+;; SPDX-License-Identifier: LGPL-3.0-or-later
+;; SPDX-FileCopyrightText: 1991, 1993, 1994, 1995 Free Software Foundation, Inc.
 
 ; The Computer Language Shootout
 ; http://shootout.alioth.debian.org/

--- a/pkgs/racket-index/Makefile
+++ b/pkgs/racket-index/Makefile
@@ -1,0 +1,8 @@
+RACO=raco
+RUN_SCRIBBLE=$(RACO) scribble --text --dest-name LICENSE.txt
+DOC=scribblings/main/license.scrbl
+
+.PHONY: render
+render:
+	$(RUN_SCRIBBLE) ++arg "--repo-root-dir" --dest ../.. $(DOC)
+	$(RUN_SCRIBBLE) ++arg "--repo-src-dir" --dest ../../racket/src $(DOC)

--- a/pkgs/racket-index/info.rkt
+++ b/pkgs/racket-index/info.rkt
@@ -3,7 +3,7 @@
 (define collection 'multi)
 
 (define deps '("base"
-               "scribble-lib"))
+               ["scribble-lib" #:version "1.46"]))
 (define build-deps '("scheme-lib"
                      "at-exp-lib"))
 

--- a/pkgs/racket-index/info.rkt
+++ b/pkgs/racket-index/info.rkt
@@ -11,7 +11,7 @@
 
 (define pkg-authors '(eli jay matthias mflatt robby ryanc samth))
 
-(define version "1.2")
+(define version "1.3")
 
 ;; We need to be able to re-render this documentation even in
 ;; binary mode, since that's how we list new documentation:

--- a/pkgs/racket-index/scribblings/main/license.scrbl
+++ b/pkgs/racket-index/scribblings/main/license.scrbl
@@ -1,75 +1,316 @@
 #lang scribble/doc
-@(require scribble/manual "private/utils.rkt")
+@(require scribble/manual
+          racket/cmdline
+          racket/match
+          "private/utils.rkt")
 
-@(define (copyright . strs) (apply verbatim #:indent 2 strs))
+@(define mode
+   (let ([mode 'docs])
+     (command-line
+      #:argv (for/list ([arg (in-vector (current-command-line-arguments))]
+                        ;; hack: with `raco setup`, might be e.g. #("setup")
+                        #:when (member arg '("--repo-root-dir" "--repo-src-dir")))
+               arg)
+      #:usage-help
+      "Use with “scribble ++arg” to generate license files for the source repository,"
+      "rather than the license page for the installed documentation."
+      #:once-any
+      [("--repo-root-dir") "Generate “LICENSE.txt” for the Git repository root."
+       (set! mode 'root)]
+      [("--repo-src-dir") "Generate “LICENSE.txt” for the “racket/src” directory."
+       (set! mode 'src)]
+      #:args ()
+      mode)))
 
-@main-page['license]
+@(define-syntax-rule (if-repo for-repo for-docs)
+   ;; For text that should be different in a LICENSE.txt file
+   ;; in the source tree than in installed documentation.
+   (if (eq? 'docs mode)
+       for-docs
+       for-repo))
+@(define-syntax-rule (when-repo arg ...)
+   (if-repo (list arg ...) null))
+@(define-syntax-rule (unless-repo arg ...)
+   (if-repo null (list arg ...)))
 
-Racket is distributed under the MIT license and the Apache version 2.0
-license, at your option. However, the Racket runtime system includes
+@(define (src-filepath . args)
+   (match mode
+     ['root
+      (apply filepath "racket/src/" args)]
+     ['src
+      (apply filepath args)]
+     ['doc
+      (error 'src-filepath "not supported in 'doc mode")]))
+
+@; ---------------------------------------------------------------------------------------------------
+
+@unless-repo[@main-page['license]]
+
+Racket is distributed under the MIT license and the Apache License,
+version 2.0, at your option. However, the Racket runtime system includes
 components distributed under other licenses. In short:
 
 @itemize[
 
- @item{The Racket CS Scheme runtime system embeds Chez Scheme, which
-       is distributed under the Apache version 2.0 license.}
+ @item{
+  The Racket @tech[#:indirect? #t #:doc '(lib "scribblings/reference/reference.scrbl")]{CS}
+  runtime system embeds Chez Scheme, which is
+  distributed under the Apache License, version 2.0.
+  @when-repo{This runtime system is built from code in
+   @src-filepath{cs} and @src-filepath{ChezScheme}.}
+ }
 
- @item{The Racket BC runtime system includes code distributed
-       under the GNU Lesser General Public License, version 3.}
+ @item{
+  The Racket @tech[#:indirect? #t #:doc '(lib "scribblings/reference/reference.scrbl")]{BC}
+  runtime system includes code distributed under the
+  GNU Lesser General Public License, either version 3 of the license,
+  or (at your option) any later version.
+  @when-repo{This runtime system is built from code in @src-filepath{bc}.}
+ }
 
-]
+ ]
 
 Except for Windows executables that are created with the ``embed DLLs''
 option, the runtime system remains separate as a shared library or
 additional executable, which means that it is dynamically linked and
 can be replaced with a modified variant by users.
 
-See @filepath{LICENSE-LGPL.txt} in your Racket installation's
-@filepath{share} directory for the full text of the GNU Lesser General
-Public License.
+@(for/list ([abbrev (in-list '("APACHE" "MIT" "LGPL"))]
+            [name (in-list '("Apache License, version 2.0"
+                             "MIT license"
+                             "GNU Lesser General Public License, version 3"))])
+   @para{
+ See @if-repo[@elem{the file @src-filepath{LICENSE-@|abbrev|.txt}}
+              @elem{
+                @filepath{LICENSE-@|abbrev|.txt} in your Racket installation's
+                @filepath{share} directory}]
+ for the full text of the @|name|.
+ })
 
-See @filepath{LICENSE-APACHE.txt} in your Racket installation's
-@filepath{share} directory for the full text of the Apache version 2.0
-license.
+The source code of Racket is available at
+@url{https://github.com/racket/racket} and
+@url{https://download.racket-lang.org/releases}.
 
-See @filepath{LICENSE-MIT.txt} in your Racket installation's
-@filepath{share} directory for the full text of the MIT license.
+The Racket runtime system includes or extends
+several components which have their own licenses.
 
-Racket software includes or extends the following copyrighted material:
+The following are used in all Racket executables:
 
-@copyright{
-  libscheme
-  Copyright (c) 1994 Brent Benson
-  All rights reserved.
+@itemize[
+ @item{
+  SHA-224 and SHA-256 implementation from Mbed TLS @(linebreak)
+  Copyright © 2006--2015, ARM Limited, All Rights Reserved @(linebreak)
+  Mbed TLS is licensed under the Apache License, version 2.0.
+  @when-repo[(linebreak)]{Code from Mbed TLS can be found in
+   @src-filepath{rktio/rktio_sha2.c} and @src-filepath{zuo/zuo.c}.}
+ }
+ @item{
+  ZLib @(linebreak)
+  Copyright © 1995--2022 Jean-loup Gailly and Mark Adler @(linebreak)
+  Zlib is distributed under a liberal license: see @url{https://zlib.net}. @(linebreak)
+  Code translated from earlier versions of Zlib can be found in
+  @(nonbreaking
+    (cond
+      [(eq? 'root mode)
+       @filepath{racket/collects/file/{gzip,gunzip}.rkt}]
+      ;; no special case for 'src because the relative path will be
+      ;; different in the repository than in a source distribution.
+      [else
+       ;; cf. path->relative-string/library
+       @filepath{<collects>/file/{gzip,gunzip}.rkt}])).
+  Racket CS executables also use Zlib via Chez Scheme@when-repo{:
+   a copy of Zlib can be found in @src-filepath{ChezScheme/zlib}}.
+  Additionally, on some platforms, Zlib is packaged with the support
+  libraries for @racketmodname[racket/draw #:indirect].
+ }
+ @item{
+  Terminal support from Chez Scheme @(linebreak)
+  Both Racket BC and Racket CS use primitive terminal support code from
+  Chez Scheme's expression editor, which is based on a command-line editor for
+  Scheme developed from 1989 through 1994 by C@._ David Boyer.
+  @when-repo{This code can be found in @src-filepath{ChezScheme/c/expeditor.c}.} @;
+  The expression editor, like the rest of Chez Scheme, is licensed
+  under the Apache License, version 2.0.
+ }
+ ]
+
+The following are used in all Racket executables for Windows:
+
+@itemize[
+ @item{
+  MemoryModule @(linebreak)
+  Copyright © 2004--2015 by Joachim Bauch / mail@"@"joachim-bauch.de
+  @url{https://www.joachim-bauch.de} @(linebreak)
+  MemoryModule is licensed under the Mozilla Public License, version 2.0:
+  see @url{https://www.mozilla.org/en-US/MPL/2.0/} for the full text of the license.
+  @(if-repo
+    @elem{Code from MemoryModule can be found in @src-filepath{start/MemoryModule.{c,h}}.}
+    @elem{The source code of MemoryModule is included with the source code of Racket.})
+ }
+ ]
+
+The following are used only in Racket BC executables:
+
+@itemize[
+ @item{
+  libscheme @(linebreak)
+  Copyright © 1994 Brent Benson @(linebreak)
+  All rights reserved. @(linebreak)
+  See the file @if-repo[
+ @src-filepath{LICENSE-libscheme.txt}
+ @elem{@filepath{LICENSE-libscheme.txt} in your Racket installation's
+    @filepath{share} directory}]
+  for the full text of the libscheme license.
+  @when-repo{Code from libscheme can be found in @src-filepath{bc/src}.}
+ }
+ @item{
+  GNU Lightning @(linebreak)
+  Copyright © 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2011
+  Free Software Foundation, Inc. @(linebreak)
+  GNU Lightning is distributed under the GNU Lesser General
+  Public License, version 3, or (at your option) any later version. @(linebreak)
+  @(if-repo
+    @elem{A fork of GNU Lightning can be found in @src-filepath{bc/src/lightning}.}
+    @elem{
+   The source code of Racket's variant of GNU Lightning is included
+   with the source code of Racket.
+   })
+ }
+ @item{
+  GNU MP Library @(linebreak)
+  Copyright © 1991, 1992, 1993, 1994, 1996, 1999, 2000, 2007
+  Free Software Foundation, Inc. @(linebreak)
+  GMP is distributed under the GNU Lesser General
+  Public License, version 3, or (at your option) any later version. @(linebreak)
+  @(if-repo
+    @elem{Code from GMP can be found in @src-filepath{bc/src/gmp}.}
+    @elem{Source code from GMP is included with the source code of Racket.})
+ }
+ @item{
+  libunwind @(linebreak)
+  Copyright © 2003--2005 Hewlett-Packard Development Company, L.P. @(linebreak)
+  libunwind is distributed under the MIT license.
+  @when-repo[(linebreak)]{Code from libunwind can be found in @src-filepath{bc/src/unwind}.}
+ }
+ @item{
+  libffi @(linebreak)
+  Copyright © 1996--2019 Anthony Green, Red Hat, Inc and others. @(linebreak)
+  libffi is distributed under the MIT license.
+  @when-repo[(linebreak)]{A copy of libffi can be found in @src-filepath{bc/foreign/libffi}.}
+ }
+ @item{
+  random.inc @(linebreak)
+  Based on @filepath{random.c} from FreeBSD 2.2. @(linebreak)
+  Copyright © 1983, 1993 The Regents of the University of California. @(linebreak)
+  This code is distributed under a three-clause BSD license.
+  @when-repo[(linebreak)]{Code from FreeBSD 2.2 can be found in @src-filepath{bc/src/random.inc}.}
+ }
+ ]
+
+In addition to the Racket runtime system, the default mode
+of building Racket will install some packages, which are
+distributed under their own licenses.
+
+The Racket code for all packages in the main Racket
+distribution is primarily under the MIT license and the
+Apache License, version 2.0, at your option, but some
+packages contain Racket code under other permissive licenses.
+
+Some components of Racket are implemented using additional
+shared libraries. For some platforms and installation modes
+(especially for Windows and Mac OS), these libraries are
+distributed in platform-specific Racket packages; in other
+cases, they may be included with the operating system or
+installable via the system's package manager. In all cases,
+these libraries are dynamically loaded and can be replaced
+with modified variants by users. In particular:
+
+@itemize[
+ @item{
+  Even the ``minimal Racket'' distribution may include shared libraries
+  for @seclink[#:indirect? #t #:doc '(lib "openssl/openssl.scrbl") "top"]{
+   OpenSSL}, @seclink[#:indirect? #t #:doc '(lib "db/scribblings/db.scrbl") "sqlite3-requirements"]{
+   SQLite}, and/or @seclink[#:indirect? #t #:doc '(lib "readline/readline.scrbl") "top"]{
+   Editline}, depending on the platform.
+
+  The Windows distribution also includes GNU libiconv, which is
+  distributed under the GNU Lesser General Public License,
+  either version 3 of the license, or (at your option) any
+  later version. See the @tech[#:indirect? #t #:doc '(lib "scribblings/reference/reference.scrbl")]{
+   byte converter} documentation for further details.
+ }
+ @item{
+  @seclink[#:indirect? #t #:doc '(lib "scribblings/draw/draw.scrbl") "libs"]{
+   The Racket Drawing Toolkit} is implemented using Cairo,
+  Pango, HarfBuzz, FriBidi, FreeType, FontConfig, and Glib.
+  Some of these libraries are distributed under the
+  GNU Lesser General Public License: see the applicable
+  platform-specific Racket packages for details.
+ }
+ @item{
+  @seclink[#:indirect? #t #:doc '(lib "scribblings/gui/gui.scrbl") "libs"]{
+   The Racket Graphical Interface Toolkit} is primarily
+  implemented using @racketmodname[racket/draw #:indirect] and
+  the native GUI framework for each platform, but can be configured to always
+  use GTK, instead. @;{TODO: When do we use ATK? We package it for Windows and Mac OS.}
+  On Mac OS, @racketmodname[racket/gui #:indirect] also uses the libraries
+  MMTabBarView and/or PSMTabBarControl, which are distributed under a three-clause
+  BSD license.
+ }
+ @item{
+  The @racketmodname[math/bigfloat #:indirect] library uses GNU MP and MPFR,
+  which are distributed under the GNU Lesser General Public License, either
+  version 3 of the license, or (at your option) any later version.
+ }
+ @item{
+  Files generated by
+  @seclink[#:indirect? #t #:doc '(lib "scribblings/scribble/scribble.scrbl") "top"]{
+   Scribble}'s LaTeX renderer use LaTeX packages with various licenses,
+  such as the LaTeX Project Public License. Some of these are distributed
+  with the Racket package @racket["scribble-lib"]; others may be installed
+  as part of your TeX distribution.
+ }
+ ]
+
+For further details about the licenses for these libraries,
+see the @filepath{LICENSE.txt} files included with the
+applicable platform-specific packages.
+
+Similarly, your Racket distribution or installation may have been configured
+with additional packages, including third-party packages, which could use
+other licenses: see the documentation or @filepath{LICENSE.txt} file included
+with each package for information about the applicable licenses.
+
+@when-repo{
+ The Racket source distribution also includes build scripts
+ generated by GNU Autoconf which are under various licenses,
+ including the GNU General Public License with Autoconf exception;
+ however, these files are not installed with Racket.
 }
 
-@copyright{
-  GNU MP Library
-  Copyright (c) 1991, 1992, 1993, 1994, 1996, 1999, 2000, 2007
-  Free Software Foundation, Inc.
-}
+@(if (eq? 'root mode)
+     @list{
+ Finally, this Git repository also contains (in the @racket["racket-benchmarks"]
+ package) the following benchmarks based third-party code which are not part of
+ the standard Racket distribution:
 
-@copyright{
-  GNU lightning
-  Copyright (c) 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2011
-  Free Software Foundation, Inc.
-}
-
-@copyright{
-  libunwind
-  Copyright (c) 2003-2005 Hewlett-Packard Development Company, L.P.
-}
-
-@copyright{
-  MemoryModule
-  Copyright (c) 2004-2015 by Joachim Bauch / mail@"@"joachim-bauch.de
-  http://www.joachim-bauch.de
-}
-
-@copyright{
-  SHA-224 and SHA-256 implementation from mbed TLS
-  Copyright (c) 2006-2015, ARM Limited, All Rights Reserved
-}
-
-See also other @filepath{LICENSE.txt} files in your distribution or
-packages.
+ @itemlist[
+ @item{
+   psyntax (Portable implementation of syntax-case) @(linebreak)
+   By R@._ Kent Dybvig, Oscar Waddell, Bob Hieb, and Carl Bruggeman @(linebreak)
+   psyntax was extracted from Chez Scheme, which is distributed under the
+   Apache License, version 2.0; see also the file header for the original
+   permissive license.
+   Code from psyntax can be found in
+   @filepath{pkgs/racket-benchmarks/tests/racket/benchmarks/common/psyntax.sch}.
+  }
+ @item{
+   SCM @(linebreak)
+   Copyright (C) 1991, 1993, 1994, 1995 Free Software Foundation, Inc. @(linebreak)
+   SCM is distributed under the GNU Lesser General
+   Public License, version 3, or (at your option) any later version. @(linebreak)
+   Code from SCM can be found in
+   @filepath{pkgs/racket-benchmarks/tests/racket/benchmarks/shootout/pidigits1.rkt}.
+  }
+ ]}
+     null)

--- a/pkgs/racket-index/scribblings/main/private/local-redirect.rkt
+++ b/pkgs/racket-index/scribblings/main/private/local-redirect.rkt
@@ -200,10 +200,11 @@
                        null
                        (resolve-get-keys #f ri
                                          (lambda (v)
-                                           ;; Support key-based indirect only on sections
-                                           ;; and module names:
+                                           ;; Support key-based indirect only on sections,
+                                           ;; module names, and @deftech{} terms:
                                            (define t (car v))
                                            (or (eq? t 'part)
+                                               (eq? t 'tech)
                                                (eq? t 'mod-path))))))
       (define (target? v) (and (vector? v) (= 5 (vector-length v))))
       (define dest-dir (send renderer get-dest-directory #t))

--- a/racket/src/LICENSE.txt
+++ b/racket/src/LICENSE.txt
@@ -1,72 +1,165 @@
-Racket is distributed under the MIT license and the Apache version 2.0
-license, at your option. However, the Racket runtime system includes
+Racket is distributed under the MIT license and the Apache License,
+version 2.0, at your option. However, the Racket runtime system includes
 components distributed under other licenses. In short:
 
-  * The Racket CS runtime system embeds Chez Scheme, which is
-    distributed under the Apache version 2.0 license. This runtime
-    system is built from code in cs and ChezScheme.
+* The Racket CS runtime system embeds Chez Scheme, which is distributed
+  under the Apache License, version 2.0. This runtime system is built
+  from code in "cs" and "ChezScheme".
 
-  * The Racket BC runtime system includes code distributed under the
-    GNU Lesser General Public License, version 3. This runtime system
-    is built from code in bc.
+* The Racket BC runtime system includes code distributed under the GNU
+  Lesser General Public License, either version 3 of the license, or (at
+  your option) any later version. This runtime system is built from code
+  in "bc".
 
-Except for Windows executables that are created with the "embed DLLs"
+Except for Windows executables that are created with the “embed DLLs”
 option, the runtime system remains separate as a shared library or
-additional executable, which means that it is dynamically linked and
-can be replaced with a modified variant by users.
+additional executable, which means that it is dynamically linked and can
+be replaced with a modified variant by users.
 
-See the file LICENSE-LGPL.txt for the full text of the GNU
-Lesser General Public License.
+See the file "LICENSE-APACHE.txt" for the full text of the Apache
+License, version 2.0.
 
-See the file LICENSE-APACHE.txt for the full text of the
-Apache version 2.0 license.
+See the file "LICENSE-MIT.txt" for the full text of the MIT license.
 
-See the file LICENSE-MIT.txt for the full text of the
-MIT license.
+See the file "LICENSE-LGPL.txt" for the full text of the GNU Lesser
+General Public License, version 3.
 
-Additionally, the default mode of building Racket will install other
-packages, which are distributed under their own license. In the
-default mode, all of those packages are distributed under the licenses
-listed above.
+The source code of Racket is available at
+https://github.com/racket/racket and
+https://download.racket-lang.org/releases.
 
-There may also be other licenses for code within this repository with
-which you must comply. Some of them are listed below.
+The Racket runtime system includes or extends several components which
+have their own licenses.
 
 The following are used in all Racket executables:
 
-* mbed TLS. Code from mbed TLS can be found in
-  rktio/rktio_sha2.c and zuo/zuo.c. mbed TLS is licensed under the
-  Apache v2.0 License.
+* SHA-224 and SHA-256 implementation from Mbed TLS
+  Copyright © 2006–2015, ARM Limited, All Rights Reserved
+  Mbed TLS is licensed under the Apache License, version 2.0.
+  Code from Mbed TLS can be found in "rktio/rktio_sha2.c" and
+  "zuo/zuo.c".
 
-The following are used only in the Racket BC executable:
+* ZLib
+  Copyright © 1995–2022 Jean-loup Gailly and Mark Adler
+  Zlib is distributed under a liberal license: see https://zlib.net.
+  Code translated from earlier versions of Zlib can be found in
+  "<collects>/file/{gzip,gunzip}.rkt". Racket CS executables also use
+  Zlib via Chez Scheme: a copy of Zlib can be found in
+  "ChezScheme/zlib". Additionally, on some platforms, Zlib is packaged
+  with the support libraries for racket/draw.
 
-* libscheme. Code from libscheme can be found in
-  racket. See the file LICENSE-libscheme.txt
+* Terminal support from Chez Scheme
+  Both Racket BC and Racket CS use primitive terminal support code from
+  Chez Scheme’s expression editor, which is based on a command-line
+  editor for Scheme developed from 1989 through 1994 by C. David Boyer.
+  This code can be found in "ChezScheme/c/expeditor.c". The expression
+  editor, like the rest of Chez Scheme, is licensed under the Apache
+  License, version 2.0.
 
-* GNU Lightning. Code from GNU Lightning can be found in
-  bc/src. GNU Lightning is distributed under the GNU
-  Lesser General Public License version 3.
+The following are used in all Racket executables for Windows:
 
-* GMP. Code from GMP can be found in bc/src. The
-  version of GMP used is distributed under the GNU Lesser General
-  Public License version 3.
+* MemoryModule
+  Copyright © 2004–2015 by Joachim Bauch / mail@joachim-bauch.de
+  https://www.joachim-bauch.de
+  MemoryModule is licensed under the Mozilla Public License, version
+  2.0: see https://www.mozilla.org/en-US/MPL/2.0/ for the full text of
+  the license. Code from MemoryModule can be found in
+  "start/MemoryModule.{c,h}".
 
-* zlib. Code translated from earlier versions of zlib can be found in
-  ../collects/file/{gzip,gunzip}.rkt. Zlib is distributed
-  under a liberal license, see http://zlib.net/.
+The following are used only in Racket BC executables:
 
-* libffi. Code from libffi can be found in foreign/libffi.
-  See foreign/libffi/LICENSE.
+* libscheme
+  Copyright © 1994 Brent Benson
+  All rights reserved.
+  See the file "LICENSE-libscheme.txt" for the full text of the
+  libscheme license. Code from libscheme can be found in "bc/src".
 
-* libunwind. Code from libunwind can be found in
-  unwind.
+* GNU Lightning
+  Copyright © 1994, 1995, 1996, 1999, 2000, 2001, 2002, 2011 Free
+  Software Foundation, Inc.
+  GNU Lightning is distributed under the GNU Lesser General Public
+  License, version 3, or (at your option) any later version.
+  A fork of GNU Lightning can be found in "bc/src/lightning".
 
-* random.c. Code from random.c from FreeBSD 2.2 found in
-  random.inc.
+* GNU MP Library
+  Copyright © 1991, 1992, 1993, 1994, 1996, 1999, 2000, 2007 Free
+  Software Foundation, Inc.
+  GMP is distributed under the GNU Lesser General Public License,
+  version 3, or (at your option) any later version.
+  Code from GMP can be found in "bc/src/gmp".
 
-* install. Code from install can be found in lt/install-sh
-  and is distributed under the MIT license.
+* libunwind
+  Copyright © 2003–2005 Hewlett-Packard Development Company, L.P.
+  libunwind is distributed under the MIT license.
+  Code from libunwind can be found in "bc/src/unwind".
 
-* MemoryModule. Code from MemoryModule can be found in
-  start/MemoryModule.c. MemoryModule is distributed under
-  the MPL v2.0.
+* libffi
+  Copyright © 1996–2019 Anthony Green, Red Hat, Inc and others.
+  libffi is distributed under the MIT license.
+  A copy of libffi can be found in "bc/foreign/libffi".
+
+* random.inc
+  Based on "random.c" from FreeBSD 2.2.
+  Copyright © 1983, 1993 The Regents of the University of California.
+  This code is distributed under a three-clause BSD license.
+  Code from FreeBSD 2.2 can be found in "bc/src/random.inc".
+
+In addition to the Racket runtime system, the default mode of building
+Racket will install some packages, which are distributed under their own
+licenses.
+
+The Racket code for all packages in the main Racket distribution is
+primarily under the MIT license and the Apache License, version 2.0, at
+your option, but some packages contain Racket code under other
+permissive licenses.
+
+Some components of Racket are implemented using additional shared
+libraries. For some platforms and installation modes (especially for
+Windows and Mac OS), these libraries are distributed in
+platform-specific Racket packages; in other cases, they may be included
+with the operating system or installable via the system’s package
+manager. In all cases, these libraries are dynamically loaded and can be
+replaced with modified variants by users. In particular:
+
+* Even the “minimal Racket” distribution may include shared libraries
+  for OpenSSL, SQLite, and/or Editline, depending on the platform.
+
+  The Windows distribution also includes GNU libiconv, which is
+  distributed under the GNU Lesser General Public License, either
+  version 3 of the license, or (at your option) any later version. See
+  the byte converter documentation for further details.
+
+* The Racket Drawing Toolkit is implemented using Cairo, Pango,
+  HarfBuzz, FriBidi, FreeType, FontConfig, and Glib. Some of these
+  libraries are distributed under the GNU Lesser General Public License:
+  see the applicable platform-specific Racket packages for details.
+
+* The Racket Graphical Interface Toolkit is primarily implemented using
+  racket/draw and the native GUI framework for each platform, but can be
+  configured to always use GTK, instead.  On Mac OS, racket/gui also
+  uses the libraries MMTabBarView and/or PSMTabBarControl, which are
+  distributed under a three-clause BSD license.
+
+* The math/bigfloat library uses GNU MP and MPFR, which are distributed
+  under the GNU Lesser General Public License, either version 3 of the
+  license, or (at your option) any later version.
+
+* Files generated by Scribble’s LaTeX renderer use LaTeX packages with
+  various licenses, such as the LaTeX Project Public License. Some of
+  these are distributed with the Racket package "scribble-lib"; others
+  may be installed as part of your TeX distribution.
+
+For further details about the licenses for these libraries, see the
+"LICENSE.txt" files included with the applicable platform-specific
+packages.
+
+Similarly, your Racket distribution or installation may have been
+configured with additional packages, including third-party packages,
+which could use other licenses: see the documentation or "LICENSE.txt"
+file included with each package for information about the applicable
+licenses.
+
+The Racket source distribution also includes build scripts generated by
+GNU Autoconf which are under various licenses, including the GNU General
+Public License with Autoconf exception; however, these files are not
+installed with Racket.

--- a/racket/src/bc/src/random.inc
+++ b/racket/src/bc/src/random.inc
@@ -10,11 +10,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -31,8 +27,11 @@
  * SUCH DAMAGE.
  */
 
-/* This is a stripped-down version of random.c distributed with
-   FreeBSD 2.2 */
+/* This is a stripped-down version of random.c distributed with FreeBSD 2.2.
+ * The above header originally specified the BSD-4-Clause-UC license, but the
+ * University of Califronia retroactively deleted the advertising clause in
+ * 1999: see <ftp://ftp.cs.berkeley.edu/pub/4bsd/README.Impt.License.Change>.
+ */
 
 /*
  * random.c:


### PR DESCRIPTION
This is an initial, incomplete attempt at generating `LICENSE.txt` and `racket/src/LICENSE.txt` from `pkgs/racket-index/scribblings/main/license.scrbl`.

This possibility first occurred to me in https://github.com/racket/racket/pull/3869. Various factors have nudged me toward thinking it's the right approach: most recently, I discovered that I myself, despite being quite cognizant of this issue, introduced a discrepancy in https://github.com/racket/racket/commit/ba84e0880401d8c638d9b83f9b03b88426cf18c5.

Thus far I've only started (and have not finished) dealing with the existing content of these files. I haven't addressed the additional content seemed in https://github.com/racket/racket/issues/4276#issuecomment-1150337747 like it should be added here.

Some issues I've found so far:

 1. Apparently I got the metadata for the `"racket-benchmarks"` package wrong, in that `LICENSE.txt` says that `pidigits1.rkt` is adapted from SCM and under the LGPL. While trying to check the version, though, I found that the url in the source file (http://shootout.alioth.debian.org/) is broken. I have not yet found a corresponding file at e.g. https://salsa.debian.org/benchmarksgame-team/archive-alioth-benchmarksgame/-/tree/master/contributed-source-code/shootout/pidigits, and the files I have found don't seem to be under the LGPL.

 2. It appears that https://github.com/racket/racket/blob/4d8c63f616961d637242848585f1c5633be53746/racket/src/bc/src/random.inc#L1-L35 uses the [`BSD-4-Clause-UC`](https://spdx.org/licenses/BSD-4-Clause-UC.html) license, which requires the acknowledgement "This product includes software developed by the University of California, Berkeley and its contributors." in all advertising. The [FSF argues](https://www.gnu.org/licenses/license-list.html#OriginalBSD) that this clause is incompatible with the GPL, but, per the details in [this essay](https://www.gnu.org/licenses/bsd.html), the University of California dropped the (arguably) problematic requirement. The SPDX page refers to <ftp://ftp.cs.berkeley.edu/pub/4bsd/README.Impt.License.Change>, which says:

    > July 22, 1999
    >
    > To All Licensees, Distributors of Any Version of BSD:
    >
    > As you know, certain of the Berkeley Software Distribution ("BSD") source
code files require that further distributions of products containing all or
portions of the software, acknowledge within their advertising materials
that such products contain software developed by UC Berkeley and its
contributors.
    >
    > Specifically, the provision reads:
    >
    > "     * 3. All advertising materials mentioning features or use of this software
    >      *    must display the following acknowledgement:
    >      *    This product includes software developed by the University of
    >      *    California, Berkeley and its contributors."
    >
    > Effective immediately, licensees and distributors are no longer required to
    > include the acknowledgement within advertising materials.  Accordingly, the
    > foregoing paragraph of those BSD Unix files containing it is hereby deleted
    > in its entirety.
    >
    > William Hoskins
    > Director, Office of Technology Licensing
    > University of California, Berkeley

    So maybe we can just update the header?

 3. It looks like MemoryModule is used in all Windows executables and is under the Mozilla Public License, version 2.0. If that's correct, @Aeva, is that a problem for your use-case?

 4. libffi is primarily used with BC, but IIRC it also is (or can be?) used with Chez Scheme in `pb` mode. Are there other things like that?

 5. Zlib comes up in at least three places: the translated version in `file/gzip` and `file/gunzip`; the copy included with the Chez Scheme source; and the support packages for `racket/draw` (listed in https://github.com/racket/racket/issues/4286).

 6. Do we also need to credit Chez Scheme for BC due to the expeditor support?

 7. I'd expected a Zuo target to regenerate `build.md`, but I don't see one. Should there be one? Or should there just be a CI check like https://github.com/racket/racket/blob/8c140a85eb31a61c8d70112177dbdbdae7c7fcaa/.github/workflows/scribble_build-guide.yml for the `LICENSE.txt` files?

CC @samth @Aeva