### PR TITLE
Parameterization for dependent function contracts

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1375,6 +1375,7 @@ symbols, and that return a symbol.
       (mandatory-dependent-dom ...)
       dependent-rest
       pre-condition
+      param-value
       dependent-range
       post-condition)
  (->i maybe-chaperone
@@ -1382,6 +1383,7 @@ symbols, and that return a symbol.
       (optional-dependent-dom ...)
       dependent-rest
       pre-condition
+      param-value
       dependent-range
       post-condition)]
 ([maybe-chaperone #:chaperone (code:line)]
@@ -1397,6 +1399,9 @@ symbols, and that return a symbol.
                            expr pre-condition)
                 (code:line #:pre/name (id ...)
                            string boolean-expr pre-condition)]
+ [param-value (code:line)
+              (code:line #:param (id ...)
+                         param-expr val-expr param-value)]
  [dependent-range any
                   id+ctc
                   un+ctc
@@ -1434,6 +1439,13 @@ which it depends. If the @racket[#:pre/name] keyword is used, the string
 supplied is used as part of the error message; similarly with @racket[#:post/name].
 If @racket[#:pre/desc] or @racket[#:post/desc] is used, the the result of
 the expression is treated the same way as @racket[->*].
+
+Following the pre-condition is the optional @racket[param-value] non-terminal
+that specifies parameters to be assigned to during the dynamic extent of the
+function. Each assignment is introduced with the @racket[#:param] keyword followed
+by the list of names on which it depends, a @racket[param-expr] that determines
+the parameter to set, and a @racket[value-expr] that will be associated with
+the parameter.
 
 The @racket[dependent-range] non-terminal specifies the possible result
 contracts. If it is @racket[any], then any value is allowed. Otherwise, the
@@ -1526,6 +1538,8 @@ is supplied:
 In contrast, @racket[_x]'s expression is always evaluated (indeed,
 it is evaluated when the @racket[->i] expression is evaluated because
 it does not have any dependencies).
+
+@history[#:changed "8.7.0.1" @list{Added @racket[#:param].}]
 }
 
 @defform*/subs[#:literals (any values)

--- a/pkgs/racket-test/tests/racket/contract/arrow-i.rkt
+++ b/pkgs/racket-test/tests/racket/contract/arrow-i.rkt
@@ -142,6 +142,11 @@
    '->i-stx23
    #'(->i ([f (f x) any/c]) (#:x [x any/c]) [res any/c]))
   
+  (contract-syntax-error-test
+   '->i-stx24
+   #'(let ([p (make-parameter #f)])
+       (->i ([x integer?]) #:param (x) p any)))
+
   (test/spec-passed
    '->i1
    '((contract (->i () () [x number?]) (lambda () 1) 'pos 'neg)))
@@ -1273,6 +1278,42 @@
    '(2 0 0 1 4 5 3 3 6)
    do-not-double-wrap)
   
+  (test/spec-passed/result
+   '->i62
+   '(let* ([p (make-parameter 0)]
+           [f (contract (->i ([x integer?])
+                             #:param (x) p x
+                             any)
+                        (λ (_) (p)) 'pos 'neg)])
+      (list (f 1) (f 2)))
+   '(1 2))
+
+  (test/spec-passed/result
+   '->i63
+   '(let* ([p (make-parameter 0)]
+           [f (contract (->i (#:x [x integer?])
+                             (#:y [y integer?])
+                             #:rest [rst (listof integer?)]
+                             #:param (x y rst) p
+                             (+ x (if (unsupplied-arg? y) 0 y) (apply + rst))
+                             any)
+                        (λ (#:x x #:y [y -100]. rst) (p)) 'pos 'neg)])
+      (list (f #:x 1 10 13) (f 10 8 #:x 2 #:y 1)))
+   '(24 21))
+
+  (test/spec-passed/result
+   '->i64
+   '(let* ([p1 (make-parameter 0)]
+           [p2 (make-parameter 0)]
+           [f (contract (->i ([x integer?]
+                              [y integer?])
+                             #:param (x) p1 (add1 x)
+                             #:param (y) p2 (add1 y)
+                             any)
+                        (λ (_x _y) (list (p1) (p2))) 'pos 'neg)])
+      (list (f 1 2) (f 3 4)))
+   '((2 3) (4 5)))
+
   (test/pos-blame
    '->i-arity1
    '(contract (->i ([x number?]) () any) (λ () 1) 'pos 'neg))

--- a/racket/collects/racket/HISTORY.txt
+++ b/racket/collects/racket/HISTORY.txt
@@ -1,3 +1,6 @@
+Version 8.8
+Add `#:param` option to `->i`
+
 Version 8.7
 Use Unicode 14.0 for character and string operations
 Add grapheme operations, such as `string-grapheme-count`


### PR DESCRIPTION
For some time now, `impersonate-procedure` and `chaperone-procedure` have supported installing a continuation mark during the dynamic extent of a wrapped procedure. While this facility is available for custom contracts, none of Racket's existing contract combinators (as far as I know) provide access to this mechanism, even though it's a useful one. A few examples:

* `yield` can only be called during the dynamic extent of a generator
* A promise cannot be forced again while it's already being forced.
* `contract-random-generate-get-current-environment` can only be called during contract generation.
* `call-with-escape-continuation` can only be called during `call-with-escape-continuation`.
* [Authorization Contracts](https://dl.acm.org/doi/10.1145/2983990.2984021)

This PR adds a `#:param` option to `->i` that sets a parameter during the protected function's execution. I chose to implement this as an option to `->i` so that the parameter's value can depend on the arguments passed to the function. I can't think of another implementation strategy that could support this. Only contracts that use `#:param` will add any code relating to parameters, so there should be no adverse performance costs to existing code. This PR doesn't include documentation, but I'll be happy to write some after getting feedback.

Here is a larger example showing it in action on a nested generator where yielded values must satisfy some predicate. The contracts are straightforward and have reasonable error messages thanks to `#:pre/desc`:

```rkt
(module generator-lib racket
  (provide
   (contract-out
    [generator
     (->i ([p predicate/c]
           [f (p) (->i ()
                       #:param ()
                       currently-generating?
                       (cons p (currently-generating?))
                       [r any/c])])
          [r generator?])]

    [yield (->i ([x any/c])
                #:pre/desc ()
                (or (cons? (currently-generating?))
                    "yield called outside a generator")
                #:pre/desc (x)
                (or ((car (currently-generating?)) x)
                    "yielded value does not satisfy generator predicate")
                [r any/c])]))

  (define currently-generating? (make-parameter null))
  (define generator-prompt-tag (make-continuation-prompt-tag))

  (struct generator (pred proc) #:mutable
    #:property prop:procedure
    (λ (self)
      (call-with-continuation-prompt
       (λ ()
         ((generator-proc self)))
       generator-prompt-tag
       (λ (v kont)
         (set-generator-proc! self (λ () (kont (void))))
         v))))

  (define (yield v)
    (let/cc kont
      (abort-current-continuation generator-prompt-tag v kont))))

;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

(require 'generator-lib)

;; A generator where the yielded value must satisfy `integer?`
(define g1
  (generator
   integer?
   (λ ()
     (for ([i 3])
       (yield i)))))

;; A generator where the yielded value must satisfy `string?`
(define g2
  (generator
   string?
   (λ ()
     (for ([_ 3])
       (yield (format "hello ~a" (g1)))))))

;; E.g.
(g2)
(g2)
(g2)
```

cc @rfindler @chrdimo @mfelleisen 
