### PR TITLE
make BOOTFILE_RACKET=racket stop pb fetch

### DIFF
--- a/main.zuo
+++ b/main.zuo
@@ -304,7 +304,7 @@
   (define (maybe-fetch vm)
     (when (eq? vm 'cs)
       (when (andmap (lambda (key) (equal? (lookup key) ""))
-                    '(RACKET PLAIN_RACKET SCHEME SCHEME_DIR))
+                    '(RACKET BOOTFILE_RACKET PLAIN_RACKET SCHEME SCHEME_DIR))
         (pb-manage 'fetch))))
 
   (define (base token vm [options (hash)])


### PR DESCRIPTION
The docs (build.md:249; section 1.6) already mention that setting `BOOTFILE_RACKET` should bootstrap the pb boot files instead of fetching them.

---

@mflatt I think I understood your Discord comment correctly, but I may have (read: probably) missed other spots where this is relevant. ~~I will test it, though.~~ Edit: building with `BOOTFILE_RACKET` from a very clean clone worked. I have not yet run any further tests.