### PR TITLE
Fix #4386

### DIFF
--- a/pkgs/racket-test-core/tests/racket/object.rktl
+++ b/pkgs/racket-test-core/tests/racket/object.rktl
@@ -2400,5 +2400,29 @@
   (test 'outer values (send (new c2%) f)))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; Check that interface contracts on a subclass work correctly.
+
+(let ()
+  (define sup%
+    (class* object% ()
+      (super-new)
+      (define/public (f x) x)))
+
+  (define f-returns-int<%>
+    (interface () [f (->m any/c integer?)]))
+
+  (define sub%
+    (class* sup% (f-returns-int<%>)
+      (super-new)))
+
+  (define sup-obj (new sup%))
+  (test #t equal? (send sup-obj f 10) 10)
+  (test #t equal? (send sup-obj f "hi") "hi")
+
+  (define sub-obj (new sub%))
+  (test #t equal? (send sub-obj f 10) 10)
+  (err/rt-test (send sub-obj f "hi") exn:fail:contract?))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (report-errs)

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -2214,7 +2214,8 @@ last few projections.
          [augonly-names (append pubment-names overment-names augment-names)]
          ;; Misc utilities
          [no-new-methods? (null? public-names)]
-         [no-method-changes? (and (null? public-names)
+         [no-method-changes? (and (null? interfaces)
+                                  (null? public-names)
                                   (null? override-names)
                                   (null? augride-names)
                                   (null? final-names))]


### PR DESCRIPTION
A subclass can share values with its superclass when there are no
changes to the method table. Attaching an interface to a subclass
was not considered a method change, however when that interface
has contracts it will mutable the method table. Sharing in this
case causes the superclass to be messed up. The solution is to
consider interface attachment as a method change so that sharing
no longer occurs.