### PR TITLE
CS: improve `cells-merge` performance

### DIFF
--- a/racket/src/cs/rumble/hash.ss
+++ b/racket/src/cs/rumble/hash.ss
@@ -786,8 +786,9 @@
                        (let loop ([i 0] [count 0])
                          (cond
                           [(fx= i new-vec-len)
-                           (values count (lambda (new-ht p) (not (hashtable-contains? new-ht p))))]
+                           (values count (lambda (_ p) (not (eq? p none))))]
                           [(hashtable-contains? new-ht (#%vector-ref new-vec i))
+                           (#%vector-set! new-vec i none)
                            (loop (fx+ i 1) (fx+ count 1))]
                           [else
                            (loop (fx+ i 1) count)]))]


### PR DESCRIPTION
This pull request consists of two changes:

1. Save memory and time by setting the elements of the smallest
    possible cell vector into `new-ht`.

    Negate the result of `hashtable-contains?` when `vec` is the
    smallest and its elements are the keys of `new-ht`.

2. This builds on the previous change by adding a fast path.

    When `vec` is the smallest possible cell vector, save time by using
    `eq?` instead of `hashtable-contains?`.

**An abbreviated description of the fast path:**
The elements of `vec` are set into `new-ht`, any intersecting elements
and keys of `new-vec` and `new-ht` are changed to `none` in `new-vec`,
and the second `merge-vec` setting loop sets into `merge-vec` only the
elements of `new-vec` that are not `eq?` to `none`.

**An abbreviated description of how the changed code used to work
before these changes:**
The elements of `new-vec` were set into `new-ht`, the elements of
`vec` were deleted from `new-ht` to remove duplicates, and the second
`merge-vec` setting loop used `hashtable-contains?` to set into
`merge-vec` only the intersecting elements and keys of `new-vec` and
`new-ht`.

---
Lastly, the improvement in performance is most noticeable when
iterating on a large hash table for the first time using
`in-mutable-hash` while it remains otherwise unmodified.