### PR TITLE
Chez Scheme; Add more reductions for if and eq? in cp0

### DIFF
--- a/racket/src/ChezScheme/mats/cp0.ms
+++ b/racket/src/ChezScheme/mats/cp0.ms
@@ -928,7 +928,28 @@
       (expand/optimize
         '(lambda (x) (if x x #f))))
     '(lambda (x) x))
- ; verify optimization of (if s s #f) => s
+ ; verify optimization of (if (eq? x y) x y)  => (begin x y) => y
+  (equivalent-expansion?
+    (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f] [optimize-level 2] [compile-profile #f])
+      (expand/optimize
+        '(lambda (x y) (if (eq? x y) x y))))
+    '(lambda (x y) y))
+  (equivalent-expansion?
+    (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f] [optimize-level 2] [compile-profile #f])
+      (expand/optimize
+        '(lambda (x y) (if (eq? y x) x y))))
+    '(lambda (x y) y))
+  (equivalent-expansion?
+    (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f] [optimize-level 2] [compile-profile #f])
+      (expand/optimize
+        '(lambda (y) (if (eq? 'x y) 'x y))))
+    '(lambda (y) y))
+  (equivalent-expansion?
+    (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f] [optimize-level 2] [compile-profile #f])
+      (expand/optimize
+        '(lambda (y) (if (eq? y 'x) 'x y))))
+    '(lambda (y) y))
+ ; verify optimization of or pattern
   (equivalent-expansion?
     (parameterize ([enable-cp0 #t] [#%$suppress-primitive-inlining #f] [optimize-level 2] [compile-profile #f])
       (expand/optimize

--- a/racket/src/ChezScheme/mats/cp0.ms
+++ b/racket/src/ChezScheme/mats/cp0.ms
@@ -1032,6 +1032,17 @@
       (expand/optimize
         `(if (not (or #t (futz))) 17 32)))
     32)
+  ; verify expansion of (eq? _ #f) pattern
+  (equivalent-expansion?
+    (parameterize ([#%$suppress-primitive-inlining #f] [run-cp0 (lambda (cp0 x) (cp0 x))] [optimize-level 2])
+      (expand/optimize
+        `(lambda (x) (eq? x #f))))
+    `(lambda (x) (if x #f #t)))
+  (equivalent-expansion?
+    (parameterize ([#%$suppress-primitive-inlining #f] [run-cp0 (lambda (cp0 x) (cp0 x))] [optimize-level 2])
+      (expand/optimize
+        `(lambda (x) (if (eq? x #f) 1 2))))
+    `(lambda (x) (if x 2 1)))
 )
 
 (mat expand-output

--- a/racket/src/ChezScheme/s/cp0.ss
+++ b/racket/src/ChezScheme/s/cp0.ss
@@ -2659,7 +2659,17 @@
         [args #f])
 
       (define-inline 2 (eq? eqv? equal?)
-        [(arg1 arg2) (handle-equality ctxt arg1 (list arg2))])
+        [(arg1 arg2) (or (handle-equality ctxt arg1 (list arg2))
+                         (let ([val1 (value-visit-operand! arg1)]
+                               [val2 (value-visit-operand! arg2)])
+                           (cond
+                             [(cp0-constant? not (result-exp val1))
+                              (residualize-seq (list arg2) (list arg1) ctxt)
+                              (make-if ctxt sc val2 false-rec true-rec)]
+                             [(cp0-constant? not (result-exp val2))
+                              (residualize-seq (list arg1) (list arg2) ctxt)
+                              (make-if ctxt sc val1 false-rec true-rec)]
+                             [else #f])))])
 
       (define-inline 3 (bytevector=? enum-set=? bound-identifier=? free-identifier=? ftype-pointer=? literal-identifier=? time=?)
         [(arg1 arg2) (handle-equality ctxt arg1 (list arg2))])

--- a/racket/src/ChezScheme/s/cp0.ss
+++ b/racket/src/ChezScheme/s/cp0.ss
@@ -906,6 +906,16 @@
                                 (make-if ctxt sc e11 (non-result-exp e12 e2) (non-result-exp e13 e3)))])))
                   #f)]
              [else #f])]
+          [(nanopass-case (Lsrc Expr) (result-exp e1)
+             [(call ,preinfo ,e10 ,e11 ,e12)
+              (guard (and (primref? e10) (memq (primref-name e10) '(eq? eqv))))
+              (if (and (or (and (record-equal? e11 e2 'value) (record-equal? e12 e3 'value))
+                           (and (record-equal? e11 e3 'value) (record-equal? e12 e2 'value)))
+                       (simple? e2)
+                       (simple? e3))
+                  (non-result-exp e1 (make-1seq ctxt e2 e3))
+                  #f)]
+             [else #f])]
           [else
            (bump sc 1)
            `(if ,e1 ,e2 ,e3)])))


### PR DESCRIPTION
In the first commit, I extend the one of the current reductions in cp0 to include 

    (if (eq? x y) x y) => (begin x y)

For now, `x` and `y` must be `record-equal?`[1] and `simple?`. Both are super restrictive, but I hope in the future to extend `record-equal?` and replace `simple?` with a weaker condition [2]. 

Anyway, I think this is general enough to include all the cases in https://github.com/racket/racket/issues/4578 and https://github.com/racket/racket/issues/4580  (Did I miss any of them?)

As explained in those issues, this is useful to reduce the code generated by functions with optional arguments in Racket.

[1] `record-equal?` is a very confusing name

[2] for example to reduce `(if (eq? (unbox x) 7) (unbox x) 7) => (begin (unbox x) 7)`

--

In the second commit, I add a reduction `(eq? x #f) => (if x #f #t)`.
Currently, `(not x)` is reduced to `(if x #f #t)` so I think is not harmful.
Expanding it makes it easier to trigger any of the other reductions, so I think it's better to expand it in this way instead of adding a special case for `(if (eq? x #f) a b)`. 

--

In the future, I'd like to add some support for `(if (null? x) '() x)`. I think it's better to add this extension in cptypes, and my idea is to just expand `(null? x) => (eq? x '())` and let the other reductions compose nicely.