### PR TITLE
Support bootstrapping via Chez Scheme from top-level makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -90,6 +90,15 @@ PLAIN_RACKET =
 # Chez Scheme boot files
 BOOTFILE_RACKET =
 
+# For CS, `SCHEME` can be set to a Chez Scheme (v9.5.3 and up)
+# executable that runs on the build platform; if set, this will be used
+# to create the Chez Scheme boot files (for both cross and non-cross
+# builds); this is a much more direct path than supplying `RACKET`; it
+# does not need to match the Chez Scheme version as used in the Racket
+# being built; a "reboot" bootstrapping path is able to reconstruct
+# boot files across versions.
+SCHEME =
+
 # For CS, points a cross build at a directory containing a host build;
 # this path can be relative to the cross build directory
 CS_HOST_WORKAREA_PREFIX =
@@ -177,6 +186,7 @@ BUILD_VARS = MAKE=$(MAKE) \
              RACKET="$(RACKET)" \
              PLAIN_RACKET="$(PLAIN_RACKET)" \
              BOOTFILE_RACKET="$(BOOTFILE_RACKET)" \
+             SCHEME="$(SCHEME)" \
              CS_HOST_WORKAREA_PREFIX="$(CS_HOST_WORKAREA_PREFIX)" \
              PB_BRANCH="$(PB_BRANCH)" \
              PB_REPO="$(PB_REPO)" \

--- a/main.zuo
+++ b/main.zuo
@@ -133,7 +133,10 @@
        (shell/wait "git checkout -q" branch
                    (hash 'dir pb-dir))]
       [(eq? step 'build)
-       (define scheme (find-executable-path "scheme"))
+       (define scheme (let ([s (lookup 'SCHEME)])
+                        (if (equal? s "")
+                            (find-executable-path "scheme")
+                            s)))
        (cond
          [scheme
           (define reboot (dynamic-require "racket/src/ChezScheme/s/reboot.zuo" 'reboot))
@@ -218,6 +221,7 @@
                                      ;; Propagate `RACKET` and similar if specified
                                      'RACKET (get-provided-racket)
                                      'BOOTFILE_RACKET (lookup 'BOOTFILE_RACKET)
+                                     'SCHEME (lookup 'SCHEME)
                                      'SCHEME_DIR (let ([s (lookup 'CS_HOST_WORKAREA_PREFIX)])
                                                    (if (equal? s "")
                                                        ""


### PR DESCRIPTION
It has been possible to supply a Chez Scheme for bootstrapping via configure args (`--enable-scheme`) for some time, but it was not clear how to do so if using the top-level makefile. This wires up that support in a similar way to the existing `RACKET`-related makefile options.