### PR TITLE
ci: fix warnings

### DIFF
--- a/.github/workflows/chez-build.yml
+++ b/.github/workflows/chez-build.yml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y make git gcc
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: 50
       - name: Download pb boot files

--- a/.github/workflows/ci-asan.yml
+++ b/.github/workflows/ci-asan.yml
@@ -15,7 +15,7 @@ jobs:
       ASAN_OPTIONS: 'halt_on_error=0,log_path=racket-asan'
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Create logs directory
@@ -83,7 +83,7 @@ jobs:
     - name: Run db tests
       continue-on-error: true
       run: raco test -l tests/db/all-tests
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: asan-errors-cs_git${{ github.sha }}
         path: ./racket-asan.*

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: make CPUS=$(nproc) PKGS="racket-test db-test unstable-flonum-lib net-test"
     - name: Test
@@ -45,7 +45,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build
       run: make CPUS=$(sysctl -n hw.physicalcpu) PKGS="racket-test db-test unstable-flonum-lib net-test"
     - name: Test
@@ -71,7 +71,7 @@ jobs:
         raco test -c tests/syntax
     - name: Tarball
       run: tar -cvjf racketcs-macos-x64_git${{ github.sha }}.tar.bz2 racket
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racketcs-macos-x64_git${{ github.sha }}
         path: racketcs-macos-x64_git${{ github.sha }}.tar.bz2
@@ -80,8 +80,8 @@ jobs:
     runs-on: macos-latest
     needs: buildtest-macos
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/download-artifact@v2
+    - uses: actions/checkout@v3
+    - uses: actions/download-artifact@v3
       with:
         name: racketcs-macos-x64_git${{ github.sha }}
         path: ${{ github.workspace }}

--- a/.github/workflows/ci-push-x86_linux.yml
+++ b/.github/workflows/ci-push-x86_linux.yml
@@ -19,7 +19,7 @@ jobs:
         cify: [nocify]
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Setup cify if enabled
@@ -54,7 +54,7 @@ jobs:
     - name: Tarballing
       working-directory: /usr/local
       run: tar -cvjf /tmp/racketcgc-debian10-${{ matrix.cify }}-x64_git${{ github.sha }}.tar.bz2 racketcgc
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racketcgc-debian10-${{ matrix.cify }}-x64_git${{ github.sha }}
         path: /tmp/racketcgc-debian10-${{ matrix.cify }}-x64_git${{ github.sha }}.tar.bz2
@@ -84,7 +84,7 @@ jobs:
             cc: gcc # clang has a problem with future tests timing out
   
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Setup cify if enabled
@@ -105,7 +105,7 @@ jobs:
     - name: Setup efp if disabled
       if: matrix.efp == 'noefp'
       run: echo "EFP_OPTIONS=--disable-extflonums --disable-places --disable-futures" >> $GITHUB_ENV
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: racketcgc-debian10-nocify-x64_git${{ github.sha }}
         path: /tmp
@@ -141,7 +141,7 @@ jobs:
     - name: Tarballing
       working-directory: /usr/local
       run: tar -cvjf /tmp/racket3m-debian10-${{ matrix.cify }}-${{ matrix.jit }}-${{ matrix.efp }}-x64_git${{ github.sha}}.tar.bz2 racket3m
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racket3m-debian10-${{ matrix.cify }}-${{ matrix.jit }}-${{ matrix.efp }}-x64_git${{ github.sha }}
         path: /tmp/racket3m-debian10-${{ matrix.cify }}-${{ matrix.jit }}-${{ matrix.efp }}-x64_git${{ github.sha }}.tar.bz2
@@ -158,10 +158,10 @@ jobs:
       matrix:
         cc: [gcc, clang]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: racketcgc-debian10-nocify-x64_git${{ github.sha }}
         path: /tmp
@@ -193,7 +193,7 @@ jobs:
     - name: Tarballing
       working-directory: /usr/local
       run: tar -cvjf /tmp/racketcs-debian10-x64_git${{ github.sha}}.tar.bz2 racketcs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racketcs-debian10-x64_git${{ github.sha }}
         path: /tmp/racketcs-debian10-x64_git${{ github.sha }}.tar.bz2
