### PR TITLE
rktboot: Add support for riscv64.

### DIFF
--- a/racket/src/rktboot/machine-def.rkt
+++ b/racket/src/rktboot/machine-def.rkt
@@ -25,6 +25,7 @@
                                      [(regexp-match? #rx"^t?arm32" target-machine) "arm32"]
                                      [(regexp-match? #rx"^t?arm64" target-machine) "arm64"]
                                      [(regexp-match? #rx"^t?ppc32" target-machine) "ppc32"]
+                                     [(regexp-match? #rx"^t?rv64" target-machine) "rv64"]
                                      [(regexp-match? #rx"^t?pb" target-machine) "pb"]
                                      [else (error "machine.def: cannot infer architecture")]))]
                [s (regexp-replace* #rx"[$][(]Mend[)]" s


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [ ] tests included
- [ ] documentation

### Description of change
<!-- Please provide a description of the change here. -->
This one-line patch adds support for riscv64 (trv64le) to rktboot. Not all of the tests passed yet.