### PR TITLE
match: add support for hash and hash* patterns

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match-grammar.rkt
+++ b/pkgs/racket-doc/scribblings/reference/match-grammar.rkt
@@ -4,62 +4,70 @@
 (provide match-grammar)
 
 (define grammar "
-pat     ::= id                                @match anything, bind identifier
-         |  (VAR id)                          @match anything, bind identifier
-         |  _                                 @match anything
-         |  literal                           @match literal
-         |  (QUOTE datum)                     @match equal% value
-         |  (LIST lvp ...)                    @match sequence of lvps
-         |  (LIST-REST lvp ... pat)           @match lvps consed onto a pat
-         |  (LIST* lvp ... pat)               @match lvps consed onto a pat
-         |  (LIST-NO-ORDER pat ...)           @match pats in any order
-         |  (LIST-NO-ORDER pat ... lvp)       @match pats in any order
-         |  (VECTOR lvp ...)                  @match vector of pats
-         |  (HASH-TABLE (pat pat) ...)        @match hash table
-         |  (HASH-TABLE (pat pat) ...+ ooo)   @match hash table
-         |  (CONS pat pat)                    @match pair of pats
-         |  (MCONS pat pat)                   @match mutable pair of pats
-         |  (BOX pat)                         @match boxed pat
-         |  (struct-id pat ...)               @match struct-id instance
-         |  (STRUCT struct-id (pat ...))      @match struct-id instance
-         |  (REGEXP rx-expr)                  @match string
-         |  (REGEXP rx-expr pat)              @match string, result with pat
-         |  (PREGEXP px-expr)                 @match string
-         |  (PREGEXP px-expr pat )            @match string, result with pat
-         |  (AND pat ...)                     @match when all pats match
-         |  (OR pat ...)                      @match when any pat match
-         |  (NOT pat ...)                     @match when no pat matches
-         |  (APP expr pats ...)               @match (expr value) output values to pats
-         |  (? expr pat ...)                  @match if (expr value) and pats
-         |  (QUASIQUOTE qp)                   @match a quasipattern
-         |  derived-pattern                   @match using extension
-literal ::= #t                                @match true
-         |  #f                                @match false
-         |  string                            @match equal% string
-         |  bytes                             @match equal% byte string
-         |  number                            @match equal% number
-         |  char                              @match equal% character
-         |  keyword                           @match equal% keyword
-         |  regexp literal                    @match equal% regexp literal
-         |  pregexp literal                   @match equal% pregexp literal
-lvp     ::= (code:line pat ooo)               @greedily match pat instances
-         |  pat                               @match pat
-qp      ::= literal                           @match literal
-         |  id                                @match symbol
-         |  (qp ...)                          @match sequences of qps
-         |  (qp ... . qp)                     @match qps ending qp
-         |  (qp ooo . qp)                     @match qps beginning with repeated qp
-         |  #(qp ...)                         @match vector of qps
-         |  #&qp                              @match boxed qp
-         |  #s(prefab-key qp ...)             @match prefab struct with qp fields
-         |  ,pat                              @match pat
-         |  ,@(LIST lvp ...)                  @match lvps, spliced
-         |  ,@(LIST-REST lvp ... pat)         @match lvps plus pat, spliced
-         |  ,@'qp                             @match list-matching qp, spliced
-ooo     ::= ***                               @zero or more; *** is literal
-         |  ___                               @zero or more
-         |  ..K                               @K or more
-         |  __K                               @K or more
+pat     ::= id                                   @match anything, bind identifier
+         |  (VAR id)                             @match anything, bind identifier
+         |  _                                    @match anything
+         |  literal                              @match literal
+         |  (QUOTE datum)                        @match equal% value
+         |  (LIST lvp ...)                       @match sequence of lvps
+         |  (LIST-REST lvp ... pat)              @match lvps consed onto a pat
+         |  (LIST* lvp ... pat)                  @match lvps consed onto a pat
+         |  (LIST-NO-ORDER pat ...)              @match pats in any order
+         |  (LIST-NO-ORDER pat ... lvp)          @match pats in any order
+         |  (VECTOR lvp ...)                     @match vector of pats
+         |  (HASH expr pat ... ... ht-opt)       @match hash table
+         |  (HASH* [expr pat kv-opt] ... ht-opt) @match hash table
+         |  (HASH-TABLE (pat pat) ...)           @match hash table - deprecated
+         |  (HASH-TABLE (pat pat) ...+ ooo)      @match hash table - deprecated
+         |  (CONS pat pat)                       @match pair of pats
+         |  (MCONS pat pat)                      @match mutable pair of pats
+         |  (BOX pat)                            @match boxed pat
+         |  (struct-id pat ...)                  @match struct-id instance
+         |  (STRUCT struct-id (pat ...))         @match struct-id instance
+         |  (REGEXP rx-expr)                     @match string
+         |  (REGEXP rx-expr pat)                 @match string, result with pat
+         |  (PREGEXP px-expr)                    @match string
+         |  (PREGEXP px-expr pat )               @match string, result with pat
+         |  (AND pat ...)                        @match when all pats match
+         |  (OR pat ...)                         @match when any pat match
+         |  (NOT pat ...)                        @match when no pat matches
+         |  (APP expr pats ...)                  @match (expr value) output values to pats
+         |  (? expr pat ...)                     @match if (expr value) and pats
+         |  (QUASIQUOTE qp)                      @match a quasipattern
+         |  derived-pattern                      @match using extension
+literal ::= #t                                   @match true
+         |  #f                                   @match false
+         |  string                               @match equal% string
+         |  bytes                                @match equal% byte string
+         |  number                               @match equal% number
+         |  char                                 @match equal% character
+         |  keyword                              @match equal% keyword
+         |  regexp literal                       @match equal% regexp literal
+         |  pregexp literal                      @match equal% pregexp literal
+lvp     ::= (code:line pat ooo)                  @greedily match pat instances
+         |  pat                                  @match pat
+qp      ::= literal                              @match literal
+         |  id                                   @match symbol
+         |  (qp ...)                             @match sequences of qps
+         |  (qp ... . qp)                        @match qps ending qp
+         |  (qp ooo . qp)                        @match qps beginning with repeated qp
+         |  #(qp ...)                            @match vector of qps
+         |  #&qp                                 @match boxed qp
+         |  #s(prefab-key qp ...)                @match prefab struct with qp fields
+         |  ,pat                                 @match pat
+         |  ,@(LIST lvp ...)                     @match lvps, spliced
+         |  ,@(LIST-REST lvp ... pat)            @match lvps plus pat, spliced
+         |  ,@'qp                                @match list-matching qp, spliced
+ooo     ::= ***                                  @zero or more; *** is literal
+         |  ___                                  @zero or more
+         |  ..K                                  @K or more
+         |  __K                                  @K or more
+kv-opt  ::= (code:line)                          @key must exist
+         |  (code:line #:default def-expr)       @key may not exist; match def-expr with the value pattern
+ht-opt  ::= (code:line)                          @default mode
+         |  #:closed                             @closed to extension mode
+         |  #:open                               @open to extension mode
+         |  (code:line #:rest pat)               @residue mode
 ")
 
 (define match-grammar

--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -345,7 +345,7 @@ In more detail, patterns match as follows:
        ]}
 
  @item{@racket[(#,(match-kw "hash-table") (_pat _pat) ...)] ---
-       @bold{This pattern is deprecated because it has a bug.}
+       @bold{This pattern is deprecated because it can be incorrect.}
        However, many programs rely on the incorrect behavior,
        so we still provide this pattern for backward compatibility reasons.
 
@@ -359,7 +359,7 @@ In more detail, patterns match as follows:
        ]}
 
  @item{@racket[(#,(racketidfont "hash-table") (_pat _pat) ...+ _ooo)] ---
-       @bold{This pattern is deprecated because it has a bug.}
+       @bold{This pattern is deprecated because it can be incorrect.}
        However, many programs rely on the incorrect behavior,
        so we still provide this pattern for backward compatibility reasons.
 

--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -274,7 +274,7 @@ In more detail, patterns match as follows:
            [_ 'not-matched]))
        ]
 
-       The behavior of unmatched key-value entries depends on @racket[_ht-opt].
+       The behavior of residue key-value entries in the hash table value depends on @racket[_ht-opt].
 
        When @racket[_ht-opt] is not provided or when it is @racket[#:closed],
        all of the keys in the hash table value must be matched.
@@ -320,11 +320,17 @@ In more detail, patterns match as follows:
        ]}
 
  @item{@racket[(#,(match-kw "hash*") [_expr _pat _kv-opt] ... _ht-opt)] ---
-       similar to @racketidfont{hash}, but (1) key-value-pattern must be grouped;
-       (2) if @racket[_ht-opt] is not specified, it behaves like @racket[#:open];
-       (3) if @racket[_kv-opt] is specified, and the key does not exist in
-       the hash table value, the default value will be matched against the
-       value pattern instead.
+       similar to @racketidfont{hash}, but with the following differences:
+
+       @itemlist[
+         @item{The key-value pattern must be grouped syntactically.}
+         @item{If @racket[_ht-opt] is not specified, it behaves like @racket[#:open]
+               (as opposed to @racket[#:closed]).}
+         @item{If @racket[_kv-opt] is specified with @racket[#:default _def-expr],
+               and the key does not exist in the hash table value, then the default value
+               from @racket[_def-expr] will be matched against the value pattern,
+               instead of immediately failing to match.}
+       ]
 
        @examples[
        #:eval match-eval

--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -246,8 +246,79 @@ In more detail, patterns match as follows:
          [(vector 1 (list a) ..3 5) a])
        ]}
 
+ @item{@racket[(#,(match-kw "hash") _expr _pat ... ... _ht-opt)] ---
+       matches against a hash table where @racket[_expr] matches
+       a key and @racket[_pat] matches a corresponding value.
+       The key matchings use the key comparator of the matching hash table.
+       Many @racket[_expr]s could evaluate to the same value.
+       The behavior of unmatched key-value entries depend on @racket[_ht-opt].
+
+       When @racket[_ht-opt] is not provided or when it is @racket[#:closed],
+       the matching is closed to extension.
+       I.e., there must not be any unmatched key-value entries.
+
+       When @racket[_ht-opt] is @racket[#:open], the matching is open to extension.
+       I.e., there can be unmatched key-value entries.
+
+       When @racket[_ht-opt] is @racket[#:rest _pat], @racket[_pat] is further
+       matched against the residue hash table.
+       If the matching hash table is immutable, this residue matching is efficient.
+       Otherwise, the matching hash table will be copied, which could be expensive.
+
+
+       @examples[
+       #:eval match-eval
+       (match #hash(("aa" . 1) ("b" . 2))
+         [(hash "b" b (string-append "a" "a") a) (list b a)])
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash "b" b) 'matched]
+         [_ 'not-matched])
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash "b" _ #:open) 'matched]
+         [_ 'not-matched])
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash "b" _ #:rest (hash "a" a)) a]
+         [_ #f])
+       (let ([k (string-append "a" "b")])
+         (match (hasheq "ab" 1)
+           [(hash k v) 'matched]
+           [_ 'not-matched]))
+       (let ([k (string-append "a" "b")])
+         (match (hasheq k 1)
+           [(hash k v) 'matched]
+           [_ 'not-matched]))
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash "b" _ "b" 2 "a" _) 'matched]
+         [_ 'not-matched])
+
+
+       ]}
+
+ @item{@racket[(#,(match-kw "hash*") [_expr _pat _kv-opt] ... _ht-opt)] ---
+       similar to @racketidfont{hash}, but (1) key-value-pattern must be grouped;
+       (2) if @racket[_ht-opt] is not specified, it behaves like @racket[#:open];
+       (3) if @racket[_kv-opt] is specified, and the key does not exist in
+       the matching hash table, the default value will be matched against the
+       value pattern instead.
+
+       @examples[
+       #:eval match-eval
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash* ["b" b] ["a" a]) (list b a)])
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash* ["b" b]) 'matched]
+         [_ 'not-matched])
+       (match #hash(("a" . 1) ("b" . 2))
+         [(hash* ["c" c #:default 10]) c]
+         [_ #f])
+       ]}
+
  @item{@racket[(#,(match-kw "hash-table") (_pat _pat) ...)] ---
-       similar to @racketidfont{list-no-order}, but matching against
+       @bold{This pattern is deprecated because it has a bug.}
+       However, many programs rely on the incorrect behavior,
+       so we still provide this pattern for backward compatibility reasons.
+
+       Similar to @racketidfont{list-no-order}, but matching against
        hash table's key--value pairs.
 
        @examples[

--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -352,8 +352,12 @@ In more detail, patterns match as follows:
          [(hash-table ("b" b) ("a" a)) (list b a)])
        ]}
 
- @item{@racket[(#,(racketidfont "hash-table") (_pat _pat) ...+ _ooo)]
-       --- Generalizes @racketidfont{hash-table} to support a final
+ @item{@racket[(#,(racketidfont "hash-table") (_pat _pat) ...+ _ooo)] ---
+       @bold{This pattern is deprecated because it has a bug.}
+       However, many programs rely on the incorrect behavior,
+       so we still provide this pattern for backward compatibility reasons.
+
+       Generalizes @racketidfont{hash-table} to support a final
        repeating pattern.
 
        @examples[

--- a/pkgs/racket-test/tests/match/hash-table-tests.rkt
+++ b/pkgs/racket-test/tests/match/hash-table-tests.rkt
@@ -1,0 +1,264 @@
+#lang racket/base
+
+(provide hash-table-tests)
+
+(require racket/match
+         rackunit)
+
+(define hash-table-tests
+  (test-suite "Test for hash tables"
+    (test-case "non hash"
+      (check-equal? (match 1
+                      [(hash* [3 x]) x]
+                      [_ 'failed])
+                    'failed))
+
+    (test-case "missing key"
+      (check-equal? (match (hash 1 2 5 4)
+                      [(hash* [3 x]) x]
+                      [_ 'failed])
+                    'failed))
+
+    (test-case "value pattern matching"
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [1 (? odd? x)]) x]
+                      [_ 'failed])
+                    'failed)
+
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [1 (? even? x)]) x]
+                      [_ 'failed])
+                    2))
+
+    (test-case "key expression"
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [(+ 1 2) x]) x]
+                      [_ 'failed])
+                    4))
+
+    (test-case "duplicate"
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [1 x] [1 y]) (list x y)]
+                      [_ 'failed])
+                    (list 2 2))
+
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [1 x] [1 y] #:closed) (list x y)]
+                      [_ 'failed])
+                    'failed)
+
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [1 x] [1 y] [3 z] #:closed) (list x y z)]
+                      [_ 'failed])
+                    (list 2 2 4)))
+
+    (test-case "partial matching"
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash* [1 x]) x]
+                      [_ 'failed])
+                    2))
+
+    (test-case "partial matching (multiple)"
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [1 x] [5 z]) (list x z)]
+                      [_ 'failed])
+                    (list 2 6)))
+
+    (test-case "full matching"
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [1 x] [3 y] [5 z] #:closed) (list x y z)]
+                      [_ 'failed])
+                    (list 2 4 6)))
+
+    (test-case "full matching failure"
+      ;; extra keys
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [1 x] [5 z] #:closed) (list x z)]
+                      [_ 'failed])
+                    'failed)
+
+      ;; missing keys
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [1 x] [4 y] [5 z] #:closed) (list x y z)]
+                      [_ 'failed])
+                    'failed))
+
+    (test-case "rest matching"
+      ;; single
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [1 x] [5 z] #:rest (? hash? h)) (list x z h)]
+                      [_ 'failed])
+                    (list 2 6 (hash 3 4)))
+
+      ;; multiple
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [5 z] #:rest (? hash? h)) (list z h)]
+                      [_ 'failed])
+                    (list 6 (hash 1 2 3 4)))
+
+      ;; nested
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [5 z] #:rest (hash* [1 x])) (list x z)]
+                      [_ 'failed])
+                    (list 2 6)))
+
+    (test-case "rest matching failure"
+      ;; rest-pat
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [1 x] [5 z] #:rest (? number? h)) (list x z h)]
+                      [_ 'failed])
+                    'failed)
+
+      ;; extra keys
+      (check-equal? (match (hash 1 2 3 4 5 6)
+                      [(hash* [4 z] #:rest (? hash? h)) (list z h)]
+                      [_ 'failed])
+                    'failed))
+
+    (test-case "evaluate only once (at least when hash* is the top-level pattern)"
+      ;; partial mode
+      (let ([var 0])
+        (check-equal? (match (hash -5 -6 1 2 3 4)
+                        [(hash* [(begin (set! var (+ var 1))
+                                        var)
+                                 x]
+                                [(begin (set! var (+ var 2))
+                                        var)
+                                 y])
+                         (list x y)]
+                        [_ 'failed])
+                      (list 2 4))
+        (check-equal? var 3))
+
+      ;; full mode
+      (let ([var 0])
+        (check-equal? (match (hash 1 2 3 4)
+                        [(hash* [(begin (set! var (+ var 1))
+                                        var)
+                                 x]
+                                [(begin (set! var (+ var 2))
+                                        var)
+                                 y]
+                                #:closed)
+                         (list x y)]
+                        [_ 'failed])
+                      (list 2 4))
+        (check-equal? var 3))
+
+      ;; rest mode
+      (let ([var 0])
+        (check-equal? (match (hash -5 -6 1 2 3 4)
+                        [(hash* [(begin (set! var (+ var 1))
+                                        var)
+                                 x]
+                                [(begin (set! var (+ var 2))
+                                        var)
+                                 y]
+                                #:rest (? (λ (h) (= 1 (hash-count h))) h))
+                         (list x y h)]
+                        [_ 'failed])
+                      (list 2 4 (hash -5 -6)))
+        (check-equal? var 3)))
+
+    (test-case "default value"
+      ;; mismatch
+      (check-equal? (match (hash 1 2
+                                 3 4
+                                 5 6)
+                      [(hash* [1 (list x) #:default (list 42)]) (list x)]
+                      [_ 'failed])
+                    'failed)
+
+      ;; partial
+      (check-equal? (match (hash 1 (list 2)
+                                 3 (list 4)
+                                 5 (list 6))
+                      [(hash* [2 (list x) #:default (list 42)]
+                              [5 (list z) #:default (list -42)])
+                       (list x z)]
+                      [_ 'failed])
+                    (list 42 6))
+
+      (check-equal? (match (hash 0 2)
+                      [(hash* [1 x #:default 3] [1 y #:default 4])
+                       (list x y)]
+                      [_ 'failed])
+                    (list 3 4))
+
+      ;; full
+      (check-equal? (match (hash 1 (list 2)
+                                 3 (list 4)
+                                 5 (list 6))
+                      [(hash* [2 w #:default (list 42)]
+                              [1 x]
+                              [3 y]
+                              [5 z #:default (list -42)]
+                              #:closed)
+                       (list w x y z)]
+                      [_ 'failed])
+                    (list (list 42) (list 2) (list 4) (list 6)))
+
+      (check-equal? (match (hash 1 2)
+                      [(hash* [1 x #:default 3] [1 y #:default 4] #:closed)
+                       (list x y)]
+                      [_ 'failed])
+                    (list 2 2))
+
+      ;; full failure
+      (check-equal? (match (hash 1 (list 2)
+                                 3 (list 4)
+                                 5 (list 6))
+                      ;; 1 is not matched here
+                      [(hash* [2 w #:default (list 42)]
+                              [3 y]
+                              [5 z #:default (list -42)]
+                              #:closed)
+                       (list w y z)]
+                      [_ 'failed])
+                    'failed)
+
+      ;; rest
+      (check-equal? (match (hash 1 (list 2)
+                                 3 (list 4)
+                                 5 (list 6))
+                      [(hash* [2 w #:default (list 42)]
+                              [3 y]
+                              [5 z #:default (list -42)]
+                              #:rest h)
+                       (list w y z h)]
+                      [_ 'failed])
+                    (list (list 42) (list 4) (list 6) (hash 1 (list 2)))))
+
+    (test-case "key comparator"
+      (let ([b-1 (box 1)]
+            [b-2 (box 3)])
+        (check-equal? (match (hasheq b-1 2 b-2 4)
+                        [(hash* [b-1 x] [b-2 y]) (list x y)]
+                        [_ 'failed])
+                      (list 2 4))
+
+        (check-equal? (match (hasheq b-1 2 b-2 4)
+                        [(hash* [(box 1) x] [(box 3) y]) (list x y)]
+                        [_ 'failed])
+                      'failed)))
+
+    (test-case "mutability/weakness"
+      (check-equal? (match (make-immutable-hash (list (cons 1 2) (cons 3 4)))
+                      [(hash* [1 x] #:rest h) (list x h (immutable? h) (hash-strong? h))]
+                      [_ 'failed])
+                    (list 2 (make-immutable-hash (list (cons 3 4))) #t #t))
+
+      (check-equal? (match (make-hash (list (cons 1 2) (cons 3 4)))
+                      [(hash* [1 x] #:rest h) (list x h (immutable? h) (hash-strong? h))]
+                      [_ 'failed])
+                    (list 2 (make-hash (list (cons 3 4))) #f #t))
+
+      (check-equal? (match (make-weak-hash (list (cons 1 2) (cons 3 4)))
+                      [(hash* [1 x] #:rest h) (list x h (immutable? h) (hash-strong? h))]
+                      [_ 'failed])
+                    (list 2 (make-weak-hash (list (cons 3 4))) #f #f)))
+
+    (test-case "hash"
+      (check-equal? (match (hash 1 2 3 4)
+                      [(hash 1 x 3 y) (list x y)])
+                    (list 2 4)))))

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -5,6 +5,7 @@
          "legacy-match-tests.rkt"
          "examples.rkt"
          "case-tests.rkt"
+         "hash-table-tests.rkt"
          rackunit rackunit/text-ui
          (only-in racket/base local-require))
 
@@ -463,7 +464,8 @@
                             ;; from bruce
                             other-tests 
                             other-plt-tests
-                            case-tests)
+                            case-tests
+                            hash-table-tests)
              'verbose))
 
 (module+ main

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -166,17 +166,20 @@
                    [(eq? mode #t) (list (App activate-fun (list (Exact #t))))]
                    [else '()])
 
-                 ;; SECTION 3
+                 ;; SECTION 3: transform user-def to the default value if needed
                  (for/list ([ref-id (in-list ref-ids)]
                             [def-expr (in-list def-exprs)]
                             [v-pat (in-list v-pats)])
                    (with-syntax ([ref-id ref-id]
                                  [def-expr def-expr])
-                     (App #'(λ (ref-id)
-                              (if (user-def? ref-id)
-                                  def-expr
-                                  ref-id))
-                          (list (parse v-pat)))))
+                     (if (and (identifier? #'def-expr)
+                              (free-identifier=? #'undef #'def-expr))
+                         (parse v-pat)
+                         (App #'(λ (ref-id)
+                                  (if (user-def? ref-id)
+                                      def-expr
+                                      ref-id))
+                              (list (parse v-pat))))))
 
                  ;; SECTION 4
                  (cond

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -8,8 +8,7 @@
          "parse-quasi.rkt"
          (only-in "stxtime.rkt" current-form-name)
          (for-template (only-in "runtime.rkt" matchable? pregexp-matcher mlist? mlist->list
-                                undef user-def undef? user-def? hash-remove-safe
-                                hash-remove-safe!
+                                undef user-def undef? user-def?
                                 hash-state hash-state-ht hash-state-keys hash-state-vals
                                 hash-state-closed? hash-state-residue)
                        (only-in racket/unsafe/ops unsafe-vector-ref)

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -268,13 +268,13 @@
        (parse (syntax/loc stx (hash* kvp ... #:rest rest-pat))))]
     [(hash es ... #:closed)
      (with-syntax ([(kvp ...) (make-kvps stx #'(es ...))])
-       (parse (syntax/loc stx (hash* kvp ... #:closed))))]
+       (do-hash stx #'(kvp ...) #t))]
     [(hash es ... #:open)
      (with-syntax ([(kvp ...) (make-kvps stx #'(es ...))])
-       (parse (syntax/loc stx (hash* kvp ... #:open))))]
+       (do-hash stx #'(kvp ...) #f))]
     [(hash es ...)
      (with-syntax ([(kvp ...) (make-kvps stx #'(es ...))])
-       (parse (syntax/loc stx (hash* kvp ... #:closed))))]
+       (do-hash stx #'(kvp ...) #t))]
 
     ;; Deprecated hash table patterns
     [(hash-table p ... dd)

--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -17,8 +17,6 @@
          user-def
          undef?
          user-def?
-         hash-remove-safe
-         hash-remove-safe!
 
          (struct-out hash-state)
          hash-state-closed?
@@ -100,15 +98,6 @@
 (define (user-def? v)
   (eq? user-def v))
 
-(define (hash-remove-safe h k)
-  (if (hash-has-key? h k)
-      (hash-remove h k)
-      h))
-
-(define (hash-remove-safe! h k)
-  (when (hash-has-key? h k)
-    (hash-remove! h k)))
-
 (struct hash-state (ht keys vals))
 
 (define (hash-state-closed? state)
@@ -133,9 +122,9 @@
     [(immutable? ht)
      (for/fold ([ht ht])
                ([k (in-list acc-keys)])
-       (hash-remove-safe ht k))]
+       (hash-remove ht k))]
     [else
      (define ht* (hash-copy ht))
      (for ([k (in-list acc-keys)])
-       (hash-remove-safe! ht* k))
+       (hash-remove! ht* k))
      ht*]))

--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -11,7 +11,14 @@
          pregexp-matcher
          match-prompt-tag
          mlist? mlist->list
-         syntax-srclocs)
+         syntax-srclocs
+
+         undef
+         user-def
+         undef?
+         user-def?
+         hash-remove-safe
+         hash-remove-safe!)
 
 (define match-prompt-tag (make-continuation-prompt-tag 'match)) 
 
@@ -79,3 +86,21 @@
                 (syntax-column stx)
                 (syntax-position stx)
                 (syntax-span stx))))
+
+(define undef (gensym))
+(define user-def (gensym))
+
+(define (undef? v)
+  (eq? undef v))
+
+(define (user-def? v)
+  (eq? user-def v))
+
+(define (hash-remove-safe h k)
+  (if (hash-has-key? h k)
+      (hash-remove h k)
+      h))
+
+(define (hash-remove-safe! h k)
+  (when (hash-has-key? h k)
+    (hash-remove! h k)))


### PR DESCRIPTION
As discussed in
https://racket.discourse.group/t/rfc-hash-table-pattern-matching/1686 and https://github.com/racket/racket/pull/4532
the currrent hash-table is buggy, so we would like to deprecate it and replace with a new set of patterns that are well-behaved.