### PR TITLE
file/zip: clamp timestamps to supported range

### DIFF
--- a/pkgs/racket-doc/file/scribblings/zip.scrbl
+++ b/pkgs/racket-doc/file/scribblings/zip.scrbl
@@ -46,6 +46,9 @@ Timestamps in @exec{zip} archives are precise only to two seconds; by
 default, the time is rounded toward the future (like WinZip or PKZIP),
 but time is rounded toward the past (like Java) if
 @racket[round-timestamps-down?]  is true.
+The @exec{zip} archive format only supports timestamps between January 1,
+1980 and December 31, 2107. Timestamps outside of this range will be
+clamped to the closest representable timestamp.
 
 The @racket[sys-type] argument determines the system type recorded in
 the archive.


### PR DESCRIPTION
Previously, timestamps outside the range supported by the Zip format would lead to an error from `integer->integer-bytes`.

The Info-ZIP `zip` utility and `libarchive` (at least as used by Ark) seem to implicitly clamp timestamps this way. Python's `zipfile.ZipFile` raises an error by default when timestamps are out of range, but it clamps timestamps this way when called with `strict_timestamps=False`.

----

This probably needs some tests.

Does it also need a history note?

I could imagine adding a `#:strict-timestamps?` option, but I think the default should be permissive: Python's strict default seems to be mostly a source of confusing errors. And at that point, it seemed better to hold off on adding a keyword until/unless someone actually wants one.

One way timestamps before 1980 happen is when translating the POSIX time 0 (1970-01-01T00:00:00Z), which is used by some tools that try to normalize extraneous metadata.