### PR TITLE
openssl updates (tls13, hostname validation, tls-exporter)

### DIFF
--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -276,6 +276,14 @@ current platform for client connections.
 @history[#:added "6.1.1.3"]
 }
 
+@defproc[(ssl-protocol-version [p ssl-port?])
+         ssl-protocol-symbol/c]{
+
+Returns a symbol representing the SSL/TLS protocol version negotiated for the
+connection represented by @racket[p].
+
+@history[#:added "8.6.0.4"]}
+
 @; ----------------------------------------------------------------------
 
 @section{TCP-like Server Procedures}
@@ -878,24 +886,43 @@ If @racket[ssl-peer-verified?] would return @racket[#t] for
 the certificate presented by the SSL port's peer, otherwise the result
 is @racket[#f].}
 
+@defproc[(ssl-default-channel-binding [p ssl-port?])
+         (list/c symbol? bytes?)]{
+
+Returns the default channel binding type and value for @racket[p], based on the
+connection's TLS protocol version. Following
+@hyperlink["https://datatracker.ietf.org/doc/html/rfc9266#section-3"]{RFC 9266 Section 3},
+the result uses @racket['tls-exporter] for TLS 1.3 and later;
+it uses @racket['tls-unique] for TLS 1.2 and earlier.
+
+@history[#:added "8.6.0.4"]}
+
 @defproc[(ssl-channel-binding [p ssl-port?]
-                              [type (or/c 'tls-unique 'tls-server-end-point)])
+                              [type (or/c 'tls-exporter
+                                          'tls-unique
+                                          'tls-server-end-point)])
          bytes?]{
 
 Returns channel binding information for the TLS connection of
 @racket[p]. An authentication protocol run over TLS can incorporate
-information identifying the TLS connection (@racket['tls-unique]) or
+information identifying the TLS connection (@racket['tls-exporter] or
+@racket['tls-unique]) or
 server certificate (@racket['tls-server-end-point]) into the
 authentication process, thus preventing the authentication steps from
 being replayed on another channel. Channel binding is described in
 general in @hyperlink["https://tools.ietf.org/html/rfc5056"]{RFC 5056};
 channel binding for TLS is described in
-@hyperlink["https://tools.ietf.org/html/rfc5929"]{RFC 5929}.
+@hyperlink["https://tools.ietf.org/html/rfc5929"]{RFC 5929} and
+@hyperlink["https://datatracker.ietf.org/doc/html/rfc9266"]{RFC 9266}.
 
 If the channel binding cannot be retrieved (for example, if the
 connection is closed), an exception is raised.
 
-@history[#:added "7.7.0.9"]}
+@history[
+#:added "7.7.0.9"
+#:changed "8.6.0.4" @elem{Added @racket['tls-exporter]. An exception is raised
+for @racket['tls-unique] with a TLS 1.3 connection.}
+]}
 
 
 @defproc[(ssl-get-alpn-selected [p ssl-port?])

--- a/pkgs/racket-test/tests/openssl/test-channel-binding.rkt
+++ b/pkgs/racket-test/tests/openssl/test-channel-binding.rkt
@@ -1,12 +1,11 @@
 #lang racket/base
 (require openssl
+         (only-in openssl/private/ffi v1.1.0/later?)
          rackunit
          racket/runtime-path)
 
 (define-runtime-path server-key "server_key.pem")
 (define-runtime-path server-crt "server_crt.pem")
-(define-runtime-path client-key "client_key.pem")
-(define-runtime-path client-crt "client_crt.pem")
 (define-runtime-path this-dir ".")
 
 (define (call/custodian proc)
@@ -19,7 +18,12 @@
 (define PORT 55009)
 
 (define (get-cb port)
-  (list (ssl-channel-binding port 'tls-unique)
+  (list (unless (eq? (ssl-protocol-version port) 'tls13)
+          (ssl-channel-binding port 'tls-unique))
+        (when v1.1.0/later?
+          ;; Extended Master Secret extension added in v1.1.0; tls-exporter
+          ;; fails if not present.
+          (ssl-channel-binding port 'tls-exporter))
         (ssl-channel-binding port 'tls-server-end-point)))
 
 (define server-ctx
@@ -27,22 +31,25 @@
                            #:private-key `(pem ,server-key)
                            #:certificate-chain server-crt))
 
-(test-case "channel binding agreement"
-  (call/custodian
-   (lambda ()
-     (define chan (make-channel))
-     (define listener (ssl-listen PORT 4 #t "localhost" server-ctx))
-     (thread (lambda ()
-               (define-values (sin sout) (ssl-accept listener))
-               (channel-put chan (get-cb sin))
-               (channel-put chan (get-cb sout))))
-     (define-values (cin cout) (ssl-connect "localhost" PORT))
-     (define client-cb (get-cb cin))
-     (define server-cb1 (channel-get chan))
-     (define server-cb2 (channel-get chan))
-     (check-equal? client-cb server-cb1)
-     (check-equal? client-cb server-cb2)
-     (check-equal? client-cb (get-cb cout)))))
+(for ([proto '(auto tls12 tls13)]
+      #:when (member proto (supported-client-protocols)))
+  (test-case (format "channel binding agreement, proto = ~v" proto)
+    (call/custodian
+     (lambda ()
+       (define chan (make-channel))
+       (define listener (ssl-listen PORT 4 #t "localhost" server-ctx))
+       (thread (lambda ()
+                 (define-values (sin sout) (ssl-accept listener))
+                 (channel-put chan (get-cb sin))
+                 (channel-put chan (get-cb sout))))
+       (define-values (cin cout) (ssl-connect "localhost" PORT proto))
+       (define client-cb (get-cb cin))
+       (define server-cb1 (channel-get chan))
+       (define server-cb2 (channel-get chan))
+       (check-equal? client-cb server-cb1)
+       (check-equal? client-cb server-cb2)
+       (check-equal? client-cb (get-cb cout))
+       (sleep 0.05)))))
 
 ;; ----------------------------------------
 
@@ -65,7 +72,9 @@
               (define server-cb
                 (delay/thread (with-output-to-string (lambda () (system* server-bin)))))
               (sleep 0.2) ;; let the server get started
-              (define-values (cin cout) (ssl-connect "localhost" PORT2))
+              (define-values (cin cout)
+                ;; Use TLS 1.2 for testing tls-unique.
+                (ssl-connect "localhost" PORT2 'tls12))
               (define client-cb
                 (format "tls-unique ~a\n"
                         (bytes->hex-string (ssl-channel-binding cin 'tls-unique))))

--- a/pkgs/racket-test/tests/openssl/test-secure.rkt
+++ b/pkgs/racket-test/tests/openssl/test-secure.rkt
@@ -173,7 +173,7 @@
 (define bad-hosts
   '(;; Invalid certificate
     expired.badssl.com
-    ;; wrong.host.badssl.com
+    wrong.host.badssl.com
     self-signed.badssl.com
     untrusted-root.badssl.com
     ;; revoked.badssl.com

--- a/pkgs/racket-test/tests/openssl/test-server-sni.rkt
+++ b/pkgs/racket-test/tests/openssl/test-server-sni.rkt
@@ -3,6 +3,8 @@
          rackunit
          racket/runtime-path)
 
+(define PORT 4438)
+
 (define (make-sctx key-file cert-file)
   (define sctx (ssl-make-server-context 'auto))
   (ssl-load-default-verify-sources! sctx)
@@ -28,7 +30,7 @@
 (ssl-seal-context! lambda-sctx)
 (ssl-seal-context! theultimate-sctx)
 (define listener
-  (ssl-listen 4433 5 #t #f lambda-sctx))
+  (ssl-listen PORT 5 #t #f lambda-sctx))
 (void
  (thread
   (lambda ()
@@ -36,7 +38,7 @@
       (ssl-accept listener)))))
 
 (define (test-name name)
-  (let*-values ([(in out) (tcp-connect "localhost" 4433)]
+  (let*-values ([(in out) (tcp-connect "localhost" PORT)]
 		[(ssl-in ssl-out)
                  (ports->ssl-ports in out
                                    #:encrypt 'auto

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -1401,8 +1401,7 @@ TO DO:
         (error/ssl who "~a failed (hostname not provided for verification)"
                    (if connect? "connect" "accept"))))
     (when (string? hostname)
-      (SSL_ctrl/bytes ssl SSL_CTRL_SET_TLSEXT_HOSTNAME
-                      TLSEXT_NAMETYPE_host_name (string->bytes/latin-1 hostname))
+      (SSL_set_tlsext_host_name ssl hostname)
       (when (and verify? verify-hostname?)
         ;; If verify? and verify-hostname? are true, then let OpenSSL
         ;; do hostname verification automatically during negotiation.

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -39,6 +39,7 @@ TO DO:
          racket/include
          "libcrypto.rkt"
          "libssl.rkt"
+         "private/ffi.rkt"
          (for-syntax racket/base))
 (lazy-require
  ["private/win32.rkt" (load-win32-store)]
@@ -228,217 +229,7 @@ TO DO:
   (or libssl-load-fail-reason
       libcrypto-load-fail-reason))
 
-;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
-;; SSL bindings and constants
-
-(define-ffi-definer define-crypto libcrypto
-  #:default-make-fail make-not-available)
-(define-ffi-definer define-ssl libssl
-  #:default-make-fail make-not-available)
-
-(define-cpointer-type _BIO_METHOD*)
-(define-cpointer-type _BIO*)
-(define-cpointer-type _SSL_METHOD*)
-(define-cpointer-type _SSL_CTX*)
-(define-cpointer-type _SSL*)
-(define-cpointer-type _X509_NAME*)
-(define-cpointer-type _X509_NAME_ENTRY*)
-(define-cpointer-type _X509*)
-(define-cpointer-type _ASN1_STRING*)
-(define-cpointer-type _STACK*)
-(define-cpointer-type _DH*)
-(define-cpointer-type _EC_KEY*)
-(define-cstruct _GENERAL_NAME ([type _int] [d _ASN1_STRING*]))
-
-(define-ssl SSLv2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv3_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv3_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv23_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv23_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-
-;; OpenSSL 1.1 defines TLS_client_method(), instead of making SSLv23_client_method()
-;; actually select the the latest
-(define-ssl TLS_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () SSLv23_client_method))
-(define-ssl TLS_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () SSLv23_server_method))
-
-(define-crypto DH_free (_fun _DH* -> _void) #:wrap (deallocator))
-(define-crypto EC_KEY_free (_fun _EC_KEY* -> _void) #:wrap (deallocator))
-
-(define-crypto EC_KEY_new_by_curve_name (_fun _int -> _EC_KEY*) #:wrap (allocator EC_KEY_free))
-
-(define-crypto BIO_s_mem (_fun -> _BIO_METHOD*))
-(define-crypto BIO_new (_fun _BIO_METHOD* -> _BIO*/null))
-(define-crypto BIO_new_mem_buf (_fun _pointer _int -> _BIO*))
-(define-crypto BIO_free (_fun _BIO* -> _void))
-
-(define-crypto BIO_read (_fun _BIO* _bytes _int -> _int))
-(define-crypto BIO_write (_fun _BIO* _bytes _int -> _int))
-(define-crypto BIO_ctrl (_fun _BIO* _int _long _long -> _long))
-(define (BIO_set_mem_eof_return b v)
-  (BIO_ctrl b BIO_C_SET_BUF_MEM_EOF_RETURN v 0))
-
-(define-ssl SSL_CTX_free (_fun _SSL_CTX* -> _void)
-  #:wrap (deallocator))
-(define-ssl SSL_CTX_new (_fun _SSL_METHOD* -> _SSL_CTX*/null)
-  #:wrap (allocator SSL_CTX_free))
-(define-ssl SSL_CTX_callback_ctrl
-  (_fun _SSL_CTX* _int
-        (_fun #:in-original-place? #t _SSL* _pointer _pointer -> _int)
-        -> _long))
-(define-ssl SSL_CTX_ctrl (_fun _SSL_CTX* _int _long _pointer -> _long))
-(define (SSL_CTX_set_mode ctx m)
-  (SSL_CTX_ctrl ctx SSL_CTRL_MODE m #f))
-(define (SSL_CTX_set_options ctx opts)
-  (SSL_CTX_ctrl ctx SSL_CTRL_OPTIONS opts #f))
-
-(define-ssl SSL_CTX_set_verify (_fun _SSL_CTX* _int _pointer -> _void))
-(define-ssl SSL_CTX_use_certificate_chain_file (_fun _SSL_CTX* _path -> _int))
-(define-ssl SSL_CTX_load_verify_locations (_fun _SSL_CTX* _path _path -> _int))
-(define-ssl SSL_CTX_set_client_CA_list (_fun _SSL_CTX* _X509_NAME* -> _int))
-(define-ssl SSL_CTX_set_session_id_context (_fun _SSL_CTX* _bytes _int -> _int))
-(define-ssl SSL_CTX_use_RSAPrivateKey_file (_fun _SSL_CTX* _path _int -> _int))
-(define-ssl SSL_CTX_use_PrivateKey_file (_fun _SSL_CTX* _path _int -> _int))
-(define-ssl SSL_load_client_CA_file (_fun _path -> _X509_NAME*/null))
-(define-ssl SSL_CTX_set_cipher_list (_fun _SSL_CTX* _string -> _int))
-
-(define-ssl SSL_free (_fun _SSL* -> _void)
-  #:wrap (deallocator))
-(define-ssl SSL_new (_fun _SSL_CTX* -> _SSL*)
-  #:wrap (allocator SSL_free))
-(define-ssl SSL_set_bio (_fun _SSL* _BIO* _BIO* -> _void))
-(define-ssl SSL_connect (_fun _SSL* -> _int))
-(define-ssl SSL_accept (_fun _SSL* -> _int))
-(define-ssl SSL_read (_fun _SSL* _bytes _int -> _int))
-(define-ssl SSL_peek (_fun _SSL* _bytes _int -> _int))
-(define-ssl SSL_write (_fun _SSL* _bytes _int -> _int))
-(define-ssl SSL_shutdown (_fun _SSL* -> _int))
-(define-ssl SSL_get_verify_result (_fun _SSL* -> _long))
-(define-ssl SSL_get_servername (_fun _SSL* _int -> _string))
-(define-ssl SSL_set_verify (_fun _SSL* _int _pointer -> _void))
-(define-ssl SSL_set_session_id_context (_fun _SSL* _bytes _int -> _int))
-(define-ssl SSL_renegotiate (_fun _SSL* -> _int))
-(define-ssl SSL_renegotiate_pending (_fun _SSL* -> _int))
-(define-ssl SSL_do_handshake (_fun _SSL* -> _int))
-(define-ssl SSL_ctrl/bytes (_fun _SSL* _int _long _bytes/nul-terminated -> _long)
-  #:c-id SSL_ctrl)
-(define-ssl SSL_set_SSL_CTX (_fun _SSL* _SSL_CTX* -> _SSL_CTX*))
-
-(define-crypto X509_free (_fun _X509* -> _void)
-  #:wrap (deallocator))
-(define-ssl SSL_get_peer_certificate (_fun _SSL* -> _X509*/null)
-  #:make-fail (lambda (name)
-                (lambda ()
-                  (and libssl
-                       (get-ffi-obj 'SSL_get1_peer_certificate libssl (_fun _SSL* -> _X509*/null)
-                                    (lambda () (make-not-available name))))))
-  #:wrap (allocator X509_free))
-(define-ssl SSL_get_certificate (_fun _SSL* -> _X509*/null)
-  #:wrap (allocator X509_free))
-
-(define-crypto X509_get_subject_name (_fun _X509* -> _X509_NAME*))
-(define-crypto X509_get_issuer_name (_fun _X509* -> _X509_NAME*))
-(define-crypto X509_NAME_oneline (_fun _X509_NAME* _bytes _int -> _bytes))
-
-(define-ssl SSL_get_error (_fun _SSL* _int -> _int))
-
-(define-crypto ERR_get_error (_fun -> _long))
-(define-crypto ERR_error_string_n (_fun _long _bytes _long -> _void))
-
-(define-ssl SSL_library_init (_fun -> _void)
-  ;; No SSL_library_init for 1.1 or later:
-  #:fail (lambda () void))
-(define-ssl SSL_load_error_strings (_fun -> _void)
-  ;; No SSL_load_error_strings for 1.1 or later:
-  #:fail (lambda () void))
-
-(define-crypto GENERAL_NAME_free _fpointer)
-(define-crypto PEM_read_bio_DHparams (_fun _BIO* _pointer _pointer _pointer -> _DH*) #:wrap (allocator DH_free))
-(define-crypto ASN1_STRING_length (_fun _ASN1_STRING* -> _int))
-(define-crypto ASN1_STRING_data (_fun _ASN1_STRING* -> _pointer))
-(define-crypto X509_NAME_get_index_by_NID (_fun _X509_NAME* _int _int -> _int))
-(define-crypto X509_NAME_get_entry (_fun _X509_NAME* _int -> _X509_NAME_ENTRY*/null))
-(define-crypto X509_NAME_ENTRY_get_data (_fun _X509_NAME_ENTRY* -> _ASN1_STRING*))
-(define-crypto X509_get_ext_d2i (_fun _X509* _int _pointer _pointer -> _STACK*/null))
-(define-crypto sk_num (_fun _STACK* -> _int)
-  #:fail (lambda ()
-           (define-crypto OPENSSL_sk_num (_fun _STACK* -> _int))
-           OPENSSL_sk_num))
-(define-crypto sk_GENERAL_NAME_value (_fun _STACK* _int -> _GENERAL_NAME-pointer)
-  #:c-id sk_value
-  #:fail (lambda ()
-           (define-crypto OPENSSL_sk_value (_fun _STACK* _int -> _GENERAL_NAME-pointer))
-           OPENSSL_sk_value))
-(define-crypto sk_pop_free (_fun _STACK* _fpointer -> _void)
-  #:fail (lambda ()
-           (define-crypto OPENSSL_sk_pop_free (_fun _STACK* _fpointer -> _void))
-           OPENSSL_sk_pop_free))
-
-;; (define-crypto X509_get_default_cert_area (_fun -> _string))
-(define-crypto X509_get_default_cert_dir  (_fun -> _string))
-(define-crypto X509_get_default_cert_file (_fun -> _string))
-(define-crypto X509_get_default_cert_dir_env (_fun -> _string))
-(define-crypto X509_get_default_cert_file_env (_fun -> _string))
-
-(define-ssl SSL_get_peer_finished (_fun _SSL* _pointer _size -> _size))
-(define-ssl SSL_get_finished (_fun _SSL* _pointer _size -> _size))
-
-(define-ssl SSL_CTX_set_alpn_protos
-  (_fun _SSL_CTX*
-        (bs : _bytes)
-        (_uint = (bytes-length bs))
-        -> _int)) ;; Note: 0 means success, other means failure!
-(define-ssl SSL_set_alpn_protos
-  (_fun _SSL*
-        (bs : _bytes)
-        (_uint = (bytes-length bs))
-        -> _int)) ;; Note: 0 means success, other means failure!
-(define-ssl SSL_get0_alpn_selected
-  (_fun _SSL*
-        (p : (_ptr o _pointer))
-        (len : (_ptr o _uint))
-        -> _void
-        -> (cond [(and p (> len 0))
-                  (let ([bs (make-bytes len)])
-                    (memcpy bs p len)
-                    bs)]
-                 [else #f])))
-
-(define-ssl SSL_CTX_set_alpn_select_cb
-  (_fun [ctx : _SSL_CTX*]
-        [cb : (_fun #:in-original-place? #t
-                    [ssl : _SSL*]
-                    [out : _pointer] ;; const unsigned char**
-                    [outlen : _pointer] ;; char *
-                    [in : _pointer]
-                    [inlen : _int]
-                    [arg : _pointer]
-                    -> _int)]
-        [arg : _pointer]
-        -> _int))
-
-(define-cpointer-type _EVP_MD*)
-(define-crypto EVP_sha224 (_fun -> _EVP_MD*/null))
-(define-crypto EVP_sha256 (_fun -> _EVP_MD*/null))
-(define-crypto EVP_sha384 (_fun -> _EVP_MD*/null))
-(define-crypto EVP_sha512 (_fun -> _EVP_MD*/null))
-(define-crypto EVP_MD_size (_fun _EVP_MD* -> _int))
-
-(define-ssl OBJ_find_sigid_algs
-  (_fun _int (alg : (_ptr o _int)) (_pointer = #f) -> (r : _int)
-        -> (if (> r 0) alg 0)))
-
-(define-ssl X509_get_signature_nid
-  (_fun _X509* -> _int))
-
-(define-ssl X509_digest
-  (_fun _X509* _EVP_MD* _pointer (_ptr i _uint) -> _int))
+;; ----------------------------------------
 
 (define (x509-root-sources)
   (cond
@@ -506,59 +297,6 @@ TO DO:
      [else
       (x509-root-sources)])))
 
-(define X509_V_OK 0)
-
-(define SSL_ERROR_SSL 1)
-(define SSL_ERROR_WANT_READ 2)
-(define SSL_ERROR_WANT_WRITE 3)
-(define SSL_ERROR_SYSCALL 5)
-(define SSL_ERROR_ZERO_RETURN 6)
-
-(define BIO_C_SET_BUF_MEM_EOF_RETURN 130)
-
-(define SSL_FILETYPE_PEM 1)
-(define SSL_FILETYPE_ASN1 2)
-
-(define SSL_VERIFY_NONE #x00)
-(define SSL_VERIFY_PEER #x01)
-(define SSL_VERIFY_FAIL_IF_NO_PEER_CERT #x02)
-
-(define SSL_MODE_ENABLE_PARTIAL_WRITE #x01)
-(define SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER #x02)
-(define SSL_CTRL_MODE 33)
-
-(define NID_subject_alt_name 85)
-(define NID_commonName 13)
-(define GEN_DNS 2)
-
-(define SSL_CTRL_OPTIONS 32)
-(define SSL_CTRL_SET_TLSEXT_SERVERNAME_CB 53)
-(define SSL_CTRL_SET_TLSEXT_HOSTNAME 55)
-(define SSL_CTRL_SET_TMP_DH 3)
-(define SSL_CTRL_SET_TMP_ECDH 4)
-
-(define SSL_OP_NO_SSLv2    #x01000000)
-(define SSL_OP_NO_SSLv3    #x02000000)
-(define SSL_OP_NO_TLSv1    #x04000000)
-(define SSL_OP_NO_TLSv1_2  #x08000000)
-(define SSL_OP_NO_TLSv1_1  #x10000000)
-
-(define SSL_OP_SINGLE_ECDH_USE #x00080000)
-(define SSL_OP_SINGLE_DH_USE #x00100000)
-
-(define TLSEXT_NAMETYPE_host_name 0)
-
-(define SSL_TLSEXT_ERR_OK 0)
-(define SSL_TLSEXT_ERR_ALERT_FATAL 2)
-(define SSL_TLSEXT_ERR_NOACK 3)
-
-(define NID_md5 4)
-(define NID_sha1 64)
-(define NID_sha224 675)
-(define NID_sha256 672)
-(define NID_sha384 673)
-(define NID_sha512 674)
-
 (define ssl-dh4096-param-bytes
   (include/reader "dh4096.pem" (lambda (src port)
                                  (let loop ([accum '()])
@@ -599,8 +337,6 @@ TO DO:
                              [state _int]
                              ;; ...
                              ))
-
-(define SSL_ST_ACCEPT #x2000)
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; Error handling

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -47,6 +47,9 @@ TO DO:
 
 (define-logger openssl)
 
+(when (and libssl (not v1.0.2/later?))
+  (log-openssl-error "OpenSSL library too old, version 1.0.2 or later required."))
+
 (define protocol-symbol/c
   (or/c 'secure 'auto 'sslv2-or-v3 'sslv2 'sslv3 'tls 'tls11 'tls12))
 

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -526,10 +526,12 @@ TO DO:
                                  #:certificate-chain [cert-chain #f])
   (cond [(and (eq? protocol-symbol 'secure) (not priv-key) (not cert-chain))
          (ssl-secure-client-context)]
-        [else
-         (define ctx (make-context 'ssl-make-client-context protocol-symbol #t priv-key cert-chain))
-         (when (eq? protocol-symbol 'secure) (secure-client-context! ctx))
-         ctx]))
+        [else (make-client-context* protocol-symbol priv-key cert-chain)]))
+
+(define (make-client-context* protocol-symbol priv-key cert-chain)
+  (define ctx (make-context 'ssl-make-client-context protocol-symbol #t priv-key cert-chain))
+  (when (eq? protocol-symbol 'secure) (secure-client-context! ctx))
+  ctx)
 
 (define (ssl-make-server-context [protocol-symbol default-encrypt]
                                  #:private-key [priv-key #f]
@@ -856,8 +858,7 @@ TO DO:
   (let ([locs (ssl-default-verify-sources)])
     (define (reset)
       (let* ([now (current-seconds)]
-             [ctx (ssl-make-client-context 'auto)])
-        (secure-client-context! ctx)
+             [ctx (make-client-context* 'secure #f #f)])
         (set! context-cache (list (make-weak-box ctx) locs now))
         ctx))
     (let* ([cached context-cache]

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -1629,7 +1629,7 @@ TO DO:
            [(< 0 r MAX_FINISH_LEN) (subbytes buf 0 r)]
            [else (error who "internal error: TLS Finished message too large")])]
     [(tls-server-end-point)
-     (define x509
+     (define x509 ;; ownership varies, don't free
        (cond [(mzssl-server? mzssl) (SSL_get_certificate ssl)]
              [else (SSL_get_peer_certificate ssl)]))
      (unless x509 (error who "failed to get server certificate"))
@@ -1646,7 +1646,6 @@ TO DO:
      (unless (> buflen 0) (error who "internal error: bad digest length"))
      (define buf (make-bytes buflen))
      (define r (X509_digest x509 hash-evp buf buflen))
-     (X509_free x509)
      (if (> r 0) buf (error who "internal error: certificate digest failed"))]))
 
 (define (ssl-protocol-version p)

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -435,7 +435,7 @@ TO DO:
 
 (define protocol-versions
   ;; (protocol security-level min-proto max-proto supported?)
-  `((secure 2 0                0                #t)
+  `((secure 2 ,TLS1_2_VERSION  0                #t)
     (auto   2 0                0                #t)
     (sslv3  1 ,SSL3_VERSION    ,SSL3_VERSION    ,(and SSLv3_client_method #t))
     (tls    2 ,TLS1_VERSION    ,TLS1_VERSION    ,(and TLSv1_client_method #t))

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -92,29 +92,37 @@
 
 ;; ----------------------------------------
 
+(begin ;; removed in v1.1.0
+  (define-ssl SSLeay (_fun -> _ulong) #:fail (lambda () (lambda () 0))))
+(begin ;; added in v1.1.0
+  (define-ssl OpenSSL_version_num (_fun -> _ulong) #:fail (lambda () SSLeay)))
+
+(define v1.0.1/later? (>= (OpenSSL_version_num) #x10001000)) ;; MNNPPxxx
+(define v1.0.2/later? (>= (OpenSSL_version_num) #x10002000))
+(define v1.1.0/later? (>= (OpenSSL_version_num) #x10100000))
+(define v1.1.1/later? (>= (OpenSSL_version_num) #x10101000))
+(define v3.0.0/later? (>= (OpenSSL_version_num) #x30000000)) ;; MNN00PP0
+
 ;; Since v1.1.0, version-specific *_{client,server}_methods are
 ;; deprecated, use TLS_{client,server}_method instead.
-
-(begin ;; Deprecated in v1.1.0:
+(begin ;; deprecated in v1.1.0
   (define-ssl SSLv23_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-  (define-ssl SSLv23_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f)))
-
-(define-ssl TLS_client_method (_fun -> _SSL_METHOD*)
-  #:fail (lambda () SSLv23_client_method))
-(define-ssl TLS_server_method (_fun -> _SSL_METHOD*)
-  #:fail (lambda () SSLv23_server_method))
-
-;; Deprecated in v1.1.0:
-(define-ssl SSLv2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv3_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl SSLv3_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
-(define-ssl TLSv1_2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl SSLv23_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl SSLv2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl SSLv2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl SSLv3_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl SSLv3_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl TLSv1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl TLSv1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl TLSv1_1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl TLSv1_1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl TLSv1_2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl TLSv1_2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f)))
+(begin ;; added in v1.1.0
+  (define-ssl TLS_client_method (_fun -> _SSL_METHOD*)
+    #:fail (lambda () SSLv23_client_method))
+  (define-ssl TLS_server_method (_fun -> _SSL_METHOD*)
+    #:fail (lambda () SSLv23_server_method)))
 
 (define-crypto DH_free (_fun _DH* -> _void) #:wrap (deallocator))
 (define-crypto EC_KEY_free (_fun _EC_KEY* -> _void) #:wrap (deallocator))
@@ -199,12 +207,9 @@
 (define-crypto ERR_get_error (_fun -> _long))
 (define-crypto ERR_error_string_n (_fun _long _bytes _long -> _void))
 
-(define-ssl SSL_library_init (_fun -> _void)
-  ;; No SSL_library_init for 1.1 or later:
-  #:fail (lambda () void))
-(define-ssl SSL_load_error_strings (_fun -> _void)
-  ;; No SSL_load_error_strings for 1.1 or later:
-  #:fail (lambda () void))
+(begin ;; removed in v1.1.0
+  (define-ssl SSL_library_init (_fun -> _void) #:fail (lambda () void))
+  (define-ssl SSL_load_error_strings (_fun -> _void) #:fail (lambda () void)))
 
 (define-crypto GENERAL_NAME_free _fpointer)
 (define-crypto PEM_read_bio_DHparams (_fun _BIO* _pointer _pointer _pointer -> _DH*) #:wrap (allocator DH_free))
@@ -275,7 +280,8 @@
 (define-crypto EVP_sha256 (_fun -> _EVP_MD*/null))
 (define-crypto EVP_sha384 (_fun -> _EVP_MD*/null))
 (define-crypto EVP_sha512 (_fun -> _EVP_MD*/null))
-(define-crypto EVP_MD_size (_fun _EVP_MD* -> _int))
+(define-crypto EVP_MD_size (_fun _EVP_MD* -> _int)
+  #:fail (lambda () (get-ffi-obj 'EVP_MD_get_size libcrypto (_fun _EVP_MD* -> _int))))
 
 (define-ssl OBJ_find_sigid_algs
   (_fun _int (alg : (_ptr o _int)) (_pointer = #f) -> (r : _int)

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -60,6 +60,7 @@
 (define SSL_CTRL_SET_TLSEXT_HOSTNAME 55)
 (define SSL_CTRL_SET_TMP_DH 3)
 (define SSL_CTRL_SET_TMP_ECDH 4)
+(define SSL_CTRL_GET_EXTMS_SUPPORT 122)
 (define SSL_CTRL_SET_MIN_PROTO_VERSION 123)
 (define SSL_CTRL_SET_MAX_PROTO_VERSION 124)
 
@@ -360,3 +361,15 @@
              (lambda (ssl host)
                (X509_VERIFY_PARAM_set1_host (SSL_get0_param ssl)
                                             (string->bytes/latin-1 host))))))
+
+(define-ssl SSL_export_keying_material
+  (_fun [ssl : _SSL*]
+        [out : _bytes] [olen : _size = (bytes-length out)]
+        [label : _bytes] [llen : _size = (bytes-length label)]
+        [context : _bytes]
+        [contextlen : _size = (if context (bytes-length context) 0)]
+        [use-context? : _bool = (and context #t #f)]
+        -> _int))
+
+(define (SSL_get_extms_support s)
+  (SSL_ctrl/bytes s SSL_CTRL_GET_EXTMS_SUPPORT 0 #f))

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -60,6 +60,8 @@
 (define SSL_CTRL_SET_TLSEXT_HOSTNAME 55)
 (define SSL_CTRL_SET_TMP_DH 3)
 (define SSL_CTRL_SET_TMP_ECDH 4)
+(define SSL_CTRL_SET_MIN_PROTO_VERSION 123)
+(define SSL_CTRL_SET_MAX_PROTO_VERSION 124)
 
 (define SSL_OP_NO_SSLv2    #x01000000)
 (define SSL_OP_NO_SSLv3    #x02000000)
@@ -84,6 +86,12 @@
 (define NID_sha512 674)
 
 (define SSL_ST_ACCEPT #x2000)
+
+(define SSL3_VERSION    #x0300)
+(define TLS1_VERSION    #x0301)
+(define TLS1_1_VERSION  #x0302)
+(define TLS1_2_VERSION  #x0303)
+(define TLS1_3_VERSION  #x0304)
 
 ;; ----------------------------------------
 
@@ -177,6 +185,16 @@
 (define-ssl SSL_load_client_CA_file (_fun _path -> _X509_NAME*/null))
 (define-ssl SSL_CTX_set_cipher_list (_fun _SSL_CTX* _string -> _int))
 
+(begin ;; added in v1.1.0
+  (define-ssl SSL_CTX_get_security_level (_fun _SSL_CTX* -> _int)
+    #:fail (lambda () (lambda (ctx) 2 #|default security level|#)))
+  (define-ssl SSL_CTX_set_security_level (_fun _SSL_CTX* _int -> _void)
+    #:fail (lambda () (lambda (ctx) 1 #|success|#)))
+  (define (SSL_CTX_set_min_proto_version ctx version)
+    (SSL_CTX_ctrl ctx SSL_CTRL_SET_MIN_PROTO_VERSION version #f))
+  (define (SSL_CTX_set_max_proto_version ctx version)
+    (SSL_CTX_ctrl ctx SSL_CTRL_SET_MAX_PROTO_VERSION version #f)))
+
 (define-ssl SSL_free (_fun _SSL* -> _void)
   #:wrap (deallocator))
 (define-ssl SSL_new (_fun _SSL_CTX* -> _SSL*)
@@ -198,6 +216,7 @@
 (define-ssl SSL_ctrl/bytes (_fun _SSL* _int _long _bytes/nul-terminated -> _long)
   #:c-id SSL_ctrl)
 (define-ssl SSL_set_SSL_CTX (_fun _SSL* _SSL_CTX* -> _SSL_CTX*))
+(define-ssl SSL_version (_fun _SSL* -> _int))
 
 (define-crypto X509_free (_fun _X509* -> _void)
   #:wrap (deallocator))

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -1,0 +1,288 @@
+#lang racket/base
+(require ffi/unsafe
+         ffi/unsafe/define
+         ffi/unsafe/atomic
+         ffi/unsafe/alloc
+         ffi/unsafe/global
+         ffi/file
+         ffi/unsafe/custodian
+         "../libcrypto.rkt"
+         "../libssl.rkt"
+         (for-syntax racket/base))
+(provide (protect-out (all-defined-out)))
+
+(define-ffi-definer define-crypto libcrypto
+  #:default-make-fail make-not-available)
+(define-ffi-definer define-ssl libssl
+  #:default-make-fail make-not-available)
+
+;; ----------------------------------------
+
+(define X509_V_OK 0)
+
+(define SSL_ERROR_SSL 1)
+(define SSL_ERROR_WANT_READ 2)
+(define SSL_ERROR_WANT_WRITE 3)
+(define SSL_ERROR_SYSCALL 5)
+(define SSL_ERROR_ZERO_RETURN 6)
+
+(define BIO_C_SET_BUF_MEM_EOF_RETURN 130)
+
+(define SSL_FILETYPE_PEM 1)
+(define SSL_FILETYPE_ASN1 2)
+
+(define SSL_VERIFY_NONE #x00)
+(define SSL_VERIFY_PEER #x01)
+(define SSL_VERIFY_FAIL_IF_NO_PEER_CERT #x02)
+
+(define SSL_MODE_ENABLE_PARTIAL_WRITE #x01)
+(define SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER #x02)
+(define SSL_CTRL_MODE 33)
+
+(define NID_subject_alt_name 85)
+(define NID_commonName 13)
+(define GEN_DNS 2)
+
+(define SSL_CTRL_OPTIONS 32)
+(define SSL_CTRL_SET_TLSEXT_SERVERNAME_CB 53)
+(define SSL_CTRL_SET_TLSEXT_HOSTNAME 55)
+(define SSL_CTRL_SET_TMP_DH 3)
+(define SSL_CTRL_SET_TMP_ECDH 4)
+
+(define SSL_OP_NO_SSLv2    #x01000000)
+(define SSL_OP_NO_SSLv3    #x02000000)
+(define SSL_OP_NO_TLSv1    #x04000000)
+(define SSL_OP_NO_TLSv1_2  #x08000000)
+(define SSL_OP_NO_TLSv1_1  #x10000000)
+
+(define SSL_OP_SINGLE_ECDH_USE #x00080000)
+(define SSL_OP_SINGLE_DH_USE #x00100000)
+
+(define TLSEXT_NAMETYPE_host_name 0)
+
+(define SSL_TLSEXT_ERR_OK 0)
+(define SSL_TLSEXT_ERR_ALERT_FATAL 2)
+(define SSL_TLSEXT_ERR_NOACK 3)
+
+(define NID_md5 4)
+(define NID_sha1 64)
+(define NID_sha224 675)
+(define NID_sha256 672)
+(define NID_sha384 673)
+(define NID_sha512 674)
+
+(define SSL_ST_ACCEPT #x2000)
+
+;; ----------------------------------------
+
+(define-cpointer-type _BIO_METHOD*)
+(define-cpointer-type _BIO*)
+(define-cpointer-type _SSL_METHOD*)
+(define-cpointer-type _SSL_CTX*)
+(define-cpointer-type _SSL*)
+(define-cpointer-type _X509_NAME*)
+(define-cpointer-type _X509_NAME_ENTRY*)
+(define-cpointer-type _X509*)
+(define-cpointer-type _ASN1_STRING*)
+(define-cpointer-type _STACK*)
+(define-cpointer-type _DH*)
+(define-cpointer-type _EC_KEY*)
+(define-cstruct _GENERAL_NAME ([type _int] [d _ASN1_STRING*]))
+(define-cpointer-type _EVP_MD*)
+
+;; ----------------------------------------
+
+;; Since v1.1.0, version-specific *_{client,server}_methods are
+;; deprecated, use TLS_{client,server}_method instead.
+
+(begin ;; Deprecated in v1.1.0:
+  (define-ssl SSLv23_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+  (define-ssl SSLv23_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f)))
+
+(define-ssl TLS_client_method (_fun -> _SSL_METHOD*)
+  #:fail (lambda () SSLv23_client_method))
+(define-ssl TLS_server_method (_fun -> _SSL_METHOD*)
+  #:fail (lambda () SSLv23_server_method))
+
+;; Deprecated in v1.1.0:
+(define-ssl SSLv2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl SSLv2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl SSLv3_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl SSLv3_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl TLSv1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl TLSv1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl TLSv1_1_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl TLSv1_1_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl TLSv1_2_client_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+(define-ssl TLSv1_2_server_method (_fun -> _SSL_METHOD*) #:fail (lambda () #f))
+
+(define-crypto DH_free (_fun _DH* -> _void) #:wrap (deallocator))
+(define-crypto EC_KEY_free (_fun _EC_KEY* -> _void) #:wrap (deallocator))
+
+(define-crypto EC_KEY_new_by_curve_name (_fun _int -> _EC_KEY*) #:wrap (allocator EC_KEY_free))
+
+(define-crypto BIO_s_mem (_fun -> _BIO_METHOD*))
+(define-crypto BIO_new (_fun _BIO_METHOD* -> _BIO*/null))
+(define-crypto BIO_new_mem_buf (_fun _pointer _int -> _BIO*))
+(define-crypto BIO_free (_fun _BIO* -> _void))
+
+(define-crypto BIO_read (_fun _BIO* _bytes _int -> _int))
+(define-crypto BIO_write (_fun _BIO* _bytes _int -> _int))
+(define-crypto BIO_ctrl (_fun _BIO* _int _long _long -> _long))
+(define (BIO_set_mem_eof_return b v)
+  (BIO_ctrl b BIO_C_SET_BUF_MEM_EOF_RETURN v 0))
+
+(define-ssl SSL_CTX_free (_fun _SSL_CTX* -> _void)
+  #:wrap (deallocator))
+(define-ssl SSL_CTX_new (_fun _SSL_METHOD* -> _SSL_CTX*/null)
+  #:wrap (allocator SSL_CTX_free))
+(define-ssl SSL_CTX_callback_ctrl
+  (_fun _SSL_CTX* _int
+        (_fun #:in-original-place? #t _SSL* _pointer _pointer -> _int)
+        -> _long))
+(define-ssl SSL_CTX_ctrl (_fun _SSL_CTX* _int _long _pointer -> _long))
+(define (SSL_CTX_set_mode ctx m)
+  (SSL_CTX_ctrl ctx SSL_CTRL_MODE m #f))
+(define (SSL_CTX_set_options ctx opts)
+  (SSL_CTX_ctrl ctx SSL_CTRL_OPTIONS opts #f))
+
+(define-ssl SSL_CTX_set_verify (_fun _SSL_CTX* _int _pointer -> _void))
+(define-ssl SSL_CTX_use_certificate_chain_file (_fun _SSL_CTX* _path -> _int))
+(define-ssl SSL_CTX_load_verify_locations (_fun _SSL_CTX* _path _path -> _int))
+(define-ssl SSL_CTX_set_client_CA_list (_fun _SSL_CTX* _X509_NAME* -> _int))
+(define-ssl SSL_CTX_set_session_id_context (_fun _SSL_CTX* _bytes _int -> _int))
+(define-ssl SSL_CTX_use_RSAPrivateKey_file (_fun _SSL_CTX* _path _int -> _int))
+(define-ssl SSL_CTX_use_PrivateKey_file (_fun _SSL_CTX* _path _int -> _int))
+(define-ssl SSL_load_client_CA_file (_fun _path -> _X509_NAME*/null))
+(define-ssl SSL_CTX_set_cipher_list (_fun _SSL_CTX* _string -> _int))
+
+(define-ssl SSL_free (_fun _SSL* -> _void)
+  #:wrap (deallocator))
+(define-ssl SSL_new (_fun _SSL_CTX* -> _SSL*)
+  #:wrap (allocator SSL_free))
+(define-ssl SSL_set_bio (_fun _SSL* _BIO* _BIO* -> _void))
+(define-ssl SSL_connect (_fun _SSL* -> _int))
+(define-ssl SSL_accept (_fun _SSL* -> _int))
+(define-ssl SSL_read (_fun _SSL* _bytes _int -> _int))
+(define-ssl SSL_peek (_fun _SSL* _bytes _int -> _int))
+(define-ssl SSL_write (_fun _SSL* _bytes _int -> _int))
+(define-ssl SSL_shutdown (_fun _SSL* -> _int))
+(define-ssl SSL_get_verify_result (_fun _SSL* -> _long))
+(define-ssl SSL_get_servername (_fun _SSL* _int -> _string))
+(define-ssl SSL_set_verify (_fun _SSL* _int _pointer -> _void))
+(define-ssl SSL_set_session_id_context (_fun _SSL* _bytes _int -> _int))
+(define-ssl SSL_renegotiate (_fun _SSL* -> _int))
+(define-ssl SSL_renegotiate_pending (_fun _SSL* -> _int))
+(define-ssl SSL_do_handshake (_fun _SSL* -> _int))
+(define-ssl SSL_ctrl/bytes (_fun _SSL* _int _long _bytes/nul-terminated -> _long)
+  #:c-id SSL_ctrl)
+(define-ssl SSL_set_SSL_CTX (_fun _SSL* _SSL_CTX* -> _SSL_CTX*))
+
+(define-crypto X509_free (_fun _X509* -> _void)
+  #:wrap (deallocator))
+(define-ssl SSL_get_peer_certificate (_fun _SSL* -> _X509*/null)
+  #:make-fail (lambda (name)
+                (lambda ()
+                  (and libssl
+                       (get-ffi-obj 'SSL_get1_peer_certificate libssl (_fun _SSL* -> _X509*/null)
+                                    (lambda () (make-not-available name))))))
+  #:wrap (allocator X509_free))
+(define-ssl SSL_get_certificate (_fun _SSL* -> _X509*/null)
+  #:wrap (allocator X509_free))
+
+(define-crypto X509_get_subject_name (_fun _X509* -> _X509_NAME*))
+(define-crypto X509_get_issuer_name (_fun _X509* -> _X509_NAME*))
+(define-crypto X509_NAME_oneline (_fun _X509_NAME* _bytes _int -> _bytes))
+
+(define-ssl SSL_get_error (_fun _SSL* _int -> _int))
+
+(define-crypto ERR_get_error (_fun -> _long))
+(define-crypto ERR_error_string_n (_fun _long _bytes _long -> _void))
+
+(define-ssl SSL_library_init (_fun -> _void)
+  ;; No SSL_library_init for 1.1 or later:
+  #:fail (lambda () void))
+(define-ssl SSL_load_error_strings (_fun -> _void)
+  ;; No SSL_load_error_strings for 1.1 or later:
+  #:fail (lambda () void))
+
+(define-crypto GENERAL_NAME_free _fpointer)
+(define-crypto PEM_read_bio_DHparams (_fun _BIO* _pointer _pointer _pointer -> _DH*) #:wrap (allocator DH_free))
+(define-crypto ASN1_STRING_length (_fun _ASN1_STRING* -> _int))
+(define-crypto ASN1_STRING_data (_fun _ASN1_STRING* -> _pointer))
+(define-crypto X509_NAME_get_index_by_NID (_fun _X509_NAME* _int _int -> _int))
+(define-crypto X509_NAME_get_entry (_fun _X509_NAME* _int -> _X509_NAME_ENTRY*/null))
+(define-crypto X509_NAME_ENTRY_get_data (_fun _X509_NAME_ENTRY* -> _ASN1_STRING*))
+(define-crypto X509_get_ext_d2i (_fun _X509* _int _pointer _pointer -> _STACK*/null))
+(define-crypto sk_num (_fun _STACK* -> _int)
+  #:fail (lambda ()
+           (define-crypto OPENSSL_sk_num (_fun _STACK* -> _int))
+           OPENSSL_sk_num))
+(define-crypto sk_GENERAL_NAME_value (_fun _STACK* _int -> _GENERAL_NAME-pointer)
+  #:c-id sk_value
+  #:fail (lambda ()
+           (define-crypto OPENSSL_sk_value (_fun _STACK* _int -> _GENERAL_NAME-pointer))
+           OPENSSL_sk_value))
+(define-crypto sk_pop_free (_fun _STACK* _fpointer -> _void)
+  #:fail (lambda ()
+           (define-crypto OPENSSL_sk_pop_free (_fun _STACK* _fpointer -> _void))
+           OPENSSL_sk_pop_free))
+
+;; (define-crypto X509_get_default_cert_area (_fun -> _string))
+(define-crypto X509_get_default_cert_dir  (_fun -> _string))
+(define-crypto X509_get_default_cert_file (_fun -> _string))
+(define-crypto X509_get_default_cert_dir_env (_fun -> _string))
+(define-crypto X509_get_default_cert_file_env (_fun -> _string))
+
+(define-ssl SSL_get_peer_finished (_fun _SSL* _pointer _size -> _size))
+(define-ssl SSL_get_finished (_fun _SSL* _pointer _size -> _size))
+
+(define-ssl SSL_CTX_set_alpn_protos
+  (_fun _SSL_CTX*
+        (bs : _bytes)
+        (_uint = (bytes-length bs))
+        -> _int)) ;; Note: 0 means success, other means failure!
+(define-ssl SSL_set_alpn_protos
+  (_fun _SSL*
+        (bs : _bytes)
+        (_uint = (bytes-length bs))
+        -> _int)) ;; Note: 0 means success, other means failure!
+(define-ssl SSL_get0_alpn_selected
+  (_fun _SSL*
+        (p : (_ptr o _pointer))
+        (len : (_ptr o _uint))
+        -> _void
+        -> (cond [(and p (> len 0))
+                  (let ([bs (make-bytes len)])
+                    (memcpy bs p len)
+                    bs)]
+                 [else #f])))
+
+(define-ssl SSL_CTX_set_alpn_select_cb
+  (_fun [ctx : _SSL_CTX*]
+        [cb : (_fun #:in-original-place? #t
+                    [ssl : _SSL*]
+                    [out : _pointer] ;; const unsigned char**
+                    [outlen : _pointer] ;; char *
+                    [in : _pointer]
+                    [inlen : _int]
+                    [arg : _pointer]
+                    -> _int)]
+        [arg : _pointer]
+        -> _int))
+
+(define-crypto EVP_sha224 (_fun -> _EVP_MD*/null))
+(define-crypto EVP_sha256 (_fun -> _EVP_MD*/null))
+(define-crypto EVP_sha384 (_fun -> _EVP_MD*/null))
+(define-crypto EVP_sha512 (_fun -> _EVP_MD*/null))
+(define-crypto EVP_MD_size (_fun _EVP_MD* -> _int))
+
+(define-ssl OBJ_find_sigid_algs
+  (_fun _int (alg : (_ptr o _int)) (_pointer = #f) -> (r : _int)
+        -> (if (> r 0) alg 0)))
+
+(define-ssl X509_get_signature_nid
+  (_fun _X509* -> _int))
+
+(define-ssl X509_digest
+  (_fun _X509* _EVP_MD* _pointer (_ptr i _uint) -> _int))

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -373,3 +373,7 @@
 
 (define (SSL_get_extms_support s)
   (SSL_ctrl/bytes s SSL_CTRL_GET_EXTMS_SUPPORT 0 #f))
+
+(define (SSL_set_tlsext_host_name s hostname)
+  (SSL_ctrl/bytes s SSL_CTRL_SET_TLSEXT_HOSTNAME
+                  TLSEXT_NAMETYPE_host_name (string->bytes/latin-1 hostname)))


### PR DESCRIPTION
This PR combines several fixes and improvements:
- sets OpenSSL 1.0.2 (LTS, released 1/2015, EOL 12/2019) as the minimum required for full functionality
- add `'tls13`, fix protocol version handling for recent OpenSSL versions
- use OpenSSL to do hostname verification (replaces some Racket code, failure sends proper alert to peer)
- add `'tls-exporter` channel binding type, fix a memory bug in `'tls-server-end-point` (when used on server)

It also splits the related FFI bindings out into a separate private/ffi.rkt module and adds some version information.
