### PR TITLE
racket/future: fix for{,*}/async #:break clauses

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/futures.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/futures.scrbl
@@ -131,8 +131,8 @@ execute through a call to @racket[touch], however.
 }
 
 @deftogether[[
-@defform[(for/async (for-clause ...) body ...+)]
-@defform[(for*/async (for-clause ...) body ...+)]]]{
+@defform[(for/async (for-clause ...) body-or-break ... body)]
+@defform[(for*/async (for-clause ...) body-or-break ... body)]]]{
 
 Like @racket[for] and @racket[for*], but each iteration of the
 @racket[body] is executed in a separate @racket[future], and

--- a/pkgs/racket-test-core/tests/racket/all.rktl
+++ b/pkgs/racket-test-core/tests/racket/all.rktl
@@ -39,6 +39,7 @@
 (load-in-sandbox "trace.rktl")
 (load-in-sandbox "trait.rktl")
 (load-in-sandbox "promise.rktl")
+(load-in-sandbox "future.rktl")
 
 (load-in-sandbox "moddep.rktl")
 (load-in-sandbox "boundmap-test.rktl")

--- a/pkgs/racket-test-core/tests/racket/future.rktl
+++ b/pkgs/racket-test-core/tests/racket/future.rktl
@@ -1,0 +1,26 @@
+(load-relative "loadtest.rktl")
+
+(require racket/future)
+
+(Section 'future)
+
+(test 2
+  (let ([futures (make-hasheq)])
+    (for/async ([_ (in-range 2)])
+      (hash-set! futures (current-future) #t))
+    (hash-count futures)))
+
+(test 2
+  (let ([futures (make-hasheq)])
+    (for/async ([i (in-range 10)])
+      #:break (= i 1)
+      (hash-set! futures (current-future) #t))
+    (hash-count futures)))
+
+;; The form should return void?, but the existing implementation
+;; returns the result of the last future instead.  For
+;; backwards-compatibility, we'll preserve the current behavior.
+(test '(1 1)
+  (for*/async ([i (in-range 2)]
+               [j (in-range 2)])
+    (list i j)))

--- a/pkgs/racket-test-core/tests/racket/future.rktl
+++ b/pkgs/racket-test-core/tests/racket/future.rktl
@@ -17,10 +17,7 @@
       (hash-set! futures (current-future) #t))
     (hash-count futures)))
 
-;; The form should return void?, but the existing implementation
-;; returns the result of the last future instead.  For
-;; backwards-compatibility, we'll preserve the current behavior.
-(test '(1 1)
+(test (void)
   (for*/async ([i (in-range 2)]
                [j (in-range 2)])
     (list i j)))

--- a/racket/collects/racket/future.rkt
+++ b/racket/collects/racket/future.rkt
@@ -1,22 +1,23 @@
 #lang racket/base
 (require '#%futures
-         (for-syntax racket/base))
+         (for-syntax racket/base
+                     syntax/for-body))
 
-(provide  future?
-          future
-          touch
-          processor-count
-          current-future
-          fsemaphore?
-          make-fsemaphore
-          fsemaphore-count
-          fsemaphore-post
-          fsemaphore-wait
-          fsemaphore-try-wait?
-          would-be-future
-          futures-enabled?
-          for/async
-          for*/async)
+(provide future?
+         future
+         touch
+         processor-count
+         current-future
+         fsemaphore?
+         make-fsemaphore
+         fsemaphore-count
+         fsemaphore-post
+         fsemaphore-wait
+         fsemaphore-try-wait?
+         would-be-future
+         futures-enabled?
+         for/async
+         for*/async)
 
 ;; Note: order of touches not guaranteed.
 
@@ -24,14 +25,23 @@
   (let ()
     (define ((transformer for/fold/derived-id) stx)
       (syntax-case stx ()
-        [(_ (clause ...) . body)
-         (quasisyntax/loc stx
-           (let ([futures
-                  (#,for/fold/derived-id #,stx ([fs null]) (clause ...)
-                                         (cons (future (lambda () . body)) fs))])
-             ;; touches futures in original order
-             (let loop ([fs futures])
-               (cond [(pair? fs) (begin (loop (cdr fs)) (touch (car fs)))]
-                     [else (void)]))))]))
+        [(_ clauses body ...)
+         (with-syntax ([this-syntax stx]
+                       [for/fold/derived for/fold/derived-id]
+                       [((pre-body ...)
+                         (post-body ...))
+                        (split-for-body stx #'(body ...))])
+           (syntax/loc stx
+             (let ([futures
+                    (for/fold/derived this-syntax
+                      ([fs null])
+                      clauses
+                      pre-body ...
+                      (cons (future (lambda () post-body ...)) fs))])
+               ;; touches futures in original order
+               (let loop ([fs futures])
+                 (when (pair? fs)
+                   (loop (cdr fs))
+                   (touch (car fs)))))))]))
     (values (transformer #'for/fold/derived)
             (transformer #'for*/fold/derived))))

--- a/racket/collects/racket/future.rkt
+++ b/racket/collects/racket/future.rkt
@@ -42,6 +42,7 @@
                (let loop ([fs futures])
                  (when (pair? fs)
                    (loop (cdr fs))
-                   (touch (car fs)))))))]))
+                   (touch (car fs))))
+               (void))))]))
     (values (transformer #'for/fold/derived)
             (transformer #'for*/fold/derived))))


### PR DESCRIPTION
While working on `for/list/concurrent`, I noticed some issues with `for/async`:

* it doesn't support break clauses,
* ~~touching the futures isn't tail recursive, and~~
* the form returns a result even though it shouldn't.

I've fixed the first ~~two~~ one and added some tests. It would be nice to fix the 3rd item as well, but it's probably not worth making a backwards-incompatible change here.

EDIT: Then again, the documentation does state that the touch order isn't guaranteed so no one should be depending on the result value anyway. Maybe it wouldn't be so bad to change it to return `void`.

EDIT2: I took some measurements and the non-tail recursive version doesn't actually consume more memory than the tail-recursive one on my machine until I do 300k iterations or more, which is probably a lot more than anybody using this form would do anyway, so I've undone that change to preserve the original implementation.

EDIT3: I wrote a little tool to iterate over all packages in a catalog, `read` their `.rkt` sources and search for uses & applications of a given `id` (it does a naïve match by symbol, so it isn't aware of renames, bindings, etc). Running it on my most recent catalog snapshot, [these](https://gist.github.com/Bogdanp/ea71e27ad53339ffb7c0196554b88c88) are all the usages of the two forms that turn up. They all look like they already assume that `for/async` doesn't return a value, so I think the chances of anything breaking if we change the forms to return `void` are very small.