### PR TITLE
add example of adding documentation to a category on the docs home page

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/setup.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/setup.scrbl
@@ -610,6 +610,13 @@ Optional @filepath{info.rkt} fields trigger additional actions by
 
    ]
 
+   This example lists the documentation in the 'Slideshow Libraries' category:
+   
+   @racketblock[
+   (define scribblings
+     '(("ppict.scrbl" () ("Slideshow Libraries"))))
+   ]
+
    If the category list has a second element, it must be a real number
    that designates the manual's sorting position with the category;
    manuals with the same sorting position are ordered


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

### Description of change
add example of adding documentation to a category on the docs home page.


taken from:
https://github.com/rmculpepper/ppict/blob/master/info.rkt