### PR TITLE
Fix release year for v7.6 in HISTORY.txt

### DIFF
--- a/racket/collects/racket/HISTORY.txt
+++ b/racket/collects/racket/HISTORY.txt
@@ -136,7 +136,7 @@ Switch Racket CS immutable hash table to HAMTs, based on
  stencil vectors in the Chez Scheme
 Bug repairs and other changes noted in the documentation
 
-Version 7.6, January 2019
+Version 7.6, January 2020
 Bug repairs and other changes noted in the documentation
 
 Version 7.5, November 2019


### PR DESCRIPTION
It was released in January 2020, not 2019.
