### PR TITLE
reference: clarify that ports are duped before being sent across places

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/places.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/places.scrbl
@@ -369,8 +369,8 @@ messages:
 
  @item{@tech{file-stream ports} and @tech{TCP ports}, where the
        underlying representation (such as a file descriptor, socket,
-       or handle) is duplicated and attached to a fresh port in the
-       receiving place;}
+       or handle) is duplicated in the sending place and attached to
+       a fresh port in the receiving place;}
 
  @item{@tech[#:doc '(lib "scribblings/foreign/foreign.scrbl")]{C
        pointers} as created or accessed via @racketmodname[ffi/unsafe]; and}


### PR DESCRIPTION
The intent here is to clarify that code like

    (place-channel-put ch a-port)
    (close-input-port a-port)

is safe.  The previous wording could be interpreted as if the fd is duplicated after receive.

(I've checked and this seems to be true of both the BC and CS implementations.)