### PR TITLE
move work for `make install` to `make`

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.10.0.3")
+(define version "8.10.0.4")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/raco/config.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/config.scrbl
@@ -3,7 +3,8 @@
           "common.rkt"
           (for-label racket/base
                      racket/contract
-                     setup/dirs))
+                     setup/dirs
+                     setup/getinfo))
 
 @title[#:tag "config-file"]{Installation Configuration and Search Paths}
 
@@ -196,6 +197,14 @@ directory}:
  @item{@indexed-racket['include-search-dirs] --- like
        @racket[doc-search-dirs], but for directories containing C
        header files.}
+
+ @item{@indexed-racket['info-domain-root] --- a path, string, byte
+       string, of @racket[#f]; used as a prefix to redirect the paths
+       used for recording and finding @filepath{info.rkt} information via
+       @racket[find-relevant-directories]. It defaults to @racket[#f], which
+       uses paths as-is.
+
+       @history[#:added "8.10.0.4"]}
 
  @item{@indexed-racket['catalogs] --- a list of URL strings used as the search
        path for resolving package names. An @racket[#f] in the list

--- a/pkgs/racket-doc/scribblings/raco/setup.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/setup.scrbl
@@ -1746,6 +1746,13 @@ current-system paths while @racket[get-cross-lib-search-dirs] and
 
   @history[#:added "8.1.0.6"]}
 
+@defproc[(get-info-domain-root) (or/c #false path?)]{
+  Returns @racket[#f] or a path to be used as a prefix to redirect the paths
+  used for recording and finding @filepath{info.rkt} information via
+  @racket[find-relevant-directories].
+
+  @history[#:added "8.10.0.4"]}
+
 @defproc[(get-doc-search-url) string?]{
   Returns a string that is used by the documentation system, augmented
   with a version and search-key query, for remote documentation links.
@@ -1959,7 +1966,9 @@ current-system paths while @racket[get-cross-lib-search-dirs] and
    the user-specific directory @racket[(build-path (find-system-path
    'addon-dir) "collects")] for all-version cases, and in @racket[(build-path
    (find-system-path 'addon-dir) (version) "collects")] for
-   version-specific cases.}
+   version-specific cases. These cache paths can be redirected
+   by an @racket['info-domain-root] entry in @filepath{config.rktd}
+   (see @secref["config-file"]).}
 
 @defproc[(find-relevant-directory-records
           [syms (listof symbol?)]

--- a/racket/collects/setup/dirs.rkt
+++ b/racket/collects/setup/dirs.rkt
@@ -19,11 +19,13 @@
                      config:share-search-dirs
                      config:man-search-dirs
                      config:doc-search-dirs
+                     config:info-domain-root
                      define-finder
                      get-config-table
                      to-path)
          find-cross-dll-dir
          find-dll-dir
+         get-info-domain-root
          get-lib-search-dirs)
 
 ;; ----------------------------------------
@@ -150,6 +152,12 @@
 
 (define (get-cross-lib-extra-search-dirs)
   (make-extra-search-list config:lib-search-dirs))
+
+;; ----------------------------------------
+;; info-domain root
+
+(define (get-info-domain-root)
+  (force config:info-domain-root))
 
 ;; ----------------------------------------
 ;; DLLs

--- a/racket/collects/setup/getinfo.rkt
+++ b/racket/collects/setup/getinfo.rkt
@@ -300,6 +300,11 @@
           [(eq? key 'no-planet) no-planet-table]
           [(eq? key 'no-user) no-user-table]
           [else (error 'find-relevant-directories "Invalid key: ~s" key)]))
+  (define info-domain-root (get-info-domain-root))
+  (define (maybe-reroot p)
+    (if info-domain-root
+        (reroot-path p info-domain-root)
+        p))
   ;; A list of (cons cache.rktd-path root-dir-path)
   ;;  If root-dir-path is not #f, then paths in the cache.rktd
   ;;  file are relative to it. #f is used for the planet cache.rktd file.
@@ -311,13 +316,15 @@
      (cons user-infotable #f)
      (append
       (map (lambda (coll)
-             (cons (build-path coll "info-domain" "compiled" "cache.rktd")
+             (cons (maybe-reroot
+                    (build-path coll "info-domain" "compiled" "cache.rktd"))
                    coll))
            (if (eq? key 'no-user)
                (get-main-collects-search-dirs)
                (current-library-collection-paths)))
       (map (lambda (base)
-             (cons (build-path base "info-cache.rktd") 
+             (cons (maybe-reroot
+                    (build-path base "info-cache.rktd") )
                    base))
            (filter
             values

--- a/racket/collects/setup/private/dirs.rkt
+++ b/racket/collects/setup/private/dirs.rkt
@@ -82,6 +82,7 @@
 (define-config config:links-search-files 'links-search-files to-path)
 (define-config config:pkgs-dir 'pkgs-dir to-path)
 (define-config config:pkgs-search-dirs 'pkgs-search-dirs to-path)
+(define-config config:info-domain-root 'info-domain-root to-path)
 (define-config config:cgc-suffix 'cgc-suffix values)
 (define-config config:3m-suffix '3m-suffix values)
 (define-config config:cs-suffix 'cs-suffix values)
@@ -298,6 +299,11 @@
          config:config-tethered-apps-dir
          config:bin-search-dirs
          config:gui-bin-search-dirs)
+
+;; ----------------------------------------
+;; info-domain root
+
+(provide config:info-domain-root)
 
 ;; ----------------------------------------
 ;; DLLs

--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -203,6 +203,14 @@ Detailed instructions:
     (which is a single C file that needs only system headers), then
     supply `CC_FOR_BUILD=<compiler>` as an argument to `make`.
 
+    For a `--prefix` build that is not a cross-compilation, this step
+    also compiles ".zo" bytecode files for collections and packages,
+    and it renders documentation; those prepared files are written in
+    the build directory and moved into place by `make install`. For a
+    build that does not use `--prefix` or is a cross compilation,
+    building collections and packages is deferred to the `make
+    install` step.
+
  4. Run `make install`.
 
     This step copies executables and libraries into place within the

--- a/racket/src/bc/Makefile.in
+++ b/racket/src/bc/Makefile.in
@@ -142,7 +142,7 @@ ZUO=bin/zuo
 BUILD_VARS = MAKE="$(MAKE)"
 
 build: $(ZUO)
-	$(ZUO) . build $(BUILD_VARS)
+	$(ZUO) . build-and-prepare $(BUILD_VARS)
 
 3m: $(ZUO)
 	$(ZUO) . 3m $(BUILD_VARS)

--- a/racket/src/bc/build.zuo
+++ b/racket/src/bc/build.zuo
@@ -30,6 +30,7 @@
   (define provided-racket? (not (equal? (or (lookup 'RACKET) "") "")))
   (define cify-mode (or (lookup 'ENABLE_CIFY) "auto"))
   (define gracket? (not (equal? (lookup 'MAKE_GRACKET) "no")))
+  (define cross? provided-racket?)
 
   (define mac? (equal? (lookup 'OSX) "t"))
   (define macx? (or mac? (glob-match? "*-DXONX*" (lookup 'CPPFLAGS))))
@@ -634,11 +635,23 @@
       (rm* (at-dir "src/startup.o"))
       (rm* (at-dir "xsrc/startup.c"))))
 
+  (define (setup-prepare-to-here?)
+    (and (equal? (lookup 'MAKE_COPYTREE) "copytree")
+         (not cross?)))
+
   (define the-targets
     (append
      (make-targets
       `([:target build ,(if 3m-default? '(3m) '(cgc)) ,void]
-        
+
+        [:target build-and-prepare ()
+                 ,(lambda (token)
+                    (build/dep (find-target "build" the-targets) token)
+                    (when (setup-prepare-to-here?)
+                      (define racket (if 3m-default? racket3m racketcgc))
+                      (raco-setup-prepare-to-here config racket at-dir (make-at-dir
+                                                                        (at-source "../..")))))]
+
         [:target 3m (,racket3m ,@(if gracket? (list gracket3m) '())
                                ,@(if windows? (list mzcom3m.exe) '())
                                ,@(if mac? (list framework3m) '())
@@ -1791,7 +1804,10 @@
                            ;; Otherwise, prefer to use the installed executable:
                            (dest-racket-exe 3m?)]))
        (define copytree-racket (and provided-racket? (get-host-racket)))
-       (maybe-copytree config dest-exe copytree-racket at-dir)
+       (define copytree-config (if (setup-prepare-to-here?)
+                                   (hash-set config 'copytree-prepared-setup-files #t)
+                                   config))
+       (maybe-copytree copytree-config dest-exe copytree-racket at-dir)
        (run-raco-setup config dest-exe copytree-racket '())
        (maybe-libzo-move config dest-exe copytree-racket at-dir)
        (maybe-destdir-fix config dest-exe copytree-racket at-dir)

--- a/racket/src/build.zuo
+++ b/racket/src/build.zuo
@@ -49,7 +49,7 @@
   (make-targets
    `([:target all ()
               ,(lambda (token)
-                 (build (find-target "build" (get-targets)) token))]
+                 (build (find-target "build-and-prepare" (get-targets)) token))]
 
      [:target bc () ,(lambda (token) (build-bc "build" token))]
      [:target 3m () ,(lambda (token) (build-bc "3m" token))]

--- a/racket/src/cs/c/Makefile.in
+++ b/racket/src/cs/c/Makefile.in
@@ -220,7 +220,7 @@ ZUO=bin/zuo
 BUILD_VARS = MAKE="$(MAKE)"
 
 cs: $(ZUO)
-	$(ZUO) . build $(BUILD_VARS)
+	$(ZUO) . build-and-prepare $(BUILD_VARS)
 
 install: $(ZUO)
 	$(ZUO) . install $(BUILD_VARS)

--- a/racket/src/cs/c/build.zuo
+++ b/racket/src/cs/c/build.zuo
@@ -371,6 +371,10 @@
         (list "--xpatch" xpatch)
         '()))
 
+  (define (setup-prepare-to-here?)
+    (and (not (equal? "" (lookup 'prefix)))
+         (not cross?)))
+
   (define the-targets
     (make-targets
      `([:target build ()
@@ -380,6 +384,13 @@
                    (build/dep (find-target "starter" starter-targets) token)
                    (when (and mac? (not mac-fw?))
                      (build/dep (find-target framework the-targets) token)))]
+
+       [:target build-and-prepare ()
+                ,(lambda (token)
+                   (build/dep (find-target "build" the-targets) token)
+                   (when (setup-prepare-to-here?)
+                     (raco-setup-prepare-to-here config racketcs at-dir (make-at-dir
+                                                                         (at-source "../../..")))))]
 
        [:target build-racketcs ()
                 ,(lambda (token)
@@ -1056,7 +1067,10 @@
     (call-with-dest-racket
      (lambda (bindir dest-racket)
        (define copytree-racket (and cross? (hash-ref (config-bootstrap-racket) 'racket)))
-       (maybe-copytree config dest-racket copytree-racket at-dir)
+       (define copytree-config (if (setup-prepare-to-here?)
+                                   (hash-set config 'copytree-prepared-setup-files #t)
+                                   config))
+       (maybe-copytree copytree-config dest-racket copytree-racket at-dir)
        (run-raco-setup config dest-racket copytree-racket
                        ;; this can be redundant if it's also supplied via `SETUP_MACHINE_FLAGS`,
                        ;; but redundant should be ok:

--- a/racket/src/lib.zuo
+++ b/racket/src/lib.zuo
@@ -41,6 +41,7 @@
          strip-debug
          strip-lib-debug
          run-raco-setup
+         raco-setup-prepare-to-here
 
          install-license-files
          maybe-copytree
@@ -445,6 +446,54 @@
              "-G" configdir
              setup-args)]))
 
+(define (raco-setup-prepare-to-here config built-racket at-dir at-root-dir)
+  (define collects-dir (at-root-dir "collects"))
+  ;; set up configuration that points to local "doc" and "info-domain" dirs,
+  ;; so that we don't write outside of a build directory
+  (define src-config (at-root-dir "etc/config.rktd"))
+  (define config-str
+    (cond
+      [(file-exists? src-config)
+       (define in (fd-open-input src-config))
+       (define str (fd-read in eof))
+       (fd-close in)
+       (let loop ([old-str str])
+         (let* ([str (string-trim old-str)]
+                [str (string-trim str "\n")]
+                [str (string-trim str "\r")])
+           (if (equal? old-str str)
+               str
+               (loop str))))]
+      [else "#hash()"]))
+  (let ()
+    (mkdir-p (at-dir "compiled/etc"))
+    (define out (fd-open-output (at-dir "compiled/etc/config.rktd") :truncate))
+    (fd-write out (substring config-str 0 (- (string-length config-str) 1)))
+    (fd-write out (~a "(doc-dir . "
+                      (~s (find-relative-path collects-dir (at-dir "compiled/doc")))
+                      ")"))
+    (fd-write out (~a "(info-domain-root . "
+                      (~s (find-relative-path collects-dir (at-dir "compiled/info-domain")))
+                      ")"))
+    (fd-write out ")")
+    (fd-close out))
+  (run-raco-setup (hash-set* config
+                             'DESTDIR ""
+                             'collectsdir collects-dir
+                             'configdir (at-dir "compiled/etc")
+                             'SETUP_MACHINE_FLAGS (build-shell
+                                                   (hash-ref config 'SETUP_MACHINE_FLAGS "")
+                                                   "-R" (path->complete-path (at-dir "compiled")))
+                             'PLT_SETUP_OPTIONS (build-shell
+                                                 (hash-ref config 'PLT_SETUP_OPTIONS "")
+                                                 "--no-launcher"
+                                                 "--no-foreign-libs"
+                                                 "--no-install"
+                                                 "--no-post-install"
+                                                 "--no-pkg-deps"))
+                  built-racket
+                  #f '()))
+
 (define (install-license-files sharepltdir)
   (mkdir-p sharepltdir)
   (for-each (lambda (path)
@@ -495,7 +544,10 @@
   (when (equal? (hash-ref config 'MAKE_COPYTREE #f) "copytree")
     (unixstyle-install-run config dest-racket cross-racket at-dir
                            "make-install-copytree"
-                           (hash-ref config 'INSTALL_ORIG_TREE "no"))))
+                           (hash-ref config 'INSTALL_ORIG_TREE "no")
+                           (if (hash-ref config 'copytree-prepared-setup-files #f)
+                               (list (at-dir "compiled"))
+                               '()))))
 
 (define (maybe-libzo-move config dest-racket cross-racket at-dir)
   (when (equal? (hash-ref config 'INSTALL_LIBZO #f) "libzo")

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 10
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 3
+#define MZSCHEME_VERSION_W 4
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
This commit is aimed at doing most `raco setup` work in `make` instead of `make install`, at least when configuring with `--prefix`.

The `make` step here performs the ".zo"- and documentation-build work (i.e., `raco setup` step) that `make install` currently performs — but with output confined to the build directory. The built files are then merged into place by `make install`. That way, `make install` can be relatively fast, and the ".zo"- and documentation-build step gets the advantage of being incremental like the rest of `make`. Related to #4737.

This change only applies to `make` as run within a "src" build directory, so it does not affect `make` in the repo's root directory. And since it only applies when `--prefix` is used, it doesn't affect a workflow that uses an in-place build (as typical with a repo checkout).

A new `info-domain-root` configuration option is needed to keep the info-domain step of `raco setup` confined to the build directory.
