### PR TITLE
setup: detect and report invalid package versions

### DIFF
--- a/racket/collects/setup/private/pkg-deps.rkt
+++ b/racket/collects/setup/private/pkg-deps.rkt
@@ -47,6 +47,7 @@
   (define dup-mods (make-hash)) ; modules that are provided by multiple packages
   (define pkg-version-deps (make-hash)) ; save version dependencies
   (define pkg-versions (make-hash)) ; save declared versions
+  (define bad-pkg-versions (make-hash))
   (define path-cache (make-hash))
   (define metadata-ns (make-base-namespace))
   (define pkg-dir-cache (make-hash))
@@ -193,11 +194,19 @@
                                                         'core))
                                               pkg))
     (when vers
+      (unless (valid-version? vers)
+        (hash-set! bad-pkg-versions pkg vers)
+        (setup-fprintf* (current-error-port) #f
+                        (string-append
+                         "invalid package version declaration:\n"
+                         "  package: ~s\n"
+                         "  declared version: ~s\n")
+                        pkg vers))
       (hash-set! pkg-versions pkg vers))
     (when check-unused?
       (hash-set! pkg-implies pkg implies))
     (values deps implies))
-  
+
   ;; ----------------------------------------
   ;; Flatten package dependencies, record mod->pkg mappings,
   ;; return representative package name (of a recursive set)
@@ -525,23 +534,42 @@
   ;; check version dependencies:
   (hash-set! pkg-versions "racket" (version))
   (define bad-version-dependencies
-    (for*/fold ([ht #hash()]) ([(pkg deps) (in-hash pkg-version-deps)]
-                               [d (in-list deps)])
+    (for*/fold ([ht #hash()])
+               ([(pkg deps) (in-hash pkg-version-deps)]
+                [d (in-list deps)])
       (define dep-pkg (car d))
       (define dep-vers (cdr d))
       (define decl-vers (hash-ref pkg-versions dep-pkg "0.0"))
       (cond
-       [(version<? decl-vers dep-vers)
-        (setup-fprintf* (current-error-port) #f 
-                        (string-append
-                         "package depends on newer version:\n"
-                         "  package: ~s\n"
-                         "  depends on package: ~s\n"
-                         "  depends on version: ~s\n"
-                         "  current package version: ~s")
-                        pkg dep-pkg dep-vers decl-vers)
-        (hash-update ht pkg (lambda (l) (cons d l)) null)]
-       [else ht])))
+        [(hash-has-key? bad-pkg-versions dep-pkg)
+         (setup-fprintf* (current-error-port) #f
+                         (string-append
+                          "package depends on package whose version is invalid:\n"
+                          "  package: ~s\n"
+                          "  depends on package: ~s\n"
+                          "  ~s version: ~s\n")
+                         pkg dep-pkg dep-pkg decl-vers)
+         ht]
+        [(not (valid-version? dep-vers))
+         (setup-fprintf* (current-error-port) #f
+                         (string-append
+                          "invalid version in package dependency specification:\n"
+                          "  package: ~s\n"
+                          "  depends on package: ~s\n"
+                          "  depends on version: ~s\n"
+                          pkg dep-pkg dep-vers))
+         (hash-update ht pkg (lambda (l) (cons d l)) null)]
+        [(version<? decl-vers dep-vers)
+         (setup-fprintf* (current-error-port) #f
+                         (string-append
+                          "package depends on newer version:\n"
+                          "  package: ~s\n"
+                          "  depends on package: ~s\n"
+                          "  depends on version: ~s\n"
+                          "  current package version: ~s")
+                         pkg dep-pkg dep-vers decl-vers)
+         (hash-update ht pkg (lambda (l) (cons d l)) null)]
+        [else ht])))
 
   (when check-unused?
     (for ([(pkg actuals) (in-hash pkg-actual-deps)])
@@ -583,10 +611,11 @@
                        (if (= (hash-count unused) 1) "y" "ies")
                        pkg
                        (if (= (hash-count unused) 1) "" "s")))))
-  
+
   ;; Report result summary and (optionally) repair:
   (define all-ok? (and (zero? (hash-count missing))
                        (zero? (hash-count dup-mods))
+                       (zero? (hash-count bad-pkg-versions))
                        (zero? (hash-count bad-version-dependencies))
                        (zero? (hash-count missing-pkgs))))
   (unless all-ok?
@@ -596,6 +625,13 @@
       (setup-fprintf* (current-error-port) #f
                       "package not installed: ~a"
                       pkg))
+    (for ([(pkg ver) (in-hash bad-pkg-versions)])
+      (setup-fprintf* (current-error-port) #f
+                      (string-append
+                       "package has invalid version:\n"
+                       "  package: ~s\n"
+                       "  version: ~s\n")
+                      pkg ver))
     (for ([(pkg deps) (in-hash bad-version-dependencies)])
       (setup-fprintf* (current-error-port) #f
                       (string-append


### PR DESCRIPTION
Currently, `raco setup` fails with an exception when a package contains an invalid `version` spec (but only when said package is depended on by another package) ~~and also when a dependency spec contains an invalid version~~ (actually, this is already checked in `extract-pkg-dependencies`, but I don't think the additional check hurts here). I noticed this because of a recent issue introduced in `futures-visualizer`, but any package could run into this problem. This change makes it so that setup instead reports these as package problems. 

Before: 

```
raco setup: ...

version<?: contract violation
  expected: valid-version?
  given: '("1.1")
  argument position: 1st
  other arguments...:
   "1.1"
  context...:
   /Users/bogdan/sandbox/racket/racket/collects/version/utils.rkt:20:0: check-version-inputs
   /Users/bogdan/sandbox/racket/racket/collects/version/utils.rkt:17:7: version<?
   /Users/bogdan/sandbox/racket/racket/collects/setup/private/pkg-deps.rkt:28:0: check-package-dependencies
   /Users/bogdan/sandbox/racket/racket/collects/setup/setup-core.rkt:2117:2: do-check-package-dependencies
   body of "/Users/bogdan/sandbox/racket/racket/collects/setup/main.rkt"
   body of "/Users/bogdan/sandbox/racket/racket/collects/raco/main.rkt"
```

After:

```
raco setup: ...
raco setup: package depends on package whose version is invalid:
raco setup:   package: "racket-doc"
raco setup:   depends on package: "future-visualizer"
raco setup:   "future-visualizer" version: ("1.1")
raco setup: --- summary of package problems ---                    [12:40:20]
raco setup: package has invalid version:
raco setup:   package: "future-visualizer"
raco setup:   version: ("1.1")
raco setup: package has invalid version:
raco setup:   package: "libargon2-x86_64-macosx"
raco setup:   version: "20210625"
raco setup: package has invalid version:
raco setup:   package: "libargon2"
raco setup:   version: "20210625"
raco setup: package has invalid version:
raco setup:   package: "memoize-lib"
raco setup:   version: "3"
raco setup: package has invalid version:
raco setup:   package: "country"
raco setup:   version: "2022-12-11"
raco setup: package has invalid version:
raco setup:   package: "box-extra"
raco setup:   version: ("1.0")
```

One difference from before is that bad package versions are now reported regardless of whether those packages are depended on by other packages. While this might be initially a little noisy, I think this is probably a good thing, because it will make authors aware that versions need to follow a certain format. I hadn't been aware of that when I wrote the `libargon2` and `country` packages, for example.