### PR TITLE
[and/c | or/c]: ignore `any/c` | `none/c`.

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/name.rkt
+++ b/pkgs/racket-test/tests/racket/contract/name.rkt
@@ -25,6 +25,9 @@
   (test-name 'any/c any/c)
 
   (test-name '(or/c) (or/c))
+  (test-name '(or/c) (or/c none/c))
+  (test-name '(or/c) (or/c (or/c)))
+  (test-name '(or/c) (or/c (first-or/c)))
   (test-name '(or/c integer? gt0?) (or/c integer? (let ([gt0? (lambda (x) (> x 0))]) gt0?)))
   (test-name '(or/c integer? boolean?)
              (or/c (flat-contract integer?)
@@ -35,7 +38,11 @@
              (or/c boolean? (-> (>=/c 5) (>=/c 5))))
   (test-name 'boolean? (or/c #f #t))
   (test-name 'boolean? (or/c #t #f))
+  (test-name 'boolean? (or/c (or/c) #t #f))
+  (test-name 'boolean? (or/c #t (or/c) #f))
+  (test-name 'boolean? (or/c #t #f (or/c)))
   (test-name '(or/c #t #f 'x) (or/c #t #f 'x))
+  (test-name '(or/c #t #f 'x) (or/c #t #f (or/c) 'x))
   (test-name '(or/c any/c #f) (or/c any/c #f))
   (test-name '(or/c #f any/c) (or/c #f any/c))
 
@@ -45,6 +52,9 @@
              (if/c integer? odd? boolean?))
   
   (test-name '(first-or/c) (first-or/c))
+  (test-name '(first-or/c) (first-or/c none/c))
+  (test-name '(first-or/c) (first-or/c (first-or/c)))
+  (test-name '(first-or/c) (first-or/c (or/c)))
   (test-name '(first-or/c integer? gt0?) (first-or/c integer? (let ([gt0? (lambda (x) (> x 0))]) gt0?)))
   (test-name '(first-or/c integer? boolean?)
              (first-or/c (flat-contract integer?)
@@ -53,6 +63,10 @@
              (first-or/c (-> (>=/c 5) (>=/c 5)) boolean?))
   (test-name '(first-or/c boolean? (-> (>=/c 5) (>=/c 5)))
              (first-or/c boolean? (-> (>=/c 5) (>=/c 5))))
+  (test-name '(first-or/c #t #f 'x) (first-or/c #t #f 'x))
+  (test-name '(first-or/c #t #f 'x) (first-or/c #t #f (first-or/c) 'x))
+  (test-name '(first-or/c any/c #f) (first-or/c any/c #f))
+  (test-name '(first-or/c #f any/c) (first-or/c #f any/c))
   
   (test-name 'mumble (let ([frotz/c integer?]
                            [bazzle/c boolean?])
@@ -230,8 +244,9 @@
                     (-> (<=/c 5) (<=/c 5) (<=/c 5))))
 
   (test-name 'any/c (and/c))
-  (test-name '(and/c any/c) (and/c any/c))
-  (test-name '(and/c any/c any/c) (and/c any/c any/c))
+  (test-name 'any/c (and/c any/c))
+  (test-name 'any/c (and/c any/c any/c))
+  (test-name '(and/c number? integer?) (and/c number? (and/c) integer?))
   (test-name '(and/c number? integer?) (and/c number? integer?))
   (test-name '(and/c number? integer?) (and/c (flat-contract number?)
                                               (flat-contract integer?)))

--- a/racket/collects/racket/contract/private/and.rkt
+++ b/racket/collects/racket/contract/private/and.rkt
@@ -190,101 +190,104 @@
      (identifier? #'x)
      #'and/c]))
 
-(define/subexpression-pos-prop/name real-and/c-name (and/c . raw-fs)
-  (let ([contracts (coerce-contracts 'and/c raw-fs)])
-    (cond
-      [(null? contracts) any/c]
-      [(andmap flat-contract? contracts)
-       (define preds (map flat-contract-predicate contracts))
-       (cond
-         [(and (pair? (cdr preds))
-               (null? (cddr preds)))
-          (cond
-            [(eq? (car preds) real?)
-             (define second-pred (cadr preds))
-             (cond
-               [(eq? second-pred negative?)
-                (renamed-<-ctc 0 `(and/c real? negative?))]
-               [(eq? second-pred positive?)
-                (renamed->-ctc 0 `(and/c real? positive?))]
-               [else
-                (define second-contract (cadr contracts))
-                (cond
-                  [(equal? (contract-name second-contract) '(not/c positive?))
-                   (renamed-between/c -inf.0 0 `(and/c real? (not/c positive?)))]
-                  [(equal? (contract-name second-contract) '(not/c negative?))
-                   (renamed-between/c 0 +inf.0 `(and/c real? (not/c negative?)))]
-                  [else
-                   (make-first-order-and/c contracts preds)])])]
-            [(or (eq? (car preds) exact-nonnegative-integer?)
-                 (eq? (car preds) natural?)
-                 (eq? (cadr preds) exact-nonnegative-integer?)
-                 (eq? (cadr preds) natural?))
-             (define other (if (procedure? (car preds)) (cadr contracts) (car contracts)))
-             (cond
-               [(between/c-s? other)
-                (define other-low (between/c-s-low other))
-                (define other-high (between/c-s-high other))
-                (integer-in (exact-ceiling (max 0 (if (= other-low -inf.0) 0 other-low)))
-                            (if (= other-high +inf.0) #f (exact-floor other-high)))]
-               [else (make-first-order-and/c contracts preds)])]
-            [(or (eq? (car preds) exact-positive-integer?)
-                 (eq? (cadr preds) exact-positive-integer?))
-             (define other (if (procedure? (car preds)) (cadr contracts) (car contracts)))
-             (cond
-               [(between/c-s? other)
-                (define other-low (between/c-s-low other))
-                (define other-high (between/c-s-high other))
-                (integer-in (exact-ceiling (max 1 (if (= other-low -inf.0) 1 other-low)))
-                            (if (= other-high +inf.0) #f (exact-floor other-high)))]
-               [else (make-first-order-and/c contracts preds)])]
-            [(or (eq? (car preds) exact-integer?)
-                 (eq? (cadr preds) exact-integer?))
-             (define other (if (procedure? (car preds)) (cadr contracts) (car contracts)))
-             (cond
-               [(between/c-s? other)
-                (define other-low (between/c-s-low other))
-                (define other-high (between/c-s-high other))
-                (integer-in (if (= other-low -inf.0) #f (exact-ceiling other-low))
-                            (if (= other-high +inf.0) #f (exact-floor other-high)))]
-               [else (make-first-order-and/c contracts preds)])]
-            [else
-             (make-first-order-and/c contracts preds)])]
-         [(and (pair? (cdr preds))
-               (pair? (cddr preds))
-               (null? (cdddr preds)))
-          (cond
-            [(or (eq? (car preds) exact-integer?)
-                 (eq? (cadr preds) exact-integer?)
-                 (eq? (caddr preds) exact-integer?))
-             (define lb #f)
-             (define ub #f)
-             (for ([ctc (in-list contracts)])
-               (cond
-                 [(between/c-s? ctc)
-                  (define lo (between/c-s-low ctc))
-                  (define hi (between/c-s-high ctc))
-                  (cond
-                    [(and (= lo -inf.0) (integer? hi))
-                     (set! ub (inexact->exact hi))]
-                    [(and (= hi +inf.0) (integer? lo))
-                     (set! lb (inexact->exact lo))])]
-                 [(</>-ctc? ctc)
-                  (define x (</>-ctc-x ctc))
-                  (when (integer? x)
-                    (cond
-                      [(<-ctc? ctc) (set! ub (- (inexact->exact x) 1))]
-                      [(>-ctc? ctc) (set! lb (+ (inexact->exact x) 1))]))]))
-             (cond
-               [(and lb ub)
-                (integer-in lb ub)]
-               [else (make-first-order-and/c contracts preds)])]
-            [else (make-first-order-and/c contracts preds)])]
-         [else
-          (make-first-order-and/c contracts preds)])]
-      [(andmap chaperone-contract? contracts)
-       (make-chaperone-and/c contracts)]
-      [else (make-impersonator-and/c contracts)])))
+(define/subexpression-pos-prop/name and/c-name and/c
+  (case-lambda
+    [() any/c]
+    [raw-f*
+     (define raw-fs (remq* (list any/c) raw-f*))
+     (case (length raw-fs)
+       [(0) any/c]
+       [(1) (coerce-contract 'and/c (car raw-fs))]
+       [else
+        (define contracts (coerce-contracts 'and/c raw-fs))
+        (cond
+          [(andmap flat-contract? contracts)
+           (define preds (map flat-contract-predicate contracts))
+           (cond
+             [(and (pair? (cdr preds))
+                   (null? (cddr preds)))
+              (cond
+                [(eq? (car preds) real?)
+                 (define second-pred (cadr preds))
+                 (cond
+                   [(eq? second-pred negative?)
+                    (renamed-<-ctc 0 `(and/c real? negative?))]
+                   [(eq? second-pred positive?)
+                    (renamed->-ctc 0 `(and/c real? positive?))]
+                   [else
+                    (define second-contract (cadr contracts))
+                    (cond 
+                      [(equal? (contract-name second-contract) '(not/c positive?))
+                       (renamed-between/c -inf.0 0 `(and/c real? (not/c positive?)))]
+                      [(equal? (contract-name second-contract) '(not/c negative?))
+                       (renamed-between/c 0 +inf.0 `(and/c real? (not/c negative?)))]
+                      [else (make-first-order-and/c contracts preds)])])]
+                [(or (eq? (car preds) exact-nonnegative-integer?)
+                     (eq? (car preds) natural?)
+                     (eq? (cadr preds) exact-nonnegative-integer?)
+                     (eq? (cadr preds) natural?))
+                 (define other (if (procedure? (car preds)) (cadr contracts) (car contracts)))
+                 (cond
+                   [(between/c-s? other)
+                    (define other-low (between/c-s-low other))
+                    (define other-high (between/c-s-high other))
+                    (integer-in (exact-ceiling (max 0 (if (= other-low -inf.0) 0 other-low)))
+                                (if (= other-high +inf.0) #f (exact-floor other-high)))]
+                   [else (make-first-order-and/c contracts preds)])]
+                [(or (eq? (car preds) exact-positive-integer?)
+                     (eq? (cadr preds) exact-positive-integer?))
+                 (define other (if (procedure? (car preds)) (cadr contracts) (car contracts)))
+                 (cond
+                   [(between/c-s? other)
+                    (define other-low (between/c-s-low other))
+                    (define other-high (between/c-s-high other))
+                    (integer-in (exact-ceiling (max 1 (if (= other-low -inf.0) 1 other-low)))
+                                (if (= other-high +inf.0) #f (exact-floor other-high)))]
+                   [else (make-first-order-and/c contracts preds)])]
+                [(or (eq? (car preds) exact-integer?)
+                     (eq? (cadr preds) exact-integer?))
+                 (define other (if (procedure? (car preds)) (cadr contracts) (car contracts)))
+                 (cond
+                   [(between/c-s? other)
+                    (define other-low (between/c-s-low other))
+                    (define other-high (between/c-s-high other))
+                    (integer-in (if (= other-low -inf.0) #f (exact-ceiling other-low))
+                                (if (= other-high +inf.0) #f (exact-floor other-high)))]
+                   [else (make-first-order-and/c contracts preds)])]
+                [else (make-first-order-and/c contracts preds)])]
+             [(and (pair? (cdr preds))
+                   (pair? (cddr preds))
+                   (null? (cdddr preds)))
+              (cond
+                [(or (eq? (car preds) exact-integer?)
+                     (eq? (cadr preds) exact-integer?)
+                     (eq? (caddr preds) exact-integer?))
+                 (define lb #f)
+                 (define ub #f)
+                 (for ([ctc (in-list contracts)])
+                   (cond
+                     [(between/c-s? ctc)
+                      (define lo (between/c-s-low ctc))
+                      (define hi (between/c-s-high ctc))
+                      (cond
+                        [(and (= lo -inf.0) (integer? hi))
+                         (set! ub (inexact->exact hi))]
+                        [(and (= hi +inf.0) (integer? lo))
+                         (set! lb (inexact->exact lo))])]
+                     [(</>-ctc? ctc)
+                      (define x (</>-ctc-x ctc))
+                      (when (integer? x)
+                        (cond
+                          [(<-ctc? ctc) (set! ub (- (inexact->exact x) 1))]
+                          [(>-ctc? ctc) (set! lb (+ (inexact->exact x) 1))]))]))
+                 (if (and lb ub)
+                     (integer-in lb ub)
+                     (make-first-order-and/c contracts preds))]
+                [else (make-first-order-and/c contracts preds)])]
+             [else (make-first-order-and/c contracts preds)])]
+          [(andmap chaperone-contract? contracts)
+           (make-chaperone-and/c contracts)]
+          [else (make-impersonator-and/c contracts)])])]))
 
 (define (exact-floor x) (floor (inexact->exact x)))
 (define (exact-ceiling x) (ceiling (inexact->exact x)))

--- a/racket/collects/racket/contract/private/opters.rkt
+++ b/racket/collects/racket/contract/private/opters.rkt
@@ -145,13 +145,14 @@
        #:chaperone chaperone?
        #:no-negative-blame? no-negative-blame
        #:name (or name-from-hos
-                  (if (= (length names) 1)
-                      (car names)
-                      #`(let ([names (list #,@names)])
-                          (if (or (equal? names '(#f #t))
-                                  (equal? names '(#t #f)))
-                              'boolean?
-                              (cons 'or/c names))))))))
+                  #`(let ([names (remove* '(none/c (or/c) (first-or/c)) (list #,@names))])
+                      (case (length names)
+                        [(0) '(or/c)]
+                        [(1) (car names)]
+                        [else
+                         (case names
+                           [((#t #f) (#f #t)) 'boolean?]
+                           [else `(or/c . ,names)])]))))))
   
   (syntax-case stx (or/c)
     [(or/c p ...)

--- a/racket/collects/racket/contract/private/types.rkt
+++ b/racket/collects/racket/contract/private/types.rkt
@@ -1,9 +1,9 @@
 #lang racket/base
 (provide types)
 (define types
-  (hash '(real-and/c-name racket/contract/private/misc)
+  (hash '(and/c-name racket/contract/private/and)
         '(->* () #:rest Contract Contract)
-        
+
         '(or/c-name racket/contract/private/orc)
         '(->* () #:rest Contract Contract)))
 


### PR DESCRIPTION
Before:
```racket
Welcome to Racket v8.6 [cs].
> (or/c #t #f (or/c))
(or/c #t #f (or/c))
> (or/c #t #f (or/c) 'x)
(or/c #t #f (or/c) 'x)
> (first-or/c #t #f (first-or/c) 'x)
(first-or/c #t #f (first-or/c) 'x)
> (and/c any/c)
(and/c any/c)
> (and/c any/c any/c)
(and/c any/c any/c)
> (and/c number? (and/c) integer?)
(and/c number? any/c integer?)
```

After:
```racket
Welcome to Racket v8.6 [cs].
> (or/c #t #f (or/c))
boolean?
> (or/c #t #f (or/c) 'x)
(or/c #t #f 'x)
> (first-or/c #t #f (first-or/c) 'x)
(first-or/c #t #f 'x)
> (and/c any/c)
any/c
> (and/c any/c any/c)
any/c
> (and/c number? (and/c) integer?)
(and/c number? integer?)
```

And the path error in `contract/private/types.rkt` seems to have no effect on TR, does the current version of TR still need this file to set up information?

By the way, I didn't find `define/subexpression-pos-prop/name` in the [document](https://docs.racket-lang.org/search/index.html?q=define%2Fsubexpression-pos-prop).
