### PR TITLE
Fix contracts for generate-temporaries

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-ops.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-ops.scrbl
@@ -376,8 +376,7 @@ If @racket[shift] is @racket[0], then the result is @racket[stx].}
 
 Returns a list of identifiers that are distinct from all other
 identifiers. The list contains as many identifiers as
-@racket[v] contains elements. The @racket[v] argument
-must be a value that can be flattened into a list (satisfying @racket[stx-list?]).
+@racket[v] contains elements.
 The elements of @racket[v] can be anything, but string, symbol, keyword
 (possibly wrapped as syntax), and identifier elements will be embedded
 in the corresponding generated name, which is useful for debugging

--- a/pkgs/racket-doc/scribblings/reference/stx-ops.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-ops.scrbl
@@ -1,6 +1,7 @@
 #lang scribble/doc
 @(require "mz.rkt"
-          (for-label racket/syntax-srcloc))
+          (for-label racket/syntax-srcloc
+                     (only-in syntax/stx stx-list?)))
 
 @(define stx-eval (make-base-eval))
 @(stx-eval '(require (for-syntax racket/base)))
@@ -370,14 +371,14 @@ at @tech{phase level} 0 are shifted to the @tech{label phase level}.
 If @racket[shift] is @racket[0], then the result is @racket[stx].}
 
 
-@defproc[(generate-temporaries [stx-pair (or syntax? list?)]) 
+@defproc[(generate-temporaries [v stx-list?])
          (listof identifier?)]{
 
 Returns a list of identifiers that are distinct from all other
 identifiers. The list contains as many identifiers as
-@racket[stx-pair] contains elements. The @racket[stx-pair] argument
-must be a syntax pair that can be flattened into a list. The elements
-of @racket[stx-pair] can be anything, but string, symbol, keyword
+@racket[v] contains elements. The @racket[v] argument
+must be a value that can be flattened into a list (satisfying @racket[stx-list?]).
+The elements of @racket[v] can be anything, but string, symbol, keyword
 (possibly wrapped as syntax), and identifier elements will be embedded
 in the corresponding generated name, which is useful for debugging
 purposes.

--- a/racket/collects/racket/private/with-stx.rkt
+++ b/racket/collects/racket/private/with-stx.rkt
@@ -76,7 +76,7 @@
     (unless (stx-list? sl)
       (raise-argument-error 
        'generate-temporaries
-       "(or/c list? syntax->list)"
+       "stx-list?"
        sl))
     (let ([l (stx->list sl)])
       (map (lambda (x) 


### PR DESCRIPTION
I avoid using the name stx-pair, since many non syntax pairs, like a regular list or an empty syntax list, are also acceptable.