### PR TITLE
Support multiple values in stream-cons + use stream-cons in stream operations

### DIFF
--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -344,16 +344,16 @@
   (let ()
     (define-values (xs cpu real gc) (time-apply (λ () e) '()))
     (when (run-unreliable-tests? 'timing)
-      (test #t < real 500))
+      (test #t < real 100))
     (apply values xs)))
 
 (let ()
   (define st
-    (for/stream ([i 10000001])
-      (modulo i 10000000)))
+    (for/stream ([i (in-naturals)])
+      (modulo i 2000000)))
   (define st* (terminate-quickly (stream-filter zero? st))) ; should be fast
   (terminate-quickly (stream-rest st*)) ; should be fast
-  (test 0 stream-first (stream-rest st*)) ; should take time
+  (time (test 0 stream-first (stream-rest st*))) ; should take time
   (test 0 'stream-filter (terminate-quickly (stream-first (stream-rest st*)))) ; should be fast
   )
 

--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -344,13 +344,13 @@
   (let ()
     (define-values (xs cpu real gc) (time-apply (λ () e) '()))
     (when (run-unreliable-tests? 'timing)
-      (test #t < real 100))
+      (test #t < real 50))
     (apply values xs)))
 
 (let ()
   (define st
     (for/stream ([i (in-naturals)])
-      (modulo i 2000000)))
+      (modulo i 1000000)))
   (define st* (terminate-quickly (stream-filter zero? st))) ; should be fast
   (terminate-quickly (stream-rest st*)) ; should be fast
   (time (test 0 stream-first (stream-rest st*))) ; should take time
@@ -359,7 +359,7 @@
 
 (let ()
   (define s (stream-cons 0 s))
-  (define t (stream-filter (λ (x) (sleep 2) #t) s))
+  (define t (stream-filter (λ (x) (sleep 0.5) #t) s))
   (test 0 stream-first t)
   (test 0 'stream-filter (terminate-quickly (stream-first t))))
 

--- a/pkgs/racket-test-core/tests/racket/stream.rktl
+++ b/pkgs/racket-test-core/tests/racket/stream.rktl
@@ -220,10 +220,175 @@
 (test #t 'stream (match '() [(stream) #t]))
 (test 1 'stream (match '(1) [(stream x) x]))
 (test 3 'stream (match '(1 2) [(stream x y) (+ x y)]))
+(test '(0 1 1 2) 'stream
+      (match (for/stream ([i 2])
+               (values i (add1 i)))
+        [(stream (values a b) (values c d)) (list a b c d)]))
 (test '(1 2) 'stream* (match '(1 2) [(stream* xs) xs]))
 (test 1 'stream* (match '(1 2) [(stream* hd _) hd]))
 (test '(2) 'stream* (match '(1 2) [(stream* _ tl) tl]))
 (test -1 'stream* (match '(1 2 3 4) [(stream* x y tl) (- x y)]))
 (test '(3 4) 'stream* (match '(1 2 3 4) [(stream* x y tl) tl]))
+(test '(0 1 1 2 #t) 'stream*
+      (match (for/stream ([i 2])
+               (values i (add1 i)))
+        [(stream* (values a b) (values c d) tl) (list a b c d (stream-empty? tl))]))
+
+;; constructors with multiple values
+(test '((1 2))
+      'stream-cons
+      (for/list ([(a b) (stream-cons (values 1 2) empty-stream)])
+        (list a b)))
+
+(test '((1 2))
+      'stream-cons
+      (for/list ([(a b) (stream-cons #:eager (values 1 2) empty-stream)])
+        (list a b)))
+
+(test '((1 2))
+      'stream-cons
+      (for/list ([(a b) (stream-cons (values 1 2) #:eager empty-stream)])
+        (list a b)))
+
+(test '((1 2))
+      'stream-cons
+      (for/list ([(a b) (stream-cons #:eager (values 1 2) #:eager empty-stream)])
+        (list a b)))
+
+(test '((1 2) (3 4))
+      'stream
+      (for/list ([(a b) (stream (values 1 2) (values 3 4))])
+        (list a b)))
+
+(test '((1 2) (3 4))
+      'stream*
+      (for/list ([(a b) (stream* (values 1 2) (stream (values 3 4)))])
+        (list a b)))
+
+(test '((0 1) (1 2))
+      'for/stream
+      (for/list ([(a b) (for/stream ([i 2]) (values i (add1 i)))])
+        (list a b)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; testing lazy operation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; stream-map
+(let ()
+  (define t (stream-cons 0 t))
+  (define s (stream-filter negative? t))
+  (test #t stream? (stream-map add1 s)))
+
+;; stream-filter
+(let ()
+  (define t (stream-cons 0 t))
+  (define s (stream-filter negative? t))
+  (test #t stream? (stream-filter positive? s)))
+
+(let ()
+  (define val #f)
+  (define st
+    (stream-cons 1
+                 (begin
+                   (set! val #t)
+                   empty-stream)))
+
+  (stream-first st)
+  (test #f 'stream-cons val)
+
+  (define st* (stream-filter (lambda (x) #t) st))
+  (stream-first st*)
+  (test #f 'stream-filter val))
+
+
+;; stream-take
+(let ()
+  (define t (stream-cons 0 t))
+  (define s (stream-filter negative? t))
+  (test #t stream? (stream-take s 10)))
+
+;; stream-append
+(let ()
+  (define t (stream-cons 0 t))
+  (define s (stream-filter negative? t))
+  (test #t stream? (stream-append s s)))
+
+;; stream-add-between
+(let ()
+  (define t (stream-cons 0 t))
+  (define s (stream-filter negative? t))
+  (test #t stream? (stream-add-between s 1)))
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; testing memoizing operation
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+;; stream-map
+(let ()
+  (define acc 0)
+  (define (f x y)
+    (set! acc (add1 acc))
+    (values (+ 1 x) (+ 2 y)))
+  (define t (stream-cons (values 0 1) t))
+  (define s (stream-map f t))
+  (test '(1 3) call-with-values (λ () (stream-first s)) list)
+  (test '(1 3) call-with-values (λ () (stream-first s)) list)
+  (test 1 'stream-map acc)
+  (test '(1 3) call-with-values (λ () (stream-first (stream-rest s))) list)
+  (test '(1 3) call-with-values (λ () (stream-first (stream-rest s))) list)
+  (test 2 'stream-map acc))
+
+;; stream-filter
+(define-syntax-rule (terminate-quickly e)
+  (let ()
+    (define-values (xs cpu real gc) (time-apply (λ () e) '()))
+    (when (run-unreliable-tests? 'timing)
+      (test #t < real 500))
+    (apply values xs)))
+
+(let ()
+  (define st
+    (for/stream ([i 10000001])
+      (modulo i 10000000)))
+  (define st* (terminate-quickly (stream-filter zero? st))) ; should be fast
+  (terminate-quickly (stream-rest st*)) ; should be fast
+  (test 0 stream-first (stream-rest st*)) ; should take time
+  (test 0 'stream-filter (terminate-quickly (stream-first (stream-rest st*)))) ; should be fast
+  )
+
+(let ()
+  (define s (stream-cons 0 s))
+  (define t (stream-filter (λ (x) (sleep 2) #t) s))
+  (test 0 stream-first t)
+  (test 0 'stream-filter (terminate-quickly (stream-first t))))
+
+;; constant space (adapted from an example by Jacob J. A. Koot)
+;; https://racket.discourse.group/t/stream-filter-not-in-constant-space/1643
+(let ()
+  (define boxes '())
+
+  (define (gc!)
+    (collect-garbage)
+    (collect-garbage)
+    (collect-garbage)
+    (set! boxes (filter weak-box-value boxes))
+    (test #t <= (length boxes) 1))
+
+  (define (pred x)
+    (zero? (remainder x 10)))
+
+  (define (make-nats n)
+    (stream-cons n
+                 (let ()
+                   (define s (make-nats (add1 n)))
+                   (set! boxes (cons (make-weak-box s) boxes))
+                   s)))
+
+  (for/fold ([nats (make-nats 0)])
+            ([i 5])
+    (gc!)
+    (stream-rest (stream-filter pred nats)))
+  (gc!))
 
 (report-errs)

--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -1345,7 +1345,7 @@
 
   (define (sequence->stream s)
     (unless (sequence? s)
-      (raise-argument-error 'sequence-generate "sequence?" s))
+      (raise-argument-error 'sequence->stream "sequence?" s))
     (cond
       [(stream? s) s]
       [else

--- a/racket/collects/racket/stream.rkt
+++ b/racket/collects/racket/stream.rkt
@@ -13,7 +13,9 @@
          (only-in "private/stream-cons.rkt"
                   stream-cons
                   stream-lazy
-                  stream-force)
+                  stream-force
+                  unpack-multivalue
+                  thunk->multivalue)
          "private/generic-methods.rkt"
          (for-syntax racket/base))
 
@@ -69,8 +71,12 @@
                      (list #t #t #t)))
 
 (define-match-expander stream
-  (syntax-rules ()
+  (syntax-rules (values)
     [(_) (? stream-empty?)]
+    [(_ (values hd ...) tl ...)
+     (? stream-cons?
+        (app stream-first hd ...)
+        (app stream-rest (stream tl ...)))]
     [(_ hd tl ...)
      (? stream-cons?
         (app stream-first hd)
@@ -85,8 +91,12 @@
      (stream-cons hd (stream tl ...)))))
 
 (define-match-expander stream*
-  (syntax-rules ()
+  (syntax-rules (values)
     [(_ tl) (? stream? tl)]
+    [(_ (values hd ...) tl ...)
+     (? stream-cons?
+        (app stream-first hd ...)
+        (app stream-rest (stream* tl ...)))]
     [(_ hd tl ...)
      (? stream-cons?
         (app stream-first hd)
@@ -139,38 +149,38 @@
     (raise-argument-error 'stream-tail "exact-nonnegative-integer?" i))
   (let loop ([n i] [s st])
     (cond
-     [(zero? n) s]
-     [(stream-empty? s)
-      (raise-arguments-error 'stream-tail
-                             "stream ended before index"
-                             "index" i
-                             ;; See "Why `"stream" st` is omitted" above
-                             #;"stream" #;st)]
-     [else
-      (loop (sub1 n) (stream-rest s))])))
+      [(zero? n) s]
+      [(stream-empty? s)
+       (raise-arguments-error 'stream-tail
+                              "stream ended before index"
+                              "index" i
+                              ;; See "Why `"stream" st` is omitted" above
+                              #;"stream" #;st)]
+      [else
+       (loop (sub1 n) (stream-rest s))])))
 
 (define (stream-take st i)
   (unless (stream? st) (raise-argument-error 'stream-take "stream?" st))
   (unless (exact-nonnegative-integer? i)
     (raise-argument-error 'stream-take "exact-nonnegative-integer?" i))
-  (let loop ([n i] [s st])
-    (cond
-     [(zero? n) empty-stream]
-     [(stream-empty? s)
-      (raise-arguments-error 'stream-take
-                             "stream ended before index"
-                             "index" i
-                             ;; See "Why `"stream" st` is omitted" above
-                             #;"stream" #;st)]
-     [else
-      (make-do-stream (lambda () #f)
-                      (lambda () (stream-first s))
-                      (lambda () (loop (sub1 n) (stream-rest s))))])))
+  (stream-lazy
+   (let loop ([n i] [s st])
+     (cond
+       [(zero? n) empty-stream]
+       [(stream-empty? s)
+        (raise-arguments-error 'stream-take
+                               "stream ended before index"
+                               "index" i
+                               ;; See "Why `"stream" st` is omitted" above
+                               #;"stream" #;st)]
+       [else
+        (stream-cons (stream-first s)
+                     (loop (sub1 n) (stream-rest s)))]))))
 
 (define (stream-append . l)
   (for ([s (in-list l)])
     (unless (stream? s) (raise-argument-error 'stream-append "stream?" s)))
-  (streams-append l))
+  (stream-lazy (streams-append l)))
 
 (define (streams-append l)
   (cond
@@ -178,19 +188,18 @@
    [(null? (cdr l)) (car l)]
    [(stream-empty? (car l)) (streams-append (cdr l))]
    [else
-    (make-do-stream (lambda () #f)
-                    (lambda () (stream-first (car l)))
-                    (lambda () (streams-append (cons (stream-rest (car l)) (cdr l)))))]))
+    (stream-cons (stream-first (car l))
+                 (streams-append (cons (stream-rest (car l)) (cdr l))))]))
 
 (define (stream-map f s)
   (unless (procedure? f) (raise-argument-error 'stream-map "procedure?" f))
   (unless (stream? s) (raise-argument-error 'stream-map "stream?" s))
-  (let loop ([s s])
-    (if (stream-empty? s)
-        empty-stream
-        (make-do-stream (lambda () #f)
-                        (lambda () (call-with-values (lambda () (stream-first s)) f))
-                        (lambda () (loop (stream-rest s)))))))
+  (stream-lazy
+   (let loop ([s s])
+     (cond
+       [(stream-empty? s) empty-stream]
+       [else (stream-cons (call-with-values (λ () (stream-first s)) f)
+                          (loop (stream-rest s)))]))))
 
 (define (stream-andmap f s)
   (unless (procedure? f) (raise-argument-error 'stream-andmap "procedure?" f))
@@ -220,47 +229,32 @@
 (define (stream-filter f s)
   (unless (procedure? f) (raise-argument-error 'stream-filter "procedure?" f))
   (unless (stream? s) (raise-argument-error 'stream-filter "stream?" s))
-  (cond
-   [(stream-empty? s) empty-stream]
-   [else
-    (let ([done? #f]
-          [empty? #f]
-          [stream-cons/fst #f]
-          [rst #f])
-      (define (force!)
-        (unless done?
-          (let loop ([s s])
-            (cond
-             [(stream-empty? s)
-              (set! done? #t)
-              (set! empty? #t)]
-             [(call-with-values (lambda () (stream-first s)) f)
-              (set! stream-cons/fst s)
-              (set! rst (stream-filter f (stream-rest s)))]
-             [else (loop (stream-rest s))]))
-          (set! done? #t)))
-      (make-do-stream (lambda () (force!) empty?)
-                      (lambda () (force!) (stream-first stream-cons/fst))
-                      (lambda () (force!) rst)))]))
+  (stream-lazy
+   (let loop ([s s])
+     (cond
+       [(stream-empty? s) empty-stream]
+       [(call-with-values (λ () (stream-first s)) f)
+        (define v (thunk->multivalue (λ () (stream-first s))))
+        (stream-cons (unpack-multivalue v)
+                     (loop (stream-rest s)))]
+       [else (loop (stream-rest s))]))))
 
 (define (stream-add-between s e)
   (unless (stream? s)
     (raise-argument-error 'stream-add-between "stream?" s))
-  (if (stream-empty? s)
-      empty-stream
-      (make-do-stream
-       (lambda () #f)
-       (lambda () (stream-first s))
-       (lambda ()
-         (let loop ([s (stream-rest s)])
-           (cond
-             [(stream-empty? s) empty-stream]
-             [else
-              (stream-cons e
-                           (make-do-stream
-                            (lambda () #f)
-                            (lambda () (stream-first s))
-                            (lambda () (loop (stream-rest s)))))]))))))
+  (stream-lazy
+   (cond
+     [(stream-empty? s) empty-stream]
+     [else
+      (stream-cons
+       (stream-first s)
+       (let loop ([s (stream-rest s)])
+         (cond
+           [(stream-empty? s) empty-stream]
+           [else
+            (stream-cons e
+                         (stream-cons (stream-first s)
+                                      (loop (stream-rest s))))])))])))
 
 ;; Impersonators and Chaperones ----------------------------------------------------------------------
 ;; (these are private because they would fail on lists, which satisfy `stream?`)


### PR DESCRIPTION
This PR supports multiple values in `stream-cons`. As a result, `stream`, `stream*`, and `for/stream` also support multiple values.

`stream` and `stream*` patterns are also adjusted to allow matching against multiple-valued elements.

We then switch stream operations which need to handle multiple values to use `stream-cons`, both simplifying the implementation and making these operations properly memoizing at the same time. The switch also fixes the non-constant space problem raised in https://racket.discourse.group/t/stream-filter-not-in-constant-space/1643.