### PR TITLE
fully overwrite build-time `coLLECTs dIRECTORy`

### DIFF
--- a/racket/collects/compiler/private/configdir.rkt
+++ b/racket/collects/compiler/private/configdir.rkt
@@ -1,28 +1,22 @@
 #lang racket/base
-(require racket/port)
+(require racket/port
+         (submod "collects-path.rkt" set-executable-tag))
 
 (provide update-config-dir
          get-current-config-dir)
 
 (define label #rx#"coNFIg dIRECTORy:")
-(define max-dir-len 1024)
 
 (define (update-config-dir dest path)
-  (let ([path-bytes (cond [(path? path) (path->bytes path)]
-                          [else (string->bytes/locale path)])])
-    (unless ((bytes-length path-bytes) . <= . max-dir-len)
-      (error 'update-config-dir "path too long: ~e" path))
-    (let ([m (with-input-from-file dest
-               (lambda ()
-                 (regexp-match-positions label (current-input-port))))])
-      (unless m
-        (error 'update-ddl-dir "cannot find config path in file: ~e" dest))
-      (with-output-to-file dest
-        #:exists 'update
-        (lambda ()
-          (file-position (current-output-port) (cdar m))
-          (write-bytes path-bytes)
-          (write-byte 0))))))
+  (set-executable-tag 'update-config-dir
+                      label
+                      "config"
+                      dest
+                      #f
+                      path
+                      (if (path? path)
+                          (path->bytes path)
+                          (string->bytes/locale path))))
       
 (define (get-current-config-dir dest)
   (with-input-from-file dest

--- a/racket/collects/compiler/private/windlldir.rkt
+++ b/racket/collects/compiler/private/windlldir.rkt
@@ -1,6 +1,7 @@
 (module windlldir racket/base
   (require racket/port
            racket/promise
+           (submod "collects-path.rkt" set-executable-tag)
            "winutf16.rkt")
 
   (provide update-dll-dir
@@ -8,26 +9,18 @@
 	   current-no-dlls?)
 
   (define label (delay/sync (byte-regexp (bytes->utf-16-bytes #"dLl dIRECTORy:"))))
-  (define max-dir-len (* 512 2)) ; sizeof(wchar_t) is 2
 
   (define (update-dll-dir dest path)
-    (let ([path-bytes (bytes->utf-16-bytes
-                       (cond [(eq? path #t) #"<system>"]
-                             [(path? path) (path->bytes path)]
-                             [else (string->bytes/locale path)]))])
-      (unless ((bytes-length path-bytes) . <= . max-dir-len)
-        (error 'update-dll-dir "path too long: ~e" path))
-      (let ([m (with-input-from-file dest
-                 (lambda ()
-                   (regexp-match-positions (force label) (current-input-port))))])
-        (unless m
-          (error 'update-ddl-dir "cannot find DLL path in file: ~e" dest))
-        (with-output-to-file dest
-          (lambda ()
-            (file-position (current-output-port) (cdar m))
-            (write-bytes path-bytes)
-            (write-byte 0))
-          #:exists 'update))))
+    (set-executable-tag 'update-dll-dir
+                        (force label)
+                        "DLL"
+                        dest
+                        #f
+                        path
+                        (bytes->utf-16-bytes
+                         (cond [(eq? path #t) #"<system>"]
+                               [(path? path) (path->bytes path)]
+                               [else (string->bytes/locale path)]))))
 
   (define (get-current-dll-dir dest)
     (with-input-from-file dest

--- a/racket/collects/setup/unixstyle-install.rkt
+++ b/racket/collects/setup/unixstyle-install.rkt
@@ -33,6 +33,7 @@
 
 #lang racket/base
 (require setup/cross-system
+         (submod compiler/private/collects-path set-executable-tag)
          racket/file
          racket/list)
 
@@ -223,22 +224,12 @@
 
 (define (fix-executable file #:ignore-non-executable? [ignore-non-executable? #f])
   (define (fix-binary file)
-    (define (fix-one tag dir)
-      (let-values ([(i o) (open-input-output-file file #:exists 'update)])
-        (cond
-          [(regexp-match-positions tag i)
-           => (lambda (m)
-                (file-position o (cdar m))
-                (display dir o)
-                (write-byte 0 o)
-                (write-byte 0 o))]
-          [else
-           (unless ignore-non-executable?
-             (error
-              (format "could not find collection-path label in executable: ~a"
-                      file)))])
-        (close-input-port i)
-        (close-output-port o)))
+    (define (fix-one tag desc dir)
+      (set-executable-tag 'unixstyle-install tag desc file ignore-non-executable? dir
+                          (path->bytes
+                           (if (string? dir)
+                               (string->path dir)
+                               dir))))
     (fix-one #rx#"coLLECTs dIRECTORy:" (dir: 'collects))
     (fix-one #rx#"coNFIg dIRECTORy:" (dir: 'config)))
   (define (fix-script file)
@@ -401,10 +392,6 @@
       (printf "\n# Remove this script\n")
       (printf "exec rm \"$0\"\n")))
   (run "chmod" "+x" uninstaller))
-
-;; we need a namespace to compile the new config, grab it now, before the
-;; collection tree moves (otherwise it won't find the `scheme' collection)
-(define base-ns (make-base-namespace))
 
 (define write-config
   (case-lambda

--- a/racket/src/start/README.txt
+++ b/racket/src/start/README.txt
@@ -1,4 +1,4 @@
-This directory constraint source programs and fragments for wrapper
+This directory contains source programs and fragments for wrapper
 executables used to start/embed Racket. The programs and fragments are
 used both for the Racket CS and BC implementations.
 
@@ -18,6 +18,18 @@ The paths are embedded in the executable immediately after a special
 entire list of paths must end with an additional NUL terminator, and
 the overall list must be less than 1024 bytes long.
 
+Under Windows, executables also embed a path to DLLs. For more
+information, see "..\worksp\README.txt".
+
+Paths to all other installation directories are found through a
+"config.rktd" file in a "configuration directory". Most paths that are
+specified in "config.rktd" have default values that are relative to
+the main collection directory. The paths of the configuration
+directory and main collection directory thus work together to
+determine a Racket configuration. A configuration directory may be
+embedded in an executable using the "coNFIg dIRECTORy:" tag similarly
+to "coLLECTs dIRECTORy:".
+
 As an alternative to editing an executable directly, the
 `create-embedding-executable` procedure from `compiler/embed` can be
 used to change the embedded path. For example, the following program
@@ -27,12 +39,8 @@ path in the clone to "/tmp/collects":
  (require compiler/embed)
  (create-embedding-executable "/tmp/mz" #:collects-path "/tmp/collects")
 
-Similarly, `raco exe` mode accepts a `--collects` flag to set the
-collection path in the generated executable.
+Similarly, `raco exe` mode accepts flags like `--collects-path` and
+`--config-path` to set these paths in the generated executable.
 
-Under Windows, executables also embed a path to DLLs. For more
-information, see "..\worksp\README.txt".
-
-Paths to all other installation directories are found through the
-"config.rkt" library of the "config" collection. Search the
-documentation for "config search paths" for more information.
+See the "Installation Configuration and Search Paths" section in the
+`raco` documentation for more details.

--- a/racket/src/start/collects-path.rkt
+++ b/racket/src/start/collects-path.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 (require racket/cmdline
-         racket/system)
+         (submod compiler/private/collects-path set-executable-tag))
 
 ;; This module is executed by the install process to update
 ;;  the embedded path to "collects" and "lib" in an executable.
@@ -8,21 +8,12 @@
 (command-line
  #:args (srcdir dest dir-path config-path)
 
- (define (fix-one label path-in)
-   (define-values (i o) (open-input-output-file dest #:exists 'update))
-   (define m (regexp-match-positions label i))
-   (define path (if (string? path-in)
-                    (string->path path-in)
-                    path-in))
-   (unless m
-     (error 'set-collects-path
-            "cannot find collection-path label in executable file"))
-   (file-position o (cdar m))
-   (write-bytes (path->bytes path) o)
-   (write-byte 0 o)
-   (write-byte 0 o)
-   (close-input-port i)
-   (close-output-port o))
+ (define (fix-one label desc path-in)
+   (set-executable-tag 'set-collects-path label desc dest #f path-in
+                       (path->bytes
+                        (if (string? path-in)
+                            (string->path path-in)
+                            path-in))))
  
- (fix-one #rx#"coLLECTs dIRECTORy:" dir-path)
- (fix-one #rx#"coNFIg dIRECTORy:" config-path))
+ (fix-one #rx#"coLLECTs dIRECTORy:" "collects" dir-path)
+ (fix-one #rx#"coNFIg dIRECTORy:" "config" config-path))

--- a/racket/src/worksp/README.txt
+++ b/racket/src/worksp/README.txt
@@ -176,7 +176,7 @@ explicit DLL load, so that the DLLs must appear in the normal DLL
 search path.
 
 See also "..\start\README.txt" for information on the embedded
-"collects" path in executables.
+"collects" and "config" paths in executables.
 
 
 ========================================================================


### PR DESCRIPTION
When rewriting the embedded `coLLECTs dIRECTORy`, `coNFIg dIRECTORy`, or `dLl dIRECTORy` in an executable, always null out any unused space so as to reliably overwrite the entire old value.

Previously, we would simply write the new value and null terminators, ignoring the contents of the rest of the buffer, which might contain a suffix of the supposedly-overwritten value. For example, the bytes following `coNFIg dIRECTORy` might end up like this:

```racket
#":../collects\0\0ld-racket-vm-cs-8.8.drv-0/source/racket/collects\0\0*"
```

In particular, preserving build paths this way was one of the problems Debian, ALT, and other distributions faced in building Racket reproducibly. The results @Ancieg shared in https://github.com/racket/racket/issues/4456#issuecomment-1281969897 helped me to find this issue.

This commit centralizes executable rewriting in a new `(submod compiler/private/collects-path set-executable-tag)`. It consistently checks that we do not write past the end of the reserved space, which only sometimes was checked previously.