### PR TITLE
Improve error messages in when/unless

### DIFF
--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -234,9 +234,9 @@
 (test 0 'when (when (< 1 2) (cons 1 2) 0))
 (test-values '(0 10) (lambda () (when (< 1 2) (values 0 10))))
 (syntax-test #'when)
-(syntax-test #'(when))
+(syntax-test #'(when) #rx"missing test expression and body")
 (syntax-test #'(when . 1))
-(syntax-test #'(when 1))
+(syntax-test #'(when 1) #rx"missing body")
 (syntax-test #'(when 1 . 2))
 (error-test #'(when (values 1 2) 0) arity?)
 
@@ -246,9 +246,9 @@
 (test 0 'unless (unless (> 1 2) (cons 1 2) 0))
 (test-values '(0 10) (lambda () (unless (> 1 2) (values 0 10))))
 (syntax-test #'unless)
-(syntax-test #'(unless))
+(syntax-test #'(unless) #rx"missing test expression and body")
 (syntax-test #'(unless . 1))
-(syntax-test #'(unless 1))
+(syntax-test #'(unless 1) #rx"missing body")
 (syntax-test #'(unless 1 . 2))
 (error-test #'(unless (values 1 2) 0) arity?)
 

--- a/racket/collects/racket/private/define-et-al.rkt
+++ b/racket/collects/racket/private/define-et-al.rkt
@@ -34,42 +34,64 @@
   (-define-syntax when
     (lambda (x)
       (let ([l (syntax->list x)])
-	(if (and l
-		 (> (length l) 2))
-	    (datum->syntax
-	     (quote-syntax here)
-	     (list (quote-syntax if)
-		   (stx-car (stx-cdr x))
-		   (list*
-		    (quote-syntax let-values)
-                    (quote-syntax ())
-		    (stx-cdr (stx-cdr x)))
-                   (quote-syntax (void)))
-	     x)
-	    (raise-syntax-error
-	     #f
-	     "bad syntax"
-	     x)))))
+        (cond
+          [(or (not l) (null? l))
+           (raise-syntax-error
+            #f
+            "bad syntax"
+            x)]
+          [(null? (cdr l))
+           (raise-syntax-error
+            #f
+            "missing test expression and body"
+            x)]
+          [(null? (cddr l))
+           (raise-syntax-error
+            #f
+            "missing body"
+            x)]
+          [else
+           (datum->syntax
+            (quote-syntax here)
+            (list (quote-syntax if)
+                  (stx-car (stx-cdr x))
+                  (list*
+                   (quote-syntax let-values)
+                   (quote-syntax ())
+                   (stx-cdr (stx-cdr x)))
+                  (quote-syntax (void)))
+            x)]))))
 
   (-define-syntax unless
     (lambda (x)
       (let ([l (syntax->list x)])
-	(if (and l
-		 (> (length l) 2))
-	    (datum->syntax
-	     (quote-syntax here)
-	     (list (quote-syntax if)
-		   (cadr l)
-		   (quote-syntax (void))
-		   (list*
-		    (quote-syntax let-values)
-                    (quote-syntax ())
-		    (cddr l)))
-	     x)
-	    (raise-syntax-error
-	     #f
-	     "bad syntax"
-	     x)))))
+        (cond
+          [(or (not l) (null? l))
+           (raise-syntax-error
+            #f
+            "bad syntax"
+            x)]
+          [(null? (cdr l))
+           (raise-syntax-error
+            #f
+            "missing test expression and body"
+            x)]
+          [(null? (cddr l))
+           (raise-syntax-error
+            #f
+            "missing body"
+            x)]
+          [else
+           (datum->syntax
+            (quote-syntax here)
+            (list (quote-syntax if)
+                  (cadr l)
+                  (quote-syntax (void))
+                  (list*
+                   (quote-syntax let-values)
+                   (quote-syntax ())
+                   (cddr l)))
+            x)]))))
 
   (define-values (call/ec) call-with-escape-continuation)
 


### PR DESCRIPTION
When you forget any of the parts of `when`/`unless`, the error you'll get is `"bad syntax"` with no additional info. It can be frustrating, especially if you have misplaced parens. This PR makes error messages more useful in the common cases when there's either test expression or body missing, and keeps `"bad syntax"` for all other cases.