### PR TITLE
match: add #:do

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -55,7 +55,7 @@ a lower-level mechanism achieving the same ends.
 (m '(2 3 4))
 ]
 
-An optional @racket[#:do [do-body ...]] simply executes @racket[do-body] forms.
+An optional @racket[#:do [do-body ...]] executes @racket[do-body] forms.
 In particular, the forms may introduce definitions that are visible in the remaining
 options and the main clause body.
 Both @racket[#:when] and @racket[#:do] options may appear multiple times
@@ -74,7 +74,7 @@ Both @racket[#:when] and @racket[#:do] options may appear multiple times
 (m '(2 3 4))
 ]
 
-An optional @racket[(=> id)], which must appear right after @racket[pat],
+An optional @racket[(=> id)], which must appear immediately after @racket[pat],
 is bound to a @deftech{failure procedure} of zero
 arguments.
 @racket[id] is visible in all clause options and the clause body.

--- a/pkgs/racket-test/tests/match/case-tests.rkt
+++ b/pkgs/racket-test/tests/match/case-tests.rkt
@@ -250,15 +250,13 @@
             (let (,_) ; next
               (case ,_
                 [(1) (syntax-parameterize (,_)
-                       (let ()
-                         (if #f
-                             (let () 'a)
-                             (fail))))]
+                       (if #f
+                           (let () 'a)
+                           (fail)))]
                 [(2) (syntax-parameterize (,_)
-                       (let ()
-                         (if #t
-                             (let () 'c)
-                             (fail))))]
+                       (if #t
+                           (let () 'c)
+                           (fail)))]
                 [(3) ,_]
                 [else ,_])))))
       (check-equal? (test 1) 'b)
@@ -288,8 +286,3 @@
       (check-false x)
       (check-equal? (test 2) 'b)
       (check-true x))))
-
-(module+ test
-  (require rackunit/text-ui)
-
-  (run-tests case-tests))

