### PR TITLE
Mark generated files for github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 .git* export-ignore
 /.mailmap export-ignore
+/racket/src/cs/schemified/*.scm linguist-generated=true
+*.zuo linguist-language=Racket

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,5 @@
 .git* export-ignore
 /.mailmap export-ignore
 /racket/src/cs/schemified/*.scm linguist-generated=true
+/racket/src/bc/src/startup.inc  linguist-generated=true
 *.zuo linguist-language=Racket


### PR DESCRIPTION
This will cause them to be hidden by default in GitHub diff view.

Also, indicate that .zuo files should be highlighted like Racket.

Other generated files could be added here too.