### PR TITLE
match: compile to case on simple cases

### DIFF
--- a/pkgs/racket-test/tests/match/case-tests.rkt
+++ b/pkgs/racket-test/tests/match/case-tests.rkt
@@ -1,0 +1,295 @@
+#lang racket/base
+
+(provide case-tests)
+
+(require racket/match
+         racket/stxparam
+         syntax/parse/define
+         rackunit
+         (for-syntax racket/base
+                     racket/syntax))
+
+(define-syntax-parameter this-value #f)
+
+;; this macro defines
+;; - `fragment`, a syntax fragment in the quoted form
+;; - `test`, a function that runs the match clauses on the input value
+(define-syntax-parse-rule (define-test clause ...)
+  #:with result ((syntax-local-value #'match) #'(match 'val-expr clause ...))
+  #:with fragment (format-id this-syntax "fragment")
+  #:with test (format-id this-syntax "test")
+  (begin
+    (define fragment 'result)
+    (define (test val)
+      (syntax-parameterize ([this-value (make-rename-transformer #'val)])
+        (match val
+          clause ...)))))
+
+;; A bit circular to use check-match to test match,
+;; though the check-match mostly operates on lists, not caseable values,
+;; so that should be ok.
+(define case-tests
+  (test-suite "Test for the compilation from match to case"
+    (test-case "Supported types"
+      (define-test
+        [1 'a]
+        [2 'a*]
+        ['a 'b]
+        ['b 'b*]
+        ["a" 'c]
+        ["b" 'c*]
+        [#"a" 'd]
+        [#"b" 'd*]
+        [#px"a" 'e]
+        [#px"b" 'e*]
+        [#rx"a" 'f]
+        [#rx"b" 'f*]
+        ['#:a 'g]
+        ['#:b 'g*]
+        [#t 'h]
+        [#f 'i])
+
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1) ,_]
+                [(2) ,_]
+                [(a) ,_]
+                [(b) ,_]
+                [("a") ,_]
+                [("b") ,_]
+                [(#"a") ,_]
+                [(#"b") ,_]
+                [(#px"a") ,_]
+                [(#px"b") ,_]
+                [(#rx"a") ,_]
+                [(#rx"b") ,_]
+                [(#:a) ,_]
+                [(#:b) ,_]
+                [(#t) ,_]
+                [(#f) ,_]
+                [else ,_])))))
+
+      (check-equal? (test 1) 'a)
+      (check-equal? (test 2) 'a*)
+      (check-equal? (test 'a) 'b)
+      (check-equal? (test 'b) 'b*)
+      (check-equal? (test "a") 'c)
+      (check-equal? (test "b") 'c*)
+      (check-equal? (test #"a") 'd)
+      (check-equal? (test #"b") 'd*)
+      (check-equal? (test #px"a") 'e)
+      (check-equal? (test #px"b") 'e*)
+      (check-equal? (test #rx"a") 'f)
+      (check-equal? (test #rx"b") 'f*)
+      (check-equal? (test '#:a) 'g)
+      (check-equal? (test '#:b) 'g*)
+      (check-equal? (test #t) 'h)
+      (check-equal? (test #f) 'i)
+      (check-exn exn:fail? (λ () (test 3))))
+
+    (test-case "Or"
+      (define-test
+        [(or 1 (or 11 111)) 'a]
+        [(or (or 2 112) 12) 'b]
+        [(or 3 13 113) 'c]
+        [4 'd]
+        ;; this is parsed as (not _), so it will break the optimization
+        ;; on subsequent clauses
+        [(or) 'e]
+        [5 'f])
+
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1 11 111) ,_]
+                [(2 112 12) ,_]
+                [(3 13 113) ,_]
+                [(4) ,_]
+                [else ,_])))))
+
+      (check-equal? (test 1) 'a)
+      (check-equal? (test 11) 'a)
+      (check-equal? (test 111) 'a)
+      (check-equal? (test 2) 'b)
+      (check-equal? (test 12) 'b)
+      (check-equal? (test 112) 'b)
+      (check-equal? (test 3) 'c)
+      (check-equal? (test 13) 'c)
+      (check-equal? (test 113) 'c)
+      (check-equal? (test 4) 'd)
+      (check-equal? (test 5) 'f))
+
+    (test-case "Overlapping"
+      (define x 0)
+
+      (define-test
+        [1 'a]
+        [2 'b]
+        [1 'c]
+        [3 'd]
+        [3 'e]
+        [4 'f]
+        [5 (set! x (add1 x))
+           (failure-cont)]
+        [5 (set! x (add1 x))
+           'h])
+
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1) (syntax-parameterize ,_ (let () 'a))]
+                [(2) (syntax-parameterize ,_ (let () 'b))]
+                [(3) (syntax-parameterize ,_ (let () 'd))]
+                [(4) (syntax-parameterize ,_ (let () 'f))]
+                [(5) (syntax-parameterize ,_ (let ()
+                                               (set! x (add1 x))
+                                               (failure-cont)))]
+                [else ,_])))))
+
+      (check-equal? (test 1) 'a)
+      (check-equal? (test 2) 'b)
+      (check-equal? (test 3) 'd)
+      (check-equal? (test 4) 'f)
+      (check-equal? x 0)
+      (check-equal? (test 5) 'h)
+      (check-equal? x 2))
+
+    (test-case "Overlapping or"
+      (define-test
+        [(or 1 2) 'a]
+        [(or 2 3) 'b]
+        [(or 3 4) 'c]
+        [(or 5 6) 'd]
+        [(or 4 7) 'e]
+        [(or 8 9) 'f])
+
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1 2) (syntax-parameterize ,_ (let () 'a))]
+                [(5 6) (syntax-parameterize ,_ (let () 'd))]
+                [(8 9) (syntax-parameterize ,_ (let () 'f))]
+                [else ,_])))))
+
+      (check-equal? (test 1) 'a)
+      (check-equal? (test 2) 'a)
+      (check-equal? (test 3) 'b)
+      (check-equal? (test 4) 'c)
+      (check-equal? (test 5) 'd)
+      (check-equal? (test 6) 'd)
+      (check-equal? (test 7) 'e)
+      (check-equal? (test 8) 'f)
+      (check-equal? (test 9) 'f))
+
+    (test-case "Duplicate in a clause"
+      (define-test
+        [(or 1 (or 1 2) 1) 'a]
+        [(or 3 3 (or 3 4)) 'b])
+
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1 1 2 1) ,_]
+                [(3 3 3 4) ,_]
+                [else ,_])))))
+      (check-equal? (test 1) 'a)
+      (check-equal? (test 2) 'a)
+      (check-equal? (test 3) 'b)
+      (check-equal? (test 4) 'b))
+
+    (test-case "Non-case pattern"
+      (define-test
+        [1 'a]
+        [2 'b]
+        [(? odd?) 'c]
+        [3 'd]
+        [4 'e])
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1) ,_]
+                [(2) ,_]
+                [else ,_])))))
+
+      (check-equal? (test 1) 'a)
+      (check-equal? (test 2) 'b)
+      (check-equal? (test 3) 'c)
+      (check-equal? (test 4) 'e)
+      (check-equal? (test 5) 'c))
+
+    (test-case "#:when"
+      (define-test
+        [1 #:when #f 'a]
+        [1 #:when #t 'b]
+        [2 #:when #t 'c]
+        [2 #:when #f 'd]
+        [3 'e])
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let (,_) ; next
+              (case ,_
+                [(1) (syntax-parameterize (,_)
+                       (let ()
+                         (if #f
+                             (let () 'a)
+                             (fail))))]
+                [(2) (syntax-parameterize (,_)
+                       (let ()
+                         (if #t
+                             (let () 'c)
+                             (fail))))]
+                [(3) ,_]
+                [else ,_])))))
+      (check-equal? (test 1) 'b)
+      (check-equal? (test 2) 'c)
+      (check-equal? (test 3) 'e))
+
+    (test-case "(=> exit-id)"
+      (define x #f)
+      (define-test
+        [(or 1 2) (=> exit-id)
+                  (cond
+                    [(even? this-value)
+                     (set! x #t)
+                     (list (exit-id))]
+                    [else 'a])]
+        [_ 'b])
+      (check-match
+       fragment
+       `(let ([,_ ,_]) ; val-expr
+          (let (,_) ; fail
+            (let ([,next ,_]) ; next
+              (case ,_
+                [(1 2) (call-with-continuation-prompt ,_ ,_ (lambda () (,next)))]
+                [else ,_])))))
+
+      (check-equal? (test 1) 'a)
+      (check-false x)
+      (check-equal? (test 2) 'b)
+      (check-true x))))
+
+(module+ test
+  (require rackunit/text-ui)
+
+  (run-tests case-tests))

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -4,6 +4,7 @@
          "match-tests.rkt" "match-exn-tests.rkt" "other-plt-tests.rkt" "other-tests.rkt"
          "legacy-match-tests.rkt"
          "examples.rkt"
+         "case-tests.rkt"
          rackunit rackunit/text-ui
          (only-in racket/base local-require))
 
@@ -461,7 +462,8 @@
                             new-tests
                             ;; from bruce
                             other-tests 
-                            other-plt-tests)
+                            other-plt-tests
+                            case-tests)
              'verbose))
 
 (module+ main

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -58,16 +58,17 @@
                            (predicate-stx x)
                            (quasisyntax/loc predicate-stx
                              (#,predicate-stx #,x)))]
-                  [rhs (compile* (cons x xs)
-                                 (map (lambda (row)
-                                        (define-values (p ps)
-                                          (Row-split-pats row))
-                                        (make-Row (cons (make-Dummy #f) ps)
-                                                  (Row-rhs row)
-                                                  (Row-unmatch row)
-                                                  (Row-vars-seen row)))
-                                      rows)
-                                 esc)])
+                  [rhs (compile**
+                        (cons x xs)
+                        (map (lambda (row)
+                               (define-values (p ps)
+                                 (Row-split-pats row))
+                               (make-Row (cons (make-Dummy #f) ps)
+                                         (Row-rhs row)
+                                         (Row-unmatch row)
+                                         (Row-vars-seen row)))
+                             rows)
+                        esc)])
       #'[lhs rhs]))
   (define (compile-con-pat accs pred pat-acc)
     ;; eliminate accessors for columns where every pat is a Dummy
@@ -86,7 +87,7 @@
                      [question (if (procedure? pred)
                                    (pred x)
                                    #`(#,pred #,x))]
-                     [body (compile*
+                     [body (compile**
                             (append (syntax->list #'(tmps ...)) xs)
                             (map (lambda (row)
                                    (define-values (p1 ps) (Row-split-pats row))
@@ -129,7 +130,7 @@
                              pat))
                          (with-syntax ([(tmps ...) (generate-temporaries ns)])
                            (with-syntax ([body
-                                          (compile*
+                                          (compile**
                                            (append (syntax->list #'(tmps ...)) xs)
                                            (map (lambda (row)
                                                   (define-values (p1 ps)
@@ -184,14 +185,15 @@
                        ht
                        (lambda (k v)
                          #`[(equal? #,x '#,k)
-                            #,(compile* xs
-                                        (map (lambda (row)
-                                               (make-Row (cdr (Row-pats row))
-                                                         (Row-rhs row)
-                                                         (Row-unmatch row)
-                                                         (Row-vars-seen row)))
-                                             v)
-                                        esc)]))])
+                            #,(compile**
+                               xs
+                               (map (lambda (row)
+                                      (make-Row (cdr (Row-pats row))
+                                                (Row-rhs row)
+                                                (Row-unmatch row)
+                                                (Row-vars-seen row)))
+                                    v)
+                               esc)]))])
          #`(cond clauses ... [else (#,esc)])))]
     ;; the Var rule
     [(Var? first)
@@ -239,7 +241,7 @@
                                   (Row-unmatch row)
                                   (cons (cons v x) (Row-vars-seen row))))]))])
        ;; compile the transformed block
-       (compile* xs (map transform block) esc))]
+       (compile** xs (map transform block) esc))]
     ;; the Constructor rule
     [(CPat? first)
      (let ;; put all the rows in the hash, indexed by their constructor
@@ -271,24 +273,26 @@
          ;; variables
          #`(let ([esc* (lambda () (values #f #,@(for/list ([v vars]) #'#f)))])
              (let-values ([(success? var ...)
-                           #,(compile* (list x)
-                                       (map (lambda (q)
-                                              (make-Row (list q)
-                                                        #'(values #t var ...)
-                                                        #f
-                                                        seen))
-                                            qs)
-                                       #'esc*
-                                       #f)])
+                           #,(compile**
+                              (list x)
+                              (map (lambda (q)
+                                     (make-Row (list q)
+                                               #'(values #t var ...)
+                                               #f
+                                               seen))
+                                   qs)
+                              #'esc*
+                              #f)])
                ;; then compile the rest of the row
                (if success?
-                   #,(compile* xs
-                               (list (make-Row (cdr pats)
-                                               (Row-rhs row)
-                                               (Row-unmatch row)
-                                               (append (map cons vars vars) seen)))
-                               esc
-                               #f)
+                   #,(compile**
+                      xs
+                      (list (make-Row (cdr pats)
+                                      (Row-rhs row)
+                                      (Row-unmatch row)
+                                      (append (map cons vars vars) seen)))
+                      esc
+                      #f)
                    (#,esc))))))]
     ;; the App rule
     [(App? first)
@@ -306,12 +310,13 @@
                                (app-expr x)
                                (quasisyntax/loc app-expr
                                  (#,app-expr #,x)))])
-             #,(compile* (append (syntax->list #'(t ...)) xs)
-                         (list (make-Row (append app-pats (cdr pats))
-                                         (Row-rhs row)
-                                         (Row-unmatch row)
-                                         (Row-vars-seen row)))
-                         esc))))]
+             #,(compile**
+                (append (syntax->list #'(t ...)) xs)
+                (list (make-Row (append app-pats (cdr pats))
+                                (Row-rhs row)
+                                (Row-unmatch row)
+                                (Row-vars-seen row)))
+                esc))))]
     ;; the And rule
     [(And? first)
      ;; we only handle 1-row Ands
@@ -322,14 +327,15 @@
      (define pats (Row-pats row))
      ;; all the patterns
      (define qs (And-ps (car pats)))
-     (compile* (append (map (lambda _ x) qs) xs)
-               (list (make-Row (append qs (cdr pats))
-                               (Row-rhs row)
-                               (Row-unmatch row)
-                               (Row-vars-seen row)))
-               esc
-               ;; don't re-order OrderedAnd patterns
-               (not (OrderedAnd? first)))]
+     (compile**
+      (append (map (lambda _ x) qs) xs)
+      (list (make-Row (append qs (cdr pats))
+                      (Row-rhs row)
+                      (Row-unmatch row)
+                      (Row-vars-seen row)))
+      esc
+      ;; don't re-order OrderedAnd patterns
+      (not (OrderedAnd? first)))]
     ;; the Not rule
     [(Not? first)
      ;; we only handle 1-row Nots atm - this is all the mixture rule should
@@ -343,20 +349,22 @@
        (with-syntax ([(f) (generate-temporaries #'(f))])
          #`(let ;; if q fails, we jump to here
                 ([f (lambda ()
-                      #,(compile* xs
-                                  (list (make-Row (cdr pats)
-                                                  (Row-rhs row)
-                                                  (Row-unmatch row)
-                                                  (Row-vars-seen row)))
-                                  esc))])
-             #,(compile* (list x)
-                         ;; if q doesn't fail, we jump to esc and fail the not
-                         ;; pattern
-                         (list (make-Row (list q)
-                                         #`(#,esc)
+                      #,(compile**
+                         xs
+                         (list (make-Row (cdr pats)
+                                         (Row-rhs row)
                                          (Row-unmatch row)
                                          (Row-vars-seen row)))
-                         #'f))))]
+                         esc))])
+               #,(compile**
+                  (list x)
+                  ;; if q doesn't fail, we jump to esc and fail the not
+                  ;; pattern
+                  (list (make-Row (list q)
+                                  #`(#,esc)
+                                  (Row-unmatch row)
+                                  (Row-vars-seen row)))
+                  #'f))))]
     [(Pred? first)
      ;; put all the rows in the hash, indexed by their Pred pattern
      ;; we use the pattern so that it can have a custom equal+hash
@@ -435,7 +443,7 @@
                                 [else
                                  (let ([hid hid-rhs] ... ...
                                        [fail-tail fail])
-                                   #,(compile*
+                                   #,(compile**
                                       (cdr vars)
                                       (list (make-Row rest-pats k
                                                       (Row-unmatch (car block))
@@ -460,27 +468,45 @@
                                 [hid-arg null] ... ...
                                 [rep 0] ...
                                 [failkv #,esc])
-                 #,(compile* (list #'x)
-                             (append
-                              (map (lambda (pats rhs)
-                                     (make-Row pats
-                                               rhs
-                                               (Row-unmatch (car block))
-                                               (Row-vars-seen
-                                                (car block))))
-                                   (map list heads)
-                                   (syntax->list #'(rhs ...)))
-                              (list (make-Row (list tail)
-                                              #`tail-rhs
-                                              (Row-unmatch (car block))
-                                              (append
-                                               heads-seen
-                                               (Row-vars-seen
-                                                (car block))))))
-                             #'failkv))))))]
+                 #,(compile**
+                    (list #'x)
+                    (append
+                     (map (lambda (pats rhs)
+                            (make-Row pats
+                                      rhs
+                                      (Row-unmatch (car block))
+                                      (Row-vars-seen
+                                       (car block))))
+                          (map list heads)
+                          (syntax->list #'(rhs ...)))
+                     (list (make-Row (list tail)
+                                     #`tail-rhs
+                                     (Row-unmatch (car block))
+                                     (append
+                                      heads-seen
+                                      (Row-vars-seen
+                                       (car block))))))
+                    #'failkv))))))]
     [else (error 'compile "unsupported pattern: ~a\n" first)]))
 
-(define (compile* vars rows esc [reorder? (can-reorder?)])
+(define (generate-block esc rhs unmatch)
+  ;; compile the block, with jumps to the previous esc
+  (with-syntax ([rhs #`(syntax-parameterize
+                           ([fail (make-rename-transformer
+                                   (quote-syntax #,esc))])
+                         #,rhs)])
+    (if unmatch
+        (quasisyntax/loc unmatch
+          (call-with-continuation-prompt
+           (lambda () (let ([#,unmatch
+                             (lambda ()
+                               (abort-current-continuation match-prompt-tag))])
+                        rhs))
+           match-prompt-tag
+           (lambda () (#,esc))))
+        #'rhs)))
+
+(define (compile** vars rows esc [reorder? (can-reorder?)])
   (define (let/wrap clauses body)
     (if (stx-null? clauses)
       body
@@ -499,22 +525,7 @@
                  (with-syntax
                   (;; f is the name this block will have
                    [(f) (generate-temporaries #'(f))]
-                   ;; compile the block, with jumps to the previous esc
-                   [c (with-syntax ([rhs #`(syntax-parameterize
-                                            ([fail (make-rename-transformer
-                                                    (quote-syntax #,esc))])
-                                            #,(Row-rhs (car blocks)))])
-                                   (define unmatch (Row-unmatch (car blocks)))
-                                   (if unmatch
-                                       (quasisyntax/loc unmatch
-                                         (call-with-continuation-prompt
-                                          (lambda () (let ([#,unmatch
-                                                            (lambda ()
-                                                              (abort-current-continuation match-prompt-tag))])
-                                                       rhs))
-                                          match-prompt-tag
-                                          (lambda () (#,esc))))
-                                       #'rhs))])
+                   [c (generate-block esc (Row-rhs (car blocks)) (Row-unmatch (car blocks)))])
                   ;; then compile the rest, with our name as the esc
                   (loop (cdr blocks) #'f (cons #'[f (lambda () c)] acc)))))])
       (with-syntax ([(fns ... [_ (lambda () body)]) fns])
@@ -551,5 +562,167 @@
       (with-syntax ([(fns ... [_ (lambda () body)]) fns])
         (let/wrap #'(fns ...) #'body)))]))
 
+;; flatten-Or :: (pattern? -> boolean?), pattern? -> (or/c #f (listof pattern?))
+(define (flatten-Or proc e)
+  (let loop ([e e] [acc '()])
+    (cond
+      [(Or? e)
+       (let loop2 ([ps (Or-ps e)] [acc2 acc])
+         (cond
+           [(null? ps) acc2]
+           [else
+            (cond
+              [(loop (car ps) acc2) => (λ (result) (loop2 (cdr ps) result))]
+              [else #f])]))]
+      [(proc e) (cons e acc)]
+      [else #f])))
+
+;; flatten-Or-Exact :: pattern? -> (or/c #f (listof pattern?))
+(define (flatten-Or-Exact v)
+  ;; technically we don't need to reverse it, but let's try to preserve
+  ;; the search order
+  (cond
+    [(flatten-Or Exact? v) => reverse]
+    [else #f]))
+
+;; pats :: (listof literal)
+;; rhs :: Expr
+;; unmatch :: (or/c #f identifier?)
+(struct CaseRow (pats rhs unmatch) #:transparent)
+
+;; generate-case+match :: identifier? identifier? CaseRow? Row? -> syntax?
+(define (generate-case+match var esc case-rows match-rows)
+  (with-syntax ([(next) (generate-temporaries #'(next))])
+    (define compiled-case
+      (for/list ([row (in-list case-rows)])
+        (with-syntax ([(lit ...) (CaseRow-pats row)]
+                      [block (generate-block #'next
+                                             (CaseRow-rhs row)
+                                             (CaseRow-unmatch row))])
+          #'[(lit ...) block])))
+    (with-syntax ([var var]
+                  [match-expr (compile** (list var) match-rows esc)]
+                  [(case-clause ...) compiled-case])
+
+      ;; Since next is shared across all generated blocks, technically we can
+      ;; syntax-parameterize fail just once at the top. But for now,
+      ;; let's reuse generate-block (which syntax-parameterizes in each block)
+      #`(let ([next #,(syntax-property
+                       #'(λ () match-expr)
+                       'typechecker:called-in-tail-position #t)])
+          (case var
+            case-clause ...
+            [else (next)])))))
+
+(define (compile* vars rows esc)
+  (define seen (make-hash))
+
+  ;; Attempt to use `case` when it is possible.
+  ;;
+  ;; (match id [case-pattern rhs] ... [other-pattern rhs*] ...)
+  ;;
+  ;; is compiled to:
+  ;;
+  ;; (let ([next (λ () (match id [other-pattern rhs*] ...))])
+  ;;   (case id
+  ;;     [(case-pattern)
+  ;;      (syntax-parameterize ([fail (make-rename-transformer #'next)])
+  ;;        rhs)] ...
+  ;;     [else (next)]))
+  ;;
+  ;; The syntax-parameterization is done to support (failure-cont).
+  ;; In match, failure-cont would yield to the next clause.
+  ;; In our scheme, however, all case-pattern clauses will be disjoint,
+  ;; so we can skip to the else clause (next) right away.
+  ;;
+  ;; Disjointness across clauses is therefore very important:
+  ;;
+  ;; (match 1 [1 (failure-cont)] [1 (displayln 'hello)])
+  ;;
+  ;; should print "hello". A compilation that doesn't take disjointness into
+  ;; account, such as:
+  ;;
+  ;; (let ([next (λ () (match id))])
+  ;;   (case id
+  ;;     [(1)
+  ;;      (syntax-parameterize ([fail (make-rename-transformer #'next)])
+  ;;        (fail))]
+  ;;     [(1)
+  ;;      (syntax-parameterize ([fail (make-rename-transformer #'next)])
+  ;;        (displayln 'hello))]
+  ;;     [else (next)]))
+  ;;
+  ;; would be incorrect.
+  ;;
+  ;; (=> exit-id) is handled regularly, but with the target being the else clause
+  ;; due to the same reason as above.
+  ;;
+  (cond
+    ;; |vars| = 1
+    [(and (pair? vars) (null? (cdr vars)))
+     (define var (car vars))
+
+     ;; Exact values are those parsed by parse-literal.
+     ;; They all can be handled by `case`.
+     ;;
+     ;; Note that `case` can handle stuff like list, vector, and hash literals too,
+     ;; but match parsing doesn't retain enough information to make
+     ;; the compilation easy, so we'll skip them (at least for now).
+     (let loop ([rows rows] [case-rows '()] [match-rows '()])
+       (cond
+         [(null? rows)
+          (generate-case+match var esc (reverse case-rows) (reverse match-rows))]
+         [else
+          (define row (car rows))
+          (define next-rows (cdr rows))
+          (cond
+            ;; |(Row-pats row)| = |vars| = 1, so we can call Row-first-pat.
+            [(flatten-Or-Exact (Row-first-pat row))
+             =>
+             (λ (exact-list)
+               (define literal-list (map Exact-v exact-list))
+               (define seen-any?
+                 (for/or ([literal (in-list literal-list)])
+                   (hash-ref seen literal #f)))
+
+               ;; We want to unconditionally iterate the whole list to mark
+               ;; all terms as seen.
+               ;;
+               ;; Consider:
+               ;;
+               ;; [1 ...]
+               ;; [(or 1 2) ...]
+               ;; [(or 2 3) ...]
+               ;;
+               ;; In this case,
+               ;; - 1 can be case-dispatched.
+               ;; - (or 1 2) can't because of duplicate 1, so it must be matched
+               ;; - (or 2 3) also can't because we just moved (or 1 2)
+               ;;   to the else clause. Since matching on 2 should reach
+               ;;   (or 1 2), not (or 2 3), (or 2 3) must be moved to the else
+               ;;   clause too.
+
+               (for ([literal (in-list literal-list)])
+                 (hash-set! seen literal #t))
+
+               (cond
+                 [seen-any?
+                  (loop next-rows case-rows (cons row match-rows))]
+                 [else
+                  (loop next-rows
+                             (cons (CaseRow literal-list (Row-rhs row) (Row-unmatch row))
+                                   case-rows)
+                             match-rows)]))]
+            [else
+             ;; in general, non-Exact pattern can have a side-effect.
+             ;; E.g. (match 1 [(? println) 2]). So we disregard the rest.
+             (generate-case+match var
+                                  esc
+                                  (reverse case-rows)
+                                  ;; append and reverse can be fused,
+                                  ;; but let's not optimize prematurely
+                                  (append (reverse match-rows) rows))])]))]
+    [else (compile** vars rows esc)]))
+
 ;; (require mzlib/trace)
-;; (trace compile* compile-one)
+;; (trace compile** compile-one)


### PR DESCRIPTION
From the code:

  ;; Attempt to use `case` when it is possible.
  ;;
  ;; (match id [case-pattern rhs] ... [other-pattern rhs*] ...)
  ;;
  ;; is compiled to:
  ;;
  ;; (let ([next (λ () (match id [other-pattern rhs*] ...))])
  ;;   (case id
  ;;     [(case-pattern)
  ;;      (syntax-parameterize ([fail (make-rename-transformer #'next)])
  ;;        rhs)] ...
  ;;     [else (next)]))
  ;;
  ;; The syntax-parameterization is done to support (failure-cont).
  ;; In match, failure-cont would yield to the next clause.
  ;; In our scheme, however, all case-pattern clauses will be disjoint,
  ;; so we can skip to the else clause (next) right away.
  ;;
  ;; Disjointness across clauses is therefore very important:
  ;;
  ;; (match 1 [1 (failure-cont)] [1 (displayln 'hello)])
  ;;
  ;; should print "hello". A compilation that doesn't take disjointness into
  ;; account, such as:
  ;;
  ;; (let ([next (λ () (match id))])
  ;;   (case id
  ;;     [(1)
  ;;      (syntax-parameterize ([fail (make-rename-transformer #'next)])
  ;;        (fail))]
  ;;     [(1)
  ;;      (syntax-parameterize ([fail (make-rename-transformer #'next)])
  ;;        (displayln 'hello))]
  ;;     [else (next)]))
  ;;
  ;; would be incorrect.
  ;;
  ;; (=> exit-id) is handled regularly, but with the target being the else clause
  ;; due to the same reason as above.


Co-authored by sam(th) and sam(ph)