### PR TITLE
rktboot: improve machene type inference

### DIFF
--- a/racket/src/rktboot/config.rkt
+++ b/racket/src/rktboot/config.rkt
@@ -15,20 +15,69 @@
                                (path->complete-path scheme-dir))))))
 (hash-set! ht 'make-boot-scheme-dir scheme-dir)
 
+(define (infer-target-machine)
+  ;; Compute a native or pbarch machine string for the current platform.
+  ;; Some caveats:
+  ;;  1. A pbarch Racket will always infer a pbarch machine,
+  ;;     even if a native machine exists. Hopefully this is an
+  ;;     unlikely scenario: if you're running Racket CS, you've
+  ;;     bootstrapped Chez somehow, so you could use `re.boot`.
+  ;;  2. A `tpb` or `pb` Racket on a 32-bit platform would still return
+  ;;     64 from `(system-type 'word)`, but, in addition to the above,
+  ;;     it is not currently possible or desired to build Racket as
+  ;;     `tpb` or `pb` (as opposed to pbarch variants):
+  ;;     see <https://github.com/racket/racket/issues/4692>.
+  ;;  3. On a hypothetical platform where Chez supported both the
+  ;;     architecture and the OS, but not the combination of the two,
+  ;;     (e.g. riscv64 Windows) this code would currently return a
+  ;;     non-existent native machine (e.g. trv64nt) instead of a
+  ;;     working pbarch machine. Presumably this could be fixed if
+  ;;     such a platform came into existence.
+  (define s (path->string (system-library-subpath #f)))
+  (define arch+os
+    (cond
+      [(regexp-match #rx"^([^\\]+)\\\\([^\\]+)$" s)
+       => (λ (m)
+            (reverse (cdr m)))]
+      [(regexp-match #rx"^([^-]+)-(.+)$" s)
+       => cdr]
+      [else
+       (error 'infer-target-machine "unknown format for system library subpath"
+              "produced" (system-library-subpath #f))]))
+  (define arch
+    (case (car arch+os)
+      [("x86_64" "amd64") "a6"] ; https://github.com/racket/racket/issues/4691
+      [("i386") "i3"]
+      [("aarch64") "arm64"]
+      [("arm") "arm32"]
+      [("ppc") "ppc32"]
+      [("riscv64") "rv64"]
+      [("unknown") #f] ; pb machine types
+      [else #f]))
+  (define os
+    (case (cadr arch+os)
+      [("macosx" "darwin" "ios") "osx"]
+      [("win32" "cygwin") "nt"]
+      [("linux" "android") "le"]
+      [("gnu-hurd") "gnu"]
+      [("freebsd") "fb"]
+      [("openbsd") "ob"]
+      [("netbsd") "nb"]
+      [("solaris") "s2"] ; NOT "sunos4" (I think)
+      [("qnx") "qnx"]
+      [("unknown") #f] ; pb machine types
+      [else #f]))
+  (if (and arch os)
+      (string-append "t" arch os)
+      (format "tpb~a~a"
+              (system-type 'word)
+              (if (system-big-endian?)
+                  "b"
+                  "l"))))
+
 (define target-machine (or (hash-ref ht 'make-boot-targate-machine #f)
                            (getenv "MACH")
-                           (case (system-type)
-                             [(macosx) (if (eqv? 64 (system-type 'word))
-                                           "ta6osx"
-                                           "ti3osx")]
-                             [(windows) (if (eqv? 64 (system-type 'word))
-                                           "ta6nt"
-                                           "ti3nt")]
-                             [else
-                              (case (path->string (system-library-subpath #f))
-                                [("x86_64-linux") "ta6le"]
-                                [("i386-linux") "ti3le"]
-                                [else #f])])))
+                           (infer-target-machine)))
 (hash-set! ht 'make-boot-targate-machine target-machine)
 
 (define optimize-level-init 3)


### PR DESCRIPTION
Related to https://issues.guix.gnu.org/62231
Related to https://github.com/racket/racket/issues/3948

I've just done the obvious thing here and parsed `(system-library-subpath #f)`, but I still feel like I've read and written this code too many times.

In particular, I noticed that RISC-V machine types are defined for the BSDs at the Chez Scheme level:

https://github.com/racket/racket/blob/373bf233ecddee44a14821d272ec7f265a1b8845/racket/src/ChezScheme/s/cmacros.ss#L376-L418

But Rumble only handles RISC-V on Linux:

https://github.com/racket/racket/blob/373bf233ecddee44a14821d272ec7f265a1b8845/racket/src/cs/rumble/system.ss#L54-L65

https://github.com/racket/racket/blob/373bf233ecddee44a14821d272ec7f265a1b8845/racket/src/cs/rumble/system.ss#L112-L113

And `raco cross` doesn't handle RISC-V at all:

https://github.com/racket/raco-cross/blob/01a58ff14ee2ee126cf65897761556501a7197ae/raco-cross-lib/private/cross/platform.rkt#L41-L82

I think it might make sense to implement more of this translation logic in Chez itself, but I haven't been completely satisfied with any of the concrete ideas I've come up with so far.