### PR TITLE
Chez Scheme: add missing type in primvars.ms

### DIFF
--- a/racket/src/ChezScheme/mats/patch-compile-0-f-f-t
+++ b/racket/src/ChezScheme/mats/patch-compile-0-f-f-t
@@ -1,5 +1,5 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2022-12-19 11:48:23.000000000 +0800
---- output-compile-0-f-f-t-experr/errors-compile-0-f-f-t	2022-12-19 11:48:16.000000000 +0800
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
+--- output-compile-0-f-f-t-experr/errors-compile-0-f-f-t	Fri Feb 24 19:33:41 2023
 ***************
 *** 4052,4058 ****
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".

--- a/racket/src/ChezScheme/mats/patch-compile-0-f-t-f
+++ b/racket/src/ChezScheme/mats/patch-compile-0-f-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2022-12-19 11:48:23.000000000 +0800
---- output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2022-12-19 11:48:18.000000000 +0800
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
+--- output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	Fri Feb 24 19:33:42 2023
 ***************
 *** 207,213 ****
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
@@ -18,22 +18,24 @@
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
   3.mo:Expected error in mat dipa-letrec: "attempt to reference undefined variable a".
 ***************
-*** 226,232 ****
+*** 226,233 ****
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
+- 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
---- 226,232 ----
+  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
+--- 226,233 ----
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
++ 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
+  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
 ***************
 *** 273,282 ****
   3.mo:Expected error in mat mrvs: "returned 3 values to single value return context".

--- a/racket/src/ChezScheme/mats/patch-compile-0-f-t-t
+++ b/racket/src/ChezScheme/mats/patch-compile-0-f-t-t
@@ -1,5 +1,5 @@
-*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2022-12-19 11:48:18.000000000 +0800
---- output-compile-0-f-t-t-experr/errors-compile-0-f-t-t	2022-12-19 11:48:13.000000000 +0800
+*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	Fri Feb 24 19:33:42 2023
+--- output-compile-0-f-t-t-experr/errors-compile-0-f-t-t	Fri Feb 24 19:33:36 2023
 ***************
 *** 9412,9424 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".

--- a/racket/src/ChezScheme/mats/patch-compile-0-t-f-f
+++ b/racket/src/ChezScheme/mats/patch-compile-0-t-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2022-12-19 11:48:23.000000000 +0800
---- output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2022-12-19 11:52:50.000000000 +0800
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
+--- output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
 ***************
 *** 175,181 ****
   3.mo:Expected error in mat case-lambda: "incorrect number of arguments 2 to #<procedure foo>".
@@ -4546,22 +4546,24 @@
   7.mo:Expected error in mat top-level-value-functions: "define-top-level-value: #<environment *scheme*> is not a symbol".
   7.mo:Expected error in mat top-level-value-functions: "variable i-am-not-bound-i-hope is not bound".
 ***************
-*** 8130,8136 ****
+*** 8130,8137 ****
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
+- record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
---- 8130,8136 ----
+  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
+--- 8130,8137 ----
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
++ record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
+  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
 ***************
 *** 8221,8340 ****
   hash.mo:Expected error in mat old-hash-table: "hash-table-for-each: ((a . b)) is not an eq hashtable".

--- a/racket/src/ChezScheme/mats/patch-compile-0-t-f-t
+++ b/racket/src/ChezScheme/mats/patch-compile-0-t-f-t
@@ -1,5 +1,5 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2022-12-19 11:52:50.000000000 +0800
---- output-compile-0-t-f-t-experr/errors-compile-0-t-f-t	2022-12-19 11:56:03.000000000 +0800
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
+--- output-compile-0-t-f-t-experr/errors-compile-0-t-f-t	Fri Feb 24 19:41:49 2023
 ***************
 *** 4052,4058 ****
   misc.mo:Expected error in mat compute-composition: "compute-composition: invalid generation -1".

