### PR TITLE
Fix `->*` where `#:pre` and `#:rest` are present

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/arrow-star.rkt
+++ b/pkgs/racket-test/tests/racket/contract/arrow-star.rkt
@@ -712,6 +712,29 @@
                  'pos 'neg)
      2)))
   
+  (test/neg-blame
+   '->*-pre/post-20
+   '((contract (->* () #:rest list? #:pre #f integer?)
+               (λ args 1)
+               'pos
+               'neg)))
+
+  (test/neg-blame
+   '->*-pre/post-21
+   '((contract (->* () #:rest (list/c integer?) #:pre #t integer?)
+               (λ args 1)
+               'pos
+               'neg)
+     ""))
+
+  (test/spec-passed
+   '->*-pre/post-22
+   '((contract (->* () #:rest (list/c integer?) #:pre #t integer?)
+               (λ args 1)
+               'pos
+               'neg)
+     2))
+
   (test/spec-passed
    '->*-opt-optional1
    '((contract (->* () integer?) (lambda () 1) 'pos 'neg)))

--- a/pkgs/racket-test/tests/racket/contract/contract-out.rkt
+++ b/pkgs/racket-test/tests/racket/contract/contract-out.rkt
@@ -1364,21 +1364,34 @@
    "provide/contract73-a")
 
   (test/spec-passed
-   'provide/contract70
+   'provide/contract74
    ;; https://github.com/racket/racket/issues/2572
    '(let ()
-      (eval '(module provide/contract70-a racket/base
+      (eval '(module provide/contract74-a racket/base
                (require racket/contract/base)
                (struct stream (x [y #:mutable]))
                (provide (contract-out (struct stream ([x any/c] [y any/c]))))))
 
-      (eval '(module provide/contract70-b racket/base
-               (require 'provide/contract70-a racket/contract/base)
+      (eval '(module provide/contract74-b racket/base
+               (require 'provide/contract74-a racket/contract/base)
                (provide (contract-out (struct stream ([x any/c] [y any/c]))))))
 
-      (eval '(module provide/contract70-c racket/base
-               (require 'provide/contract70-b racket/contract/base)
+      (eval '(module provide/contract74-c racket/base
+               (require 'provide/contract74-b racket/contract/base)
                (void stream stream? stream-x stream-y set-stream-y!)))))
+
+  (test/spec-passed/result
+   'provide/contract75
+   '(let ()
+      (eval '(module provide/contract75 racket/base
+               (require racket/contract/base)
+               (provide
+                (contract-out
+                 [f (->* () #:rest (listof integer?) #:pre #t any)]))
+               (define (f . args) args)))
+      (eval '(require 'provide/contract75))
+      (eval '(f 1 12)))
+   '(1 12))
 
   (test/spec-passed/result
    'provide/contract-struct-out

--- a/racket/collects/racket/contract/private/arrow-val-first.rkt
+++ b/racket/collects/racket/contract/private/arrow-val-first.rkt
@@ -502,9 +502,9 @@ plus1 arg list construction: build-plus-one-arity-function/real
         (define number-of-rngs (and rngs (with-syntax ([rngs rngs]) (length (syntax->list #'rngs)))))
         #`(λ (f)
             (λ (blame regb ... optb ... kb ... okb ...
+                      #,@(if rest (list #'restb) '())
                       #,@(if pre (list pre) '())
                       #,@(if pre/desc (list pre/desc) '())
-                      #,@(if rest (list #'restb) '())
                       rb ...
                       #,@(if post (list post) '())
                       #,@(if post/desc (list post/desc) '()))


### PR DESCRIPTION
The following program

```rkt
(module m racket
  (provide
   (contract-out
    [f (->* () #:rest (listof integer?) #:pre #t any)]))
  (define (f . args) args))

(require 'm)

(f 1 12)
```

has a cryptic internal error:

```
...ct/private/list.rkt:215:14: arity mismatch;
 the expected number of arguments does not match the given number
  expected: 2
  given: 0
  context...:
   /usr/share/racket/collects/racket/contract/private/arrow-higher-order.rkt:83:0: check-pre-cond
   /usr/share/racket/collects/racket/contract/private/arrow-val-first.rkt:486:18
```

I tracked this down to the inconsistent ordering of `#:pre` and `#:rest` components in various parts of the arrow contract implementation. In the above code, the thunk for the `#:pre` is being used instead of the late neg projection of the `#:rest`. I didn't bother to try and make everything consistent, only to flip the order in the one place that mattered to fix this bug.