### PR TITLE
ci: fix .github/workflows/scribble_license.yml

### DIFF
--- a/.github/workflows/scribble_license.yml
+++ b/.github/workflows/scribble_license.yml
@@ -26,8 +26,8 @@ jobs:
         distribution: 'full'
         variant: 'CS'
         version: 'current'
-    - name: Scribble License Files
-      run: raco pkg install --auto -j $(nproc) pkgs/racket-index
+    - name: Update racket-index
+      run: sudo raco pkg update -j $(nproc) --batch --auto pkgs/racket-index
 
   generation-check:
     runs-on: ubuntu-18.04


### PR DESCRIPTION
Since we're using the `'full'` Racket distribution, the `racket-index` package will already be installed: we can't `raco pkg install` again. Instead, we should `raco pkg update` to the potentially-changed version to be tested. This should fix failures like
<https://github.com/racket/racket/actions/runs/3230196005/jobs/5288363302>:

    Run raco pkg install --auto -j $(nproc) pkgs/racket-index
      raco pkg install --auto -j $(nproc) pkgs/racket-index
      shell: /bin/bash -e {0}
    raco pkg install: package is currently installed in a wider scope
      package: racket-index
      installed scope: installation
      given scope: user
    Error: Process completed with exit code 1.

The revised workflow is still not fully robust against more complex changes to `racket-index` and its dependencies, but it should serve for making sure that `LICENSE.txt`, `racket/src/LICENSE.txt`, and `pkgs/racket-index/scribblings/main/license.scrbl` stay in sync.

Related to https://github.com/racket/racket/pull/4460