### PR TITLE
ci: run arm linux on schedule

### DIFF
--- a/.github/workflows/ci-arm_linux.yml
+++ b/.github/workflows/ci-arm_linux.yml
@@ -1,6 +1,12 @@
+# Due to low availability of the machine, we can't afford
+# to run this workflow on every push.
+# Instead, run it on schedule (every day)
+
 name: CI Linux ARM
 
-on: [push]
+on:
+  schedule:
+    - cron: '0 0 * * *'
 
 jobs:
 


### PR DESCRIPTION
Due to low availability of the machine, we can't afford to run this workflow on every push. Instead, run it on schedule (every day).