### PR TITLE
Refactor some things in racket/unit

### DIFF
--- a/pkgs/racket-test/tests/units/test-unit-contracts.rkt
+++ b/pkgs/racket-test/tests/units/test-unit-contracts.rkt
@@ -87,10 +87,10 @@
  "misuse of define-signature keyword"
  contracted)
 (test-syntax-error
- "expected a list of [id contract]"
+ "expected [id contract] pair"
   (define-signature x ((contracted x y))))
 (test-syntax-error
- "expected a list of [id contract]"
+ "expected identifier"
   (define-signature x ((contracted [(-> number? number?) x]))))
 
 (test-syntax-error

--- a/pkgs/racket-test/tests/units/test-unit.rkt
+++ b/pkgs/racket-test/tests/units/test-unit.rkt
@@ -331,31 +331,31 @@
 
 ;; compound-unit syntax errors (without sub-signatures)
 (test-syntax-error 
- "compound-unit: expected syntax matching (<identifier> : <identifier>) or (<identifier> : (tag <identifier> <identifier>))"
+ "compound-unit: expected the literal symbol `:'"
  (compound-unit (import (a empty-sig)) (export) (link)))
 (test-syntax-error 
- "compound-unit: expected syntax matching (<identifier> : <identifier>) or (<identifier> : (tag <identifier> <identifier>))"
+ "compound-unit: expected identifier"
  (compound-unit (import (1 : empty-sig)) (export) (link)))
 (test-syntax-error 
- "compound-unit: unknown signature"
+ "compound-unit: expected identifier bound to a signature"
  (compound-unit (import (a : empty-si)) (export) (link)))
 (test-syntax-error 
- "compound-unit: not an identifier"
+ "compound-unit: expected tagged link identifier"
  (compound-unit (import) (export a 1 b) (link)))
 (test-syntax-error 
- "compound-unit: not an identifier"
+ "compound-unit: expected tagged link identifier"
  (compound-unit (import) (export) (link (((a : empty-sig)) b 1))))
 (test-syntax-error 
- "compound-unit: not an identifier"
+ "compound-unit: expected identifier or expected more terms"
  (compound-unit (import (a : ())) (export) (link)))
 (test-syntax-error 
- "compound-unit: not an identifier"
+ "compound-unit: expected tagged signature identifier"
  (compound-unit (import) (export) (link (((a : "")) b))))
 (test-syntax-error 
- "compound-unit: expected syntax matching (<identifier> : <identifier>) or (<identifier> : (tag <identifier> <identifier>))"
+ "compound-unit: expected the literal symbol `:'"
  (compound-unit (import) (export) (link (((a empty-sig)) b))))
 (test-syntax-error 
- "compound-unit: unknown signature"
+ "compound-unit: expected identifier bound to a signature"
  (compound-unit (import) (export) (link (((a : b)) b))))
 (test-syntax-error 
  "compound-unit: duplicate linking identifier definition"
@@ -376,7 +376,7 @@
  "compound-unit: cannot directly export an import"
  (compound-unit (import (S : x-sig)) (export S) (link)))
 (test-syntax-error 
- "compound-unit: expected syntax matching (<identifier> : <identifier>) or (<identifier> : (tag <identifier> <identifier>))"
+ "compound-unit: expected the literal symbol `:'"
  (compound-unit (import (tag s (S : x-sig)))  (export (tag t S)) (link)))
 (test-syntax-error 
  "compound-unit: the signature of X1 extends this signature"
@@ -1117,7 +1117,7 @@
 (let ()
   (define u (unit (import) (export x-sub) (define x 1) (define xx 1)))
   (test-syntax-error 
-   "compound-unit: unknown signature"
+   "compound-unit: expected identifier bound to a signature"
    (compound-unit (import) (export l1 l2)
                   (link (((l1 : s1)) u)
                         (((l2 : s2)) u)))))

--- a/pkgs/racket-test/tests/units/test-unit.rkt
+++ b/pkgs/racket-test/tests/units/test-unit.rkt
@@ -1,12 +1,13 @@
 #lang racket/load
 
-(require (for-syntax racket/private/unit-compiletime
+(require (for-syntax racket/syntax
+                     racket/private/unit-compiletime
                      racket/private/unit-syntax))
 (require "test-harness.rkt"
          racket/unit)
 
 (define-syntax (lookup-sig-mac stx)
-  (parameterize ((error-syntax stx))
+  (parameterize ((current-syntax-context stx))
     (syntax-case stx ()
       ((_ id)
        #`#'#,(let ((s (lookup-signature #'id)))

--- a/pkgs/racket-test/tests/units/test-unit.rkt
+++ b/pkgs/racket-test/tests/units/test-unit.rkt
@@ -107,34 +107,34 @@
 
 ;; define-signature syntax-errors
 (test-syntax-error 
- "expected syntax matching" 
+ "expected more terms" 
  (define-signature))
 (test-syntax-error 
- "expected syntax matching"
+ "expected more terms"
  (define-signature x))
 (test-syntax-error 
- "expected syntax matching"
+ "unexpected term"
  (define-signature x (a b) 1))
 (test-syntax-error 
- "not an identifier"
+ "expected identifier"
  (define-signature 1 (a b)))
 (test-syntax-error 
- "not an identifier"
+ "expected identifier"
  (define-signature x extends 1 (a b)))
 (test-syntax-error 
- "unknown signature"
+ "expected identifier bound to a signature"
  (define-signature x extends y12 (a b)))
 (test-syntax-error 
- "unknown signature"
+ "expected identifier bound to a signature"
  (let () (define-signature x extends x (a b))))
 (test-syntax-error 
- "not an identifier"
+ "expected identifier"
  (define-signature (a . b) (a b)))
 (test-syntax-error 
- "expected syntax matching"
+ "expected signature elements or expected the identifier `extends'"
  (define-signature b . (a b)))
 (test-syntax-error 
- "bad syntax (illegal use of `.')"
+ "expected the literal ()"
  (define-signature b (a b) . 2))
 (test-syntax-error 
  "set!: illegal use of signature name"
@@ -142,23 +142,23 @@
    (define-signature a (a))
    (set! a 1)))
 (test-syntax-error 
- "expected syntax matching"
+ "expected signature elements or expected the identifier `extends'"
  (define-signature x y))
 (test-syntax-error 
- "define-signature: expected either an identifier or signature form"
+ "define-signature: expected signature element"
  (define-signature x (1)))
 
 (test-syntax-error 
- "define-signature: bad syntax (illegal use of `.')"
+ "define-signature: expected signature element"
  (define-signature x (a . b)))
 (test-syntax-error 
- "define-signature: unknown signature form"
+ "define-signature: not a signature form"
  (define-signature x ((a))))
 (test-syntax-error 
  "define-signature: not a signature form"
  (define-signature x ((define-signature))))
 (test-syntax-error 
- "define-values: bad variable list"
+ "define-signature: expected signature element"
  (define-signature x ((define-values 1 2))))
 (test-syntax-error 
  "define-signature: expected list of results from signature form, got 1"
@@ -166,7 +166,7 @@
    (define-signature-form (a b) 1)
    (define-signature x ((a 1)))))
 (test-syntax-error 
- "define-signature: unknown signature form"
+ "define-signature: not a signature form"
  (let ()
    (define-signature-form a (lambda (b) (list #'(c d))))
    (define-signature x ((a 1)))

--- a/racket/collects/racket/private/unit-compiletime.rkt
+++ b/racket/collects/racket/private/unit-compiletime.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require syntax/boundmap
+(require racket/syntax
+         syntax/boundmap
          syntax/parse
          "unit-syntax.rkt")
 (require (for-syntax racket/base))
@@ -121,13 +122,13 @@
 ;;                 identifier)
 (define-struct/proc signature (siginfo vars val-defs stx-defs post-val-defs ctcs orig-binder)
   (lambda (_ stx)
-    (parameterize ((error-syntax stx))
+    (parameterize ((current-syntax-context stx))
       (raise-stx-err "illegal use of signature name"))))
 
 ;; (make-signature-form (syntax-object -> any))
 (define-struct/proc signature-form (f)
   (lambda (_ stx)
-    (parameterize ((error-syntax stx))
+    (parameterize ((current-syntax-context stx))
       (raise-stx-err "illegal use of signature form"))))
 
 ;; (make-unit-info identifier (listof (cons symbol identifier)) (listof (cons symbol identifier)) identifier boolean)

--- a/racket/collects/racket/private/unit-contract.rkt
+++ b/racket/collects/racket/private/unit-contract.rkt
@@ -1,10 +1,10 @@
 #lang racket/base
 
 (require (for-syntax racket/base
+                     racket/syntax
                      syntax/boundmap
                      syntax/name
                      syntax/parse
-                     (only-in racket/syntax generate-temporary)
                      "unit-compiletime.rkt"
                      "unit-contract-syntax.rkt"
                      "unit-syntax.rkt")
@@ -80,6 +80,7 @@
 
 (define-for-syntax (unit/c/core name stx)
   (syntax-parse stx
+    #:context (current-syntax-context)
     [(:import-clause/c
       :export-clause/c
       (~optional d:dep-clause #:defaults ([(d.s 1) null]))

--- a/racket/collects/racket/private/unit-runtime.rkt
+++ b/racket/collects/racket/private/unit-runtime.rkt
@@ -1,6 +1,8 @@
 #lang racket/base
 
-(require (for-syntax "unit-syntax.rkt" racket/base))
+(require (for-syntax racket/base
+                     racket/syntax
+                     "unit-syntax.rkt"))
 (provide define-syntax/err-param
          (rename-out [make-a-unit make-unit]) unit-import-sigs unit-export-sigs unit-go unit? unit-deps
          check-unit check-no-imports check-sigs check-deps check-helper)
@@ -9,7 +11,7 @@
   (syntax-rules ()
     ((_ (name arg) body ...)
      (define-syntax (name arg)
-       (parameterize ((error-syntax arg))
+       (parameterize ((current-syntax-context arg))
          body ...)))))
 
 ;; for named structures

--- a/racket/collects/racket/private/unit-syntax.rkt
+++ b/racket/collects/racket/private/unit-syntax.rkt
@@ -1,17 +1,20 @@
 #lang racket/base
 
-(require syntax/stx)
+(require racket/syntax
+         syntax/stx)
 (require (for-template "unit-keywords.rkt"))
   
-(provide (all-defined-out))
+(provide (all-defined-out)
+         (rename-out
+          ;; for mzlib/a-signature
+          [current-syntax-context error-syntax]))
 
 (define bind-at #f)
 
-(define error-syntax (make-parameter #f #f 'error-syntax))
 (define raise-stx-err
   (case-lambda
-    ((msg) (raise-syntax-error #f msg (error-syntax)))
-    ((msg stx) (raise-syntax-error #f msg (error-syntax) stx))))
+    ((msg) (raise-syntax-error #f msg (current-syntax-context)))
+    ((msg stx) (raise-syntax-error #f msg (current-syntax-context) stx))))
 
 ;; check-id: syntax-object -> identifier
 (define (check-id id)

--- a/racket/collects/racket/signature/lang.rkt
+++ b/racket/collects/racket/signature/lang.rkt
@@ -4,6 +4,7 @@
          racket/contract
          (submod racket/unit compat)
          (for-syntax racket/base
+                     racket/syntax
                      racket/private/unit-compiletime
                      racket/private/unit-syntax))
 
@@ -25,7 +26,7 @@
   (split-requires* (list #'require #'#%require)))
 
 (define-syntax (module-begin stx)
-  (parameterize ((error-syntax stx))
+  (parameterize ((current-syntax-context stx))
     (with-syntax ((name (datum->syntax stx
                                        (make-name (syntax-property stx 'enclosing-module-name)))))
       (syntax-case stx ()

--- a/racket/collects/racket/unit-exptime.rkt
+++ b/racket/collects/racket/unit-exptime.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
-(require "private/unit-syntax.rkt"
+(require racket/syntax
+         "private/unit-syntax.rkt"
          "private/unit-compiletime.rkt")
 
 (provide unit-static-signatures
@@ -8,18 +9,18 @@
          signature-members)
 
 (define (unit-static-signatures name err-stx)
-  (parameterize ((error-syntax err-stx))
+  (parameterize ((current-syntax-context err-stx))
     (let ((ui (lookup-def-unit name)))
       (values (apply list (unit-info-import-sig-ids ui))
               (apply list (unit-info-export-sig-ids ui))))))
 
 (define (unit-static-init-dependencies name err-stx)
-  (parameterize ((error-syntax err-stx))
+  (parameterize ((current-syntax-context err-stx))
     (let ((ui (lookup-def-unit name)))
       (unit-info-deps ui))))
 
 (define (signature-members name err-stx)
-  (parameterize ((error-syntax err-stx))
+  (parameterize ((current-syntax-context err-stx))
     (let ([s (lookup-signature name)])
       (define intro
         (make-relative-introducer name


### PR DESCRIPTION
This PR refactors some things in `racket/unit`. There should be **no behavioral changes** aside from some minor alterations to error messages, and the new error messages should be better and more consistent (since they are now generated by `syntax/parse`).

The bulk of the changes are new implementations of `define-signature` and `compound-unit`, which I’ve rewritten to use `syntax/parse`. There are also a couple minor tweaks: I’ve eliminated the `error-syntax` parameter from `racket/private/unit-syntax` in favor of using `current-syntax-context` from `racket/syntax`, and I’ve changed the type of the internal `unit-deps` field to be more consistent with the other unit fields.

One might wonder why I would go to the trouble of making these changes out of the blue, and the answer is that I wanted to make a minor improvement to `define-signature` but found the implementation largely inscrutable. So you can consider this PR mostly a side-effect of me trying to understand the way everything works, and I hope to submit a followup PR with my behavioral changes.