### PR TITLE
syntax/parse: repairs to contract and error reporting

### DIFF
--- a/racket/collects/syntax/parse/experimental/provide.rkt
+++ b/racket/collects/syntax/parse/experimental/provide.rkt
@@ -86,11 +86,11 @@
                       (rename-contract
                        (->* (any/c any/c any/c any/c any/c any/c any/c any/c any/c
                              mpc-id ... mkw-c-part ... ...)
-                            (okw-c-part ... ...)
+                            (opc-id ... okw-c-part ... ...)
                             any)
                        `(,(if 'splicing? 'splicing-syntax-class/c 'syntax-class/c)
                          [,(contract-name mpc-id) ... mkw-name-part ... ...]
-                         [okw-name-part ... ...]))))
+                         [,(contract-name opc-id) ... okw-name-part ... ...]))))
                   (define-module-boundary-contract contracted-parser
                     parser parser-contract #:pos-source #,pos-module-source)
                   (define-syntax contracted-scname

--- a/racket/collects/syntax/parse/private/kws.rkt
+++ b/racket/collects/syntax/parse/private/kws.rkt
@@ -73,7 +73,7 @@
     (cond [(pair? optkws)
            (format " plus optional keyword argument~a ~a"
                    (s-if-plural optkws)
-                   (join-sep (map kw->string minkws) "," "and"))]
+                   (join-sep (map kw->string optkws) "," "and"))]
           [else ""]))
   (string-append pos-part kws-part optkws-part))
 


### PR DESCRIPTION
##### Checklist
- [x] Bugfix

### Description of change
Fix missing optional-argument subcontracts in syntax class contracts (fix #4697).  Also fix arity-error reporting for optional keyword arguments.