@@ -217,8 +217,8 @@ jobs:
         cify: [nocify]
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: racketcgc-debian10-${{ matrix.cify }}-x64_git${{ github.sha }}
           path: /tmp
@@ -300,8 +300,8 @@ jobs:
             cc: gcc
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: racket3m-debian10-${{ matrix.cify }}-${{ matrix.jit }}-${{ matrix.efp }}-x64_git${{ github.sha }}
           path: /tmp
@@ -366,8 +366,8 @@ jobs:
     needs: build-racketcs
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: racketcs-debian10-x64_git${{ github.sha }}
           path: /tmp

--- a/.github/workflows/ci-push_macos.yml
+++ b/.github/workflows/ci-push_macos.yml
@@ -22,7 +22,7 @@ jobs:
       RACKET_EXTRA_CONFIGURE_ARGS: ""
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Setup cify if enabled1
@@ -58,7 +58,7 @@ jobs:
     - name: Tarballing
       working-directory: ${{ github.workspace }}
       run: tar -cvjf racketcgc-macos-${{ matrix.cify }}-x64_git${{ github.sha }}.tar.bz2 racketcgc
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racketcgc-macos-${{ matrix.cify }}-x64_git${{ github.sha }}
         path: ${{ github.workspace }}/racketcgc-macos-${{ matrix.cify }}-x64_git${{ github.sha }}.tar.bz2
@@ -77,7 +77,7 @@ jobs:
       RACKET_EXTRA_CONFIGURE_ARGS: ""
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Setup cify if enabled
@@ -86,7 +86,7 @@ jobs:
     - name: Setup cify if disabled
       if: matrix.cify == 'nocify'
       run: echo "CIFY_OPTION=--disable-cify" >> $GITHUB_ENV
-    - uses: actions/download-artifact@v2
+    - uses: actions/download-artifact@v3
       with:
         name: racketcgc-macos-nocify-x64_git${{ github.sha }}
         path: ${{ runner.temp }}
@@ -123,7 +123,7 @@ jobs:
     - name: Tarballing
       working-directory: ${{ github.workspace }}
       run: tar -cvjf racket3m-macos-${{ matrix.cify }}-x64_git${{ github.sha}}.tar.bz2 racket3m
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racket3m-macos-${{ matrix.cify }}-x64_git${{ github.sha }}
         path: ${{ github.workspace }}/racket3m-macos-${{ matrix.cify }}-x64_git${{ github.sha }}.tar.bz2
@@ -133,7 +133,7 @@ jobs:
     needs: build-racketcgc
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - uses: actions/download-artifact@master
@@ -170,7 +170,7 @@ jobs:
     - name: Tarballing
       working-directory: ${{ github.workspace }}
       run: tar -cvjf racketcs-macos-x64_git${{ github.sha}}.tar.bz2 racketcs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: racketcs-macos-x64_git${{ github.sha }}
         path: ${{ github.workspace }}/racketcs-macos-x64_git${{ github.sha }}.tar.bz2
@@ -179,8 +179,8 @@ jobs:
     runs-on: macos-latest
     needs: build-racketcs
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: racketcs-macos-x64_git${{ github.sha }}
           path: ${{ github.workspace }}
@@ -217,8 +217,8 @@ jobs:
     needs: build-racketcgc
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: racketcgc-macos-${{ matrix.cify }}-x64_git${{ github.sha }}
           path: ${{ github.workspace }}
@@ -284,7 +284,7 @@ jobs:
     needs: build-racket3m
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - uses: actions/download-artifact@master
         with:
           name: racket3m-macos-${{ matrix.cify }}-x64_git${{ github.sha }}
@@ -346,8 +346,8 @@ jobs:
     needs: build-racketcs
 
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/download-artifact@v2
+      - uses: actions/checkout@v3
+      - uses: actions/download-artifact@v3
         with:
           name: racketcs-macos-x64_git${{ github.sha }}
           path: ${{ github.workspace }}

