### PR TITLE
match: nonlinear pat refs in list-no-order

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -94,12 +94,19 @@ In more detail, patterns match as follows:
        @racket[_k]) @margin-note{Unlike in @racket[cond] and @racket[case],
        @racket[else] is not a keyword in @racket[match].} or @racket[(var _id)]
        --- matches anything, and binds @racket[_id] to the
-       matching values. If an @racket[_id] is used multiple times
+       matching values.
+
+       If an @racket[_id] is used multiple times
        within a pattern, the corresponding matches must be the same
        according to @racket[(match-equality-test)], except that
        instances of an @racket[_id] in different @racketidfont{or} and
        @racketidfont{not} sub-patterns are independent. The binding for @racket[_id] is
        not available in other parts of the same pattern.
+
+       If @racket[_id] is used multiple times, but the first
+       use is in the scope of a @racketidfont{...} pattern
+       that doesn't encompass all uses, a syntax error is
+       raised.
 
        @examples[
        #:eval match-eval

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -282,6 +282,11 @@
                    (convert-syntax-error
                     (match '((1 2 3) (1 2 3))
                       [(list (list a ...) a) a]))))
+      (check-exn #rx"^a: non-linear pattern used in `match` with ...$"
+                 (lambda ()
+                   (convert-syntax-error
+                    (match '((1 2 3 4) (1 2 3))
+                      [(list (list a ... _) a) a]))))
       (check-exn #rx"^x: non-linear pattern used in `match` with ...$"
                  (lambda ()
                    (convert-syntax-error

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -256,7 +256,10 @@
                     [_ #f]))
      (check-equal? (match '((1 1 2 3) (2 1 2 3) (3 1 2 3))
                      [(list (cons a (list pre ... a post ...)) ...) (list a pre post)])
-                   '((1 2 3) (() (1) (1 2)) ((2 3) (3) ()))))))
+                   '((1 2 3) (() (1) (1 2)) ((2 3) (3) ())))
+     (check-equal? (match '((1 1 2 3) (2 1 2 3) (3 1 2 3))
+                     [(list (cons a (list-no-order a rst ...)) ...) (list a rst)])
+                   '((1 2 3) ((2 3) (1 3) (1 2)))))))
 
 
 (define doc-tests

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -5,6 +5,7 @@
          "legacy-match-tests.rkt"
          "examples.rkt"
          rackunit rackunit/text-ui
+         syntax/macro-testing
          (only-in racket/base local-require))
 
 (require mzlib/plt-match)
@@ -246,6 +247,9 @@
      (check-equal? (match '(1 1 1 1)
                      [(list x x ...) x])
                    1)
+     (check-false (match '(1 1 2 1)
+                    [(list x x ...) x]
+                    [_ #f]))
      (check-false (match '(1 2 2 2)
                     [(list x x ...) x]
                     [_ #f])))
@@ -266,7 +270,13 @@
                    '((1 2 3) (() (1) (1 2)) ((2 3) (3) ())))
      (check-equal? (match '((1 1 2 3) (2 1 2 3) (3 1 2 3))
                      [(list (cons a (list-no-order a rst ...)) ...) (list a rst)])
-                   '((1 2 3) ((2 3) (1 3) (1 2)))))))
+                   '((1 2 3) ((2 3) (1 3) (1 2)))))
+    (test-case "Invalid nonlinear pattern declarations under ellipses"
+      (check-exn #rx"^a: non-linear pattern used in `match` with ...$"
+                 (lambda ()
+                   (convert-syntax-error
+                    (match '(1 2 3 4)
+                      [(list a ... a) a])))))))
 
 
 (define doc-tests

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -242,6 +242,13 @@
                 (check = 5 (match '((3) (3)) [(list a a) a] [_ 5]))))
    (test-case "Nonlinear patterns use equal?"
               (check equal? '(3) (match '((3) (3)) [(list a a) a] [_ 5])))
+   (test-case "Nonlinear pattern reference in id ..."
+     (check-equal? (match '(1 1 1 1)
+                     [(list x x ...) x])
+                   1)
+     (check-false (match '(1 2 2 2)
+                    [(list x x ...) x]
+                    [_ #f])))
    (test-case "Nonlinear patterns and list-no-order"
      (check-equal? (match '(2 1 2 3)
                      [(cons a (list-no-order a rst ...)) (list a rst)])

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -242,6 +242,10 @@
                 (check = 5 (match '((3) (3)) [(list a a) a] [_ 5]))))
    (test-case "Nonlinear patterns use equal?"
               (check equal? '(3) (match '((3) (3)) [(list a a) a] [_ 5])))
+   (test-case "Nonlinear patterns and list-no-order"
+     (check-equal? (match '(2 1 2 3)
+                     [(cons a (list-no-order a rst ...)) (list a rst)])
+                   '(2 (1 3))))
    (test-case "Nonlinear patterns under ellipses"
      (check-equal? (match '((1 1) (2 2) (3 3))
                      [(list (list a a) ...) a]

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -276,7 +276,17 @@
                  (lambda ()
                    (convert-syntax-error
                     (match '(1 2 3 4)
-                      [(list a ... a) a])))))))
+                      [(list a ... a) a]))))
+      (check-exn #rx"^a: non-linear pattern used in `match` with ...$"
+                 (lambda ()
+                   (convert-syntax-error
+                    (match '((1 2 3) (1 2 3))
+                      [(list (list a ...) a) a]))))
+      (check-exn #rx"^x: non-linear pattern used in `match` with ...$"
+                 (lambda ()
+                   (convert-syntax-error
+                    (match '((1 2 3 4) (1 2 3 4))
+                      [(list (list x ...) (list x ...)) x])))))))
 
 
 (define doc-tests

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -560,10 +560,9 @@
      (lambda (id)
        (if (identifier? id)
            id
-           (begin
-             (log-error "non-linear pattern used in `match` with ... at ~a and ~a"
-                        (car id) (cadr id))
-             #f)))]
+           (raise-syntax-error #f
+             "non-linear pattern used in `match` with ..."
+             (car id) (cadr id))))]
     [else #f]))
 
 ;; generate-temporaries/seen :

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -228,7 +228,7 @@
                    [else (make-Row ps
                                    #`(let ([#,v* #,x]) #,(Row-rhs row))
                                    (Row-unmatch row)
-                                   (cons (cons v* x) (Row-vars-seen row)))])]))])
+                                   (append (Row-vars-seen row) (list (cons v* x))))])]))])
        ;; compile the transformed block
        (compile* xs (map transform block) esc))]
     ;; the Constructor rule
