### PR TITLE
Fix the documentation of `resolve-module-path`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/module-reflect.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/module-reflect.scrbl
@@ -665,7 +665,7 @@ more than the namespace's @tech{base phase}.}
          boolean?]{
 
 Returns @racket[#t] if the module indicated by @racket[mod] is
-declared (but not necessarily @tech{instantiate}d or @tech{visit}ed)
+@tech{declare}d (but not necessarily @tech{instantiate}d or @tech{visit}ed)
 in the current namespace, @racket[#f] otherwise.
 
 If @racket[load?] is @racket[#t] and @racket[mod] is not a

--- a/pkgs/racket-doc/syntax/scribblings/modresolve.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/modresolve.scrbl
@@ -25,8 +25,8 @@ a thunk, or to the current directory otherwise.
 
 When @racket[module-path-v] refers to a module using a
 collection-based path, resolution invokes the current @tech[#:doc
-refman]{module name resolver} and loads the module if it is not
-declared. Beware that concurrent resolution in namespaces that share a
+refman]{module name resolver}, but without loading the module even if it is not
+@tech[#:doc refman]{declare}d. Beware that concurrent resolution in namespaces that share a
 module registry can create race conditions when loading modules; see
 also @racket[namespace-call-with-registry-lock].}
 


### PR DESCRIPTION
The function `resolve-module-path` does not load new modules when resolving the given module path. This commit fixes the documentation.

Closes #4498.