### PR TITLE
racket-index: fix release.scrbl for layered installations

### DIFF
--- a/pkgs/racket-index/scribblings/main/info.rkt
+++ b/pkgs/racket-index/scribblings/main/info.rkt
@@ -6,4 +6,4 @@
     ("local-redirect.scrbl" (depends-all-main no-depend-on every-main-layer) (omit) "local-redirect" 1 10)
     ("license.scrbl" () (omit))
     ("acks.scrbl"    () (omit))
-    ("release.scrbl" (depends-all-main no-depend-on) (omit))))
+    ("release.scrbl" (depends-all-main no-depend-on every-main-layer) (omit))))


### PR DESCRIPTION
Configure the release notes page to be rendered separately at every installation layer. Otherwise, rendering documentation for packages installed in a new layer might try to write to `release/in.sxref` in the parent layer’s docs directory.

Related to https://github.com/videolang/video/issues/67
Related to https://issues.guix.gnu.org/56534

----

This patch avoids the problem I encountered, but I'm not entirely confident that it's the best approach:

1. I feel like my understanding of how the documentation rendering and cross-referencing code actually works is fairly shallow overall; and
2. I thought this had all been working properly after https://github.com/racket/racket/commit/a40bfc52040b657f8f412d400fd743e9feb14caa, but I haven't dug up whatever example code I used (I think) to test it at the time, so I'm not sure if I just hadn't triggered this problem or if something is going on.

In case it's useful context, I encountered the problem while building a Guix package `racket-with-video`, which adds `#lang video` and its dependencies in a config-tethered layer chaining to the Guix `racket` package (which further chains to `racket-minimal`, then `racket-vm-cs`). This commit to my Guix fork can reproduce the issue: https://gitlab.com/philip1/guix-patches/-/commit/70622db249640fda5cbed64c081d95337de937c8

[Here is a complete log](https://github.com/racket/racket/files/13050102/csw18gggxgfxkm1pmqcfkfdc4y69yx-racket-with-video-8.10%2Bvideo0.2.3-1.3c69669.drv.log) of a failing build. The build sets `(setenv "PLTSTDERR" "error debug@setup")` at the point where the log says ``starting phase `log'``. It then tries to install the new packages as follows, where `#$output` is the destination prefix and `make-flags` is `'("video")`:
```scheme
(invoke racket
        "-l-"
        "pkg/dirs-catalog"
        "--link"
        "local-catalog"
        (string-append #$output "/lib/racket/pkgs"))
(apply invoke
       racket
       "--config" (string-append #$output "/etc/racket")
       "-l" "raco"
       "pkg" "install"
       "--installation"
       "--auto"
       "--catalog" "local-catalog"
       make-flags)
```