### PR TITLE
fix the interaction of `#:unprotected-submodule` and `struct`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -1931,7 +1931,9 @@ If @racket[#:unprotected-submodule] appears, the identifier
 that follows it is used as the name of a submodule that
 @racket[contract-out] generates. The submodule exports all
 of the names in the @racket[contract-out], but without
-contracts.
+contracts. In particular, the original structure-type name is exported
+for each @racket[struct] form, which means @racket[#:omit-constructor]
+only omits the extra constructor, if any.
 
 The implementation of @racket[contract-out] uses
 @racket[syntax-property] to attach properties to the code it generates

--- a/pkgs/racket-test/tests/racket/contract/contract-out.rkt
+++ b/pkgs/racket-test/tests/racket/contract/contract-out.rkt
@@ -1958,4 +1958,39 @@
                #`'#,(struct-field-info-list (syntax-local-value #'foo))))
       (eval '(extract-field-names)))
    (list 'x))
+
+  (test/spec-passed/result
+   'provide/contract-upe-struct-transformer
+   '(begin
+      (eval '(module provide/contract-upe-struct-transformer-def racket/base
+               (require racket/contract/base)
+               (provide (contract-out
+                         #:unprotected-submodule no-contract
+                         (struct s ([x integer?]))))
+               (struct s (x) #:constructor-name make-s)))
+      (eval '(module provide/contract-upe-struct-transformer-ans racket/base
+               (require racket/match
+                        (submod 'provide/contract-upe-struct-transformer-def no-contract))
+               (provide answer)
+               (define answer (match (make-s 1) [(s x) x]))))
+      (dynamic-require ''provide/contract-upe-struct-transformer-ans 'answer))
+   1)
+
+  (test/spec-passed/result
+   'provide/contract-upe-struct-type-descriptor
+   '(begin
+      (eval '(module provide/contract-upe-struct-type-descriptor-def racket/base
+               (require racket/contract/base)
+               (provide (contract-out
+                         #:unprotected-submodule no-contract
+                         (struct s ([x integer?]))))
+               (struct s (x))))
+      (eval '(module provide/contract-upe-struct-type-descriptor-ans racket/base
+               (require racket/match
+                        (submod 'provide/contract-upe-struct-type-descriptor-def no-contract))
+               (provide answer)
+               (struct t s (y))
+               (define answer (match (t 1 2) [(t x y) (list x y)]))))
+      (dynamic-require ''provide/contract-upe-struct-type-descriptor-ans 'answer))
+   (list 1 2))
   )


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [x] tests included

### Description of change
Make the `#:unprotected-submodule` submodule export structs as `struct-out` does:

- `tl-code-for-one-id/new-name` is adjusted to accept `upe-id`, which is used as the exported id in the submodule when present;

- The original struct-type name and descriptor are exported in the submodule.

`#:omit-constructor` has no effect on the original struct-type name.  This is intended and documented accordingly.

Fix #4661.
