### PR TITLE
Chez Scheme: configure: Ensure portability by using `=` to compare strings

### DIFF
--- a/racket/src/ChezScheme/configure
+++ b/racket/src/ChezScheme/configure
@@ -867,7 +867,7 @@ case "${flagsmuni}" in
         exePostStep='paxctl +m'
         ;;
     em)
-        if [ "$empetite" == yes ]; then
+        if [ "$empetite" = yes ]; then
             preloadBootFiles="$w/boot/$m/petite.boot"
         else
             preloadBootFiles="$w/boot/$m/petite.boot $w/boot/$m/scheme.boot"


### PR DESCRIPTION
The operator `==` is not supported in all shells an can silently fail (evaluates to false even when the strings are equal).