### PR TITLE
improve check syntax for `struct-copy` with an arrow to the struct definition

### DIFF
--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -1073,6 +1073,7 @@
 
       ;; the actual result
       #`(let ([the-struct struct-expr])
+          #,(syntax-property #'(void) 'disappeared-use (syntax-local-introduce #'info))
           (if (#,pred the-struct)
               (let #,(map (lambda (new-field)
                             #`[#,(caddr new-field) #,(cadr new-field)])


### PR DESCRIPTION
If this should have some test cases, those test cases are easiest to put [here](https://github.com/racket/drracket/blob/master/drracket-tool-test/tests/check-syntax/syncheck-direct.rkt).