### PR TITLE
Fix typos

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/other.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other.scrbl
@@ -32,7 +32,7 @@ installed on your system and specific to your user account.
 packages contributed by Racketeers. The
 @link["https://docs.racket-lang.org"]{online Racket documentation}
 includes documentation for packages in that catalog, updated daily.
-For more information about packages, see see @other-manual['(lib
+For more information about packages, see @other-manual['(lib
 "pkg/scribblings/pkg.scrbl")].
 
 @link["https://planet.racket-lang.org/"]{@|PLaneT|} serves packages that

--- a/pkgs/racket-doc/scribblings/raco/exe.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe.scrbl
@@ -80,7 +80,7 @@ such mapping is created for filesystem paths. By default, a module's
 symbolic name is generated in an unspecified but deterministic
 way where the name starts with @as-index{@litchar{#%embedded:}},
 except that the main module is prefixed with @litchar{#%mzc:}. The
-relative lack of specification for module names can be be a problem
+relative lack of specification for module names can be a problem
 for language constructs that are sensitive to module names, such as
 serialization. To take more control over a module's symbolic name, use
 the @DPFlag{named-lib} or @DPFlag{named-file} argument to specify a

--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1437,7 +1437,7 @@ rest-args contract, and an optional pre-condition. The pre-condition is
 introduced with the @racket[#:pre] keyword followed by the list of names on
 which it depends. If the @racket[#:pre/name] keyword is used, the string
 supplied is used as part of the error message; similarly with @racket[#:post/name].
-If @racket[#:pre/desc] or @racket[#:post/desc] is used, the the result of
+If @racket[#:pre/desc] or @racket[#:post/desc] is used, the result of
 the expression is treated the same way as @racket[->*].
 
 Following the pre-condition is the optional @racket[param-value] non-terminal
@@ -3851,7 +3851,7 @@ A predicate recognizing structures with the @racket[prop:collapsible-contract] p
                                   [ref (or/c #f impersonator?)])]{
  The parent struct of properties that should be attached to chaperones or impersonators
  of values protected with a collapsible contract. The @racket[c-c] field stores the collapsible
- contract that is or will in the future be attached to the the value. The @racket[neg-party] field
+ contract that is or will in the future be attached to the value. The @racket[neg-party] field
  stores the latest missing blame party passed to the contract on the value. The @racket[ref] field
  is mutable and stores a reference to the chaperone or impersonator to which this property is
  attached. This is necessary to determine whether an unknown chaperone has been attached to a value

--- a/pkgs/racket-doc/scribblings/reference/eval.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/eval.scrbl
@@ -392,7 +392,7 @@ use for the initial parameter value.
 
 @defparam*[current-compiled-file-roots paths (listof (or/c path-string? 'same)) (listof (or/c path? 'same))]{
 
-A list of paths and @racket['same]s that is is used by the default
+A list of paths and @racket['same]s that is used by the default
 @tech{compiled-load handler} (see @racket[current-load/use-compiled]).
 
 The parameter is normally initialized to @racket[(list 'same)], but

--- a/pkgs/racket-doc/scribblings/reference/interaction-info.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/interaction-info.scrbl
@@ -17,7 +17,7 @@ prompt with syntax coloring and indentation support. This parameter is
 typically set by a @racketidfont{configure-runtime} module; see also
 @secref["configure-runtime"].
 
-Instead of providing configuration information directly, the the
+Instead of providing configuration information directly, the
 @racket[current-interaction-info] parameter specifies a module to
 load, a exported function to call, and data to pass as an argument to
 the exported function. The result of that function should be another

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -866,7 +866,7 @@ each element in the sequence.
 @subsection{Sequence Conversion}
 
 @defproc[(sequence->stream [seq sequence?]) stream?]{
-  Coverts a sequence to a @tech{stream}, which supports the
+  Converts a sequence to a @tech{stream}, which supports the
   @racket[stream-first] and @racket[stream-rest] operations. Creation
   of the stream eagerly @tech{initiates} the sequence, but the stream
   lazily draws elements from the sequence, caching each element so

--- a/pkgs/racket-doc/scribblings/reference/surrogate.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/surrogate.scrbl
@@ -36,7 +36,7 @@ new value of the field. The @racket[get-surrogate] method returns the
 current value of the field.
 
 If @racket[#:use-wrapper-proc] does appear, the host mixin adds
-and a second private field and its getter and setter
+a second private field and its getter and setter
 methods @racket[get-surrogate-wrapper-proc] and @racket[set-surrogate-wrapper-proc].
 The additional field holds a wrapper procedure whose contract
 is @racket[(-> (-> any) (-> any) any)], so the procedure is invoked with two thunks.

--- a/pkgs/racket-doc/scribblings/reference/surrogate.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/surrogate.scrbl
@@ -35,7 +35,7 @@ previous value of the field and @racket[on-enable-surrogate] for the
 new value of the field. The @racket[get-surrogate] method returns the
 current value of the field.
 
-If @racket[#:use-wrapper-proc] does appear, the the host mixin adds
+If @racket[#:use-wrapper-proc] does appear, the host mixin adds
 and a second private field and its getter and setter
 methods @racket[get-surrogate-wrapper-proc] and @racket[set-surrogate-wrapper-proc].
 The additional field holds a wrapper procedure whose contract


### PR DESCRIPTION
### Checklist

- [x] documentation

### Description of change

I removed a few duplicated words in the documentation.

In the second commit, I removed a word "and" which doesn't seem to belong there. I hope the resulting sentence is correct. If not, please change it as appropriate. I can remove the last commit and force-push if necessary.
