### PR TITLE
Add syntax-property for srcloc of module+ spliced source modules

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -369,7 +369,7 @@ A submodule must not be defined using @racket[module+] @emph{and}
 of @racket[module+] pieces, then it must be made @emph{only} of
 @racket[module+] pieces. }
 
-@history[#:added "8.9.0.1"
+@history[#:changed "8.9.0.1"
          @elem{Added @racket['origin-form-srcloc] syntax property.}]
 
 

--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -354,6 +354,10 @@ enclosing module. If there is only one @racket[module+] for a given
 @racket[(module* id #f form ...)], but still moved to the end of the
 enclosing module.
 
+A @tech{syntax property} on the @racket[module*] form with the key
+@indexed-racket['origin-form-srcloc] records the @racket[srcloc] for
+every contributing @racket[module+] form.
+
 When a module contains multiple submodules declared with
 @racket[module+], then the relative order of the initial
 @racket[module+] declarations for each submodule determines the
@@ -364,6 +368,9 @@ A submodule must not be defined using @racket[module+] @emph{and}
 @racket[module] or @racket[module*]. That is, if a submodule is made
 of @racket[module+] pieces, then it must be made @emph{only} of
 @racket[module+] pieces. }
+
+@history[#:added "8.9.0.1"
+         @elem{Added @racket['origin-form-srcloc] syntax property.}]
 
 
 @defform[(#%module-begin form ...)]{

--- a/racket/collects/racket/private/submodule.rkt
+++ b/racket/collects/racket/private/submodule.rkt
@@ -27,7 +27,10 @@
                 (set-box! stxs-box
                           (cons (append (reverse (syntax->list (syntax-local-introduce #'(e ...))))
                                         (car (unbox stxs-box)))
-                                (cons (syntax-local-introduce stx) (cdr (unbox stxs-box))))))
+                                (cons (syntax-property (syntax-local-introduce stx)
+                                                       'spliced-module-srcloc
+                                                       (syntax-srcloc stx))
+                                      (cdr (unbox stxs-box))))))
               (syntax/loc stx (begin)))])]
         [else
          (raise-syntax-error #f

--- a/racket/collects/racket/private/submodule.rkt
+++ b/racket/collects/racket/private/submodule.rkt
@@ -28,7 +28,7 @@
                           (cons (append (reverse (syntax->list (syntax-local-introduce #'(e ...))))
                                         (car (unbox stxs-box)))
                                 (cons (syntax-property (syntax-local-introduce stx)
-                                                       'spliced-module-srcloc
+                                                       'origin-form-srcloc
                                                        (syntax-srcloc stx))
                                       (cdr (unbox stxs-box))))))
               (syntax/loc stx (begin)))])]


### PR DESCRIPTION
As discussed in <https://racket.discourse.group/t/finding-srcloc-for-modules-in-fully-expanded-code/1932>.

The motivation is to make it possible for check-syntax(-like) tools to build from fully expanded syntax a data structure supporting a conversion of a source position to a module name. 

This would support various things:

- a "run/enter module at point" command
- building smarter (more limited) lists of completion candidates, based on imports visible in the module around point
- possibly other things

I'm not attached to the name of the syntax property, or its value using a `srcloc` `struct` (as opposed to say a `vector` of srcloc values).