### PR TITLE
Fix bootstrapping via Racket from top-level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -176,7 +176,7 @@ BUILD_VARS = MAKE=$(MAKE) \
              CS_CROSS_SUFFIX="$(CS_CROSS_SUFFIX)" \
              RACKET="$(RACKET)" \
              PLAIN_RACKET="$(PLAIN_RACKET)" \
-             RACKET_FOR_BOOTFILES="$(RACKET_FOR_BOOTFILES)" \
+             BOOTFILE_RACKET="$(BOOTFILE_RACKET)" \
              CS_HOST_WORKAREA_PREFIX="$(CS_HOST_WORKAREA_PREFIX)" \
              PB_BRANCH="$(PB_BRANCH)" \
              PB_REPO="$(PB_REPO)" \

--- a/build.md
+++ b/build.md
@@ -246,7 +246,7 @@ downloaded from a separate Git repository by `make`. If you have Racket
 v7.1 or later, then you can choose instead to bootstrap using that
 Racket implementation with
 
-  `make cs RACKET_FOR_BOOTFILES=racket`
+  `make cs BOOTFILE_RACKET=racket`
 
 The `make bc` target (or `make bc-as-is` for a rebuild) builds an older
 variant of Racket, called Racket BC, which does not use Chez Scheme. By

--- a/pkgs/racket-build-guide/build.scrbl
+++ b/pkgs/racket-build-guide/build.scrbl
@@ -222,7 +222,7 @@ downloaded from a separate Git repository by @exec{make}. If you have
 Racket v7.1 or later, then you can choose instead to bootstrap using
 that Racket implementation with
 
-@commandline{make cs RACKET_FOR_BOOTFILES=racket}
+@commandline{make cs BOOTFILE_RACKET=racket}
 
 The @exec{make bc} target (or @exec{make bc-as-is} for a rebuild) builds an older
 variant of Racket, called Racket BC, which does not use Chez Scheme.


### PR DESCRIPTION
The build docs mention `RACKET_FOR_BOOTFILES` as a top-level makefile argument for bootstrapping via existing Racket, but this seems to have been renamed to `BOOTFILE_RACKET` somewhere along the way. This fixes the build docs and top-level makefile to follow along.