### PR TITLE
doc: show value of defthing via #:auto-value

### DIFF
--- a/pkgs/racket-doc/info.rkt
+++ b/pkgs/racket-doc/info.rkt
@@ -6,7 +6,7 @@
                ["base" #:version "6.5.0.2"]
                "net-lib"
                "sandbox-lib"
-               ["scribble-lib" #:version "1.34"]
+               ["scribble-lib" #:version "1.51"]
                "racket-index"))
 (define build-deps '("rackunit-doc"
                      "errortrace-doc"

--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -416,7 +416,7 @@ or otherwise escaping. Results from the leaves are combined with
 
 @section{Parameters}
 
-@defparam[current-unescaped-tags tags (listof symbol?) #:value null]{
+@defparam[current-unescaped-tags tags (listof symbol?) #:auto-value]{
   A parameter that determines which tags' string contents should not
   be escaped.  For backwards compatibility, this defaults to the empty
   list.
@@ -424,7 +424,7 @@ or otherwise escaping. Results from the leaves are combined with
   @history[#:added "8.0.0.12"]
 }
 
-@defthing[html-unescaped-tags (listof symbol?) #:value '(script style)]{
+@defthing[html-unescaped-tags (listof symbol?) #:auto-value]{
   The list of tags whose contents are normally not escaped in HTML.
   See @racket[current-unescaped-tags].
 
@@ -458,7 +458,7 @@ document uses a mixture of the two formats. The
 recommended list of XHTML tags that should use the shorthand. This
 list is the default value of @racket[empty-tag-shorthand].}
 
-@defthing[html-empty-tags (listof symbol?)]{
+@defthing[html-empty-tags (listof symbol?) #:auto-value]{
 
 See @racket[empty-tag-shorthand].
 


### PR DESCRIPTION
Not sure if this is the best approach, so let me know if there's a better way.

Before:

<img width="876" alt="Screenshot 2023-10-30 at 3 48 43 AM" src="https://github.com/racket/racket/assets/9099577/f0c1b596-b6b9-4cf1-97cc-bea783e72a8e">

After:

<img width="723" alt="Screenshot 2023-10-30 at 3 48 58 AM" src="https://github.com/racket/racket/assets/9099577/569e9253-c9ad-4d27-9f18-081dc99a4ae2">
