### PR TITLE
Fixes a bug in bc's unicode normalization

### DIFF
--- a/pkgs/racket-test-core/tests/racket/uni-norm.rktl
+++ b/pkgs/racket-test-core/tests/racket/uni-norm.rktl
@@ -16,7 +16,7 @@
 
 (define (get-test-file)
   (define name "NormalizationTest.txt")
-  (define base "http://www.unicode.org/Public/7.0.0/ucd/")
+  (define base "http://www.unicode.org/Public/14.0.0/ucd/")
   (define here (current-load-relative-directory))
   (or (for/or ([dir (list here (current-directory))])
         (define path (build-path dir name))

--- a/racket/src/bc/src/string.c
+++ b/racket/src/bc/src/string.c
@@ -4269,6 +4269,10 @@ static Scheme_Object *do_string_normalize_c (const char *who, int argc, Scheme_O
 	&& (scheme_combining_class(s[i+1]) < scheme_combining_class(s[i]))) {
       /* Need to reorder */
       break;
+    } else if ((s[i] >= MZ_JAMO_SYLLABLE_START)
+               && (s[i] <= MZ_JAMO_SYLLABLE_END)) {
+      /* Need Hangul decomposition */
+      break;
     } else if ((s[i] >= MZ_JAMO_INITIAL_CONSONANT_START)
 	       && (s[i] <= MZ_JAMO_INITIAL_CONSONANT_END)
 	       && (s[i+1] >= MZ_JAMO_VOWEL_START)


### PR DESCRIPTION
Addresses a missing Hangul decomposition case in
do_string_normalize_c(), which is caught by a more recent version of the NormalizationTest.txt file.