### PR TITLE
Respect `#:decimal-sep` with exponential notation (Fixes #4635)

### DIFF
--- a/pkgs/racket-test/tests/racket/format.rkt
+++ b/pkgs/racket-test/tests/racket/format.rkt
@@ -320,6 +320,12 @@
     "0e+00")
 (tc (~r #:notation 'exponential 0 #:precision '(= 4))
     "0.0000e+00")
+(tc (~r #:notation 'exponential 0 #:precision '(= 4) #:decimal-sep ",")
+    "0,0000e+00")
+(tc (~r 12345678.123456 #:notation 'exponential #:decimal-sep ",")
+    "1,234568e+07")
+(tc (~r 12345678.123456 #:notation 'exponential #:decimal-sep "::")
+    "1::234568e+07")
 
 (tc (~r 123456789.123)
     "123456789.123")

--- a/racket/collects/racket/format.rkt
+++ b/racket/collects/racket/format.rkt
@@ -332,18 +332,18 @@
                         (if exactly? (make-string significand-precision #\0) "")
                         (exponent-part 0 format-exponent base))]
         [else
-         (%exponential-nz N-abs base upper? format-exponent significand-precision exactly?)]))
+         (%exponential-nz N-abs base upper? format-exponent significand-precision exactly? decimal-sep)]))
 
-(define (%exponential-nz N-abs base upper? format-exponent significand-precision exactly?)
+(define (%exponential-nz N-abs base upper? format-exponent significand-precision exactly? decimal-sep)
   (define-values (N* e-adjust actual-precision)
     (scale N-abs base significand-precision exactly?))
-  ;; hack: from 1234 want "1.234"; convert to "1234", mutate to ".234" after saving "1"
   (let* ([digits (number->string* N* base upper?)]
          [leading-digit (string (string-ref digits 0))]
          [exponent (- significand-precision e-adjust)])
-    (string-set! digits 0 #\.)
     (string-append leading-digit
-                   (if (or exactly? (positive? actual-precision)) digits "")
+                   (if (or exactly? (positive? actual-precision))
+                       (string-append decimal-sep (substring digits 1))
+                       "")
                    (exponent-part exponent format-exponent base))))
 
 (define (exponent-part exponent format-exponent base)


### PR DESCRIPTION
Currently when you give `~r` a non-zero number with `#:notation 'exponential` it uses `#\.` as the hard-coded decimal separator, ignoring the `#:decimal-sep` argument.

I tried to think of a clever way to keep the original speed hack in place but I’m not that smart. Of course feel free to edit if there’s a better way.