### PR TITLE
match: fix pregexp pattern

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -321,9 +321,10 @@ In more detail, patterns match as follows:
        }
 
  @item{@racket[(#,(match-kw "regexp") _rx-expr)] --- matches a
-       string that matches the regexp pattern produced by
-       @racket[_rx-expr]; see @secref["regexp"] for more information
-       about regexps.
+       string that matches the regexp pattern produced by @racket[_rx-expr],
+       where @racket[_rx-expr] can be a @racket[regexp] or @racket[pregexp] or a string.
+       A string value is converted to a pattern using @racket[regexp].
+       See @secref["regexp"] for more information about regexps.
 
        @examples[
        #:eval match-eval
@@ -331,7 +332,10 @@ In more detail, patterns match as follows:
          [(regexp #rx"p+") 'yes]
          [_ 'no])
        (match "banana"
-         [(regexp #rx"p+") 'yes]
+         [(regexp #px"(na){2}") 'yes]
+         [_ 'no])
+       (match "banana"
+         [(regexp "(na){2}") 'yes]
          [_ 'no])
        ]}
 
@@ -352,8 +356,9 @@ In more detail, patterns match as follows:
 
  @item{@racket[(#,(match-kw "pregexp") _rx-expr)] or
        @racket[(#,(racketidfont "pregexp") _rx-expr _pat)] --- like the
-       @racketidfont{regexp} patterns, but if @racket[_rx-expr]
-       produces a string, it is converted to a pattern using
+       @racketidfont{regexp} patterns, but @racket[_rx-expr] must be either
+       a @racket[pregexp] or a string.
+       If @racket[_rx-expr] produces a string, it is converted to a pattern using
        @racket[pregexp] instead of @racket[regexp].}
 
  @item{@racket[(#,(match-kw "and") _pat ...)] --- matches if all

--- a/pkgs/racket-test/tests/match/match-tests.rkt
+++ b/pkgs/racket-test/tests/match/match-tests.rkt
@@ -4,6 +4,73 @@
   
   (provide match-tests)
 
+  (define regexp-tests
+    (test-suite "Tests for regexp and pregexp"
+      (test-case "regexp"
+        ;; string
+        (check-false
+         (match "banana"
+           [(regexp "(na){2}") #t]
+           [_ #f]))
+        ;; #rx
+        (check-false
+         (match "banana"
+           [(regexp #rx"(na){2}") #t]
+           [_ #f]))
+        ;; #px
+        (check-true
+         (match "banana"
+           [(regexp #px"(na){2}") #t]
+           [_ #f])))
+
+      (test-case "regexp side-effect"
+        (define cnt 0)
+
+        (check-true
+         (match "banana"
+           [(regexp (begin (set! cnt (add1 cnt)) "nan")) #t]
+           [_ #f]))
+        (check-equal? cnt 1)
+
+        (check-false
+         (match "banana"
+           [(regexp (begin (set! cnt (add1 cnt)) "inf")) #t]
+           [_ #f]))
+        (check-equal? cnt 2))
+
+      (test-case "pregexp"
+        ;; string
+        (check-true
+         (match "banana"
+           [(pregexp "(na){2}") #t]
+           [_ #f]))
+        ;; #rx
+        (check-exn exn:fail:contract?
+                   (λ ()
+                     (match "banana"
+                       [(pregexp #rx"(na){2}") #t]
+                       [_ #f])))
+        ;; #px
+        (check-true
+         (match "banana"
+           [(pregexp #px"(na){2}") #t]
+           [_ #f])))
+
+      (test-case "pregexp side-effect"
+        (define cnt 0)
+
+        (check-true
+         (match "banana"
+           [(pregexp (begin (set! cnt (add1 cnt)) "nan")) #t]
+           [_ #f]))
+        (check-equal? cnt 1)
+
+        (check-false
+         (match "banana"
+           [(pregexp (begin (set! cnt (add1 cnt)) "inf")) #t]
+           [_ #f]))
+        (check-equal? cnt 2))))
+
   (define option-tests
     (test-suite "Tests for clause options"
       (test-case "#:do and #:when"
@@ -188,6 +255,7 @@
 
   (define match-tests
     (test-suite "Tests for match.rkt"
+      regexp-tests
       option-tests
       doc-tests
       simple-tests

--- a/racket/collects/racket/match/gen-match.rkt
+++ b/racket/collects/racket/match/gen-match.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 
 (require "patterns.rkt" "compiler.rkt"
+         (only-in "stxtime.rkt" current-form-name)
          syntax/stx syntax/parse/pre racket/syntax
          (for-template racket/base (only-in "runtime.rkt" match:error fail syntax-srclocs)))
 
@@ -53,7 +54,8 @@
              (raise-syntax-error 
               'match (format "wrong number of match clauses, expected ~a and got ~a" len lp) pats))
            (define (mk unm rhs)
-             (make-Row (for/list ([p (syntax->list pats)]) (parse p))
+             (make-Row (parameterize ([current-form-name (syntax-e #'form-name)])
+                         (for/list ([p (syntax->list pats)]) (parse p)))
                        (syntax-property
                         (datum->syntax rhs (syntax-e rhs) stx rhs)
                         'feature-profile:pattern-matching 'antimark)

--- a/racket/collects/racket/match/parse.rkt
+++ b/racket/collects/racket/match/parse.rkt
@@ -6,7 +6,8 @@
          "patterns.rkt"
          "parse-helper.rkt"
          "parse-quasi.rkt"
-         (for-template (only-in "runtime.rkt" matchable? mlist? mlist->list)
+         (only-in "stxtime.rkt" current-form-name)
+         (for-template (only-in "runtime.rkt" matchable? pregexp-matcher mlist? mlist->list)
                        (only-in racket/unsafe/ops unsafe-vector-ref)
                        racket/base))
 
@@ -91,15 +92,11 @@
      (trans-match #'matchable? #'(lambda (e) (regexp-match r e)) (parse #'p))]
     [(pregexp r)
      (trans-match #'matchable?
-                  (rearm
-                   #'(lambda (e)
-                       (regexp-match (if (pregexp? r) r (pregexp r)) e)))
+                  #`(pregexp-matcher r '#,(current-form-name))
                   (Pred #'values))]
     [(pregexp r p)
      (trans-match #'matchable?
-                  (rearm 
-                   #'(lambda (e)
-                       (regexp-match (if (pregexp? r) r (pregexp r)) e)))
+                  #`(pregexp-matcher r '#,(current-form-name))
                   (rearm+parse #'p))]
     [(box e) (Box (parse #'e))]
     [(vector es ...)

--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -8,6 +8,7 @@
          match:error
          fail
          matchable?
+         pregexp-matcher
          match-prompt-tag
          mlist? mlist->list
          syntax-srclocs)
@@ -37,6 +38,14 @@
 ;; can we pass this value to regexp-match?
 (define (matchable? e)
   (or (string? e) (bytes? e)))
+
+(define ((pregexp-matcher rx who) e)
+  (regexp-match
+   (cond
+     [(pregexp? rx) rx]
+     [(string? rx) (pregexp rx)]
+     [else (raise-argument-error who "(or/c pregexp? string?)" rx)])
+   e))
 
 ;; duplicated because we can't depend on `compatibility` here
 (define (mlist? l)

--- a/racket/collects/racket/match/stxtime.rkt
+++ b/racket/collects/racket/match/stxtime.rkt
@@ -27,3 +27,5 @@
 
 (define-values (prop:legacy-match-expander legacy-match-expander? legacy-match-expander-proc)
   (make-struct-type-property/accessor 'prop:legacy-match-expander ))
+
+(define current-form-name (make-parameter #f))


### PR DESCRIPTION
This commit fixes two issues with the pregexp pattern.

1. Avoids unintentional expression duplication, which results in multiple evaluations (#4710)
2. Provides better error handling when a regexp value is given to pregexp pattern (#4281), along with better documentation.

Fixes #4281, #4710