### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/ARM32-fastbuild.yml
+++ b/.github/workflows/ARM32-fastbuild.yml
@@ -2,6 +2,9 @@ name: ARM32 Linux Fast Build
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   build-racket3m:
     if: github.repository == 'racket/racket'

--- a/.github/workflows/chez-build.yml
+++ b/.github/workflows/chez-build.yml
@@ -14,6 +14,9 @@ on:
       - ".github/workflows/chez-build.yml"
       - "Makefile"
       
+permissions:
+  contents: read
+
 jobs:
   build-linux:
     runs-on: ubuntu-20.04

--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -2,6 +2,9 @@ name: Test with ASan
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
 
   racketcs-asan:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -2,6 +2,9 @@ name: CI Pull Request
 
 on: [pull_request]
 
+permissions:
+  contents: read
+
 jobs:
 
   buildtest-linux-x86:

--- a/.github/workflows/ci-push_macos.yml
+++ b/.github/workflows/ci-push_macos.yml
@@ -2,6 +2,9 @@ name: CI MacOS
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
   
 # Build jobs

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -2,6 +2,9 @@ name: CI Win
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   
 # Build jobs

--- a/.github/workflows/docker-racketci.yml
+++ b/.github/workflows/docker-racketci.yml
@@ -8,6 +8,9 @@ on:
       - '.github/images/Dockerfile'
       - '.github/workflows/docker-racketci.yml'
 
+permissions:
+  contents: read
+
 jobs:
   build-image:
     runs-on: ubuntu-18.04

--- a/.github/workflows/ubsan-arm.yml
+++ b/.github/workflows/ubsan-arm.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
 
 # Build jobs

--- a/.github/workflows/ubsan-x86.yml
+++ b/.github/workflows/ubsan-x86.yml
@@ -2,6 +2,9 @@ name: Test with UBSan on X86
 
 on: [push]
 
+permissions:
+  contents: read
+
 jobs:
 
 # Build jobs


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
