### PR TITLE
Minor typo in continuations explainer (guide)

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/control.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/control.scrbl
@@ -221,7 +221,7 @@ changing @racket[0] to grab the continuation before returning 0:
 (+ 1 (+ 1 (+ 1 (save-it!))))
 ]
 
-The @tech{continuation} saved in @racket[save-k] encapsulates the
+The @tech{continuation} saved in @racket[saved-k] encapsulates the
 program context @racket[(+ 1 (+ 1 (+ 1 _?)))], where @racket[_?]
 represents a place to plug in a result value---because that was the
 expression context when @racket[save-it!] was called. The


### PR DESCRIPTION
In the [Continuations](https://docs.racket-lang.org/guide/conts.html) chapter of the guide, corrected a single occurrence of `save-k`  to `saved-k`.