### PR TITLE
BC: shared mutable empty string

### DIFF
--- a/pkgs/racket-test-core/tests/racket/unsafe.rktl
+++ b/pkgs/racket-test-core/tests/racket/unsafe.rktl
@@ -1043,6 +1043,8 @@
     (test #f immutable? (make-bytes 0))
     (test #t immutable? (unsafe-string->immutable-string! (make-string 0)))
     (test #f immutable? (make-string 0))
+    (test #t immutable? (unsafe-string->immutable-string! (string-append)))
+    (test #f immutable? (string-append))
     (test #t immutable? (unsafe-vector*->immutable-vector! (make-vector 0)))
     (test #f immutable? (make-vector 0))))
 

--- a/racket/src/bc/src/schpriv.h
+++ b/racket/src/bc/src/schpriv.h
@@ -602,9 +602,9 @@ extern Scheme_Object *scheme_unsafe_fxrshift_proc;
 extern Scheme_Object *scheme_unsafe_fx_to_fl_proc;
 extern Scheme_Object *scheme_unsafe_pure_proc;
 
-READ_ONLY static Scheme_Object *zero_length_char_string;
-READ_ONLY static Scheme_Object *zero_length_char_immutable_string;
-READ_ONLY static Scheme_Object *zero_length_byte_string;
+extern Scheme_Object *scheme_zero_length_char_string;
+extern Scheme_Object *scheme_zero_length_char_immutable_string;
+extern Scheme_Object *scheme_zero_length_byte_string;
 
 extern Scheme_Object *scheme_string_p_proc;
 extern Scheme_Object *scheme_unsafe_string_length_proc;

--- a/racket/src/bc/src/schpriv.h
+++ b/racket/src/bc/src/schpriv.h
@@ -602,6 +602,10 @@ extern Scheme_Object *scheme_unsafe_fxrshift_proc;
 extern Scheme_Object *scheme_unsafe_fx_to_fl_proc;
 extern Scheme_Object *scheme_unsafe_pure_proc;
 
+READ_ONLY static Scheme_Object *zero_length_char_string;
+READ_ONLY static Scheme_Object *zero_length_char_immutable_string;
+READ_ONLY static Scheme_Object *zero_length_byte_string;
+
 extern Scheme_Object *scheme_string_p_proc;
 extern Scheme_Object *scheme_unsafe_string_length_proc;
 extern Scheme_Object *scheme_unsafe_string_set_proc;

--- a/racket/src/bc/src/string.c
+++ b/racket/src/bc/src/string.c
@@ -192,9 +192,6 @@ ROSYM static Scheme_Object *fs_change_symbol, *target_machine_symbol, *cross_sym
 ROSYM static Scheme_Object *racket_symbol, *cgc_symbol, *_3m_symbol, *cs_symbol;
 ROSYM static Scheme_Object *force_symbol, *infer_symbol;
 ROSYM static Scheme_Object *platform_3m_path, *platform_cgc_path, *platform_cs_path;
-READ_ONLY static Scheme_Object *zero_length_char_string;
-READ_ONLY static Scheme_Object *zero_length_char_immutable_string;
-READ_ONLY static Scheme_Object *zero_length_byte_string;
 
 SHARED_OK static char *embedding_banner;
 SHARED_OK static Scheme_Object *vers_str;

--- a/racket/src/bc/src/string.c
+++ b/racket/src/bc/src/string.c
@@ -192,6 +192,9 @@ ROSYM static Scheme_Object *fs_change_symbol, *target_machine_symbol, *cross_sym
 ROSYM static Scheme_Object *racket_symbol, *cgc_symbol, *_3m_symbol, *cs_symbol;
 ROSYM static Scheme_Object *force_symbol, *infer_symbol;
 ROSYM static Scheme_Object *platform_3m_path, *platform_cgc_path, *platform_cs_path;
+READ_ONLY Scheme_Object *scheme_zero_length_char_string;
+READ_ONLY Scheme_Object *scheme_zero_length_char_immutable_string;
+READ_ONLY Scheme_Object *scheme_zero_length_byte_string;
 
 SHARED_OK static char *embedding_banner;
 SHARED_OK static Scheme_Object *vers_str;
@@ -276,13 +279,13 @@ scheme_init_string (Scheme_Startup_Env *env)
   force_symbol = scheme_intern_symbol("force");
   infer_symbol = scheme_intern_symbol("infer");
 
-  REGISTER_SO(zero_length_char_string);
-  REGISTER_SO(zero_length_char_immutable_string);
-  REGISTER_SO(zero_length_byte_string);
-  zero_length_char_string = scheme_alloc_char_string(0, 0);
-  zero_length_char_immutable_string = scheme_alloc_char_string(0, 0);
-  SCHEME_SET_CHAR_STRING_IMMUTABLE(zero_length_char_immutable_string);
-  zero_length_byte_string = scheme_alloc_byte_string(0, 0);
+  REGISTER_SO(scheme_zero_length_char_string);
+  REGISTER_SO(scheme_zero_length_char_immutable_string);
+  REGISTER_SO(scheme_zero_length_byte_string);
+  scheme_zero_length_char_string = scheme_alloc_char_string(0, 0);
+  scheme_zero_length_char_immutable_string = scheme_alloc_char_string(0, 0);
+  SCHEME_SET_CHAR_STRING_IMMUTABLE(scheme_zero_length_char_immutable_string);
+  scheme_zero_length_byte_string = scheme_alloc_byte_string(0, 0);
 
   REGISTER_SO(complete_symbol);
   REGISTER_SO(continues_symbol);
@@ -1142,8 +1145,8 @@ Scheme_Object *string_append_immutable(int argc, Scheme_Object *argv[])
 
   r = do_string_append("string-append-immutable", argc, argv);
 
-  if (r == zero_length_char_string)
-    return zero_length_char_immutable_string;
+  if (r == scheme_zero_length_char_string)
+    return scheme_zero_length_char_immutable_string;
 
   SCHEME_SET_CHAR_STRING_IMMUTABLE(r);
 

--- a/racket/src/bc/src/strops.inc
+++ b/racket/src/bc/src/strops.inc
@@ -345,7 +345,7 @@ X__(do_string_append) (const char *who, int argc, Scheme_Object *argv[])
   }
 
   if (!len)
-    return X(zero_length, _string);
+    return X(scheme_zero_length, _string);
 
   naya = X(scheme_alloc, _string)(len, 0);
   chars = SCHEME_X_STR_VAL(naya);

--- a/racket/src/bc/src/vector.c
+++ b/racket/src/bc/src/vector.c
@@ -1528,8 +1528,8 @@ static Scheme_Object *unsafe_string_immutable_bang (int argc, Scheme_Object *arg
     scheme_wrong_contract("unsafe-string->immutable-string!", "string?", 0, argc, argv);
 
   if (!SCHEME_CHAR_STRLEN_VAL(o)) {
-    if (zero_length_char_immutable_string) {
-      return zero_length_char_immutable_string;
+    if (scheme_zero_length_char_immutable_string) {
+      return scheme_zero_length_char_immutable_string;
     } else {
       o = scheme_alloc_char_string(0, 0);
     }

--- a/racket/src/bc/src/vector.c
+++ b/racket/src/bc/src/vector.c
@@ -1528,11 +1528,7 @@ static Scheme_Object *unsafe_string_immutable_bang (int argc, Scheme_Object *arg
     scheme_wrong_contract("unsafe-string->immutable-string!", "string?", 0, argc, argv);
 
   if (!SCHEME_CHAR_STRLEN_VAL(o)) {
-    if (scheme_zero_length_char_immutable_string) {
-      return scheme_zero_length_char_immutable_string;
-    } else {
-      o = scheme_alloc_char_string(0, 0);
-    }
+    return scheme_zero_length_char_immutable_string;
   }
 
   SCHEME_SET_IMMUTABLE(o);

--- a/racket/src/bc/src/vector.c
+++ b/racket/src/bc/src/vector.c
@@ -1527,6 +1527,14 @@ static Scheme_Object *unsafe_string_immutable_bang (int argc, Scheme_Object *arg
   if (!SCHEME_CHAR_STRINGP(o))
     scheme_wrong_contract("unsafe-string->immutable-string!", "string?", 0, argc, argv);
 
+  if (!SCHEME_CHAR_STRLEN_VAL(o)) {
+    if (zero_length_char_immutable_string) {
+      return zero_length_char_immutable_string;
+    } else {
+      o = scheme_alloc_char_string(0, 0);
+    }
+  }
+
   SCHEME_SET_IMMUTABLE(o);
 
   return o;


### PR DESCRIPTION
Fixes `unsafe-string->immutable-string!` on BC so that it doesn't mutate any empty strings, since mutable empty strings may be shared through `zero_length_char_string` (now `scheme_zero_length_char_string`). Instead of mutating empty strings, it returns `scheme_zero_length_char_immutable_string`.