### PR TITLE
improve errors for yield outside generator

### DIFF
--- a/racket/collects/racket/generator.rkt
+++ b/racket/collects/racket/generator.rkt
@@ -44,7 +44,7 @@
 
 (define current-yielder
   (make-parameter
-   (lambda (v)
+   (lambda _
      (error 'yield "must be called in the context of a generator"))
    #f
    'current-yielder))


### PR DESCRIPTION
The spec requires that `yield` be variable arity, but the default
`yield` outside of `generator` forms accepts only a single argument,
leading to:

```
> ,r racket/generator
> (yield)
...acket/generator.rkt:47:3: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 1
  given: 0
 [,bt for context]
> (yield 1) ;; this is what I expect for the others, as it's more clear about the problem
yield: must be called in the context of a generator [,bt for context]
> (yield 2 3)
...acket/generator.rkt:47:3: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 1
  given: 2
 [,bt for context]
```

The expression `(yield 1)` gives the best error message; now, the others
should give the same, and the behavior is tested.