### PR TITLE
fix random docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -928,7 +928,7 @@ both in binary and as integers.
                     [max (integer-in (+ 1 min) (+ 4294967087 min))]
                     [rand-gen pseudo-random-generator?
                               (current-pseudo-random-generator)])
-            exact-nonnegative-integer?]
+            exact-integer?]
            [(random [rand-gen pseudo-random-generator?
                               (current-pseudo-random-generator)])
             (and/c real? inexact? (>/c 0) (</c 1))])]{


### PR DESCRIPTION
The result of `(random -20 -10)` is a negative number.