--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -11,7 +11,7 @@ jobs:
     if: github.repository == 'racket/racket'
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 0
 

--- a/.github/workflows/ci_win.yml
+++ b/.github/workflows/ci_win.yml
@@ -24,7 +24,7 @@ jobs:
     #   Version: VisualStudio/16.3.6+29418.71
     #   Location: C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Build 3m
       if: matrix.mode == '3m'
       shell: cmd

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
       with:
         # We must fetch at least the immediate parents so that if this is
         # a pull request then we can checkout the head.

--- a/.github/workflows/docker-racketci.yml
+++ b/.github/workflows/docker-racketci.yml
@@ -20,7 +20,7 @@ jobs:
       VERSION: ${{ github.sha }}
       
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Build image
         working-directory: ./.github/images
         run: docker build --tag image .

--- a/.github/workflows/scanbuild_static-analysis.yml
+++ b/.github/workflows/scanbuild_static-analysis.yml
@@ -56,7 +56,7 @@ jobs:
       run: |
         find . -type f -name '*.sarif' > list.txt
         split -d -l15 list.txt list.
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: scanbuild-cgc-${{ github.sha }}
         path: sarif-files/
@@ -118,7 +118,7 @@ jobs:
       run: |
         find . -type f -name '*.sarif' > list.txt
         split -d -l15 list.txt list.
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: scanbuild-3m-${{ github.sha }}
         path: sarif-files/
@@ -176,7 +176,7 @@ jobs:
       run: |
         find . -type f -name '*.sarif' > list.txt
         split -d -l15 list.txt list.
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: scanbuild-cs-${{ github.sha }}
         path: sarif-files/
@@ -202,9 +202,9 @@ jobs:
       run: |
         if [[ -e "list.${{ matrix.chunks }}" ]]
         then
-          echo "::set-output name=presence::1"
+          echo "presence=1" >> $GITHUB_OUTPUT
         else
-          echo "::set-output name=presence::0"
+          echo "presence=0" >> $GITHUB_OUTPUT
         fi
     - name: Partition the chunk
       if: ${{ steps.chunk_presence.outputs.presence == '1' }}

--- a/.github/workflows/scribble_build-guide.yml
+++ b/.github/workflows/scribble_build-guide.yml
@@ -17,7 +17,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Bogdanp/setup-racket@v1.5
       with:
         architecture: 'x64'
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Bogdanp/setup-racket@v1.5
       with:
         architecture: 'x64'

--- a/.github/workflows/scribble_license.yml
+++ b/.github/workflows/scribble_license.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Bogdanp/setup-racket@v1.5
       with:
         architecture: 'x64'
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-22.04
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: Bogdanp/setup-racket@v1.5
       with:
         architecture: 'x64'

--- a/.github/workflows/ubsan-x86.yml
+++ b/.github/workflows/ubsan-x86.yml
@@ -14,7 +14,7 @@ jobs:
     container: racket/racket-ci:latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Create logs directory
@@ -86,7 +86,7 @@ jobs:
       run: |
         grep 'runtime error' logs/*.log > runtime-errors_git${{ github.sha }}.log || true
         test ! -s runtime-errors_git${{ github.sha }}.log
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       with:
         name: runtime-errors_git${{ github.sha }}
         path: runtime-errors_git${{ github.sha }}.log
@@ -96,7 +96,7 @@ jobs:
     container: racket/racket-ci:latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         fetch-depth: 100
     - name: Create logs directory
@@ -168,7 +168,7 @@ jobs:
       run: |
         grep 'runtime error' logs/*.log > runtime-errors-cs_git${{ github.sha }}.log || true
         test ! -s runtime-errors_git${{ github.sha }}.log
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v3
       if: failure()
       with:
         name: runtime-errors-cs_git${{ github.sha }}


### PR DESCRIPTION
The first change is to use $GITHUB_OUTPUT instead of `set-output`, following this instruction:

```
The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```

The second change is to upgrade several @v2s to @v3s, following this instruction:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/download-artifact@v2, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.
```