### PR TITLE
Chez Scheme: Fix build on GNU/Hurd.

### DIFF
--- a/racket/src/ChezScheme/README.md
+++ b/racket/src/ChezScheme/README.md
@@ -13,6 +13,7 @@ Supported platforms (bytecode interpreter may work for others):
  * OpenBSD: x86, x86_64, ARMv6, AArch64, PowerPC32
  * NetBSD: x86, x86_64, ARMv6, AArch64, PowerPC32
  * Solaris: x86, x86_64
+ * GNU/Hurd: x86
  * Android: ARMv7, AArch64
  * iOS: AArch64
  * WebAssembly via Emscripten (bytecode interpreter only)

--- a/racket/src/ChezScheme/c/number.c
+++ b/racket/src/ChezScheme/c/number.c
@@ -1041,15 +1041,15 @@ floating-point operations
 
 #ifdef IEEE_DOUBLE
 /* exponent stored + 1024, hidden bit to left of decimal point */
-#define bias 1023
-#define bitstoright 52
-#define m1mask 0xf
-#ifdef WIN32
-#define hidden_bit 0x10000000000000
-#else
-#define hidden_bit 0x10000000000000ULL
-#endif
-#ifdef LITTLE_ENDIAN_IEEE_DOUBLE
+# define bias 1023
+# define bitstoright 52
+# define m1mask 0xf
+# ifdef WIN32
+#  define hidden_bit 0x10000000000000
+# else
+#  define hidden_bit 0x10000000000000ULL
+# endif
+# ifdef LITTLE_ENDIAN_IEEE_DOUBLE
 struct dblflt {
     UINT m4: 16;
     UINT m3: 16;
@@ -1058,7 +1058,7 @@ struct dblflt {
     UINT e: 11;
     UINT sign: 1;
 };
-#else
+# else
 struct dblflt {
     UINT sign: 1;
     UINT e: 11;
@@ -1067,7 +1067,7 @@ struct dblflt {
     UINT m3: 16;
     UINT m4: 16;
 };
-#endif
+# endif
 #endif
 
 double S_random_double(U32 m1, U32 m2, U32 m3, U32 m4, double scale) {

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -80,7 +80,7 @@ FORCEINLINE void store_unaligned_uptr(uptr *addr, uptr val) {
 /*****************************************/
 /* Operating systems                     */
 
-#if defined(__linux__)
+#if defined(__linux__) || defined(__GNU__) /* Hurd */
 #define NOBLOCK O_NONBLOCK
 #define LOAD_SHARED_OBJECT
 #define USE_MMAP
@@ -91,7 +91,10 @@ FORCEINLINE void store_unaligned_uptr(uptr *addr, uptr val) {
 #define GETPAGESIZE() getpagesize()
 typedef char *memcpy_t;
 #define MAKE_NAN(x) { x = 0.0; x = x / x; }
-#define GETWD(x) getcwd((x),PATH_MAX)
+#ifndef __GNU__ /* Hurd: no PATH_MAX */
+/* n.b. don't test PATH_MAX directly: we have not yet included <limits.h>  */
+# define GETWD(x) getcwd((x),PATH_MAX)
+#endif
 typedef int tputsputcchar;
 #ifndef __ANDROID__
 # define LOCKF

--- a/racket/src/ChezScheme/configure
+++ b/racket/src/ChezScheme/configure
@@ -102,6 +102,11 @@ case "${CONFIG_UNAME}" in
     installprefix=/usr
     installmansuffix=share/man
     ;;
+  GNU)
+    unixsuffix=gnu # the Hurd
+    installprefix=/usr
+    installmansuffix=share/man
+    ;;
   QNX)
     if uname -a | egrep 'x86' > /dev/null 2>&1 ; then
       m32=i3qnx
@@ -591,7 +596,7 @@ fi
 
 # Infer flags needed for threads:
 case "${flagsm}" in
-  *le|*fb|*ob|*nb)
+  *le|*gnu|*fb|*ob|*nb)
       threadFlags="-D_REENTRANT -pthread"
       threadLibs="-lpthread"
       ;;
@@ -627,7 +632,7 @@ if [ "$cflagsset" = "no" ] ; then
     a6*)
         CFLAGS="-m64 ${optFlags}"
         ;;
-    i3le)
+    i3le) # intentionally not including i3gnu, which may not support sse2
         CFLAGS="-m32 -msse2 -mfpmath=sse ${optFlags}"
         ;;
     i3nt)
