### PR TITLE
match: speed up vector pattern matching with one ddk

### DIFF
--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -473,6 +473,27 @@
       (match vec
         [(vector a _ ..7) (if (equal? (s:mutable-set 0) touched-indices) 'ok 'fail)])))
 
+   (comp
+    '(12 14 24 26)
+    (let ()
+      (define vec (vector 12 14 16 18 20 22 24 26))
+      (match vec
+        [(vector a b _ ... c d) (list a b c d)])))
+
+   (comp
+    '(12 14)
+    (let ()
+      (define vec (vector 12 14 16 18 20 22 24 26))
+      (match vec
+        [(vector a b _ ...) (list a b)])))
+
+   (comp
+    '(24 26)
+    (let ()
+      (define vec (vector 12 14 16 18 20 22 24 26))
+      (match vec
+        [(vector _ ... c d) (list c d)])))
+
    (comp 1
          (match #&1
            [(box a) a]

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -107,14 +107,20 @@
      (let-values ([(prefix suffix ddk-size) (split-one-wildcard-ddk (syntax->list #'(es ...)))])
        (define prefix-len (length prefix))
        (define suffix-len (length suffix))
-       (trans-match
-        #`(λ (e) (and (vector? e) (>= (vector-length e) #,(+ prefix-len suffix-len ddk-size))))
-        #`(λ (e)
-            (define vec-len (vector-length e))
-            (for/list ([idx (in-sequences (in-range #,prefix-len)
-                                          (in-range (- vec-len #,suffix-len) vec-len))])
-              (unsafe-vector-ref e idx)))
-        (rearm+parse (quasisyntax/loc stx (list #,@prefix #,@suffix)))))]
+       (define pre+suf-len (+ prefix-len suffix-len))
+       (trans-match*
+        (list #`(λ (e)
+                  (and (vector? e)
+                       (>= (vector-length e) #,(+ pre+suf-len ddk-size)))))
+        (for/list ([idx (in-range pre+suf-len)])
+          #`(λ (e)
+              (define vec-len (vector-length e))
+              (unsafe-vector-ref
+               e
+               #,(if (< idx prefix-len)
+                     idx
+                     #`(- (+ #,idx vec-len) #,pre+suf-len)))))
+        (map parse (append prefix suffix))))]
     [(vector es ...)
      (ormap ddk? (syntax->list #'(es ...)))
      (trans-match #'vector?


### PR DESCRIPTION
`in-sequences` has a very high overhead.
Switch to computing index in the loop instead.

Consider:

```

(define a (vector 1 2 3 4 5 6 7))
(define b (list 1 2 3 4 5 6 7))
(for ([times '(#e1e5 #e1e6 #e1e7)])
  (println times)
  (time (for ([i (in-range times)]) (match a [(vector a b c _ ...)  (+ a b c)])))
  (time (for ([i (in-range times)]) (match b [(list a b c _ ...)  (+ a b c)]))))
```

Before the PR, it produces:

```
100000
cpu time: 75 real time: 78 gc time: 29
cpu time: 0 real time: 0 gc time: 0
1000000
cpu time: 444 real time: 457 gc time: 3
cpu time: 8 real time: 9 gc time: 0
10000000
cpu time: 4427 real time: 4556 gc time: 31
cpu time: 89 real time: 91 gc time: 0
```

After the PR, it produces:

```
100000
cpu time: 0 real time: 0 gc time: 0
cpu time: 0 real time: 0 gc time: 0
1000000
cpu time: 2 real time: 2 gc time: 0
cpu time: 8 real time: 9 gc time: 0
10000000
cpu time: 24 real time: 25 gc time: 0
cpu time: 88 real time: 90 gc time: 0
```