### PR TITLE
Support required methods in racket/generic

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/custom-write.scrbl
@@ -99,6 +99,10 @@ implementation of a @racket[write-proc], as in this example:
   (print (point 1 2))
 
   (write (point 1 2))]
+
+@history[#:changed "8.7.0.5"
+         @elem{Added a check so that omitting
+               @racket[_write-proc] is now a syntax error.}]
 }
 
 @defthing[prop:custom-write struct-type-property?]{

--- a/pkgs/racket-doc/scribblings/reference/equality.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/equality.scrbl
@@ -389,7 +389,12 @@ indexing and comparison operations, especially in the implementation of
 
    (equal? eastern-farm western-farm)
    (equal? eastern-farm northern-farm)
-   (equal? western-farm southern-farm))}
+   (equal? western-farm southern-farm))
+
+ @history[#:changed "8.7.0.5"
+          @elem{Added a check so that omitting any of
+                @racket[_equal-proc], @racket[_hash-proc], and @racket[_hash2-proc]
+                is now a syntax error.}]}
 
 
 @defthing[gen:equal-mode+hash any/c]{
@@ -447,7 +452,11 @@ indexing and comparison operations, especially in the implementation of
    (eval:check (equal-always? gsx gsy) #f)
    (eval:check (equal-always? gsx gsx) #t))
 
-@history[#:added "8.5.0.3"]}
+@history[#:added "8.5.0.3"
+         #:changed "8.7.0.5"
+         @elem{Added a check so that omitting either
+               @racket[_equal-mode-proc] or @racket[_hash-mode-proc]
+               is now a syntax error.}]}
 
 
 @defthing[prop:equal+hash struct-type-property?]{

--- a/pkgs/racket-doc/scribblings/reference/generic.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/generic.scrbl
@@ -22,7 +22,8 @@ a structure type are defined using the @racket[#:methods] keyword
                 (code:line #:fallbacks [fallback-impl ...])
                 (code:line #:defined-predicate defined-pred-id)
                 (code:line #:defined-table defined-table-id)
-                (code:line #:derive-property prop-expr prop-value-expr)]
+                (code:line #:derive-property prop-expr prop-value-expr)
+                (code:line #:requires [required-method-id ...])]
                [kw-formals* (arg* ...)
                             (arg* ...+ . rest-id)
                             rest-id]
@@ -109,6 +110,11 @@ automatically implement this structure type property using the provided values.
 When @racket[prop-value-expr] is executed, each @racket[method-id] is bound to
 its specific implementation for the @tech{structure type}.
 
+The @racket[#:requires] option may be provided at most once.
+When it is provided, any instance of the generic interface
+@emph{must} supply an implementation of the specified @racket[required-method-id]s.
+Otherwise, a compile-time error is raised.
+
 If a value @racket[v] satisfies @racket[id]@racketidfont{?}, then @racket[v] is
 a @deftech{generic instance} of @racketidfont{gen:}@racket[id].
 
@@ -122,6 +128,9 @@ If @racket[method-id] is not an implemented generic method of a generic
 instance @racket[v], and @racket[method-id] has a fallback implementation that
 does not raise an @racket[exn:fail:support] exception when given @racket[v],
 then @racket[method-id] is a @deftech{supported generic method} of @racket[v].
+
+@history[#:changed "8.7.0.5"
+         @elem{Added the @racket[#:requires] option.}]
 
 }
 

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1390,12 +1390,12 @@ stream, but plain lists can be used as streams, and functions such as
 
   To supply method implementations, the @racket[#:methods] keyword
   should be used in a structure type definition. The following three
-  methods should be implemented:
+  methods must be implemented:
 
   @itemize[
-    @item{@racket[stream-empty?] : accepts one argument}
-    @item{@racket[stream-first] : accepts one argument}
-    @item{@racket[stream-rest] : accepts one argument}
+    @item{@racket[_stream-empty?] : accepts one argument}
+    @item{@racket[_stream-first] : accepts one argument}
+    @item{@racket[_stream-rest] : accepts one argument}
   ]
 
   @examples[#:eval sequence-evaluator
@@ -1412,6 +1412,12 @@ stream, but plain lists can be used as streams, and functions such as
     (stream? l1)
     (stream-first l1)
   ]
+
+  @history[#:changed "8.7.0.5"
+           @elem{Added a check so that omitting any of
+                 @racket[_stream-empty?], @racket[_stream-first], and @racket[_stream-rest]
+                 is now a syntax error.}]
+
 }
 
 @defthing[prop:stream struct-type-property?]{

--- a/pkgs/racket-test/tests/generic/syntax-errors.rkt
+++ b/pkgs/racket-test/tests/generic/syntax-errors.rkt
@@ -192,3 +192,66 @@
      (struct thing []
        #:methods gen:foo
        [(define/generic gbar bar)]))))
+
+(check-good-syntax
+ (begin
+   (define-generics foo
+     #:requires (bar)
+     (bar foo)
+     (baz foo))
+
+   (struct thing []
+     #:methods gen:foo
+     [(define (bar self) 1)])
+
+   (struct thing2 []
+     #:methods gen:foo
+     [(define (bar self) 1)
+      (define (baz self) 2)])
+
+   (struct thing3 []
+     #:methods gen:foo
+     [(define (bar self) 1)
+      (define (baz self) 2)
+      (define (bam self) 3)])))
+
+
+(check-bad-syntax
+ (begin
+   (define-generics foo
+     #:requires (bar)
+     (bar foo)
+     (baz foo))
+
+   (struct thing []
+     #:methods gen:foo
+     [(define (baz self) 1)])))
+
+(check-good-syntax
+ (begin
+   (define-generics foo
+     #:requires ()
+     (bar foo)
+     (baz foo))
+
+   (struct thing []
+     #:methods gen:foo
+     [(define (baz self) 1)])))
+
+;; tests from https://github.com/racket/racket/issues/1554
+
+(check-bad-syntax
+ (struct wuznub (x)
+   #:transparent
+   #:methods gen:equal+hash
+   [(define (equal-proc a b _) (= (wuznub-x a) (wuznub-x b)))
+    (define (hash-proc a _) (wuznub-x a))
+    (define (hash-proc2 a _) (wuznub-x a))]))
+
+(check-good-syntax
+ (struct wuznub (x)
+   #:transparent
+   #:methods gen:equal+hash
+   [(define (equal-proc a b _) (= (wuznub-x a) (wuznub-x b)))
+    (define (hash-proc a _) (wuznub-x a))
+    (define (hash2-proc a _) (wuznub-x a))]))

--- a/racket/collects/racket/generic.rkt
+++ b/racket/collects/racket/generic.rkt
@@ -101,6 +101,12 @@
                               (hash-ref options 'derived '()))))]
       [(#:derive-property . other)
        (wrong-syntax (stx-car stx) "invalid #:derive-property specification")]
+      [(#:requires [required-meth ...] . args)
+       (if (hash-ref options 'requires #f)
+           (wrong-syntax (stx-car stx) "duplicate #:requires specification")
+           (parse #'args (hash-set options 'requires #'[required-meth ...])))]
+      [(#:requires . other)
+       (wrong-syntax (stx-car stx) "invalid #:requires specification")]
       [(kw . args)
        (keyword? (syntax-e #'kw))
        (wrong-syntax #'kw "invalid keyword argument")]
@@ -120,7 +126,8 @@
                   (hash-ref options 'fast-defaults '())
                   (hash-ref options 'defaults '())
                   (hash-ref options 'fallbacks '())
-                  (hash-ref options 'derived '()))]
+                  (hash-ref options 'derived '())
+                  (hash-ref options 'requires '()))]
       [other
        (wrong-syntax #'other
                      "expected a list of arguments with no dotted tail")])))
@@ -132,12 +139,13 @@
        (unless (identifier? #'name)
          (wrong-syntax #'name "expected an identifier"))
        (define-values
-         (methods support table fasts defaults fallbacks derived)
+         (methods support table fasts defaults fallbacks derived requires)
          (parse #'rest))
        (define/with-syntax [fast-default ...] fasts)
        (define/with-syntax [default ...] defaults)
        (define/with-syntax [fallback ...] fallbacks)
        (define/with-syntax [derive ...] derived)
+       (define/with-syntax [required-meth ...] requires)
        (define/with-syntax [method ...] methods)
        (define/with-syntax [method-name ...] (map stx-car methods))
        (define/with-syntax [method-index ...]
@@ -166,6 +174,7 @@
              #:defaults [default ...]
              #:fallbacks [fallback ...]
              #:derive-properties [derive ...]
+             #:requires [required-meth ...]
              method ...)
            table-defn
            (define-generics-contract ctc-name gen-name)))]))

--- a/racket/collects/racket/private/generic-interfaces.rkt
+++ b/racket/collects/racket/private/generic-interfaces.rkt
@@ -48,7 +48,8 @@
                        ;; Bound identifiers used for implementations:
                        (list (quote-syntax equal-proc-impl)
                              (quote-syntax hash-proc-impl)
-                             (quote-syntax hash2-proc-impl))))
+                             (quote-syntax hash2-proc-impl))
+                       (list #t #t #t)))
 
   (define-values (prop:gen:equal-mode+hash equal-mode+hash? gen:equal-mode+hash-acc)
     (make-struct-type-property
@@ -84,7 +85,8 @@
                              (quote-syntax hash-mode-proc))
                        ;; Bound identifiers used for implementations:
                        (list (quote-syntax equal-mode-proc-impl)
-                             (quote-syntax hash-mode-proc-impl) )))
+                             (quote-syntax hash-mode-proc-impl) )
+                       (list #t #t)))
 
   (define-values (prop:gen:custom-write gen:custom-write? gen:custom-write-acc)
     (make-struct-type-property
@@ -114,6 +116,7 @@
                        (quote-syntax gen:custom-write?)
                        (quote-syntax gen:custom-write-acc)
                        (list (quote-syntax write-proc))
-                       (list (quote-syntax write-proc-impl))))
+                       (list (quote-syntax write-proc-impl))
+                       (list #t)))
 
   )

--- a/racket/collects/racket/private/generic-methods.rkt
+++ b/racket/collects/racket/private/generic-methods.rkt
@@ -16,6 +16,7 @@
                          generic-info-accessor
                          generic-info-method-names
                          generic-info-methods
+                         generic-info-required-methods
                          find-generic-method-index
                          make-method-delta))
 
@@ -25,20 +26,22 @@
                     generic-info?
                     generic-info-get
                     generic-info-set!)
-      (make-struct-type 'generic-info #f 6 0))
+      (make-struct-type 'generic-info #f 7 0))
 
     (define-values (generic-info-name
                     generic-info-property
                     generic-info-predicate
                     generic-info-accessor
                     generic-info-method-names
-                    generic-info-methods)
+                    generic-info-methods
+                    generic-info-required-methods)
       (values (make-struct-field-accessor generic-info-get 0 'name)
               (make-struct-field-accessor generic-info-get 1 'property)
               (make-struct-field-accessor generic-info-get 2 'predicate)
               (make-struct-field-accessor generic-info-get 3 'accessor)
               (make-struct-field-accessor generic-info-get 4 'method-names)
-              (make-struct-field-accessor generic-info-get 5 'methods)))
+              (make-struct-field-accessor generic-info-get 5 'methods)
+              (make-struct-field-accessor generic-info-get 6 'required-methods)))
 
     (define (check-identifier! name ctx stx)
       (unless (identifier? stx)
@@ -62,7 +65,7 @@
                     unimplemented-set!)
       (make-struct-type 'unimplemented
                         #f
-                        1
+                        3
                         0
                         #f
                         (list (cons prop:set!-transformer
@@ -70,6 +73,12 @@
 
     (define unimplemented-method
       (make-struct-field-accessor unimplemented-get 0 'method))
+
+    (define unimplemented-required?
+      (make-struct-field-accessor unimplemented-get 1 'required?))
+
+    (define unimplemented-orig-src
+      (make-struct-field-accessor unimplemented-get 2 'orig-src))
 
     (define (find-generic-method who ctx gen-id delta gen-info method-id proc)
 
@@ -162,7 +171,16 @@
       [(_ method)
        (let ([val (syntax-local-value #'method (lambda () #f))])
          (cond
-           [(unimplemented? val) #'(quote #f)]
+           [(unimplemented? val)
+            (cond
+              [(unimplemented-required? val)
+               (raise-syntax-error
+                (unimplemented-method val)
+                "required method is not implemented"
+                #f
+                #f
+                (unimplemented-orig-src val))]
+              [else #'(quote #f)])]
            [else #'method]))]))
 
   (define-syntax (generic-property stx)
@@ -172,28 +190,48 @@
 
   (define-syntax (generic-methods stx)
     (syntax-case stx ()
-      [(_ gen combine #:scope scope def ...)
+      [(_ gen combine #:scope scope #:check? check? def ...)
        (let ()
+         (unless (boolean? (syntax-e #'check?))
+           (raise-syntax-error
+            'generic-methods
+            "check? must be a boolean literal"
+            #'check?))
+
          (define info (get-info 'generic-methods stx #'gen))
          (define orig-id (generic-info-name info))
          (define methods (map (make-method-delta #'scope orig-id)
                               (generic-info-method-names info)))
-         (with-syntax ([(method ...) methods])
+         (define checking? (syntax-e #'check?))
+         (define req-methods (map (λ (m)
+                                    (if (and m checking?)
+                                        #'#t
+                                        #'#f))
+                                  (generic-info-required-methods info)))
+         (with-syntax ([(method ...) methods]
+                       [(req-method ...) req-methods])
            (syntax/loc stx
              (syntax-parameterize ([generic-method-outer-context #'gen])
                (letrec-syntaxes+values
-                ([(method) (make-unimplemented 'method)] ...)
-                ()
-                (syntax-parameterize ([generic-method-inner-context #'gen])
-                  def ...
-                  (combine (implementation method) ...)))))))]
+                   ([(method ...)
+                     (let ([defs (list (quote-syntax def) ...)])
+                       (values (make-unimplemented 'method
+                                                   req-method
+                                                   defs)
+                               ...))])
+                   ()
+                 (syntax-parameterize ([generic-method-inner-context #'gen])
+                   def ...
+                   (combine (implementation method) ...)))))))]
+      [(_ gen combine #:scope scope def ...)
+       #'(generic-methods gen combine #:scope scope #:check? #f def ...)]
       [(_ gen combine def ...)
-       #'(generic-methods gen combine #:scope gen def ...)]))
+       #'(generic-methods gen combine #:scope gen #:check? #f def ...)]))
 
   (define-syntax (generic-method-table stx)
     (syntax-case stx ()
       [(_ gen #:scope scope def ...)
-       #'(generic-methods gen vector #:scope scope def ...)]
+       #'(generic-methods gen vector #:scope scope #:check? #t def ...)]
       [(_ gen def ...)
        #'(generic-method-table gen #:scope gen def ...)]))
 

--- a/racket/collects/racket/private/generic.rkt
+++ b/racket/collects/racket/private/generic.rkt
@@ -20,16 +20,26 @@
 
   (define (check-identifier! stx)
     (unless (identifier? stx)
-      (wrong-syntax stx "expected an identifier")))
-
-  (define (free-id-table) (make-free-identifier-mapping))
-  (define (free-id-ref table id default)
-    (free-identifier-mapping-get table id (lambda () default)))
-  (define (free-id-set! table id value)
-    (free-identifier-mapping-put! table id value)))
-
+      (wrong-syntax stx "expected an identifier"))))
 (define-syntax (define-primitive-generics/derived stx)
   (syntax-case stx ()
+    [(_ original
+        names
+        #:fast-defaults fast-defaults
+        #:defaults defaults
+        #:fallbacks fallbacks
+        #:derive-properties derive-props
+        [method-name . method-signature]
+        ...)
+     #'(define-primitive-generics/derived original
+         names
+         #:fast-defaults fast-defaults
+         #:defaults defaults
+         #:fallbacks fallbacks
+         #:derive-properties derive-props
+         #:requires []
+         [method-name . method-signature]
+         ...)]
     [(_ original
         (self-name generic-name
                    property-name
@@ -40,6 +50,7 @@
         #:defaults ([default-pred default-disp default-defn ...] ...)
         #:fallbacks [fallback-defn ...]
         #:derive-properties ([derived-prop derived-impl] ...)
+        #:requires [required-meth ...]
         [method-name . method-signature]
         ...)
      (parameterize ([current-syntax-context #'original])
@@ -110,6 +121,17 @@
                  (values))
              #'(begin)))
 
+       (define required-meths (make-free-identifier-mapping))
+
+       (for ([m (in-list (syntax->list #'(required-meth ...)))])
+         (free-identifier-mapping-put! required-meths m #t))
+
+       (define/with-syntax (filled-required-meth ...)
+         (for/list ([m (in-list (syntax->list #'(method-name ...)))])
+           (if (free-identifier-mapping-get required-meths m (λ () #f))
+               #'#t
+               #'#f)))
+
        #'(begin
            (define-syntax generic-name
              (make-generic-info (quote-syntax generic-name)
@@ -117,7 +139,8 @@
                                 (quote-syntax prop:pred)
                                 (quote-syntax accessor-name)
                                 (list (quote-syntax method-name) ...)
-                                (list (quote-syntax method-name) ...)))
+                                (list (quote-syntax method-name) ...)
+                                (list filled-required-meth ...)))
            (define (prop:guard x info)
              (unless (and (vector? x) (= (vector-length x) 'size))
                (raise-argument-error 'generic-name

--- a/racket/collects/racket/stream.rkt
+++ b/racket/collects/racket/stream.rkt
@@ -65,7 +65,8 @@
                            (quote-syntax stream-rest))
                      (list (quote-syntax stream-empty?)
                            (quote-syntax stream-first)
-                           (quote-syntax stream-rest))))
+                           (quote-syntax stream-rest))
+                     (list #t #t #t)))
 
 (define-match-expander stream
   (syntax-rules ()


### PR DESCRIPTION
This PR makes it possible to mark some methods in a generic interface as "required". Required methods must be implemented in struct's #:methods clauses. If they are not implemented, a compile time error is raised.

The PR also switches gen:equal+hash, gen:equal-mode+hash, gen:custom-write, and gen:stream to use this new protocol, mandating that methods must be implemented. This allows the error message to be much more better.

Fixes #1554