### PR TITLE
doc: correct the contract for the `new-scope?` argument to `syntax-local-lift-require`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/stx-trans.scrbl
@@ -932,7 +932,7 @@ within a @racket[module] form (see @racket[syntax-transforming-module-expression
 then the @exnraise[exn:fail:contract].}
 
 
-@defproc[(syntax-local-lift-require [raw-require-spec any/c] [stx syntax?] [new-scope? #t])
+@defproc[(syntax-local-lift-require [raw-require-spec any/c] [stx syntax?] [new-scope? any/c #t])
          syntax?]{
 
 Lifts a @racket[#%require] form corresponding to


### PR DESCRIPTION
##### Checklist

- [x] Documentation update


### Description of change

The `new-scope?` argument to `syntax-local-lift-require` currently shows up in the docs as a required argument with a contract of `#t`. This update fixes the docs to show that it's an optional argument with a contract of `any/c` and a default value of `#t`.