### PR TITLE
match: fix box pattern

### DIFF
--- a/pkgs/racket-test/tests/match/examples.rkt
+++ b/pkgs/racket-test/tests/match/examples.rkt
@@ -1,6 +1,7 @@
 #lang scheme/base
 
 (require racket/match
+         (prefix-in c: racket/contract)
          (prefix-in s: racket/set)
          scheme/mpair
          scheme/control scheme/foreign
@@ -729,6 +730,14 @@
 
    (comp 1
          (match (box 'x) ('#&x 1) (_ #f)))
+
+   (let ()
+     (c:define/contract (my-unbox obj)
+       (c:-> (c:box/c c:any/c) c:any/c)
+       (match obj
+         [(box x) x]))
+
+     (comp 1 (my-unbox (box 1))))
 
    (comp 2
          (match (vector 1 2) ('#(1 2) 2) (_ #f)))

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -100,7 +100,7 @@
         #`[question (let ([tmps (accs #,x)] ...) body)])))
   (cond
     [(eq? 'box k)
-     (compile-con-pat (list #'unsafe-unbox*) #'box? (compose list Box-p))]
+     (compile-con-pat (list #'unsafe-unbox) #'box? (compose list Box-p))]
     [(eq? 'pair k)
      (compile-con-pat (list #'unsafe-car #'unsafe-cdr) #'pair?
                       (lambda (p) (list (Pair-a p) (Pair-d p))))]


### PR DESCRIPTION
A box could be impersonated, so we can't use unsafe-unbox*.

Fixes #4799

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [x] tests included
