### PR TITLE
search: ranking results based on package status

### DIFF
--- a/pkgs/racket-index/scribblings/main/private/make-search.rkt
+++ b/pkgs/racket-index/scribblings/main/private/make-search.rkt
@@ -22,7 +22,8 @@
          (for-syntax racket/base)
          (for-syntax racket/runtime-path)
          (for-syntax compiler/cm-accomplice)
-         "index-scope.rkt")
+         "index-scope.rkt"
+         "pkg.rkt")
 
 (provide make-search)
 
@@ -177,10 +178,12 @@
              [else
               "\"module\""])]
           [else "false"]))
+      (define pre-pkg-name (tag->pkg tag))
+      (define pkg-name (if pre-pkg-name (quote-string pre-pkg-name) "false"))
       (and href
            (string-append "[" (quote-string text) ","
                           (quote-string href) ","
-                          html "," from-libs "]"))))
+                          html "," from-libs "," pkg-name "]"))))
   (define l (filter values l-all))
 
   (define user (if user-dir? "user_" ""))
@@ -223,7 +226,13 @@
                                  (string-append (quote-string (car x)) ": "
                                                 (number->string (cdr x))))
                                ms)])
-                 (add-between ms ",\n  "))};
+                 (add-between ms ",\n  "))
+          };
+          @||
+          // an array of (transitive) dependencies of main-distribution
+          var plt_main_dist_pkgs = [
+            @,@(add-between (map quote-string (get-main-dist-pkgs)) ",\n  ")
+          ];
           @||})))
 
   (for ([src (append (list search-script search-context-page)

--- a/pkgs/racket-index/scribblings/main/private/make-search.rkt
+++ b/pkgs/racket-index/scribblings/main/private/make-search.rkt
@@ -40,9 +40,11 @@
 ;; ideally we could just inform scribble/raco that they need
 ;; installing, and they would just do that when appropriate.
 (begin-for-syntax
+  (define-runtime-path search-style "search.css")
   (define-runtime-path search-script "search.js")
   (define-runtime-path search-merge-script "search-merge.js")
   (define-runtime-path search-context-page "search-context.html")
+  (register-external-file search-style)
   (register-external-file search-script)
   (register-external-file search-merge-script)
   (register-external-file search-context-page))

--- a/pkgs/racket-index/scribblings/main/private/pkg.rkt
+++ b/pkgs/racket-index/scribblings/main/private/pkg.rkt
@@ -76,7 +76,6 @@
          (list 'tech (list path-string _ ...)))
 
      (match path-string
-       ;; remove /xxx.scrbl
        [(pregexp #px"^\\(lib (.*)\\)$" (list _ path))
         (module-path->path (list 'lib path))])]
 

--- a/pkgs/racket-index/scribblings/main/private/pkg.rkt
+++ b/pkgs/racket-index/scribblings/main/private/pkg.rkt
@@ -1,0 +1,108 @@
+#lang racket/base
+
+(provide get-main-dist-pkgs
+         tag->pkg)
+
+(require racket/match
+         racket/set
+         pkg/lib
+         setup/main-collects
+         setup/getinfo)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; get-main-dist-pkgs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define MAIN-DIST-NAME "main-distribution")
+(define main-dist-pkgs #f)
+(define pkg-cache-for-pkg-directory (make-hash))
+
+(define (get-main-dist-pkgs)
+  (unless main-dist-pkgs
+    (set! main-dist-pkgs
+          (match (pkg-directory MAIN-DIST-NAME
+                                #:cache pkg-cache-for-pkg-directory)
+            [#f '()]
+            [_ (find-main-dist-pkgs)])))
+  main-dist-pkgs)
+
+(define (find-main-dist-pkgs)
+  (define result '())
+  (define seen (mutable-set))
+  (let loop ([pkg MAIN-DIST-NAME])
+    (unless (set-member? seen pkg)
+      (set-add! seen pkg)
+      (match (pkg-directory pkg #:cache pkg-cache-for-pkg-directory)
+        [#f
+         ;; these are platform dependent packages (like racket-win32-i386-3)
+         ;; they have no deps, and if they are platform dependent,
+         ;; they are not that useful (for documentation search) anyway
+         (set! result (cons pkg result))]
+        [dir
+         (set! result (cons pkg result))
+         (define get-info (get-info/full dir))
+         (define direct-deps
+           (for/list ([dep (extract-pkg-dependencies get-info #:build-deps? #f)])
+             (match dep
+               [(? string?) dep]
+               [(cons dep _) dep])))
+         ;; we need to recur. For example, 2dtabular is in 2d-lib,
+         ;; which is not a direct dep of main-distribution
+         (for ([dep direct-deps])
+           (loop dep))])))
+  result)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; tag->pkg
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define pkg-cache-for-path->pkg (make-hash))
+
+(define (module-path->path module-path)
+  (with-handlers ([exn:missing-module? (lambda (exn) #f)])
+    (resolved-module-path-name
+     (module-path-index-resolve
+      (module-path-index-join module-path #f)))))
+
+(define (->pkg path)
+  (cond
+    [(path->pkg path #:cache pkg-cache-for-path->pkg)]
+    [else (and (path->main-collects-relative path) "base")]))
+
+(define (->path tag)
+  (match tag
+    [(or (list 'part (list path-string _ ...))
+         (list 'idx (list 'gentag _ path-string _ ...))
+         (list 'tech (list path-string _ ...)))
+
+     (match path-string
+       ;; remove /xxx.scrbl
+       [(pregexp #px"^\\(lib (.*)\\)$" (list _ path))
+        (module-path->path (list 'lib path))])]
+
+    [(or (list 'def (list path _ ...))
+         (list 'form (list path _ ...))
+         (list 'meth (list (list path _ ...) _))
+         (list 'sig-val (list path _ ...)))
+     (module-path->path path)]
+
+    [(list 'mod-path path-string)
+     (module-path->path (read (open-input-string path-string)))]
+
+    ;; HACK: xrepl weirdly forges their own tag.
+    ;; Since it is a part of the main distribution, we add a hack to handle it
+    [(list 'xrepl _) 'xrepl]
+
+    [pkg
+     (log-debug "search script: unrecognized tag shape: ~s" pkg)
+     #f]))
+
+(define (tag->pkg tag)
+  (let loop ([path (->path tag)])
+    (match path
+      [(? path? path) (->pkg path)]
+      ['xrepl "xrepl"]
+      ['#%kernel "base"]
+      ['#%foreign "base"]
+      [(cons path _) (loop path)]
+      [_ #f])))

--- a/pkgs/racket-index/scribblings/main/private/search.css
+++ b/pkgs/racket-index/scribblings/main/private/search.css
@@ -4,7 +4,9 @@
     cursor: help;
 }
 
-/* The following pair of colors are picked to account for color blindness  */
+/* The following pair of colors are picked to account for color blindness
+ * See https://davidmathlogic.com/colorblind/
+ */
 
 .search-result-wrapper-pkg-base {
     background-color: #005AB5;

--- a/pkgs/racket-index/scribblings/main/private/search.css
+++ b/pkgs/racket-index/scribblings/main/private/search.css
@@ -4,13 +4,15 @@
     cursor: help;
 }
 
+/* The following pair of colors are picked to account for color blindness  */
+
 .search-result-wrapper-pkg-base {
-    background-color: #0C7BDC;
+    background-color: #005AB5;
     padding-right: 5px;
 }
 
 .search-result-wrapper-pkg-main-dist {
-    background-color: #FFC20A;
+    background-color: #DC3220;
     padding-right: 5px;
 }
 

--- a/pkgs/racket-index/scribblings/main/private/search.css
+++ b/pkgs/racket-index/scribblings/main/private/search.css
@@ -5,12 +5,12 @@
 }
 
 .search-result-wrapper-pkg-base {
-    background-color: red;
+    background-color: #0C7BDC;
     padding-right: 5px;
 }
 
 .search-result-wrapper-pkg-main-dist {
-    background-color: green;
+    background-color: #FFC20A;
     padding-right: 5px;
 }
 

--- a/pkgs/racket-index/scribblings/main/private/search.css
+++ b/pkgs/racket-index/scribblings/main/private/search.css
@@ -1,0 +1,21 @@
+.search-result-wrapper {
+    display: none;
+    box-sizing: border-box;
+    cursor: help;
+}
+
+.search-result-wrapper-pkg-base {
+    background-color: red;
+    padding-right: 5px;
+}
+
+.search-result-wrapper-pkg-main-dist {
+    background-color: green;
+    padding-right: 5px;
+}
+
+.search-result-row {
+    margin: 0.1em 0em;
+    padding: 0.25em 1em;
+    cursor: default;
+}

--- a/pkgs/racket-index/scribblings/main/private/search.js
+++ b/pkgs/racket-index/scribblings/main/private/search.js
@@ -244,9 +244,7 @@ function InitializeSearch() {
 
 function makeProtoSearchResult() {
   var proto_search_result = document.createElement('div');
-  proto_search_result.style.display = 'none';
-  proto_search_result.style.margin = '0.1em 0em';
-  proto_search_result.style.padding = '0.25em 1em';
+  proto_search_result.classList.add('search-result-wrapper');
   return proto_search_result;
 }
 
@@ -552,6 +550,22 @@ function MakeShowProgress() {
   };
 }
 
+function packageCompare(a, b) {
+  var a_is_base = a[4] === 'base';
+  var b_is_base = b[4] === 'base';
+  if (a_is_base && b_is_base) return 0;
+  if (a_is_base) return -1;
+  if (b_is_base) return 1;
+
+  var a_in_main = plt_main_dist_pkgs.indexOf(a[4]) >= 0;
+  var b_in_main = plt_main_dist_pkgs.indexOf(b[4]) >= 0;
+  if (a_in_main && b_in_main) return 0;
+  if (a_in_main) return -1;
+  if (b_in_main) return 1;
+
+  return 0;
+}
+
 function Search(data, term, is_pre, K) {
   // `K' is a continuation if this run is supposed to happen in a "thread"
   // false otherwise
@@ -589,6 +603,11 @@ function Search(data, term, is_pre, K) {
     }
     if (i<data.length) t = setTimeout(DoChunk,5);
     else {
+      i = 0;
+      for (i = 0; i < matches.length; i++) {
+        matches[i].sort(packageCompare);
+      }
+
       r = [matches[0].length, [].concat.apply([],matches)];
       if (K) K(r); else return r;
     }
@@ -758,11 +777,28 @@ function UpdateResults() {
         else
           href = href + link_args;
       }
+
       result_links[i].innerHTML =
-        '<a href="' + href + '" class="indexlink" tabIndex="2">'
-        + UncompactHtml(res[2]) + '</a>' + (note || "");
-      result_links[i].style.backgroundColor =
+        '<div title="" class="search-result-row"><a href="' + href
+        + '" class="indexlink" tabIndex="2">'
+        + UncompactHtml(res[2]) + '</a>' + (note || "") + '</div>';
+      result_links[i].classList.remove(
+        'search-result-wrapper-pkg-base',
+        'search-result-wrapper-pkg-main-dist'
+      );
+      if (res[4] === 'base') {
+        result_links[i].classList.add('search-result-wrapper-pkg-base');
+        result_links[i].title = "from official Racket (base)";
+      } else if (plt_main_dist_pkgs.indexOf(res[4]) >= 0) {
+        result_links[i].classList.add('search-result-wrapper-pkg-main-dist');
+        result_links[i].title = "from official Racket (main-distribution)";
+      } else {
+        result_links[i].title = '';
+      }
+
+      result_links[i].firstChild.style.backgroundColor =
         (n < exact_results_num) ? highlight_color : background_color;
+
       result_links[i].style.display = "block";
     } else {
       result_links[i].style.display = "none";

--- a/pkgs/racket-index/scribblings/main/private/utils.rkt
+++ b/pkgs/racket-index/scribblings/main/private/utils.rkt
@@ -42,7 +42,8 @@
 ;; it's missing, then it's a page with a single version
 (define (main-page id [installation-specific? '?]
                    #:force-racket-css? [force-racket-css? #f]
-                   #:show-root-info? [show-root-info? #f])
+                   #:show-root-info? [show-root-info? #f]
+                   #:extra-additions [extra-additions '()])
   (define info (page-info id))
   (define title-string (car info))
   (define root (cadr info))
@@ -65,7 +66,8 @@
                                         null
                                         (list
                                          (make-css-addition (collection-file-path "root-info.css" "scribblings/main/private"))
-                                         (make-js-addition (collection-file-path "root-info.js" "scribblings/main/private")))))))
+                                         (make-js-addition (collection-file-path "root-info.js" "scribblings/main/private"))))
+                                    extra-additions)))
            title-string
            #;
            ;; the "(installation)" part shouldn't be visible on the web, but

--- a/pkgs/racket-index/scribblings/main/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/search.scrbl
@@ -7,7 +7,12 @@
           "private/notice.rkt"
           "config.rkt")
 
-@main-page['search #t]
+@main-page['search #t
+           #:extra-additions
+           (list (make-css-addition
+                  (collection-file-path
+                   "search.css"
+                   "scribblings/main/private")))]
 
 @global-notice
 @local-notice

--- a/pkgs/racket-index/scribblings/main/user/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/user/search.scrbl
@@ -1,11 +1,17 @@
 #lang scribble/doc
-@(require "../private/utils.rkt"
+@(require scribble/html-properties
+          "../private/utils.rkt"
           "../private/make-search.rkt"
           "../private/notice.rkt")
 
 @main-page['search #f
-                   ;; "racket.css" needs to be installed for search results:
-                   #:force-racket-css? #t]
+           ;; "racket.css" needs to be installed for search results:
+           #:force-racket-css? #t
+           #:extra-additions
+           (list (make-css-addition
+                  (collection-file-path
+                   "search.css"
+                   "scribblings/main/private")))]
 
 @local-notice
 


### PR DESCRIPTION
This is a first cut for search result ranking.
Within a group of search results of the same score, search results associated with the `base` package will come first, followed by those in `main-distribution`, and then everything else.

Search results also have an additional indicator on the right border, which can be hovered to read the description.

Unfortunately, it slows down `raco setup scribblings/main` by about 10 seconds. The command is invoked quite often, as it is run as a part of `raco pkg install` and `raco pkg remove`.
It is unclear if the performance hit is a deal breaker.

Fixes #4083 and issues raised in
https://racket.discourse.group/t/whats-official-racket-and-whats-not/1447