### PR TITLE
Linklet: Add logging option to show all passes

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/compiler.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/compiler.scrbl
@@ -110,9 +110,6 @@ forms or adjust the way forms are displayed:
          compilation of form that were previously prepared by
          compilation with @envvar{PLT_CS_JIT} set}
 
-   @item{@envvar-indexed{PLT_LINKLET_SHOW_PATHS} --- show lifted
-         path and serialization information alongside a schemified form}
-
    @item{@envvar-indexed{PLT_LINKLET_SHOW_KNOWN} --- show recorded
          known-binding information alongside a schemified form}
 

--- a/pkgs/racket-doc/scribblings/reference/compiler.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/compiler.scrbl
@@ -123,7 +123,8 @@ forms or adjust the way forms are displayed:
    @item{@envvar-indexed{PLT_LINKLET_SHOW_PASSES} --- show the
          intermediate form of a schemified linklet after the specified
          passes (listed space-separated) in Chez Scheme's internal
-         representation}
+         representation; the special name @tt{all} will show the
+         intermediate form after all Chez Scheme passes}
 
    @item{@envvar-indexed{PLT_LINKLET_SHOW_ASSEMBLY} --- show the
          compiled form of a schemified linklet in Chez Scheme's
@@ -136,3 +137,6 @@ set on startup, then Racket prints cumulative timing information about
 compilation and evaluation times on exit. When the
 @envvar-indexed{PLT_EXPANDER_TIMES} environment variable is set,
 information about macro-expansion time is printed on exit.
+
+@history[#:changed "8.8.0.10" @elem{Added special pass name @tt{all}
+                                    to @envvar{PLT_LINKLET_SHOW_PASSES}}]

--- a/racket/src/cs/linklet.sls
+++ b/racket/src/cs/linklet.sls
@@ -206,9 +206,10 @@
                            (lambda (e)
                              (let lp ([p (open-string-input-port e)])
                                (define pass (read p))
-                               (if (symbol? pass)
-                                   (cons pass (lp p))
-                                   '())))]
+                               (cond
+                                 [(eq? pass 'all) '(#t)]
+                                 [(symbol? pass) (cons pass (lp p))]
+                                 [else '()])))]
                           [else '()]))
   (define cp0-on? (getenv "PLT_LINKLET_SHOW_CP0"))
   (define assembly-on? (getenv "PLT_LINKLET_SHOW_ASSEMBLY"))
@@ -258,7 +259,10 @@
                                               [compile-procedure-realm realm])
                                  (let* ([print-header (lambda ()
                                                         (printf ";;")
-                                                        (for-each (lambda (p) (printf " ~a" p))
+                                                        (for-each (lambda (p)
+                                                                    (define pass
+                                                                      (if (eq? p #t) 'all p))
+                                                                    (printf " ~a" pass))
                                                                   (if assembly-on?
                                                                       (append passes-on '(assembly))
                                                                       passes-on))

--- a/racket/src/cs/linklet.sls
+++ b/racket/src/cs/linklet.sls
@@ -215,6 +215,7 @@
   (define assembly-on? (getenv "PLT_LINKLET_SHOW_ASSEMBLY"))
   (define show-on? (or (eq? #t gensym-mode)
                        pre-jit-on?
+                       lambda-on?
                        post-lambda-on?
                        post-interp-on?
                        jit-demand-on?


### PR DESCRIPTION
Chez Scheme's tracer will log the output of all passes if `#t` is supplied as a pass name to log. This wires that up to Racket's linklet-level `PLT_LINKLET_SHOW_PASSES` env var via the special pass name `all`.

While this does log a semi-overwhelming amount of info since there are so many passes, I am planning wire it up to a pass-by-pass view in Compiler Explorer, which should be more comprehensible.

I attached additional commits to fix a few other minor issues in this area that I happened to notice while working on this.