@@ -688,7 +693,7 @@ fi
 # Add automatic linking flags, unless suppressed by --disable-auto-flags
 if [ "$addflags" = "yes" ] ; then
   case "${flagsm}" in
-    *le)
+    *le|*gnu)
         LDFLAGS="${LDFLAGS} -rdynamic"
         ;;
     *fb|*nb)
@@ -702,7 +707,7 @@ if [ "$addflags" = "yes" ] ; then
   esac
 
   case "${flagsm}" in
-    *le)
+    *le|*gnu)
         LIBS="${LIBS} -lm -ldl ${ncursesLib} -lrt"
         ;;
     *fb|*ob)
@@ -749,7 +754,7 @@ exeSuffix=
 
 # compile flags for c/Mf-unix and mats/Mf-unix
 case "${flagsmuni}" in
-    *le)
+    *le|*gnu)
         mdcflags="-fPIC -shared"
         ;;
     *fb|*ob)
@@ -781,7 +786,7 @@ case "${flagsmuni}" in
     i3le)
         mdldflags="-melf_i386"
         ;;
-    *le)
+    *le|*gnu)
         ;;
     i3nb)
         mdldflags="-m elf_i386"

--- a/racket/src/ChezScheme/s/cmacros.ss
+++ b/racket/src/ChezScheme/s/cmacros.ss
@@ -385,6 +385,7 @@
   i3fb      ti3fb
   i3ob      ti3ob
   i3osx     ti3osx
+  i3gnu     ti3gnu
   a6le      ta6le
   a6osx     ta6osx
   a6ob      ta6ob

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -4449,8 +4449,15 @@ case "$host_os" in
     ;;
   irix*)
     ;;
-  linux*)
-    MACH_OS=le
+  linux*|gnu*)
+    case "$host_os" in
+      *linux*)
+        MACH_OS=le
+        ;;
+      *)
+        MACH_OS=gnu # Hurd
+        ;;
+    esac
     case "$host_os" in
       *linux-android*)
         ;;
@@ -4729,6 +4736,9 @@ if test "${build_os}_${build_cpu}" != "${host_os}_${host_cpu}" ; then
       ;;
     linux*)
       BUILD_OS=le
+      ;;
+    gnu*) # Hurd: must come after linux*
+      BUILD_OS=gnu
       ;;
     *mingw*)
       BUILD_OS=nt

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -272,8 +272,15 @@ case "$host_os" in
     ;;
   irix*)
     ;;
-  linux*)
-    MACH_OS=le
+  linux*|gnu*)
+    case "$host_os" in
+      linux*)
+        MACH_OS=le
+        ;;
+      *)
+        MACH_OS=gnu # Hurd
+        ;;
+    esac
     case "$host_os" in
       *linux-android*)
         ;;
@@ -465,6 +472,9 @@ if test "${build_os}_${build_cpu}" != "${host_os}_${host_cpu}" ; then
       ;;
     linux*)
       BUILD_OS=le
+      ;;
+    gnu*) # Hurd - must come after linux*
+      BUILD_OS=gnu
       ;;
     *mingw*)
       BUILD_OS=nt

--- a/racket/src/cs/rumble/system.ss
+++ b/racket/src/cs/rumble/system.ss
@@ -48,6 +48,8 @@
            arm32le tarm32le arm64le tarm64le
            ppc32le tppc32le)
      'linux]
+    [(i3gnu ti3gnu)
+     'gnu-hurd]
     [(a6fb ta6fb i3fb ti3fb
            arm32fb tarm32fb arm64fb tarm64fb
            ppc32fb tppc32fb)
@@ -85,6 +87,7 @@
             i3nb ti3nb
             i3fb ti3fb
             i3s2 ti3s2
+            i3gnu ti3gnu
             i3qnx)
      'i386]
     [(arm32le tarm32le


### PR DESCRIPTION
Mostly GNU/Hurd should take the same options as GNU/Linux. One
difference is that the Hurd does not define macros such as `PATH_MAX` or
`NOFILE`, because it avoids imposing arbitrary limits on such resources.
This patch provides alternatives for localized uses of those constants,
but it accepts the pervasive use of `PATH_MAX` in finding bootfiles for
now. See https://www.gnu.org/software/hurd/hurd/porting/guidelines.html.

Tested on Debian GNU/Hurd 20220331 and cross-compilation via Guix for
i586-pc-gnu with the pb and tpb32l backends.