### PR TITLE
Clarify status of Chez Scheme bootstrapping across versions

### DIFF
--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -430,9 +430,11 @@ Cross-compilation requires at least two flags to `configure`:
 
 For Racket CS, an additional flag is required:
 
- * `--enable-scheme=SCHEME`, where SCHEME is a Chez Scheme executable
-   executable that runs on the build platform; the executable must be
-   the same version as used in Racket built for the target platform.
+ * `--enable-scheme=SCHEME`, where SCHEME is a Chez Scheme (v9.5.3 and
+   up) executable that runs on the build platform; it does not need to
+   match the Chez Scheme version as used in the Racket being built; a
+   "reboot" bootstrapping path is able to reconstruct boot files across
+   versions.
  
    Supplying `--enable-scheme=DIR` is also supported, where DIR is a
    path that has a "ChezScheme" directory where Chez Scheme is built
@@ -443,9 +445,9 @@ allowed for non-cross builds, too:
 
  * For Racket CS, supplying either selects a Racket or Chez Scheme
    implementation used to create boot files to the build platform.
-   Suppling Chez Scheme is a much more direct path, but when Racket is
-   supplied, its version does not have to match the version being
-   built.
+   Supplying Chez Scheme is a much more direct path. These executables
+   do not need to match the versions being built, as there are
+   bootstrapping paths that can handle differences where needed.
 
  * For Racket BC, `--enable-racket=RACKET` selects a Racket for
    prepare C sources to cooperate with garbage collection. Its version

--- a/racket/src/cs/README.txt
+++ b/racket/src/cs/README.txt
@@ -42,10 +42,12 @@ or Chez Scheme build:
    installed in the "../ChezScheme/boot/pb" directory as described by
    "../ChezScheme/BUILDING".
 
-   Supplying `--enable-scheme=...` is also an option if you alerady
-   have the same version of Chez Scheme built on the current platform.
-   Another build will be created, anyway, but more quickly than
-   without Chez Scheme.
+   Supplying `--enable-scheme=...` is also an option if you already have
+   Chez Scheme built on the current platform; it does not need to match
+   the Chez Scheme version as used in the Racket being built; a "reboot"
+   bootstrapping path is able to reconstruct boot files even across
+   versions. Another build will be created anyway, but more quickly
+   than without Chez Scheme.
 
  * Racket is needed to generate the files in the "schemified"
    directory from the sources in sibling directories like "../io". The

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -36,18 +36,14 @@ RACKET = @RACKET@
 # doesn't replace the Racket build here for other purposes
 BOOTFILE_RACKET = @BOOTFILE_RACKET@
 
-# If `SCHEME` is set, it must be compatible to the current build;
+# If `SCHEME` is set, then it needs only to be a Scheme that
+# is recent enough to run "../../ChezScheme/s/reboot.ss";
 # if `SCHEME_DIR` is set and `SCHEME` is not, then `SCHEME_DIR` refers
 # to an existing build directory;
 # if `RACKET` is "auto", then an auto-generated Scheme is used and
 # both of these are ignored
 SCHEME = @SCHEME@
 SCHEME_DIR = @SCHEME_DIR@
-
-# If `BOOTFILE_SCHEME` is set, then it needs only to be a Scheme that
-# is recent enough to run "../../ChezScheme/s/reboot.ss", and it
-# doesn't replace the Scheme build here for other purposes
-BOOTFILE_SCHEME = @BOOTFILE_SCHEME@
 
 # C compiler, etc.
 CC = @CC@

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -1445,7 +1445,7 @@ Optional Features:
   --enable-docs           build docs on install (enabled by default)
   --enable-usersetup      setup user-specific files on install
   --enable-racket=<path>  use <path> as Racket for build; or "auto" to create
-  --enable-scheme=<path>  use <path> as host build for cross
+  --enable-scheme=<path>  use <path> as Chez Scheme for build
   --enable-mach=<mach>    use Chez Scheme machine type <mach>
   --enable-target=<mach>  cross-build for Chez Scheme machine type <mach>
   --enable-pb             build for platform without native-code backend

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -23,7 +23,7 @@ AC_ARG_ENABLE(compressmore, [  --enable-compressmore   compress compiled code ev
 AC_ARG_ENABLE(compressboot, [  --enable-compressboot   compress boot files])
 m4_include(../ac/path_arg.m4)
 AC_ARG_ENABLE(racket,     [  --enable-racket=<path>  use <path> as Racket for build; or "auto" to create])
-AC_ARG_ENABLE(scheme,     [  --enable-scheme=<path>  use <path> as host build for cross])
+AC_ARG_ENABLE(scheme,     [  --enable-scheme=<path>  use <path> as Chez Scheme for build])
 AC_ARG_ENABLE(mach,       [  --enable-mach=<mach>    use Chez Scheme machine type <mach>])
 AC_ARG_ENABLE(target,     [  --enable-target=<mach>  cross-build for Chez Scheme machine type <mach>])
 AC_ARG_ENABLE(pb,         [  --enable-pb             build for platform without native-code backend])


### PR DESCRIPTION
3f853dc05a8832cf1a10751ee12f673b99218a5f and related commits have added support for "rebooting" the boot files, which allows older Chez Scheme versions to be used (in particular, they don't have to exactly match the version being built together with Racket).

This clarifies various build docs to highlight this new ability. It also removes the (unused) makefile template variable `BOOTFILE_SCHEME`, as its functionality is actually part of the existing `SCHEME` / `--enable-scheme` pathways.

Fixes https://github.com/racket/racket/issues/4448