### PR TITLE
[ ci ] Run at most one snapshot action at a time

### DIFF
--- a/.github/workflows/ci-snapshot.yml
+++ b/.github/workflows/ci-snapshot.yml
@@ -5,6 +5,13 @@ on:
     branches:
       - master
 
+# Only run at most one snapshot action
+#   https://docs.github.com/en/enterprise-cloud@latest/actions/using-jobs/using-concurrency
+#   https://stackoverflow.com/questions/66335225/how-to-cancel-previous-runs-in-the-pr-when-you-push-new-commitsupdate-the-curre
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
 jobs:
   create-installer:
     runs-on: ubuntu-22.04


### PR DESCRIPTION

### Description of change

I think it makes sense to generate snapshots only for the latest commit to `master`.
Therefore, this PR cancels any in-progress snapshot actions when a new one is triggered.
However, there are some drawbacks.

- Up sides: no need to wait for earlier snapshot actions to finish when they are going to be superseded by the newer commit
- Down sides: the canceled snapshot actions will send an email. They are also marked as "**✗**" in commit history.