### PR TITLE
openssl: add ssl-set-keylog-callback!

### DIFF
--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -738,7 +738,7 @@ The client sends this information via the TLS
 extension, which was created to allow @hyperlink["http://en.wikipedia.org/wiki/Virtual_hosting"]{virtual hosting}
 for secure servers.
 
-The suggested use it to prepare the appropriate server contexts,
+The suggested use is to prepare the appropriate server contexts,
 define a single callback which can dispatch between them, and then
 apply it to all the contexts before sealing them. A minimal example:
 

--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -738,7 +738,7 @@ The client sends this information via the TLS
 extension, which was created to allow @hyperlink["http://en.wikipedia.org/wiki/Virtual_hosting"]{virtual hosting}
 for secure servers.
 
-The suggested use it to prepare the appropriate server contexts, 
+The suggested use it to prepare the appropriate server contexts,
 define a single callback which can dispatch between them, and then
 apply it to all the contexts before sealing them. A minimal example:
 
@@ -789,11 +789,57 @@ connection is refused.
 
 @history[#:added "8.4.0.5"]}
 
+@defproc[(ssl-set-keylogger! [context (or/c ssl-server-context? ssl-client-context?)]
+                             [logger (or/c #f logger?)]) void?]{
+
+Instructs the @racket[context] to log a message to @racket[logger]
+whenever TLS key material is generated or received.  The message is
+logged with its level set to @racket['debug], its topic set to
+@racket['openssl-keylogger], and its associated data is a byte string
+representing the key material.  When @racket[logger] is @racket[#f],
+the context is instructed to stop logging this information.
+
+@bold{Warning:} if @racket[logger] has any ancestors, then this
+information may also be available to them, depending on the logger's
+propagation settings.
+
+Debugging is the typical use case for this functionality.  The owner
+of a context can use it to write key material to a file to be consumed
+by tools such as Wireshark.  In the following example, anyone with
+access to "keylogfile.txt" is able to decrypt connections made via
+@racket[ctx]:
+
+@racketblock[
+  (define out
+    (open-output-file
+     #:exists 'append
+     "keylogfile.txt"))
+  (define logger
+    (make-logger))
+  (void
+   (thread
+    (lambda ()
+      (define receiver
+        (make-log-receiver logger 'debug 'openssl-keylogger))
+      (let loop ()
+        (match-define (vector _ _ key-data _)
+          (sync receiver))
+        (write-bytes key-data out)
+        (newline out)
+        (flush-output out)
+        (loop)))))
+
+  (define ctx (ssl-make-client-context 'auto))
+  (ssl-set-keylogger! ctx logger)
+]
+
+@history[#:added "8.7.0.7"]}
+
 @; ----------------------------------------------------------------------
 @section[#:tag "peer-verif"]{Peer Verification}
 
 @defproc[(ssl-set-verify! [clp (or/c ssl-client-context? ssl-server-context?
-                                     ssl-listener? ssl-port?)] 
+                                     ssl-listener? ssl-port?)]
                           [on? any/c])
          void?]{
 

--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -806,7 +806,7 @@ propagation settings.
 Debugging is the typical use case for this functionality.  The owner
 of a context can use it to write key material to a file to be consumed
 by tools such as Wireshark.  In the following example, anyone with
-access to "keylogfile.txt" is able to decrypt connections made via
+access to @filepath{keylogfile.txt} is able to decrypt connections made via
 @racket[ctx]:
 
 @racketblock[
@@ -833,7 +833,7 @@ access to "keylogfile.txt" is able to decrypt connections made via
   (ssl-set-keylogger! ctx logger)
 ]
 
-@history[#:added "8.7.0.7"]}
+@history[#:added "8.7.0.8"]}
 
 @; ----------------------------------------------------------------------
 @section[#:tag "peer-verif"]{Peer Verification}

--- a/pkgs/racket-test/tests/openssl/test-keylog.rkt
+++ b/pkgs/racket-test/tests/openssl/test-keylog.rkt
@@ -1,0 +1,128 @@
+#lang racket/base
+
+(require net/url
+         net/url-connect
+         openssl
+         racket/runtime-path
+         rackunit)
+
+(define (request ctx url)
+  (parameterize ([current-custodian (make-custodian)]
+                 [current-https-protocol ctx])
+    (close-input-port (get-pure-port (string->url url)))))
+
+(define (call-with-unsealed-context proc)
+  (define ctx (ssl-make-client-context))
+  (ssl-load-default-verify-sources! ctx)
+  (ssl-set-verify! ctx #t)
+  (ssl-set-verify-hostname! ctx #t)
+  (ssl-set-ciphers! ctx "DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2")
+  (proc ctx))
+
+(define ch (make-channel))
+(define logger (make-logger))
+(void
+ (thread
+  (lambda ()
+    (define receiver
+      (make-log-receiver logger 'debug))
+    (let loop ()
+      (channel-put ch (sync receiver))
+      (loop)))))
+(define (drain-data)
+  (let loop ([data null])
+    (sync (system-idle-evt))
+    (cond
+      [(sync/timeout 0 ch)
+       => (λ (d) (loop (cons d data)))]
+      [else
+       (reverse data)])))
+
+(test-case "client context keylogger"
+  (call-with-unsealed-context
+   (lambda (ctx)
+     (ssl-set-keylogger! ctx logger)
+     (request ctx "https://api.github.com/")
+     (check-true (positive? (length (drain-data))))
+
+     (ssl-set-keylogger! ctx #f)
+     (ssl-seal-context! ctx)
+     (request ctx "https://api.github.com/")
+     (check-equal? (drain-data) null))))
+
+(test-case "discarded client context does not cause problems"
+  (parameterize ([current-custodian (make-custodian)])
+    (define-values (in out)
+      (call-with-unsealed-context
+       (lambda (ctx)
+         (ssl-set-keylogger! ctx logger)
+         (ssl-seal-context! ctx)
+         (define-values (in out)
+           (parameterize ([current-custodian (make-custodian)])
+             (ssl-connect "www.racket-lang.org" 443 ctx)))
+         (check-true (positive? (length (drain-data))))
+         (values in out))))
+    (collect-garbage)
+    (display #"GET / HTTP/1.1\r\nHost: www.racket-lang.org\r\n\r\n" out)
+    (flush-output)
+    (check-equal? (read-line in 'return-linefeed) "HTTP/1.1 200 OK")
+    (sync (system-idle-evt))
+    (check-equal? (drain-data) null)
+    (custodian-shutdown-all (current-custodian))))
+
+(define-runtime-path server-key "server_key.pem")
+(define-runtime-path server-cert "server_lambda_crt.pem")
+
+(test-case "server context retains keylogger"
+  (parameterize ([current-custodian (make-custodian)])
+    (define listener
+      (let ()
+        (define ctx (ssl-make-server-context))
+        (ssl-load-default-verify-sources! ctx)
+        (ssl-set-ciphers! ctx "DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2")
+        (ssl-load-certificate-chain! ctx server-cert)
+        (ssl-load-private-key! ctx server-key)
+        (ssl-set-keylogger! ctx logger)
+        (ssl-seal-context! ctx)
+        (ssl-listen 0 512 #t "127.0.0.1" ctx)))
+    (collect-garbage)
+    (check-equal? (drain-data) null)
+
+    (define-values (host port _remote-host _remote-port)
+      (ssl-addresses listener #t))
+
+    (define handler-thd
+      (thread
+       (lambda ()
+         (let loop ()
+           (sync
+            (handle-evt (thread-receive-evt) void)
+            (handle-evt
+             listener
+             (lambda (l)
+               (define-values (in out)
+                 (ssl-accept l))
+               (write-string (read-line in) out)
+               (flush-output out)
+               (close-output-port out)
+               (close-input-port in)
+               (loop))))))))
+
+    (define (ping message)
+      (define-values (in out)
+        (ssl-connect host port))
+      (displayln message out)
+      (check-equal? (read-line in) message)
+      (close-output-port out)
+      (close-input-port in))
+
+    (ping "hello from client 1")
+    (check-true (positive? (length (drain-data))))
+
+    (ping "hello from client 2")
+    (check-true (positive? (length (drain-data))))
+
+    (thread-send handler-thd '(stop))
+    (thread-wait handler-thd)
+    (ssl-close listener)
+    (check-equal? (drain-data) null)))

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -314,6 +314,13 @@
         [arg : _pointer]
         -> _int))
 
+(define-ssl SSL_CTX_set_keylog_callback
+  (_fun [ctx : _SSL_CTX*]
+        [cb : (_fun [ssl : _SSL*]
+                    [line : _bytes/nul-terminated] ;; const char *
+                    -> _void)]
+        -> _void))
+
 (define-crypto EVP_sha224 (_fun -> _EVP_MD*/null))
 (define-crypto EVP_sha256 (_fun -> _EVP_MD*/null))
 (define-crypto EVP_sha384 (_fun -> _EVP_MD*/null))


### PR DESCRIPTION
I needed to debug some TLS connections today using Wireshark and couldn't find an existing way to do it with the openssl lib. This commit exposes a way to hook into OpenSSL's built-in [keylogging callback](https://www.openssl.org/docs/man1.1.1/man3/SSL_CTX_set_keylog_callback.html) from Racket.

cc @rmculpepper 