### PR TITLE
Provide `racket/symbol` from `racket`

### DIFF
--- a/racket/collects/racket/main.rkt
+++ b/racket/collects/racket/main.rkt
@@ -15,6 +15,7 @@
          racket/list
          racket/vector
          racket/string
+         racket/symbol
          racket/bytes
          racket/function
          racket/path
@@ -48,6 +49,7 @@
                        racket/list
                        racket/vector
                        racket/string
+                       racket/symbol
                        racket/bytes
                        racket/function
                        racket/path


### PR DESCRIPTION
The function `symbol->immutable-string` was moved out of `racket/base` in 37ce9478cd, but was not provided from `racket` at that time, even though the doc edits in that commit indicate that the intent was to do so.

Obviously if the preferred fix is to amend the docs, please feel free to close this PR.