### PR TITLE
add link to `17.3.2 Using #lang reader` to line 103

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/module-syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/module-syntax.scrbl
@@ -100,7 +100,7 @@ is
 racket
 _decl ...]
 
-which reads the same as
+which @tt{@hyperlink["https://docs.racket-lang.org/guide/hash-lang_reader.html"]{reads}} the same as
 
 @racketblock[
 (module _name racket

--- a/pkgs/racket-doc/scribblings/guide/module-syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/module-syntax.scrbl
@@ -100,7 +100,7 @@ is
 racket
 _decl ...]
 
-which @tt{@hyperlink["https://docs.racket-lang.org/guide/hash-lang_reader.html"]{reads}} the same as
+which @secref["hash-lang reader"]{reads} the same as
 
 @racketblock[
 (module _name racket

--- a/pkgs/racket-doc/scribblings/guide/module-syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/module-syntax.scrbl
@@ -100,7 +100,7 @@ is
 racket
 _decl ...]
 
-which @secref["hash-lang reader"]{reads} the same as
+which @seclink["hash-lang reader"]{reads} the same as
 
 @racketblock[
 (module _name racket


### PR DESCRIPTION
add link to `17.3.2 Using #lang reader` suggested by @elfprince13 in toot https://mumak.app/@elfprince13/109468503011177024 


> Thomas Dickerson
> @elfprince13@mumak.app
> @spdegabrielle @shriramk so while you're submitting documentation PRs on this topic, when you're reading the docs on Module Syntax and get to "6.2.2 The `#lang` Shorthand" the phrase "which reads the same as" between the two sections of example code should really have the word "reads" formatted as code and hyperlinked to https://docs.racket-lang.org/guide/hash-lang_reader.html to be clear that there is a very precise technical definition of "reads" at play


looked at @secref["hash-lang reader"], but couldn't see how  https://docs.racket-lang.org/scribble/base.html#%28def._%28%28lib._scribble%2Fbase..rkt%29._secref%29%29