### PR TITLE
Chez Scheme: replace another internal `#3%fx+`

### DIFF
--- a/racket/src/ChezScheme/s/5_3.ss
+++ b/racket/src/ChezScheme/s/5_3.ss
@@ -2450,7 +2450,7 @@
              [(fixnum?) (integer* x y)]
             [(bignum?) (if (fixnum? x)
                            (cond
-                            [($fxu< (#3%fx+ x 1) 3)
+                            [($fxu< (fx+/wraparound x 1) 3)
                              (cond
                               [(fx= x 0) (unless (number? y) (nonnumber-error who y)) 0]
                               [(fx= x 1) (unless (number? y) (nonnumber-error who y)) y]


### PR DESCRIPTION
As a followup of https://github.com/racket/racket/commit/7027a001ee1b9bbb5e48a5bfcf582cb23c0a80c8 , I think this should be changed too.

(By the way, it's a very strange code. I can't believe it's better than comparing with `(eq? x 1)` `(eq? x 0)` `(eq? x -1)`.)