### PR TITLE
license: add LLVM Project to credits

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -57,6 +57,13 @@ The following are used in all Racket executables:
   expression editor, like the rest of Chez Scheme, is licensed under the
   Apache License, version 2.0.
 
+* Startup path support from LLVM
+  The implementation of the C API function racket_get_self_exe_path in
+  Racket CS and related internal functions in Racket BC includes code
+  from the LLVM Project, which is licensed under the Apache License,
+  version 2.0, with LLVM exceptions. Code adapted from the LLVM Project
+  can be found in "racket/src/start/self_exe.inc".
+
 The following are used in all Racket executables for Windows:
 
 * MemoryModule
@@ -167,8 +174,8 @@ Public License with Autoconf exception; however, these files are not
 installed with Racket.
 
 Finally, this Git repository also contains (in the "racket-benchmarks"
-package) the following benchmarks based third-party code which are not
-part of the standard Racket distribution:
+package) the following benchmarks based on third-party code which are
+not part of the standard Racket distribution:
 
 * psyntax (Portable implementation of syntax-case)
   By R. Kent Dybvig, Oscar Waddell, Bob Hieb, and Carl Bruggeman

--- a/pkgs/racket-index/scribblings/main/license.scrbl
+++ b/pkgs/racket-index/scribblings/main/license.scrbl
@@ -132,6 +132,16 @@ The following are used in all Racket executables:
   The expression editor, like the rest of Chez Scheme, is licensed
   under the Apache License, version 2.0.
  }
+  @item{
+  Startup path support from LLVM @(linebreak)
+  The implementation of the C API function
+  @seclink[#:indirect? #t #:doc '(lib "scribblings/inside/inside.scrbl") "cs-self-exe"]{
+   @racketplainfont{racket_get_self_exe_path}} in Racket CS and related internal
+  functions in Racket BC includes code from the LLVM Project, which is licensed
+  under the Apache License, version 2.0, with
+  @hyperlink["https://spdx.org/licenses/LLVM-exception.html"]{LLVM exceptions}.
+  @when-repo{Code adapted from the LLVM Project can be found in @src-filepath{start/self_exe.inc}.}
+ }
  ]
 
 The following are used in all Racket executables for Windows:
@@ -291,7 +301,7 @@ with each package for information about the applicable licenses.
 @(if (eq? 'root mode)
      @list{
  Finally, this Git repository also contains (in the @racket["racket-benchmarks"]
- package) the following benchmarks based third-party code which are not part of
+ package) the following benchmarks based on third-party code which are not part of
  the standard Racket distribution:
 
  @itemlist[

--- a/racket/src/LICENSE.txt
+++ b/racket/src/LICENSE.txt
@@ -56,6 +56,13 @@ The following are used in all Racket executables:
   editor, like the rest of Chez Scheme, is licensed under the Apache
   License, version 2.0.
 
+* Startup path support from LLVM
+  The implementation of the C API function racket_get_self_exe_path in
+  Racket CS and related internal functions in Racket BC includes code
+  from the LLVM Project, which is licensed under the Apache License,
+  version 2.0, with LLVM exceptions. Code adapted from the LLVM Project
+  can be found in "start/self_exe.inc".
+
 The following are used in all Racket executables for Windows:
 
 * MemoryModule


### PR DESCRIPTION
This is a follow-up to commit 5983026fe3cad6616dedb79dd4970d1b5aa1c6f2, which improved the function to find the current executable using code from LLVM on some platforms.

Related to https://github.com/racket/racket/issues/4483

----

I expect this is much too late for v8.8, but I'll ping @jbclements in case it seems trivial enough. (I've been almost completely offline for the last few weeks.)