### PR TITLE
Modify `ssl-load-private-key!` to accept a `bytes` containing the key in PEM format, in place of a pathname

### DIFF
--- a/pkgs/racket-test/tests/openssl/basic.rkt
+++ b/pkgs/racket-test/tests/openssl/basic.rkt
@@ -17,7 +17,7 @@
   (test 'ok values (with-handlers ([exn? (lambda (x) 'ok)])
                      e)))
 
-(define (test-ssl limit buffer? close?)
+(define (test-ssl limit buffer? close? private-bytes?)
   ;; Test SSL communication using a limited pipe.
   ;; (Using a pipe limited to a small buffer helps make sure
   ;; that race conditions and deadlocks are eliminated in the
@@ -44,7 +44,9 @@
       (thread (lambda ()
 		(define ctx (ssl-make-server-context))
 		(ssl-load-certificate-chain! ctx pem)
-		(ssl-load-private-key! ctx pem)
+		(ssl-load-private-key! ctx (if private-bytes?
+            (file->bytes pem)
+            pem))
 		(let-values ([(r w) (ports->ssl-ports
 				     r2 w2
 				     #:context ctx
@@ -69,15 +71,16 @@
 	  (test v2 read-byte r2)))
     (void)))
 
-(test-ssl 1 #t #t)
-(test-ssl 10 #t #t)
-(test-ssl 100 #t #t)
-(test-ssl 1 #f #t)
-(test-ssl 10 #f #t)
-(test-ssl 100 #f #t)
+(test-ssl 1 #t #t #f)
+(test-ssl 10 #t #t #f)
+(test-ssl 100 #t #t #f)
+(test-ssl 1 #f #t #f)
+(test-ssl 10 #f #t #f)
+(test-ssl 100 #f #t #f)
 
-(test-ssl 100 #t #f)
-(test-ssl 100 #f #f)
+(test-ssl 100 #t #f #f)
+(test-ssl 100 #f #f #f)
+(test-ssl 100 #f #f #t)
 
 (newline)
 (when errs?

--- a/pkgs/racket-test/tests/openssl/basic.rkt
+++ b/pkgs/racket-test/tests/openssl/basic.rkt
@@ -17,7 +17,7 @@
   (test 'ok values (with-handlers ([exn? (lambda (x) 'ok)])
                      e)))
 
-(define (test-ssl limit buffer? close? private-bytes?)
+(define (test-ssl limit buffer? close? #:private-bytes? [private-bytes? #f])
   ;; Test SSL communication using a limited pipe.
   ;; (Using a pipe limited to a small buffer helps make sure
   ;; that race conditions and deadlocks are eliminated in the
@@ -71,16 +71,16 @@
 	  (test v2 read-byte r2)))
     (void)))
 
-(test-ssl 1 #t #t #f)
-(test-ssl 10 #t #t #f)
-(test-ssl 100 #t #t #f)
-(test-ssl 1 #f #t #f)
-(test-ssl 10 #f #t #f)
-(test-ssl 100 #f #t #f)
+(test-ssl 1 #t #t)
+(test-ssl 10 #t #t)
+(test-ssl 100 #t #t)
+(test-ssl 1 #f #t)
+(test-ssl 10 #f #t)
+(test-ssl 100 #f #t)
 
-(test-ssl 100 #t #f #f)
-(test-ssl 100 #f #f #f)
-(test-ssl 100 #f #f #t)
+(test-ssl 100 #t #f)
+(test-ssl 100 #f #f)
+(test-ssl 100 #f #f #:private-bytes? #t)
 
 (newline)
 (when errs?

--- a/pkgs/racket-test/tests/openssl/basic.rkt
+++ b/pkgs/racket-test/tests/openssl/basic.rkt
@@ -45,8 +45,8 @@
 		(define ctx (ssl-make-server-context))
 		(ssl-load-certificate-chain! ctx pem)
 		(ssl-load-private-key! ctx (if private-bytes?
-            (file->bytes pem)
-            pem))
+			(file->bytes pem)
+			pem))
 		(let-values ([(r w) (ports->ssl-ports
 				     r2 w2
 				     #:context ctx

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -124,7 +124,7 @@ TO DO:
   [ssl-load-certificate-chain!
    (c-> (or/c ssl-context? ssl-listener?) path-string? void?)]
   [ssl-load-private-key!
-   (->* ((or/c ssl-context? ssl-listener?) path-string?)
+   (->* ((or/c ssl-context? ssl-listener?) (or/c path-string? bytes?))
         (any/c any/c)
         void?)]
   [ssl-load-verify-root-certificates!

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -100,7 +100,7 @@ TO DO:
   [ssl-make-client-context
    (->* ()
         (protocol-symbol/c
-         #:private-key (or/c (list/c 'pem path-string?) (list/c 'der path-string?) #f)
+         #:private-key (or/c (list/c 'pem (or/c path-string? bytes?)) (list/c 'der path-string?) #f)
          #:certificate-chain (or/c path-string? #f))
         ssl-client-context?)]
   [ssl-secure-client-context
@@ -108,7 +108,7 @@ TO DO:
   [ssl-make-server-context
    (->* ()
         (protocol-symbol/c
-         #:private-key (or/c (list/c 'pem path-string?) (list/c 'der path-string?) #f)
+         #:private-key (or/c (list/c 'pem (or/c path-string? bytes?)) (list/c 'der path-string?) #f)
          #:certificate-chain (or/c path-string? #f))
         ssl-server-context?)]
   [ssl-server-context-enable-dhe!

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -101,6 +101,8 @@
 (define-cpointer-type _SSL_METHOD*)
 (define-cpointer-type _SSL_CTX*)
 (define-cpointer-type _SSL*)
+(define-cpointer-type _RSA*)
+(define-cpointer-type _EVP_PKEY*)
 (define-cpointer-type _X509_NAME*)
 (define-cpointer-type _X509_NAME_ENTRY*)
 (define-cpointer-type _X509*)
@@ -176,6 +178,11 @@
   (SSL_CTX_ctrl ctx SSL_CTRL_MODE m #f))
 (define (SSL_CTX_set_options ctx opts)
   (SSL_CTX_ctrl ctx SSL_CTRL_OPTIONS opts #f))
+
+(define-ssl SSL_CTX_use_RSAPrivateKey (_fun _SSL_CTX* _RSA* -> _int))
+(define-ssl PEM_read_bio_RSAPrivateKey (_fun _BIO* _void _int _void -> _RSA*))
+(define-ssl SSL_CTX_use_PrivateKey (_fun _SSL_CTX* _EVP_PKEY* -> _int))
+(define-ssl PEM_read_bio_PrivateKey (_fun _BIO* _void _int _void -> _EVP_PKEY*))
 
 (define-ssl SSL_CTX_set_verify (_fun _SSL_CTX* _int _pointer -> _void))
 (define-ssl SSL_CTX_use_certificate_chain_file (_fun _SSL_CTX* _path -> _int))

--- a/racket/collects/openssl/private/ffi.rkt
+++ b/racket/collects/openssl/private/ffi.rkt
@@ -180,9 +180,9 @@
   (SSL_CTX_ctrl ctx SSL_CTRL_OPTIONS opts #f))
 
 (define-ssl SSL_CTX_use_RSAPrivateKey (_fun _SSL_CTX* _RSA* -> _int))
-(define-ssl PEM_read_bio_RSAPrivateKey (_fun _BIO* _void _int _void -> _RSA*))
+(define-ssl PEM_read_bio_RSAPrivateKey (_fun _BIO* _pointer _int _pointer -> _RSA*))
 (define-ssl SSL_CTX_use_PrivateKey (_fun _SSL_CTX* _EVP_PKEY* -> _int))
-(define-ssl PEM_read_bio_PrivateKey (_fun _BIO* _void _int _void -> _EVP_PKEY*))
+(define-ssl PEM_read_bio_PrivateKey (_fun _BIO* _pointer _int _pointer -> _EVP_PKEY*))
 
 (define-ssl SSL_CTX_set_verify (_fun _SSL_CTX* _int _pointer -> _void))
 (define-ssl SSL_CTX_use_certificate_chain_file (_fun _SSL_CTX* _path -> _int))


### PR DESCRIPTION
Currently in order to load a private key into an SSL context, it must be written to disk. For applications that have the key in memory, they must currently write it out to a temporary file, which is undesirable for such sensitive data.

This extends ssl-load-private-key to load the key directly, making use of openssl's `PEM_read_bio_PrivateKey` functions to parse and then load the key in to the context. I've also modified the contracts of `ssl-make-client-context` and `ssl-make-server-context` accordingly.

I added a test to openssl/basic.rkt that exercises the new code, but let me know if there's something else I should do instead.

Thanks!