### PR TITLE
Bump base version (due to dd5696e7)

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.10.0.1")
+(define version "8.10.0.2")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))


### PR DESCRIPTION
##### Checklist

- [x] Bugfix

### Description of change

Bump the version of the `base` package due to dd5696e7
