### PR TITLE
match: make duplicate hash keys always fail

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -435,6 +435,11 @@ may evaluate expressions embedded in patterns such as @racket[(#,(racketidfont
 "app") expr pat)] in arbitrary order, or multiple times.  Therefore, such
 expressions must be safe to call multiple times, or in an order other than they
 appear in the original program.
+
+@history[
+  #:changed "8.7.0.11"
+  @elem{Adjusted the @racket[hash-table] pattern where the keys are all literals
+        to match against a full hash table value.}]
 }
 
 @; ----------------------------------------------------------------------

--- a/pkgs/racket-test/tests/match/match-tests.rkt
+++ b/pkgs/racket-test/tests/match/match-tests.rkt
@@ -95,7 +95,21 @@
                         [(hash-table ("a" x) ("a" y))
                          (list x y)]
                         [(hash-table _ _) 42])
-                      42))
+                      42)
+
+        (check-equal? (match (hash "a" "b")
+                        [(hash-table ("a" x) ("a" y))
+                         (list x y)]
+                        [(hash-table _) 42])
+                      42)
+        (check-equal? (match (hash "a" "b")
+                        [(hash-table ("a" x) ("a" y))
+                         (list x y)]
+                        [(hash-table _) 42])
+                      (match (hash "a" "b")
+                        [(hash-table ((== "a") x) ("a" y))
+                         (list x y)]
+                        [(hash-table _) 42])))
 
       (test-case "non literal keys"
         (check-equal? (match (hash (list 1 2) 'b (list 3 4) 'd)
@@ -129,7 +143,12 @@
                         [(hash-table a b c) 3]
                         [(hash-table (p 'd) _) p]
                         [(hash-table a b) 4])
-                      (list 3 4)))))
+                      (list 3 4))
+
+        (check-equal? (match (hash 1 2)
+                        [(hash-table (a b) (c d)) 1]
+                        [_ 42])
+                      42))))
 
   (define hash-table-rep-tests
     (test-suite "hash-table patterns (with ..k)"
@@ -149,11 +168,25 @@
                          (list a b)])
                       '(4 6))
 
-        ;; Duplicate keys are fine
+        ;; Duplicate keys
         (check-equal? (match (hash 1 2 3 4 5 6)
                         [(hash-table (3 a) (3 b) _ ...)
-                         (list a b)])
-                      '(4 4))
+                         (list a b)]
+                        [_ 42])
+                      42)
+        (check-equal? (match (hash 1 2 3 4 5 6)
+                        [(hash-table (3 a) (3 b) _ ...)
+                         (list a b)]
+                        [_ 42])
+                      (match (hash 1 2 3 4 5 6)
+                        [(hash-table ((== 3) a) (3 b) _ ...)
+                         (list a b)]
+                        [_ 42]))
+        (check-equal? (match (hash 3 4)
+                        [(hash-table (3 a) (3 b) _ ...)
+                         (list a b)]
+                        [_ 42])
+                      42)
 
         (check-true (match (hash 1 2 3 4 5 6)
                       [(hash-table _ ...) #t]))

--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -10,7 +10,8 @@
          matchable?
          match-prompt-tag
          mlist? mlist->list
-         syntax-srclocs)
+         syntax-srclocs
+         false-proc)
 
 (define match-prompt-tag (make-continuation-prompt-tag 'match)) 
 
@@ -69,3 +70,5 @@
                 (syntax-column stx)
                 (syntax-position stx)
                 (syntax-span stx))))
+
+(define (false-proc x) #f)


### PR DESCRIPTION
In the hash-table pattern, the ground truth is the generic case, which compiles the pattern to list-no-order. Hence, patterns with duplicate keys will always fail.

The PR #4532 has a mistake because it allows duplicate keys with ..0 to match successfully. This PR amends #4532 to always fail such cases.

Also added a history note that should have been added in #4532