### PR TITLE
Update Honest Custom Equality docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/equality.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/equality.scrbl
@@ -663,31 +663,16 @@ Type-specific equality functions on immutable types, such as
 
 @compare0[#:left "fine" #:right "bad"
 @racketblock0[
-  (struct thing (name)
+  (define (equal-proc self other rec)
     (code:comment "symbols are immutable: no problem")
-    #:methods gen:equal+hash
-    [(define (equal-proc self other rec)
-       (symbol=? (thing-name self) (thing-name other)))
-     (define (hash-proc self rec)
-       (+ (eq-hash-code struct:thing)
-          (rec (thing-name self))))
-     (define (hash2-proc self rec)
-       (+ (eq-hash-code struct:thing)
-          (rec (thing-name self))))])
+    (symbol=? (thing-name self) (thing-name other)))
 ]
 
 @racketblock0[
-  (struct thing (name)
-    (code:comment "strings can be mutable: wrongly accesses mutable data")
-    #:methods gen:equal+hash
-    [(define (equal-proc self other rec)
-       (string=? (thing-name self) (thing-name other)))
-     (define (hash-proc self rec mode)
-       (+ (eq-hash-code struct:mcell)
-          (rec (thing-name self))))
-     (define (hash2-proc self rec)
-       (+ (eq-hash-code struct:thing)
-          (rec (thing-name self))))])
+  (define (equal-proc self other rec)
+    (code:comment "strings can be mutable: accesses mutable data")
+    (code:comment "wrong for an struct that's not declared mutable")
+    (string=? (thing-name self) (thing-name other)))
 ]
 ]
 

--- a/pkgs/racket-doc/scribblings/reference/equality.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/equality.scrbl
@@ -655,6 +655,42 @@ and only access mutable data when the mode is true:
 ]
 ]
 
+Certain type-specific equality functions on mutable types,
+such as @racket[string=?], should also be avoided unless the
+struct is mutable or the mode is true.
+Type-specific equality functions on immutable types, such as
+@racket[symbol=?], are fine.
+
+@compare0[#:left "fine" #:right "bad"
+@racketblock0[
+  (struct thing (name)
+    (code:comment "symbols are immutable: no problem")
+    #:methods gen:equal+hash
+    [(define (equal-proc self other rec)
+       (symbol=? (thing-name self) (thing-name other)))
+     (define (hash-proc self rec)
+       (+ (eq-hash-code struct:thing)
+          (rec (thing-name self))))
+     (define (hash2-proc self rec)
+       (+ (eq-hash-code struct:thing)
+          (rec (thing-name self))))])
+]
+
+@racketblock0[
+  (struct thing (name)
+    (code:comment "strings can be mutable: wrongly accesses mutable data")
+    #:methods gen:equal+hash
+    [(define (equal-proc self other rec)
+       (string=? (thing-name self) (thing-name other)))
+     (define (hash-proc self rec mode)
+       (+ (eq-hash-code struct:mcell)
+          (rec (thing-name self))))
+     (define (hash2-proc self rec)
+       (+ (eq-hash-code struct:thing)
+          (rec (thing-name self))))])
+]
+]
+
 @section{Combining Hash Codes}
 
 @note-lib-only[racket/hash-code]

--- a/pkgs/racket-doc/scribblings/reference/equality.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/equality.scrbl
@@ -531,6 +531,27 @@ and enables some cycle detection.
 ]
 ]
 
+Don't use the third argument to ``recur'' on counts of
+elements.
+When a data structure cares about discrete numbers, it can
+use @racket[=] on those, not @racket[equal?] or ``recur''.
+
+@compare0[
+@racketblock0[
+  (define (equal-proc self other rec)
+    (and (= (tuple-length self) (tuple-length other))
+         (for/and ([i (in-range (tuple-length self))])
+           (rec ((tuple-getter self) i) ((tuple-getter other) i)))))
+]
+
+@racketblock0[
+  (define (equal-proc self other rec)
+    (and (rec (tuple-length self) (tuple-length other))
+         (for/and ([i (in-range (tuple-length self))])
+           (rec ((tuple-getter self) i) ((tuple-getter other) i)))))
+]
+]
+
 The operations @racket[equal?] and @racket[equal-always?]
 should be symmetric, so @racket[_equal-proc] instances
 should not change their answer when the arguments swap:


### PR DESCRIPTION
Don't use "recur" on counts, don't use type-specific equality on mutable types. Type-specific equality on immutable types, such as `=` and `symbol=?`, are fine.