### PR TITLE
doc: linkify the trait section

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -2,7 +2,8 @@
 @(require "mz.rkt"
           racket/class
           (for-syntax racket/base racket/serialize racket/trait)
-          (for-label racket/serialize))
+          (for-label racket/serialize
+                     racket/trait))
 
 @(begin
 


### PR DESCRIPTION
- [x] documentation

Linkify the trait section.

Before:

<img width="723" alt="Screenshot 2023-08-14 at 7 26 54 AM" src="https://github.com/racket/racket/assets/9099577/c05f1bd5-809d-4488-b1fd-7a438421b3f6">

After:

<img width="719" alt="Screenshot 2023-08-14 at 7 27 11 AM" src="https://github.com/racket/racket/assets/9099577/23324a6a-67ff-4bcb-9b04-30a49902fc4f">