### PR TITLE
Clarify that `predicate/c` is obsolete.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1665,18 +1665,12 @@ be blamed using the above contract:
 
 @defthing[predicate/c contract?]{
 
- Use this contract to indicate that some function is a
- predicate.
-
-  This contract also includes an optimization so that functions returning
-  @racket[#t] from @racket[struct-predicate-procedure?] are just returned directly, without
-  being wrapped. This contract is used by @racket[provide/contract]'s
-  @racket[struct] sub-form so that struct predicates end up not being wrapped.
-
- This contract is semantically equivalent to
- @racket[(-> any/c boolean?)] and
- @racket[(-> any/c boolean?)] also has the same optimization.
-
+ Equivalent to @racket[(-> any/c boolean?)]. This contract includes an optimization so that functions returning
+ @racket[#t] from @racket[struct-predicate-procedure?] are just returned directly, without
+ being wrapped. This contract is used by @racket[provide/contract]'s
+ @racket[struct] sub-form so that struct predicates end up not being wrapped. In previous versions of Racket,
+ this contract was necessary for that optimization. Now however, @racket[(-> any/c boolean?)] performs the same
+ optimization. This contract is still provided for backwards compatibility.
 }
 
 @defthing[the-unsupplied-arg unsupplied-arg?]{

--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1668,7 +1668,7 @@ be blamed using the above contract:
  was necessary as it included an additional optimization that was not
  included in @racket[->]. Now however, @racket[->] performs the same
  optimization, so the contract should no longer be used. The contract
- is still provided for backwards compatibility.
+ is still provided for backward compatibility.
 }
 
 @defthing[the-unsupplied-arg unsupplied-arg?]{

--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1664,13 +1664,11 @@ be blamed using the above contract:
 ]}
 
 @defthing[predicate/c contract?]{
-
- Equivalent to @racket[(-> any/c boolean?)]. This contract includes an optimization so that functions returning
- @racket[#t] from @racket[struct-predicate-procedure?] are just returned directly, without
- being wrapped. This contract is used by @racket[provide/contract]'s
- @racket[struct] sub-form so that struct predicates end up not being wrapped. In previous versions of Racket,
- this contract was necessary for that optimization. Now however, @racket[(-> any/c boolean?)] performs the same
- optimization. This contract is still provided for backwards compatibility.
+ Equivalent to @racket[(-> any/c boolean?)]. Previously, this contract
+ was necessary as it included an additional optimization that was not
+ included in @racket[->]. Now however, @racket[->] performs the same
+ optimization, so the contract should no longer be used. The contract
+ is still provided for backwards compatibility.
 }
 
 @defthing[the-unsupplied-arg unsupplied-arg?]{


### PR DESCRIPTION
This change strengthens the wording a bit. See prior conversation in 09f74002eb346fd22996fcc70f5d0c2bc011bc0d and https://github.com/jackfirth/resyntax/issues/191.