### PR TITLE
stencil vector doc: correct xref and code highlight

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stencil-vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stencil-vectors.scrbl
@@ -13,7 +13,7 @@
                                   (with-syntax ([str str]
                                                 [e (read (open-input-string str))])
                                     #'(eval:alts #,(code str) e)))])
-         #'@mz-examples[form ...])]))
+         (syntax-local-introduce #'@mz-examples[form ...]))]))
 
 @title[#:tag "stencil vectors"]{Stencil Vectors}
 


### PR DESCRIPTION
EDITED: jk, it looks like one `syntax-local-introduce` suffices to correct xref. No need for hacks.

Before:
<img width="555" alt="Screenshot 2023-07-31 at 11 12 58 PM" src="https://github.com/racket/racket/assets/9099577/684c8a7e-b12e-4f2d-8808-5975e2575778">

After:

<img width="650" alt="Screenshot 2023-08-01 at 3 08 04 AM" src="https://github.com/racket/racket/assets/9099577/cfb1ab25-51b8-44d9-8500-93624733c672">


