### PR TITLE
Use `#%app` for wrap and guard in `make-derived-parameter`

### DIFF
--- a/pkgs/racket-test-core/tests/racket/param.rktl
+++ b/pkgs/racket-test-core/tests/racket/param.rktl
@@ -79,6 +79,13 @@
                        (struct s (x)
                          #:property prop:procedure 0)
                        (s (lambda (x) x)))))
+(define test-param6 (let ()
+                      (struct s (x)
+                         #:property prop:procedure 0)
+                      (make-derived-parameter
+                       test-param5
+                       (s (lambda (x) x))
+                       (s (lambda (x) x)))))
 
 (test 'one test-param1)
 (test 'two test-param2) 
@@ -136,6 +143,10 @@
 (test 'five test-param5)
 (test (void) test-param5 5)
 (test 5 test-param5)
+
+(test 5 test-param6)
+(test (void) test-param6 6)
+(test 6 test-param6)
 
 (let ([cd (make-derived-parameter current-directory values values)])
   (test (current-directory) cd)

--- a/racket/src/cs/rumble/parameter.ss
+++ b/racket/src/cs/rumble/parameter.ss
@@ -117,8 +117,8 @@
   (check who (procedure-arity-includes/c 1) wrap)
   (make-arity-wrapper-procedure
    (case-lambda
-    [(v) (p (guard v))]
-    [() (wrap (p))])
+    [(v) (p (|#%app| guard v))]
+    [() (|#%app| wrap (p))])
    3
    (make-derived-parameter-data
     guard


### PR DESCRIPTION
##### Checklist

- [x] Bugfix
- [x] tests included

### Description of change

Imitating cb959879de2140657, fix #4722 by using `#%app` to apply `guard` and `wrap` in `make-derived-parameter`.
