### PR TITLE
Use Ubuntu 22.04 in GHA CI.

### DIFF
--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
 
   racketcs-asan:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container: racket/racket-ci:latest
 
     env:

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -12,7 +12,7 @@ jobs:
       image: racket/racket-ci:latest
       options: --init
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-push-x86_linux.yml
+++ b/.github/workflows/ci-push-x86_linux.yml
@@ -9,7 +9,7 @@ jobs:
 # component finishes building.
 
   build-racketcgc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
 
@@ -60,7 +60,7 @@ jobs:
         path: /tmp/racketcgc-debian10-${{ matrix.cify }}-x64_git${{ github.sha }}.tar.bz2
 
   build-racket3m:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
                 
@@ -147,7 +147,7 @@ jobs:
         path: /tmp/racket3m-debian10-${{ matrix.cify }}-${{ matrix.jit }}-${{ matrix.efp }}-x64_git${{ github.sha }}.tar.bz2
 
   build-racketcs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
 
@@ -204,7 +204,7 @@ jobs:
   # Note: the reason we cannot transform this into a matrix
   # build is because we cannot use variables in the needs keyword.
   test-cgc:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
       options: --init
@@ -275,7 +275,7 @@ jobs:
         run: raco test -c tests/syntax
 
   test-3m:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
       options: --init
@@ -358,7 +358,7 @@ jobs:
         run: raco test -c tests/syntax
 
   test-cs:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
       options: --init

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   create-installer:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     if: github.repository == 'racket/racket'
 
     steps:

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -8,7 +8,7 @@ permissions:
 jobs:
   CodeQL-Build:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - name: Checkout repository

--- a/.github/workflows/docker-racketci.yml
+++ b/.github/workflows/docker-racketci.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   build-image:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     env:
       IMAGE_NAME: racket-ci

--- a/.github/workflows/scribble_build-guide.yml
+++ b/.github/workflows/scribble_build-guide.yml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   scribble:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -28,7 +28,7 @@ jobs:
       run: raco pkg install --auto -j $(nproc) pkgs/racket-build-guide
 
   generation-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/scribble_license.yml
+++ b/.github/workflows/scribble_license.yml
@@ -16,7 +16,7 @@ on:
 
 jobs:
   scribble:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
       run: sudo raco pkg update -j $(nproc) --batch --auto pkgs/racket-index
 
   generation-check:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ubsan-x86.yml
+++ b/.github/workflows/ubsan-x86.yml
@@ -10,7 +10,7 @@ jobs:
 # Build jobs
 # These jobs build Racket using undefined behaviour sanitizers and gathers the results into a final log
   racket3m-ubsan:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container: racket/racket-ci:latest
 
     steps:
@@ -92,7 +92,7 @@ jobs:
         path: runtime-errors_git${{ github.sha }}.log
 
   racketcs-ubsan:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     container: racket/racket-ci:latest
 
     steps:


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/6002 for
deprecation.