### PR TITLE
racket/unit: refactor many forms to use syntax/parse

### DIFF
--- a/pkgs/racket-test/tests/units/test-unit-contracts.rkt
+++ b/pkgs/racket-test/tests/units/test-unit-contracts.rkt
@@ -634,7 +634,7 @@
   (unit/c (import)
           (export (sig1 [x string?] [x number?]))))
 (test-syntax-error
- "unit/c: unknown signature"
+ "unit/c: expected identifier bound to a signature"
   (unit/c (import faux^) (export)))
 
 (test-contract-error "(definition bad-export@)" "bad-export@" "unit must export signature sig1"
@@ -1057,15 +1057,15 @@
      (unit/c (import) (export) (init-depend a^))))
 
   (test-syntax-error
-   "unit/c: unknown signature"
+   "unit/c: expected identifier bound to a signature"
    (unit/c (import x^) (export) (init-depend)))
 
   (test-syntax-error
-   "unit/c: unknown signature"
+   "unit/c: expected identifier bound to a signature"
    (unit/c (import) (export) (init-depend x^)))
 
   (test-syntax-error
-   "unit/c: unknown signature"
+   "unit/c: expected identifier bound to a signature"
    (unit/c (import) (export x^) (init-depend)))
 
   (void))

--- a/pkgs/racket-test/tests/units/test-unit.rkt
+++ b/pkgs/racket-test/tests/units/test-unit.rkt
@@ -251,10 +251,10 @@
 
 ;; unit syntax errors (without sub-signatures)
 (test-syntax-error 
- "unit: bad import spec"
+ "unit: expected tagged import spec"
  (unit (import 1) (export)))
 (test-syntax-error 
- "unit: bad export spec"
+ "unit: expected tagged export spec"
  (unit (import) (export 1)))
 (test-syntax-error 
  "unit: unknown signature"
@@ -263,10 +263,10 @@
  "unit: unknown signature"
  (unit (import) (export a)))
 (test-syntax-error 
- "unit: tag must be a symbol"
+ "unit: expected identifier"
  (unit (import (tag 1 empty-sig)) (export)))
 (test-syntax-error 
- "unit: tag must be a symbol"
+ "unit: expected identifier"
  (unit (import) (export (tag 'a empty-sig))))
 (test-syntax-error 
  "define-values: bad syntax (has 0 parts after keyword)"
@@ -1243,7 +1243,7 @@
  "unit-from-context: nothing is permitted after export-spec"
  (unit-from-context s1 . s2))
 (test-syntax-error 
- "unit-from-context: bad export spec"
+ "unit-from-context: expected tagged export spec"
  (unit-from-context 1))
 
 (test-syntax-error 
@@ -1262,7 +1262,7 @@
  "define-unit-from-context: nothing is permitted after export-spec"
  (define-unit-from-context n s1 . s2))
 (test-syntax-error 
- "define-unit-from-context: bad export spec"
+ "define-unit-from-context: expected tagged export spec"
  (define-unit-from-context n 1))
 
 
@@ -1585,7 +1585,7 @@
   (define-values/invoke-unit/infer (export x-sig) v)
   x)
 (test-syntax-error 
- "define-values/invoke-unit/infer: no subunit exports signature y-sig"
+ "define-values/invoke-unit/infer: no subunit exports signature\n  at: y-sig"
  (define-values/invoke-unit/infer (export y-sig) (link u v)))
 
 (test-runtime-error exn? "x: undefined"
@@ -1593,7 +1593,7 @@
                       (define-values/invoke-unit/infer (export) (link u v))
                       x))
 (test-syntax-error 
- "define-values/invoke-unit/infer: no subunit exports signature y-sig"
+ "define-values/invoke-unit/infer: no subunit exports signature\n  at: y-sig"
  (define-values/invoke-unit/infer (export y-sig) v))
 (test-runtime-error exn?
                     "x: undefined"
@@ -2233,3 +2233,24 @@
   (define a1 1)
   (define a2 2)
   (test 1 (invoke-unit v (import a2^))))
+
+;; Test `invoke-unit` that imports a signature containing `struct` form
+(let ()
+  (define-signature point-struct^
+    [(struct point (x y))])
+  (define-signature point-ops^
+    [points-add])
+
+  (define-unit point-ops@
+    (import point-struct^)
+    (export point-ops^)
+    (define (points-add a b)
+      (point (+ (point-x a) (point-x b))
+             (+ (point-y a) (point-y b)))))
+
+  (let ()
+    (struct point (x y) #:transparent)
+    (define-values/invoke-unit point-ops@
+      (import point-struct^)
+      (export point-ops^))
+    (test (point 4 6) (points-add (point 1 2) (point 3 4)))))

--- a/racket/collects/racket/private/unit-keywords.rkt
+++ b/racket/collects/racket/private/unit-keywords.rkt
@@ -1,7 +1,7 @@
 #lang racket/base
 (require (for-syntax racket/base))
 
-(provide only except prefix rename tag
+(provide only except bind-at prefix rename tag
          import export init-depend link
          extends contracted)
 
@@ -18,6 +18,8 @@
   "misuse of unit import keyword")
 (define-syntax-for-error except
   "misuse of unit import keyword")
+(define-syntax-for-error bind-at
+  "misuse of unit import and export keyword")
 (define-syntax-for-error prefix
   "misuse of unit import and export keyword")
 (define-syntax-for-error rename

--- a/racket/collects/racket/private/unit-syntax.rkt
+++ b/racket/collects/racket/private/unit-syntax.rkt
@@ -9,8 +9,6 @@
           ;; for mzlib/a-signature
           [current-syntax-context error-syntax]))
 
-(define bind-at #f)
-
 (define raise-stx-err
   (case-lambda
     ((msg) (raise-syntax-error #f msg (current-syntax-context)))


### PR DESCRIPTION
This PR significantly overhauls some of the key internal logic of `racket/unit`. As with its predecessor, #4543, there should be **no behavioral changes** aside from some minor alterations to error messages. The changes can be summarized as follows:

  1. The code that handles processing of unit imports and exports has been restructured to represent parsed imports and exports as compile-time `signature` structures rather than as 5-element lists. This makes code that manipulates these values significantly easier to read, as it is no longer filled with uses of `cadddr`.

  2. Parsing and processing of imports, exports, and init dependencies is handled by syntax classes that provide a variety of convenience attributes, which reduces the need for procedural syntax manipulation in many places.

  3. The `unit`, `unit/new-import-export`, `invoke-unit`, `invoke-unit/infer`, `define-values/invoke-unit`, `build-unit-from-context`, `provide-signature-elements`, and `open` forms have been updated to use `syntax/parse`. (Some other unit forms continue to use `syntax-case`, but many of them also share the bulk of their implementation with the forms mentioned above.)

The first of the above points was really my main goal, and the other two were just necessary improvements along that path. I think the more structured representation is significantly easier to understand and should also be much easier to change.