### PR TITLE
Fix fallback implementation of ffi/unsafe/com's string->guid

### DIFF
--- a/racket/collects/ffi/unsafe/private/win32.rkt
+++ b/racket/collects/ffi/unsafe/private/win32.rkt
@@ -332,7 +332,7 @@
              (set-GUID-s1! guid (bitwise-and #xFFFF (arithmetic-shift n (* -10 8))))
              (set-GUID-s2! guid (bitwise-and #xFFFF (arithmetic-shift n (* -8 8))))
              (set-GUID-c! guid (for/list ([i (in-range 8)])
-                                 (bitwise-and #xFF (arithmetic-shift n (* (- -7 i)))))))))
+                                 (bitwise-and #xFF (arithmetic-shift n (* (+ -7 i) 8))))))))
 
 (define-ole StringFromIID(_hfun _GUID-pointer (p : (_ptr o _pointer))
                                 -> StringFromIID p))


### PR DESCRIPTION
I came across this while experimenting with `ffi/unsafe/com` on linux.

As far as I can tell any generated GUID is wrong, demonstrated here:

```rkt
#lang racket

(require ffi/unsafe/private/win32
         ffi/unsafe/com)

(define c (GUID-c IID_IUnknown))
(format "{~a-~a-~a-~a~a-~a~a~a~a~a~a}"
        (~r (GUID-l IID_IUnknown) #:base 16 #:min-width 8 #:pad-string "0")
        (~r (GUID-s1 IID_IUnknown) #:base 16 #:min-width 4 #:pad-string "0")
        (~r (GUID-s2 IID_IUnknown) #:base 16 #:min-width 4 #:pad-string "0")
        (~r (first c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (second c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (third c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (fourth c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (fifth c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (sixth c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (seventh c) #:base 16 #:min-width 2 #:pad-string "0")
        (~r (eighth c) #:base 16 #:min-width 2 #:pad-string "0"))
```
This produces all zeroes, instead of the input value `"{00000000-0000-0000-C000-000000000046}"`.