--- a/pkgs/racket-test/tests/match/match-exn-tests.rkt
+++ b/pkgs/racket-test/tests/match/match-exn-tests.rkt
@@ -72,7 +72,27 @@
                    (lambda () (convert-syntax-error (match 1 [])))))
       (test-case "match*"
         (check-exn #rx"match\\*: expected more terms starting with any term"
-                   (lambda () (convert-syntax-error (match* 1 [])))))))
+                   (lambda () (convert-syntax-error (match* 1 [])))))
+
+      (test-case "ill-formed =>"
+        (check-exn #rx"expected an identifier"
+                   (lambda () (convert-syntax-error (match 1 [1 (=> 1) 2]))))
+        (check-exn #rx"after => option"
+                   (lambda () (convert-syntax-error (match 1 [1 (=> x)])))))
+
+      (test-case "ill-formed #:when"
+        (check-exn #rx"cond-expr"
+                   (lambda () (convert-syntax-error (match 1 [1 #:when]))))
+        (check-exn #rx"after #:when option"
+                   (lambda () (convert-syntax-error (match 1 [1 #:when #t])))))
+
+      (test-case "ill-formed #:do"
+        (check-exn #rx"sequence of do-bodys"
+                   (lambda () (convert-syntax-error (match 1 [1 #:do]))))
+        (check-exn #rx"sequence of do-bodys"
+                   (lambda () (convert-syntax-error (match 1 [1 #:do #t 1]))))
+        (check-exn #rx"after #:do option"
+                   (lambda () (convert-syntax-error (match 1 [1 #:do []])))))))
 
   (define match-exn-tests
     (test-suite "Tests for exceptions raised by match.rkt"

--- a/pkgs/racket-test/tests/match/match-tests.rkt
+++ b/pkgs/racket-test/tests/match/match-tests.rkt
@@ -3,6 +3,62 @@
            (for-syntax racket/base))
   
   (provide match-tests)
+
+  (define option-tests
+    (test-suite "Tests for clause options"
+      (test-case "#:do and #:when"
+        (define (f xs)
+          (match xs
+            [(list a b)
+             #:do [(define sum (+ a b))
+                   (define sum^2 (* sum sum))]
+             #:when (< sum^2 50)
+             #:do [(define sum^2+1 (add1 sum^2))]
+             sum^2+1]
+            [_ 'no-match]))
+
+        (check-equal? (f (list 3 4)) 50)
+        (check-equal? (f (list 4 4)) 'no-match))
+
+      (test-case "=> scope"
+        (define (f xs)
+          (match xs
+            [(list a b)
+             (=> exit)
+             #:do [(when (= a b)
+                     (exit))]
+             a]
+            [_ 'no-match]))
+
+        (check-equal? (f (list 5 5)) 'no-match)
+        (check-equal? (f (list 5 6)) 5))
+
+      (test-case "define/match"
+        (define/match (f xs)
+          [((list a b))
+           #:do [(define sum (+ a b))
+                 (define sum^2 (* sum sum))]
+           #:when (< sum^2 50)
+           #:do [(define sum^2+1 (add1 sum^2))]
+           sum^2+1]
+          [(_) 'no-match])
+
+        (check-equal? (f (list 3 4)) 50)
+        (check-equal? (f (list 4 4)) 'no-match))
+
+      (test-case "match*"
+        (define (f xs)
+          (match* (xs)
+            [((list a b))
+             #:do [(define sum (+ a b))
+                   (define sum^2 (* sum sum))]
+             #:when (< sum^2 50)
+             #:do [(define sum^2+1 (add1 sum^2))]
+             sum^2+1]
+            [(_) 'no-match]))
+
+        (check-equal? (f (list 3 4)) 50)
+        (check-equal? (f (list 4 4)) 'no-match))))
   
   (define match-expander-tests
     (test-suite
@@ -132,8 +188,9 @@
 
   (define match-tests
     (test-suite "Tests for match.rkt"
-                     doc-tests
-                     simple-tests
-                     nonlinear-tests
-                     match-expander-tests))
+      option-tests
+      doc-tests
+      simple-tests
+      nonlinear-tests
+      match-expander-tests))
   )

--- a/racket/collects/racket/match/gen-match.rkt
+++ b/racket/collects/racket/match/gen-match.rkt
@@ -72,15 +72,23 @@
                       (string-append " after " after)
                       ""))
                  clause)]
+
                [(#:when e rest ...)
                 #`(if e
                       #,(parse-options #'(rest ...) #:after "#:when option")
                       (fail))]
+               [(#:when . _)
+                (raise-syntax-error 'match "expected a cond-expr after #:when" clause)]
+
                [(#:do [do-body ...] rest ...)
                 #`(let ()
                     do-body ...
                     #,(parse-options #'(rest ...) #:after "#:do option"))]
+               [(#:do . _)
+                (raise-syntax-error 'match "expected a sequence of do-bodys after #:do" clause)]
+
                [(rest ...) #'(let () rest ...)]))
+
            (syntax-parse rhs
              [(((~datum =>) unm) rest ...)
               (unless (identifier? #'unm)

--- a/racket/collects/racket/match/gen-match.rkt
+++ b/racket/collects/racket/match/gen-match.rkt
@@ -55,8 +55,7 @@
            (define (mk unm rhs)
              (make-Row (for/list ([p (syntax->list pats)]) (parse p))
                        (syntax-property
-                        (quasisyntax/loc stx
-                          (let () #,rhs))
+                        (datum->syntax rhs (syntax-e rhs) stx rhs)
                         'feature-profile:pattern-matching 'antimark)
                        unm null))
            ;; NOTE: parse-options must generate code at a tail-position,


### PR DESCRIPTION
This PR adds a support of `#:do` in match clauses and generalizes the existing match clause options.

Currently, match clause option is either:

1. None
2. `(=> id)`
3. `#:when cond-expr`

With this PR, the option becomes: `option=> option ...` where `option=>` is either:

1. None
2. `(=> id)`

and `option` is either:

1. `#:when cond-expr`
2. `#:do [do-body ...]` 

In particular, it allows `#:when` and `#:do` to appear multiple times.

All match programs prior this PR continue to work under this PR.

## Examples

```
> (define (m x)
    (match x
      [(list a b c)
       #:do [(define sum (+ a b c))]
       #:when (> sum 6)
       (format "the sum, which is ~a, is greater than 6" sum)]
      [(list a b c) 'sum-is-not-greater-than-six]))
> (m '(1 2 3))
'sum-is-not-greater-than-six
> (m '(2 3 4))
"the sum, which is 9, is greater than 6"
```

Resolves #4591 and #4674. But it does not resolve #4675, as it's unclear what should be done.