--- a/racket/src/ChezScheme/mats/patch-compile-0-t-t-f
+++ b/racket/src/ChezScheme/mats/patch-compile-0-t-t-f
@@ -1,22 +1,24 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2022-12-19 11:52:50.000000000 +0800
---- output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	2022-12-19 11:54:09.000000000 +0800
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
+--- output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	Fri Feb 24 19:40:20 2023
 ***************
-*** 226,232 ****
+*** 226,233 ****
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
+- 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
---- 226,232 ----
+  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
+--- 226,233 ----
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable b".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable a".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
-! 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
++ 3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable g".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable f".
   3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable c".
   3.mo:Expected warning in mat cpvalid: "possible attempt to reference undefined variable x".
+  3.mo:Expected error in mat cpvalid: "attempt to reference undefined variable x".
 ***************
 *** 4094,4100 ****
   misc.mo:Expected error in mat cpletrec: "foreign-procedure: no entry for "foo"".

--- a/racket/src/ChezScheme/mats/patch-interpret-0-f-f-f
+++ b/racket/src/ChezScheme/mats/patch-interpret-0-f-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	2022-12-19 11:48:23.000000000 +0800
---- output-interpret-0-f-f-f-experr/errors-interpret-0-f-f-f	2022-12-19 11:49:51.000000000 +0800
+*** output-compile-0-f-f-f-experr/errors-compile-0-f-f-f	Fri Feb 24 19:33:45 2023
+--- output-interpret-0-f-f-f-experr/errors-interpret-0-f-f-f	Fri Feb 24 19:35:15 2023
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -234,21 +234,23 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7691,7697 ****
+*** 7691,7698 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7691,7697 ----
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
+--- 7691,7698 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
++ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
 *** 8086,8092 ****
@@ -268,22 +270,24 @@
   record.mo:Expected error in mat record25: "invalid value 13.0 for foreign type unsigned-long-long".
   record.mo:Expected error in mat record25: "invalid value 3.0 for foreign type int".
 ***************
-*** 8130,8136 ****
+*** 8130,8137 ****
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
+- record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
---- 8130,8136 ----
+  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
+--- 8130,8137 ----
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 1 to #<procedure>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 3 to #<procedure>".
-! record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
++ record.mo:Expected error in mat r6rs-records-procedural: "incorrect number of arguments 4 to #<procedure constructor>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-constructor-descriptor: record constructor descriptor #<record constructor descriptor> is not for parent of record type #<record type grand-child>".
   record.mo:Expected error in mat r6rs-records-procedural: "make-record-type-descriptor: cannot extend sealed record type #<record type bar> as foo".
+  record.mo:Expected error in mat r6rs-records-syntactic: "invalid syntax point".
 ***************
 *** 9412,9424 ****
   fx.mo:Expected error in mat fx-/wraparound: "fx-: <-int> is not a fixnum".

--- a/racket/src/ChezScheme/mats/patch-interpret-0-f-t-f
+++ b/racket/src/ChezScheme/mats/patch-interpret-0-f-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	2022-12-19 11:48:18.000000000 +0800
---- output-interpret-0-f-t-f-experr/errors-interpret-0-f-t-f	2022-12-19 11:49:41.000000000 +0800
+*** output-compile-0-f-t-f-experr/errors-compile-0-f-t-f	Fri Feb 24 19:33:42 2023
+--- output-interpret-0-f-t-f-experr/errors-interpret-0-f-t-f	Fri Feb 24 19:35:01 2023
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -207,21 +207,23 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7691,7697 ****
+*** 7691,7698 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7691,7697 ----
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
+--- 7691,7698 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
++ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
 *** 7891,7898 ****

