### PR TITLE
racket/promise: add for{,*}/concurrent

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/promise.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/promise.scrbl
@@ -174,3 +174,49 @@ TODO: Say something on:
   demand.
 ;}
 }
+
+@(define promise-eval
+   (let ([eval (make-base-eval)])
+     (eval '(require racket/promise))
+     eval))
+
+@defform[
+  (for/list/concurrent maybe-group (for-clause ...)
+    body-or-break ... body)
+  #:grammar
+  [(maybe-group (code:line)
+                (code:line #:group thread-group-expr))]
+  #:contracts ([thread-group-expr thread-group?])]{
+
+  Iterates like @racket[for/list], but the bodies (following any
+  @racket[#:break] or @racket[#:final] clauses) are wrapped in
+  @racket[delay/thread].  Each @tech{promise} is forced before the
+  result list is returned.
+
+  Threads are created under @racket[thread-group-expr], which defaults
+  to @racket[(make-thread-group)].  An optional @racket[#:group]
+  clause may be provided, in which case the threads will be created
+  under that thread group.
+
+  This form does not support returning multiple values.
+
+  @examples[
+    #:eval promise-eval
+    (time
+     (for/list/concurrent ([i (in-range 5)])
+       (define duration (/ 1.0 (random 50 100)))
+       (sleep duration)
+       (printf "thread ~a slept for ~a milliseconds~n" i (truncate (* duration 1000)))
+       i))
+  ]
+
+  @history[#:added "8.6.0.4"]
+}
+
+@defform[(for*/list/concurrent maybe-group (for-clause ...)
+           body-or-break ... body)]{
+  Like @racket[for/list/concurrent], but with the implicit nesting of
+  @racket[for*/list].
+
+  @history[#:added "8.6.0.4"]
+}

--- a/pkgs/racket-test-core/tests/racket/all.rktl
+++ b/pkgs/racket-test-core/tests/racket/all.rktl
@@ -38,6 +38,7 @@
 (load-in-sandbox "bytes.rktl")
 (load-in-sandbox "trace.rktl")
 (load-in-sandbox "trait.rktl")
+(load-in-sandbox "promise.rktl")
 
 (load-in-sandbox "moddep.rktl")
 (load-in-sandbox "boundmap-test.rktl")

--- a/pkgs/racket-test-core/tests/racket/promise.rktl
+++ b/pkgs/racket-test-core/tests/racket/promise.rktl
@@ -1,0 +1,33 @@
+(load-relative "loadtest.rktl")
+
+(require racket/promise)
+
+(Section 'promise)
+
+(test '(0 1)
+  (for/list/concurrent ([i (in-range 3)])
+    #:break (= i 1)
+    i))
+
+(test '((0 0) (0 1) (1 0) (1 1))
+  (for*/list/concurrent ([i (in-range 2)]
+                         [j (in-range 2)])
+    (list i j)))
+
+;; Test that the bodies run in different threads, but the results are
+;; ordered.
+(let ()
+  (define-syntax (test-concurrent-result stx)
+    (syntax-case stx ()
+      [(_ for/list/concurrent-id)
+       #'(let* ([group (make-thread-group)]
+                [thds (make-hasheq)]
+                [results (for/list/concurrent-id #:group group ([i (in-range 3)])
+                           (test group (current-thread-group))
+                           (hash-set! thds (current-thread) #t)
+                           i)])
+           (test '(0 1 2) results)
+           (test 3 (hash-count thds)))]))
+
+  (test-concurrent-result for/list/concurrent)
+  (test-concurrent-result for*/list/concurrent))

--- a/racket/collects/racket/promise.rkt
+++ b/racket/collects/racket/promise.rkt
@@ -1,11 +1,13 @@
 #lang racket/base
-(require "private/promise.rkt" (for-syntax racket/base))
+(require "private/promise.rkt" (for-syntax racket/base syntax/for-body))
 (provide delay lazy force promise? promise-forced? promise-running? promise/name?
          (rename-out [delay/name* delay/name]
                      [delay/strict* delay/strict]
                      [delay/sync* delay/sync]
                      [delay/thread* delay/thread]
-                     [delay/idle* delay/idle]))
+                     [delay/idle* delay/idle])
+         for/list/concurrent
+         for*/list/concurrent)
 
 ;; ----------------------------------------------------------------------------
 ;; More delay-like values, with different ways of deferring computations
@@ -223,3 +225,31 @@
                               (cons '#:work-while #'(system-idle-evt))
                               (cons '#:tick       #'0.2)
                               (cons '#:use        #'0.12))))
+
+(define-syntaxes (for/list/concurrent for*/list/concurrent)
+  (let ()
+    (define ((make-transformer for/fold/derived-stx [orig-stx #f]) stx)
+      (syntax-case stx ()
+        [(_ #:group group-expr clauses body ...)
+         (let ([stx (or orig-stx stx)])
+           (with-syntax ([this-syntax stx]
+                         [for/fold/derived for/fold/derived-stx]
+                         [((pre-body ...)
+                           (post-body ...))
+                          (split-for-body stx #'(body ...))])
+             (syntax/loc stx
+               (let ([group group-expr])
+                 (for/fold/derived this-syntax
+                   ([promises null] #:result (map force (reverse promises)))
+                   clauses
+                   pre-body ...
+                   (cons (delay/thread*
+                          #:group group
+                          (let () post-body ...))
+                         promises))))))]
+        [(_ clauses body ...)
+         ((make-transformer for/fold/derived-stx stx)
+          #'(fc #:group (make-thread-group) clauses body ...))]))
+    (values
+     (make-transformer #'for/fold/derived)
+     (make-transformer #'for*/fold/derived))))


### PR DESCRIPTION
I often find myself wanting a form like this when I write code that does concurrent IO over a set of things. Happy to change the name if anyone can think of a better one.