### PR TITLE
Add sidebars to guide for those that only need to use sytnax objects

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/read.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/read.scrbl
@@ -28,6 +28,8 @@ See @secref["reader"] for information on the default reader in
 @racket[read-syntax] mode and @secref["parse-reader"] for
 the protocol of @racket[read-syntax].}
 
+@guidealso["stx-obj"]
+
 @defproc[(read/recursive [in input-port? (current-input-port)]
                          [start (or/c char? #f) #f]
                          [readtable (or/c readtable? #f) (current-readtable)]

--- a/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl
@@ -173,6 +173,8 @@ mismatches due to local bindings that shadow only in some spaces.
 @;------------------------------------------------------------------------
 @section[#:tag "stxobj-model"]{Syntax Objects}
 
+@guideintro["stx-obj"]{the use of syntax objects}
+
 A @deftech{syntax object} combines a simpler Racket value, such as a symbol or pair, with
 @tech{lexical information}, @tech{source-location} information, @tech{syntax properties}, and
 whether the syntax object is


### PR DESCRIPTION
Those who just want to _use_ syntax objects might be overwhelmed by the reference docs and would be better suited by reading the guide, at least I was.

This PR add two sidebars for those that got lost in the same way I did:

* If you're looking at the [reference docs for syntax objects](pkgs/racket-doc/scribblings/reference/syntax-model.scrbl), I've added a `guideintro`, matching the [`guideintro` for binding](https://github.com/racket/racket/blob/3237147eb6d2b4180d986d3a819c516822fa61d6/pkgs/racket-doc/scribblings/reference/syntax-model.scrbl#L36)  just above (at the recommendation of samth).
* If you're looking at the [reference docs for `read-syntax`](pkgs/racket-doc/scribblings/reference/read.scrbl), I've added a `guidealso` for how to use syntax objects, this matches the [`guidealso` for `read-language`](https://github.com/racket/racket/blob/3237147eb6d2b4180d986d3a819c516822fa61d6/pkgs/racket-doc/scribblings/reference/read.scrbl#L130).

Thanks for all the work you all do!