--- a/racket/src/ChezScheme/mats/patch-interpret-0-t-f-f
+++ b/racket/src/ChezScheme/mats/patch-interpret-0-t-f-f
@@ -1,5 +1,5 @@
-*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	2022-12-19 11:52:50.000000000 +0800
---- output-interpret-0-t-f-f-experr/errors-interpret-0-t-f-f	2022-12-19 11:54:27.000000000 +0800
+*** output-compile-0-t-f-f-experr/errors-compile-0-t-f-f	Fri Feb 24 19:38:21 2023
+--- output-interpret-0-t-f-f-experr/errors-interpret-0-t-f-f	Fri Feb 24 19:40:01 2023
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -199,21 +199,23 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7691,7697 ****
+*** 7691,7698 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7691,7697 ----
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
+--- 7691,7698 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
++ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
 *** 8086,8092 ****

--- a/racket/src/ChezScheme/mats/patch-interpret-0-t-t-f
+++ b/racket/src/ChezScheme/mats/patch-interpret-0-t-t-f
@@ -1,5 +1,5 @@
-*** output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	2022-12-19 11:54:09.000000000 +0800
---- output-interpret-0-t-t-f-experr/errors-interpret-0-t-t-f	2022-12-19 11:54:35.000000000 +0800
+*** output-compile-0-t-t-f-experr/errors-compile-0-t-t-f	Fri Feb 24 19:40:20 2023
+--- output-interpret-0-t-t-f-experr/errors-interpret-0-t-t-f	Fri Feb 24 19:40:04 2023
 ***************
 *** 24,31 ****
   primvars.mo:Expected error testing (call-in-continuation 1.0+2.0i (quote #f) values): Exception in call-in-continuation: 1.0+2.0i is not a continuation
@@ -199,21 +199,23 @@
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
   4.mo:Expected error in mat refcount-guardians: "first field must be a word-sized integer with native endianness (ftype-guardian A)".
 ***************
-*** 7691,7697 ****
+*** 7691,7698 ****
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+- 7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
---- 7691,7697 ----
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
+--- 7691,7698 ----
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for testfile-mc-1a.ss: no such file or directory
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: file "testfile-mc-1a.ss" not found in source directories
   7.mo:Expected error in mat maybe-compile: "separate-compile: Exception in include: failed for ./testfile-mc-3a.ss: no such file or directory
-! 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
++ 7.mo:Expected error in mat eval: "interpret: 7 is not an environment".
   7.mo:Expected error in mat eval: "compile: 7 is not an environment".
+  7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
   7.mo:Expected error in mat expand: "sc-expand: 7 is not an environment".
 ***************
 *** 7891,7898 ****

--- a/racket/src/ChezScheme/mats/primvars.ms
+++ b/racket/src/ChezScheme/mats/primvars.ms
@@ -341,6 +341,7 @@
             (def *cost-center (make-cost-center))
             (def *date (current-date))
             (def *phantom-bytevector (make-phantom-bytevector 10))
+            (def *pseudo-random-generator (make-pseudo-random-generator))
             (def *eq-hashtable (make-eq-hashtable))
             (def *ftype-pointer (make-ftype-pointer double 0))
             (def *symbol-hashtable (make-hashtable symbol-hash eq?))

--- a/racket/src/ChezScheme/mats/root-experr-compile-0-f-f-f
+++ b/racket/src/ChezScheme/mats/root-experr-compile-0-f-f-f
@@ -58,11 +58,11 @@ primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fi
 primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fixnum) 1) (- (most-negative-fixnum) 1) *time *time (quote 1/2)): Exception in make-sstats: gc-bytes value 1/2 is not an exact integer
 primvars.mo:Expected error testing (make-sstats *time *time (- (most-negative-fixnum) 1) (- (most-negative-fixnum) 1) *time *time (quote #f)): Exception in make-sstats: gc-bytes value #f is not an exact integer
 primvars.mo:Expected error testing (pseudo-random-generator->vector (quote #f)): Exception in pseudo-random-generator->vector: not a pseudo-random generator #f
-primvars.mo:Expected error testing (pseudo-random-generator-seed! *pseudo-random-generator (quote #!eof)): Exception: variable *pseudo-random-generator is not bound
-primvars.mo:Expected error testing (pseudo-random-generator-seed! *pseudo-random-generator (quote #f)): Exception: variable *pseudo-random-generator is not bound
+primvars.mo:Expected error testing (pseudo-random-generator-seed! *pseudo-random-generator (quote #!eof)): Exception in pseudo-random-generator-seed!: not a nonnegative exact integer #!eof
+primvars.mo:Expected error testing (pseudo-random-generator-seed! *pseudo-random-generator (quote #f)): Exception in pseudo-random-generator-seed!: not a nonnegative exact integer #f
 primvars.mo:Expected error testing (pseudo-random-generator-next! (quote #f)): Exception in pseudo-random-generator-next!: not a pseudo-random generator #f
-primvars.mo:Expected error testing (pseudo-random-generator-next! (quote #!eof) *pseudo-random-generator): Exception: variable *pseudo-random-generator is not bound
-primvars.mo:Expected error testing (pseudo-random-generator-next! (quote #f) *pseudo-random-generator): Exception: variable *pseudo-random-generator is not bound
+primvars.mo:Expected error testing (pseudo-random-generator-next! (quote #!eof) *pseudo-random-generator): Exception in pseudo-random-generator-next!: not a pseudo-random generator #!eof
+primvars.mo:Expected error testing (pseudo-random-generator-next! (quote #f) *pseudo-random-generator): Exception in pseudo-random-generator-next!: not a pseudo-random generator #f
 primvars.mo:Expected error testing (reference-address->object (quote #!eof)): Exception in reference-address->object: invalid address #!eof
 primvars.mo:Expected error testing (reference-address->object (quote #f)): Exception in reference-address->object: invalid address #f
 primvars.mo:Expected error testing (reference*-address->object (quote #!eof)): Exception in reference*-address->object: invalid address #!eof
@@ -76,8 +76,8 @@ primvars.mo:Expected error testing (string-grapheme-span "a" (quote #f)): Except
 primvars.mo:Expected error testing (vector->pseudo-random-generator (quote "a")): Exception in vector->pseudo-random-generator: not a valid pseudo-random generator state vector "a"
 primvars.mo:Expected error testing (vector->pseudo-random-generator (quote #f)): Exception in vector->pseudo-random-generator: not a valid pseudo-random generator state vector #f
 primvars.mo:Expected error testing (vector->pseudo-random-generator! (quote #f) (quote #(a))): Exception in vector->pseudo-random-generator!: not a pseudo-random generator #f
-primvars.mo:Expected error testing (vector->pseudo-random-generator! *pseudo-random-generator (quote "a")): Exception: variable *pseudo-random-generator is not bound
-primvars.mo:Expected error testing (vector->pseudo-random-generator! *pseudo-random-generator (quote #f)): Exception: variable *pseudo-random-generator is not bound
+primvars.mo:Expected error testing (vector->pseudo-random-generator! *pseudo-random-generator (quote "a")): Exception in vector->pseudo-random-generator!: not a valid pseudo-random generator state vector "a"
+primvars.mo:Expected error testing (vector->pseudo-random-generator! *pseudo-random-generator (quote #f)): Exception in vector->pseudo-random-generator!: not a valid pseudo-random generator state vector #f
 primvars.mo:Expected error testing (verify-loadability (quote #!eof)): Exception in verify-loadability: invalid situation #!eof; should be one of load, visit, or revisit
 primvars.mo:Expected error testing (verify-loadability (quote #f)): Exception in verify-loadability: invalid situation #f; should be one of load, visit, or revisit
 primvars.mo:Expected error in mat make-parameter: "make-parameter: 2 is not a procedure".


### PR DESCRIPTION
The definition of `*pseudo-random-generator` was missing and it created spurious errors.

I don't know how to build the new version of the files with the expected errors.