### PR TITLE
Annotate immediate class body forms with a syntax property

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -372,7 +372,9 @@ Each @racket[class-clause] is (partially) macro-expanded to reveal its
 shapes. If a @racket[class-clause] is a @racket[begin] expression, its
 sub-expressions are lifted out of the @racket[begin] and treated as
 @racket[class-clause]s, in the same way that @racket[begin] is
-flattened for top-level and embedded definitions.
+flattened for top-level and embedded definitions. Each @racket[class-clause]
+has the @tech{syntax property} @racket['class-body] set to true before
+expansion.
 
 Within a @racket[class*] form for instances of the new class,
 @racket[this] is bound to the object itself;
@@ -384,6 +386,10 @@ available for calling superclass methods (see
 @secref["clmethoddefs"]); and @racket[inner] is available for
 calling subclass augmentations of methods (see
 @secref["clmethoddefs"]).}
+
+@history[#:changed "8.8.0.10"
+         @string-append{Added the @racket['class-body] syntax property
+          to class body forms}]
 
 @defform[(class superclass-expr class-clause ...)]{
 

--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -388,8 +388,8 @@ calling subclass augmentations of methods (see
 @secref["clmethoddefs"]).}
 
 @history[#:changed "8.8.0.10"
-         @string-append{Added the @racket['class-body] syntax property
-          to class body forms}]
+         @elem{Added the @racket['class-body] syntax property
+          to class body forms.}]
 
 @defform[(class superclass-expr class-clause ...)]{
 

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -366,7 +366,7 @@
              [expand
               (lambda (defn-or-expr)
                 (local-expand
-                 defn-or-expr
+                 (syntax-property defn-or-expr 'class-body #true)
                  expand-context
                  stop-forms
                  def-ctx))]


### PR DESCRIPTION
This allows macros and tools to treat code within a class differently. The primary use case for this information is in Resyntax, particularly https://github.com/jackfirth/resyntax/issues/186.