### PR TITLE
Add the missing history note of `raco test --errortrace` and bump version

### DIFF
--- a/pkgs/compiler-lib/info.rkt
+++ b/pkgs/compiler-lib/info.rkt
@@ -13,7 +13,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.11")
+(define version "1.12")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/pkgs/racket-doc/scribblings/raco/test.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/test.scrbl
@@ -222,7 +222,8 @@ The @exec{raco test} command accepts several flags:
          #:changed "1.5" @elem{Added @DPFlag{ignore-stderr}.}
          #:changed "1.6" @elem{Added @DPFlag{arg} and @DPFlag{args}.}
          #:changed "1.8" @elem{Added @DFlag{output} and @Flag{o}.}
-         #:changed "1.11" @elem{Added @DFlag{output} and @DFlag{make}/@Flag{y}.}]
+         #:changed "1.11" @elem{Added @DFlag{make}/@Flag{y}.}
+         #:changed "1.12" @elem{Added @DFlag{errortrace}.}]
 
 @section[#:tag "test-config"]{Test Configuration by Submodule}
 


### PR DESCRIPTION
Add the missing history note of `raco test --errortrace` and bump version. Fix up of #4396.