### PR TITLE
Use `~.a` to display error messages instead of `~e`.

### DIFF
--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -300,14 +300,14 @@
 
       ;; Check results:
       (when check-stderr?
-        (unless (let ([s (get-output-bytes e)])
-                  (or (equal? #"" s)
-                      (ormap (lambda (p) (regexp-match? p s))
-                             ignore-stderr-patterns)
-                      (and ignore-stderr
-                           (regexp-match? ignore-stderr s))))
+        (define s (get-output-bytes e))
+        (unless (or (equal? #"" s)
+                    (ormap (lambda (p) (regexp-match? p s))
+                           ignore-stderr-patterns)
+                    (and ignore-stderr
+                         (regexp-match? ignore-stderr s)))
           (parameterize ([error-print-width 16384])
-            (error test-exe-name "#<<non-empty stderr\n~.a\nnon-empty stderr\n" (get-output-bytes e)))))
+            (error test-exe-name "#<<non-empty stderr\n~.a\nnon-empty stderr\n" s))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))
       (cond

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -307,7 +307,7 @@
                       (and ignore-stderr
                            (regexp-match? ignore-stderr s))))
           (parameterize ([error-print-width 16384])
-            (error test-exe-name "#<<non empty-stderr\n~.a\nnon empty-stderr" (get-output-bytes e)))))
+            (error test-exe-name "#<<non-empty stderr\n~.a\nnon-empty stderr" (get-output-bytes e)))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))
       (cond

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -307,7 +307,7 @@
                       (and ignore-stderr
                            (regexp-match? ignore-stderr s))))
           (parameterize ([error-print-width 16384])
-            (error test-exe-name "#<<non-empty stderr\n~.a\nnon-empty stderr" (get-output-bytes e)))))
+            (error test-exe-name "#<<non-empty stderr\n~.a\nnon-empty stderr\n" (get-output-bytes e)))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))
       (cond

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -307,7 +307,7 @@
                       (and ignore-stderr
                            (regexp-match? ignore-stderr s))))
           (parameterize ([error-print-width 16384])
-            (error test-exe-name "non-empty stderr:\n~.a" (get-output-bytes e)))))
+            (error test-exe-name "#<<non empty-stderr\n~.a\nnon empty-stderr" (get-output-bytes e)))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))
       (cond

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -307,7 +307,7 @@
                       (and ignore-stderr
                            (regexp-match? ignore-stderr s))))
           (parameterize ([error-print-width 16384])
-            (error test-exe-name "non-empty stderr: ~e" (get-output-bytes e)))))
+            (error test-exe-name "non-empty stderr: ~.a" (get-output-bytes e)))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))
       (cond

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -315,7 +315,7 @@
                                 [b (in-bytes (subbytes s 19))]
                                 #:when (eq? 10 b))
                       i))
-               => (λ (i) (gensym (~a (subbytes s (+ 3 (bytes-length tag)) i))))]
+               => (λ (i) (gensym (~a (subbytes s 19 i))))]
               [else '||]))
           (parameterize ([error-print-width #x4000])
             (error test-exe-name "#<<~a~a\n~.a\n~a~a" tag n s tag n))))

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -311,10 +311,9 @@
             (define n
               (let ([s (~.a s)] [tag (~a #"\n" tag)])
                 (if (string-contains? s tag)
-                    (let loop ([n 0])
-                      (if (string-contains? s (~a tag n))
-                          (loop (add1 n))
-                          n))
+                    (for/first ([i (in-naturals)]
+                                #:unless (string-contains? s (~a tag i)))
+                      i)
                     #"")))
             (error test-exe-name "#<<~a~a\n~.a\n~a~a" tag n s tag n))))
       (unless (zero? result-code)

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -311,9 +311,7 @@
             (define n
               (let ([s (~.a s)] [tag (~a #"\n" tag)])
                 (if (string-contains? s tag)
-                    (for/first ([i (in-naturals)]
-                                #:unless (string-contains? s (~a tag i)))
-                      i)
+                    (for/first ([i (in-naturals)] #:unless (string-contains? s (~a tag i))) i)
                     #"")))
             (error test-exe-name "#<<~a~a\n~.a\n~a~a" tag n s tag n))))
       (unless (zero? result-code)

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -306,18 +306,16 @@
                            ignore-stderr-patterns)
                     (and ignore-stderr
                          (regexp-match? ignore-stderr s)))
-          (define tag #"non-empty stderr")
-          (define n
-            (cond
-              [(and (equal? #"#<<" (subbytes s 0 3))
-                    (equal? tag (subbytes s 3 19))
-                    (for/first ([i (in-naturals 19)]
-                                [b (in-bytes (subbytes s 19))]
-                                #:when (eq? 10 b))
-                      i))
-               => (λ (i) (gensym (~a (subbytes s 19 i))))]
-              [else '||]))
           (parameterize ([error-print-width #x4000])
+            (define tag #"non-empty stderr")
+            (define n
+              (let ([s (~.a s)] [tag (~a #"\n" tag)])
+                (if (string-contains? s tag)
+                    (let loop ([n 0])
+                      (if (string-contains? s (~a tag n))
+                          (loop (add1 n))
+                          n))
+                    #"")))
             (error test-exe-name "#<<~a~a\n~.a\n~a~a" tag n s tag n))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))

--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -307,7 +307,7 @@
                       (and ignore-stderr
                            (regexp-match? ignore-stderr s))))
           (parameterize ([error-print-width 16384])
-            (error test-exe-name "non-empty stderr: ~.a" (get-output-bytes e)))))
+            (error test-exe-name "non-empty stderr:\n~.a" (get-output-bytes e)))))
       (unless (zero? result-code)
         (error test-exe-name "non-zero exit: ~e" result-code))
       (cond


### PR DESCRIPTION
Use `~.a` to display error messages for better readability.

For example, `draft.rkt`:
```racket
#lang racket/base
(require rackunit)
(check-eq? (eq? 0) #t)
```

Before:
```
$ raco test --drdr draft.rkt
raco test: 0 "draft.rkt"
draft.rkt: raco test: non-empty stderr: #"--------------------\nERROR\nname:       check-eq?\nlocation:   draft.rkt:5:0\n\neq?: arity mismatch;\n the expected number of arguments does not match the given number\n  expected: 2\n  given: 1\n--------------------\n"
1 1 draft.rkt
1/1 test failures
```

After:
```
$ raco test --drdr draft.rkt
raco test: 0 "draft.rkt"
draft.rkt: raco test: non-empty stderr:
--------------------
ERROR
name:       check-eq?
location:   draft.rkt:5:0

eq?: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 2
  given: 1
--------------------

1 1 draft.rkt
1/1 test failures
```
