### PR TITLE
pkg/strip: handle read-only input

### DIFF
--- a/pkgs/racket-index/setup/scribble.rkt
+++ b/pkgs/racket-index/setup/scribble.rkt
@@ -257,7 +257,10 @@
         ;; we might not have write permissions for the previous layer:
         ;; ensure that we do for the new file
         (define orig-mode (file-or-directory-permissions db-file 'bits))
-        (define writeable-mode (bitwise-ior user-write-bit orig-mode))
+        (define writeable-mode
+          (if (eq? (system-type) 'windows)
+              (bitwise-ior orig-mode user-write-bit group-write-bit other-write-bit)
+              (bitwise-ior orig-mode user-write-bit)))
         (unless (= writeable-mode orig-mode)
           (file-or-directory-permissions db-file writeable-mode)))
       (doc-db-disconnect


### PR DESCRIPTION
A package directory supplied to the functions from `pkg/strip` might have had all of its write permission bits unset. Since `copy-file` preserves the permissions of the source file, we may end up with a read-only file that we want to overwrite (e.g. an `info.rkt` file). Explicitly setting `user-write-bit` before writing avoids this problem. Conservatively, we restore the original permissions when we are done.