### PR TITLE
syntax/parse: configurable failed-match error

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.9.0.4")
+(define version "8.9.0.5")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/syntax/scribblings/parse.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse.scrbl
@@ -27,6 +27,7 @@ messages embedded in the macro's syntax patterns.
 
 @;{Description of how error reporting works}
 @;{and designing for good errors}
+@include-section["parse/error.scrbl"]
 
 @;{Cut and Commit for efficiency and error reporting.}
 

--- a/pkgs/racket-doc/syntax/scribblings/parse/error.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/error.scrbl
@@ -1,0 +1,83 @@
+#lang scribble/doc
+@(require scribble/manual
+          scribble/struct
+          scribble/decode
+          scribble/eval
+          "../common.rkt"
+          "parse-common.rkt"
+          (for-label syntax/parse/report-config))
+
+@(define the-eval (make-sp-eval))
+
+@title[#:tag "error"]{Configuring Error Reporting}
+
+@defmodule[syntax/parse/report-config]
+
+@history[#:added "8.9.0.5"]
+
+@defparam[current-report-configuration config report-configuration?]{
+
+ A parameter that determines parts error messages that are generated
+ by @racket[syntax-parse] for failed matches. When
+ @racket[syntax-parse] needs to report that a particular datum or
+ literal identifier was expected, it consults the configuration in
+ this parameter.
+
+ A configuration is a hash table with the following keys:
+
+ @itemlist[
+
+  @item{@racket['datum-to-what] --- a procedure of one argument used
+  to get a noun describing an expected datum, which appears in a
+  pattern either with @racket[~datum], as ``self-quoting,'' or so on.
+  The procedure's argument is the datum value. The result must be
+  either a string or a list containing two strings; if two strings are
+  provided, the first is used when a singular noun is needed, and the
+  second is used as a plural noun.
+
+  The default configuration returns @racket['("literal symbol"
+  "literal symbols")] for a symbol and @racket['("literal"
+  "literals")] for any other datum value.}
+
+  @item{@racket['datum-to-string] --- a procedure of one argument, used
+  to convert the datum value to a string that is included in the error
+  message. The procedure's argument is the datum value, and the result
+  must be a string.
+
+  The default configuration formats a symbol value using
+  @racket[(format "`~s'" v)] any other datum value using
+  @racket[(format "~s" v)].}
+
+  @item{@racket['literal-to-what] --- a procedure of one argument used
+  to get a noun describing an expected literal identifier, which
+  appears in a pattern with @racket[~literal], as declared with
+  @racket[#:literals], or so on. The procedure's argument is an
+  identifier when available, or a symbol when only simplified
+  information has been preserved. The result must be either a string
+  or a list containing two strings, like the result for a
+  @racket['datum-to-what] procedure.
+
+  The default configuration returns @racket['("identifier"
+  "identifiers")].}
+
+  @item{@racket['literal-to-string] --- a procedure of one argument,
+  used to convert a literal identifier or symbol to a string that is
+  included in the error message.
+
+  The default configuration formats a symbol value using
+  @racket[(format "`~s'" v)], and it formats an identifier the same
+  after extracting its symbol with @racket[syntax-e].}
+
+ ]
+
+}
+
+
+@defproc[(report-configuration? [v any/c]) boolean?]{
+
+ Checks whether @racket[v] is an immutable hash table that maps each
+ of the keys @racket['datum-to-what],
+ @racket['datum-to-string] @racket['identifier-to-what] and
+ @racket['identifier-to-string] to a procedure that accepts one argument.
+
+}

--- a/pkgs/racket-test/tests/stxparse/report-config.rkt
+++ b/pkgs/racket-test/tests/stxparse/report-config.rkt
@@ -1,0 +1,120 @@
+#lang racket
+(require rackunit
+         syntax/parse
+         syntax/parse/debug
+         syntax/parse/define
+         syntax/parse/report-config
+         "setup.rkt")
+
+(define config1
+  (hasheq 'literal-to-what (lambda (v) '("id" "ids"))
+          'literal-to-string (lambda (v)
+                               (format "«~s»" (if (syntax? v)
+                                                  (syntax-e v)
+                                                  v)))
+          'datum-to-what (lambda (v)
+                             (cond
+                               [(number? v)
+                                '("number" "numbers")]
+                               [(or (eq? v 'spike)
+                                    (eq? v 'prickly))
+                                '("cactus" "cacti")]
+                               [else
+                                "stuff"]))
+          'datum-to-string (lambda (v)
+                             (format "=~s" v))))
+
+(check-equal? (report-configuration? config1) #t)
+(check-equal? (report-configuration? (hasheq)) #f)
+(check-equal? (report-configuration? 0) #f)
+
+(tcerr "id"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [(~literal cons) #true]))
+       #rx"expected the id «cons»")
+
+(tcerr "ids"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [(~literal cons) #true]
+           [(~literal list) #true]))
+       #rx"expected one of these ids: «cons» or «list»")
+
+(tcerr "number"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [11 #true]))
+       #rx"expected the number =11")
+
+(tcerr "cactus"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [(~datum spike) #true]))
+       #rx"expected the cactus =spike")
+
+(tcerr "stuff"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [#true #true]))
+       #rx"expected the stuff =#t")
+
+(tcerr "numbers"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [11 #true]
+           [12 #true]
+           [13 #true]))
+       #rx" expected one of these numbers: =11, =12, or =13")
+
+(tcerr "cacti"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [(~datum spike) #true]
+           [(~datum prickly) #true]))
+       #rx"expected one of these cacti: =spike or =prickly")
+
+(tcerr "stuff (plural)"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [#true #true]
+           [#false #true]
+           ["apple" #true]))
+       #rx"expected one of these stuff: =#t, =#f, or =\"apple\"")
+
+(tcerr "number or cactus"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [11 #true]
+           [(~datum spike) #true]))
+       #rx"expected the number =11 or expected the cactus =spike")
+
+(tcerr "numbers or cactus"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [11 #true]
+           [12 #true]
+           [(~datum spike) #true]))
+       #rx"expected one of these numbers: =11 or =12 or expected the cactus =spike")
+
+(tcerr "numbers or cactus or ids"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'no
+           [11 #true]
+           [12 #true]
+           [(~datum spike) #true]
+           [(~literal cons) #true]
+           [(~literal list) #true]))
+       #rx"expected one of these ids: «cons» or «list»; expected one of these numbers: =11 or =12; or expected the cactus =spike")
+
+(tcerr "numbers or cactus or ids"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'(no)
+           [(_ (~literal cons)) #true]))
+       #rx"expected more terms starting with the id «cons»")
+
+(tcerr "numbers or cactus or ids"
+       (parameterize ([current-report-configuration config1])
+         (syntax-parse #'(no)
+           [(_ (~datum spike)) #true]))
+       #rx"expected more terms starting with the cactus =spike")

--- a/racket/collects/syntax/parse/report-config.rkt
+++ b/racket/collects/syntax/parse/report-config.rkt
@@ -1,0 +1,35 @@
+#lang racket/base
+
+(provide report-configuration?
+         current-report-configuration)
+
+(define (report-configuration? v)
+  (define (procedure1? key)
+    (define p (hash-ref v key #f))
+    (and (procedure? p) (procedure-arity-includes? p 1)))
+  (and (hash? v)
+       (immutable? v)
+       (procedure1? 'literal-to-what)
+       (procedure1? 'literal-to-string)
+       (procedure1? 'datum-to-what)
+       (procedure1? 'datum-to-string)))
+
+(define current-report-configuration
+  (make-parameter (hasheq 'literal-to-what (lambda (v)
+                                             '("identifier" "identifiers"))
+                          'literal-to-string (lambda (v)
+                                               (format "`~s'" (if (syntax? v)
+                                                                  (syntax-e v)
+                                                                  v)))
+                          'datum-to-what (lambda (v)
+                                           (if (symbol? v)
+                                               '("literal symbol" "literal symbols")
+                                               '("literal" "literals")))
+                          'datum-to-string (lambda (v)
+                                             (if (symbol? v)
+                                                 (format "`~s'" v)
+                                                 (format "~s" v))))
+                  (lambda (v)
+                    (unless (report-configuration? v)
+                      (raise-argument-error 'current-report-configuration "report-configuration?" v))
+                    v)))

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 9
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 4
+#define MZSCHEME_VERSION_W 5
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
CC @rmculpepper 

Add `syntax/parse/report-config` with `current-report-configuration` to support configuring parts of the message that `syntax-parse` generates for a failed match. Configuration controls the way that datum and identifier literals are described and printed.

The existing `~describe` form can generally configure the way that expected input is described in an error message, but for the common cases of literals (including keywords), an external configuration can be more convenient and seems likely more efficient. This configuration is enough to make Rhombus error messages better, covering the key cases of keywords, identifiers, and literals. It doesn't cover operator matching for Rhombus, since operators have the shape `(op <identifier>)` in S-expression form; using `~describe` for the specific case of operators seems fine. Although Rhombus obviously motivates this change, the goal here is to be reasonably general and to leave room when further generalization is needed.

This PR also includes a use of `error-syntax->string-handler` instead of `~s` to format a source term.