### PR TITLE
Support .rhm as a module suffix.

### DIFF
--- a/racket/collects/compiler/module-suffix.rkt
+++ b/racket/collects/compiler/module-suffix.rkt
@@ -28,7 +28,7 @@
                    [(docs) '(doc-module-suffixes)]))
   (define dirs (find-relevant-directories fields key))
   (define rkt-ht (if (memq 'module-suffixes fields)
-                     (hash #"rkt" #t #"ss" #t #"scm" #t)
+                     (hash #"rkt" #t #"ss" #t #"scm" #t #"rhm" #t)
                      (hash)))
   (define init-ht (if (memq 'doc-module-suffixes fields)
                       (hash-set rkt-ht #"scrbl" #t)


### PR DESCRIPTION
Right now, opening require paths doesn't find `.rhm` files in DrRacket or racket-mode. This should fix that, although I'm not sure if it's the best way.