@@ -277,7 +277,7 @@
                                (list (make-Row (cdr pats)
                                                (Row-rhs row)
                                                (Row-unmatch row)
-                                               (append (map cons vars vars) seen)))
+                                               (append seen (map cons vars vars))))
                                esc
                                #f)
                    (#,esc))))))]
@@ -439,9 +439,9 @@
                                       (list (make-Row rest-pats k
                                                       (Row-unmatch (car block))
                                                       (append
+                                                       prev-seen
                                                        heads-seen
-                                                       tail-seen
-                                                       prev-seen)))
+                                                       tail-seen)))
                                       #'fail-tail))])])
            (parameterize ([current-renaming
                            (for/fold ([ht (copy-mapping (current-renaming))])
@@ -474,8 +474,8 @@
                                               #`tail-rhs
                                               (Row-unmatch (car block))
                                               (append
-                                               heads-seen
-                                               prev-seen))))
+                                               prev-seen
+                                               heads-seen))))
                              #'failkv))))))]
     [else (error 'compile "unsupported pattern: ~a\n" first)]))
 

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -384,9 +384,15 @@
             [head-idss
              (for/list ([heads headss])
                (apply append (map bound-vars heads)))]
+            [head-idss/depth
+             (for/list ([head-ids head-idss] [once? onces?])
+               (if once? head-ids (map depth+1 head-ids)))]
             [heads-seen
-             (map (lambda (x) (cons x #f))
-                  (apply append (map bound-vars heads)))]
+             (for/list ([head heads] [once? onces?]
+                        #:when #t
+                        [v (bound-vars head)])
+               (define v* (if once? v (depth+1 v)))
+               (if (zero? (get-depth v*)) (cons v* v*) (cons v* #f)))]
             [tail-seen
              (map (lambda (x) (cons x x))
                   (bound-vars tail))]
@@ -398,6 +404,7 @@
                      [var0 (car vars)]
                      [((hid ...) ...) head-idss]
                      [((hid* ...) ...) head-idss*]
+                     [((hid/depth ...) ...) head-idss/depth]
                      [((hid-arg ...) ...) hid-argss]
                      [(rep ...) reps]
                      [(maxrepconstraint ...)
@@ -425,7 +432,7 @@
                        [tail-rhs
                         #`(cond minrepclause ...
                                 [else
-                                 (let ([hid hid-rhs] ... ...
+                                 (let ([hid/depth hid-rhs] ... ...
                                        [fail-tail fail])
                                    #,(compile*
                                       (cdr vars)

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -218,7 +218,7 @@
                     =>
                     (lambda (id)
                       (make-Row ps
-                                #`(if ((match-equality-test) #,x #,id)
+                                #`(if #,(nonlinear-reference id x (get-depth v))
                                       #,(Row-rhs row)
                                       (fail))
                                 (Row-unmatch row)
@@ -571,6 +571,17 @@
 (define ((generate-temporaries/seen seen) vs)
   (for/list ([v (in-list vs)])
     (or (find-seen v seen) (generate-temporary v))))
+
+;; nonlinear-reference : Identifier Identifier Natural -> Syntax
+(define (nonlinear-reference decl ref ref-depth)
+  (cond
+    [(zero? ref-depth) #`((match-equality-test) #,ref #,decl)]
+    [else 
+     (define good? #`(curryr (match-equality-test) #,decl))
+     (let loop ([depth ref-depth] [good? good?])
+       (cond
+         [(= 1 depth) #`(andmap #,good? #,ref)]
+         [else (loop (sub1 depth) #`(curry andmap #,good?))]))]))
 
 ;; (require mzlib/trace)
 ;; (trace compile* compile-one)

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -555,18 +555,15 @@
 
 ;; find-seen : Id (Listof (Pairof Id (U #f Id))) -> (U #f Id)
 (define (find-seen v seen)
-  (cond
-    [(for/or ([e (in-list seen)])
-       (let ([v* (car e)] [id (cdr e)])
-         (and (bound-identifier=? v v*) (or id (list v v*)))))
-     =>
-     (lambda (id)
-       (if (identifier? id)
-           id
-           (raise-syntax-error #f
-             "non-linear pattern used in `match` with ..."
-             (car id) (cadr id))))]
-    [else #f]))
+  (define e (assoc v seen bound-identifier=?))
+  (and
+   e
+   (let ([v* (car e)] [id (cdr e)])
+     (if (and (identifier? id) (zero? (get-depth v*)))
+         id
+         (raise-syntax-error #f
+           "non-linear pattern used in `match` with ..."
+           v v* (list v))))))
 
 ;; generate-temporaries/seen :
 ;; (Listof (Pairof Id (U #f Id))) -> (Listof Id) -> (Listof Id)

--- a/racket/collects/racket/match/parse-helper.rkt
+++ b/racket/collects/racket/match/parse-helper.rkt
@@ -61,8 +61,8 @@
               (or (Var? pat) (Dummy? pat)))
          (make-OrderedAnd (list (make-Pred pred?)
                                 (if to-list
-                                    (make-App to-list (list pat))
-                                    pat)))]
+                                    (make-App to-list (list (VarDummy-depth+1 pat)))
+                                    (VarDummy-depth+1 pat))))]
         [else (make-GSeq (list (list pat))
                          (list min)
                          ;; no upper bound

--- a/racket/collects/racket/match/patterns.rkt
+++ b/racket/collects/racket/match/patterns.rkt
@@ -156,7 +156,7 @@
     [(Pred? p) null]
     [(Var? p)
      (let ([v (Var-v p)])
-       (list (free-identifier-mapping-get (current-renaming) v (lambda () v))))]
+       (list (depth0 (free-identifier-mapping-get (current-renaming) v (lambda () v)))))]
     [(Or? p)
      (bound-vars (car (Or-ps p)))]
     [(Box? p)
@@ -168,9 +168,12 @@
      (merge (list (bound-vars (MPair-a p)) (bound-vars (MPair-d p))))]
     [(GSeq? p)
      (merge (cons (bound-vars (GSeq-tail p))
-                  (for/list ([pats (GSeq-headss p)])
-                    (merge (for/list ([pat pats])
-                             (bound-vars pat))))))]
+                  (for/list ([pats (GSeq-headss p)]
+                             [once? (GSeq-onces? p)])
+                    (define vs
+                      (merge (for/list ([pat pats])
+                               (bound-vars pat))))
+                    (if once? vs (map depth+1 vs)))))]
     [(Vector? p)
      (merge (map bound-vars (Vector-ps p)))]
     [(Struct? p)
@@ -195,6 +198,26 @@
   (free-identifier-mapping-for-each
    ht (lambda (k v) (free-identifier-mapping-put! new-ht k v)))
   new-ht)
+
+;; get-depth : Identifier -> Natural
+;; Gets the 'match-ellipsis-depth property, default 0
+(define (get-depth x)
+  ;; Repeatedly take the car as long as its a pair
+  (define (ca*r v) (if (pair? v) (ca*r (car v)) v))
+  (define v (ca*r (syntax-property x 'match-ellipsis-depth)))
+  (if (exact-nonnegative-integer? v) v 0))
+
+;; depth0 : Identifier -> Identifier
+;; Sets 'match-ellipsis-depth property to 0
+;; (get-depth (depth0 x)) = 0
+(define (depth0 x)
+  (syntax-property x 'match-ellipsis-depth 0))
+
+;; depth+1 : Identifier -> Identifier
+;; Increments the 'match-ellipsis-depth property
+;; (get-depth (depth+1 x)) = (add1 (get-depth x))
+(define (depth+1 x)
+  (syntax-property x 'match-ellipsis-depth (add1 (get-depth x))))
 
 #|
 ;; EXAMPLES

--- a/racket/collects/racket/match/patterns.rkt
+++ b/racket/collects/racket/match/patterns.rkt
@@ -156,7 +156,10 @@
     [(Pred? p) null]
     [(Var? p)
      (let ([v (Var-v p)])
-       (list (depth0 (free-identifier-mapping-get (current-renaming) v (lambda () v)))))]
+       (list
+        (set-depth
+         (free-identifier-mapping-get (current-renaming) v (lambda () v))
+         (get-depth v))))]
     [(Or? p)
      (bound-vars (car (Or-ps p)))]
     [(Box? p)
@@ -207,17 +210,22 @@
   (define v (ca*r (syntax-property x 'match-ellipsis-depth)))
   (if (exact-nonnegative-integer? v) v 0))
 
-;; depth0 : Identifier -> Identifier
-;; Sets 'match-ellipsis-depth property to 0
-;; (get-depth (depth0 x)) = 0
-(define (depth0 x)
-  (syntax-property x 'match-ellipsis-depth 0))
+;; set-depth : Identifier Natural -> Identifier
+(define (set-depth x d)
+  (syntax-property x 'match-ellipsis-depth d))
 
 ;; depth+1 : Identifier -> Identifier
 ;; Increments the 'match-ellipsis-depth property
 ;; (get-depth (depth+1 x)) = (add1 (get-depth x))
-(define (depth+1 x)
-  (syntax-property x 'match-ellipsis-depth (add1 (get-depth x))))
+(define (depth+1 x) (set-depth x (add1 (get-depth x))))
+
+;; VarDummy-depth+1 : Var -> Var, Dummy -> Dummy
+(define (VarDummy-depth+1 p)
+  (cond
+    [(Dummy? p) (Dummy (depth+1 (Var-v p)))]
+    [(Var? p) (Var (depth+1 (Var-v p)))]
+    [else (error 'match "bad pattern: ~a" p)]))
+
 
 #|
 ;; EXAMPLES

--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require racket/stxparam
+(require racket/function
+         racket/stxparam
          (for-syntax racket/base))
 
 (provide match-equality-test
@@ -10,7 +11,9 @@
          matchable?
          match-prompt-tag
          mlist? mlist->list
-         syntax-srclocs)
+         syntax-srclocs
+         curry
+         curryr)
 
 (define match-prompt-tag (make-continuation-prompt-tag 'match)) 
 


### PR DESCRIPTION
Allows patterns inside `list-no-order` to refer to nonlinear patterns declared prior, such as in `(cons a (list-no-order a rst ...))`.

Includes nonlinear patterns declared under ellipses, such as in `(list (cons a (list-no-order a rst ...)) ...)`.

This also makes nonlinear pattern declarations syntax errors if the first use is in the scope of a `...` pattern that doesn't encompass all uses.