### PR TITLE
docs: update old-fashioned contracts

### DIFF
--- a/pkgs/net-doc/net/scribblings/cgi.scrbl
+++ b/pkgs/net-doc/net/scribblings/cgi.scrbl
@@ -104,7 +104,7 @@ prints them with the subject line "Internal error", and exits via
 @racket[exit].}
 
 
-@defproc[(get-cgi-method) (one-of/c "GET" "POST")]{
+@defproc[(get-cgi-method) (or/c "GET" "POST")]{
 
 Returns either @racket["GET"] or @racket["POST"] when invoked inside a
 CGI script, unpredictable otherwise.}

--- a/pkgs/net-doc/net/scribblings/cookie.scrbl
+++ b/pkgs/net-doc/net/scribblings/cookie.scrbl
@@ -111,7 +111,7 @@ initial-request structure, etc.  The @racket[get-cookie] and
 from a @racket["Cookie"] field value.}
 
 
-@defproc[(get-cookie/single [name cookie-name?] [cookies string?]) (or/c cookie-value? false/c)]{
+@defproc[(get-cookie/single [name cookie-name?] [cookies string?]) (or/c cookie-value? #f)]{
 
 Like @racket[get-cookie], but returns the just first value string
 associated to @racket[name], or #f if no association is found.}

--- a/pkgs/net-doc/net/scribblings/dns.scrbl
+++ b/pkgs/net-doc/net/scribblings/dns.scrbl
@@ -101,7 +101,7 @@ for @racket["ollie.cs.rice.edu"] might be @racket["cs.rice.edu"].}
 
 
 
-@defproc[(dns-find-nameserver) (or/c string? false/c)]{
+@defproc[(dns-find-nameserver) (or/c string? #f)]{
 
 Attempts to find the address of a nameserver on the present system.
 On Unix and Mac OS, this procedure parses @filepath{/etc/resolv.conf} to

--- a/pkgs/net-doc/net/scribblings/ftp.scrbl
+++ b/pkgs/net-doc/net/scribblings/ftp.scrbl
@@ -41,8 +41,8 @@ The @racket[new-dir] argument is not interpreted at all, but simply
 passed on to the server; it must not contain a newline.}
 
 @defproc[(ftp-directory-list [ftp-conn ftp-connection?]
-                             [path (or/c false/c string?) #f])
-         (listof (list/c (one-of/c "-" "d" "l")
+                             [path (or/c #f string?) #f])
+         (listof (list/c (or/c "-" "d" "l")
                          string?
                          string?))]{
 

--- a/pkgs/net-doc/net/scribblings/head.scrbl
+++ b/pkgs/net-doc/net/scribblings/head.scrbl
@@ -36,7 +36,7 @@ exception is raised.}
 
 
 @defproc[(extract-field [field (or/c string? bytes?)] [header (or/c string? bytes?)])
-         (or/c string? bytes? false/c)]{
+         (or/c string? bytes? #f)]{
 
 Returns the header content for the specified field, or @racket[#f] if
 the field is not in the header. The @racket[field] string should not
@@ -96,7 +96,7 @@ type.}
 
 
 @defproc[(replace-field [field (or/c string? bytes?)]
-                        [value (or/c string? bytes? false/c)]
+                        [value (or/c string? bytes? #f)]
                         [header (or/c string? bytes?)])
           (or/c string? bytes?)]{
 
@@ -135,8 +135,7 @@ adding CRLF-TAB separators.}
 
 
 @defproc[(extract-addresses [line string?]
-                            [kind (one-of/c 'name 'address
-                                            'full 'all)])
+                            [kind (or/c 'name 'address 'full 'all)])
           (or/c (listof string?)
                 (listof (list/c string? string? string?)))]{
 

--- a/pkgs/net-doc/net/scribblings/http-client.scrbl
+++ b/pkgs/net-doc/net/scribblings/http-client.scrbl
@@ -99,7 +99,7 @@ configured to @tech{auto-reconnect}.
                           [#:close? close? boolean? #f]
                           [#:headers headers (listof (or/c bytes? string?)) empty]
                           [#:content-decode decodes (listof symbol?) '(gzip deflate)]
-                          [#:data data (or/c false/c bytes? string? data-procedure/c) #f])
+                          [#:data data (or/c #f bytes? string? data-procedure/c) #f])
          void?]{
 
 Sends an HTTP request to @racket[hc] to the URI @racket[uri] using
@@ -156,7 +156,7 @@ to do so.
                               [#:version version (or/c bytes? string?) #"1.1"]
                               [#:method method (or/c bytes? string? symbol?) #"GET"]
                               [#:headers headers (listof (or/c bytes? string?)) empty]
-                              [#:data data (or/c false/c bytes? string? data-procedure/c) #f]
+                              [#:data data (or/c #f bytes? string? data-procedure/c) #f]
                               [#:content-decode decodes (listof symbol?) '(gzip deflate)]
                               [#:close? close? boolean? #f])
          (values bytes? (listof bytes?) input-port?)]{
@@ -172,7 +172,7 @@ Calls @racket[http-conn-send!] and @racket[http-conn-recv!] in sequence.
                         [#:version version (or/c bytes? string?) #"1.1"]
                         [#:method method (or/c bytes? string? symbol?) #"GET"]
                         [#:headers headers (listof (or/c bytes? string?)) empty]
-                        [#:data data (or/c false/c bytes? string? data-procedure/c) #f]
+                        [#:data data (or/c #f bytes? string? data-procedure/c) #f]
                         [#:content-decode decodes (listof symbol?) '(gzip deflate)])
          (values bytes? (listof bytes?) input-port?)]{
 

--- a/pkgs/net-doc/net/scribblings/mime.scrbl
+++ b/pkgs/net-doc/net/scribblings/mime.scrbl
@@ -172,11 +172,11 @@ consumes an output out and writes the decoded message to the port. If
 the encoded body is pulled from a stream).}
 
 @defstruct[disposition ([type symbol?]
-                        [filename (or/c string? false/c)]
-                        [creation (or/c string? false/c)]
-                        [modification (or/c string? false/c)]
-                        [read (or/c string? false/c)]
-                        [size (or/c exact-nonnegative-integer? false/c)]
+                        [filename (or/c string? #f)]
+                        [creation (or/c string? #f)]
+                        [modification (or/c string? #f)]
+                        [read (or/c string? #f)]
+                        [size (or/c exact-nonnegative-integer? #f)]
                         [params (listof (cons/c symbol? string?))])]{
 
 Represents a @racket["Content-Disposition"] header as defined in RFC

--- a/pkgs/net-doc/net/scribblings/pop3.scrbl
+++ b/pkgs/net-doc/net/scribblings/pop3.scrbl
@@ -12,7 +12,7 @@ tools for the Post Office Protocol version 3 @cite["RFC977"].}
                          [receiver input-port?]
                          [server string?]
                          [port (integer-in 0 65535)]
-                         [state (one-of/c 'disconnected 'authorization 'transaction)])]{
+                         [state (or/c 'disconnected 'authorization 'transaction)])]{
 
 Once a connection to a POP-3 server has been established, its state is
 stored in a @racket[communicator] instance, and other procedures take

--- a/pkgs/net-doc/net/scribblings/sendmail.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendmail.scrbl
@@ -14,7 +14,7 @@ corresponding SMTP specifications, except as noted otherwise.
 
 @section{Sendmail Functions}
 
-@defproc[(send-mail-message/port [from (or/c string? false/c)]
+@defproc[(send-mail-message/port [from (or/c string? #f)]
                                  [subject string?]
                                  [to (listof string?)]
                                  [cc (listof string?)]

--- a/pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -34,8 +34,8 @@ procedure to override the above behavior, and the procedure will be
 called with the URL @racket[str].}
 
 @defproc[(send-url/file [path path-string?] [separate-window? any/c #t]
-                        [#:fragment fragment (or/c string? false/c) #f]
-                        [#:query query (or/c string? false/c) #f])
+                        [#:fragment fragment (or/c string? #f) #f]
+                        [#:query query (or/c string? #f) #f])
          void?]{
 
 Similar to @racket[send-url] (with @racket[#:escape? #t]), but accepts
@@ -50,9 +50,9 @@ all encoded in the same way as a path provided to @racket[send-url],
 which means that already-encoded characters are used as-is.}
 
 @defproc[(send-url/contents [contents string?] [separate-window? any/c #t]
-                            [#:fragment fragment (or/c string? false/c) #f]
-                            [#:query query (or/c string? false/c) #f]
-                            [#:delete-at seconds (or/c number? false/c) #f])
+                            [#:fragment fragment (or/c string? #f) #f]
+                            [#:query query (or/c string? #f) #f]
+                            [#:delete-at seconds (or/c number? #f) #f])
          void?]{
 
 Similar to @racket[send-url/file], but it consumes the contents of a

--- a/pkgs/net-doc/net/scribblings/smtp.scrbl
+++ b/pkgs/net-doc/net/scribblings/smtp.scrbl
@@ -25,19 +25,19 @@ module assume that the given string arguments are well-formed.
                             [header string?]
                             [message (listof (or/c string? bytes?))]
                             [#:port-no port-no/k (integer-in 0 65535) 25]
-                            [#:auth-user user (or/c string? false/c) #f]
-                            [#:auth-passwd pw (or/c string? false/c) #f]
+                            [#:auth-user user (or/c string? #f) #f]
+                            [#:auth-passwd pw (or/c string? #f) #f]
                             [#:tcp-connect connect
-                                           ((string? (integer-in 0 65535))
-                                            . ->* . (input-port? output-port?))
+                                           (string? (integer-in 0 65535)
+                                            . -> . (values input-port? output-port?))
                                            tcp-connect]
                             [#:tls-encode encode
-                                          (or/c false/c
-                                                ((input-port? output-port?
-                                                  #:mode (one-of/c 'connect)
-                                                  #:encrypt (one-of/c 'tls)
-                                                  #:close-original? (one-of/c #t))
-                                                 . ->* . (input-port? output-port?)))
+                                          (or/c #f
+                                                (input-port? output-port?
+                                                 #:mode 'connect
+                                                 #:encrypt 'tls
+                                                 #:close-original? #t
+                                                 . -> . (values input-port? output-port?)))
                                           #f]
                             [port-no (integer-in 0 65535) port-no/k])
          void?]{

--- a/pkgs/net-doc/net/scribblings/ssl-tcp-unit.scrbl
+++ b/pkgs/net-doc/net/scribblings/ssl-tcp-unit.scrbl
@@ -7,12 +7,12 @@
 library provides a function for creating a @racket[tcp^]
 implementation with @racketmodname[openssl] functionality.}
 
-@defproc[(make-ssl-tcp@ [server-cert-file (or/c path-string? false/c)]
-                        [server-key-file (or/c path-string? false/c)]
-                        [server-root-cert-files (or/c (listof path-string?) false/c)]
+@defproc[(make-ssl-tcp@ [server-cert-file (or/c path-string? #f)]
+                        [server-key-file (or/c path-string? #f)]
+                        [server-root-cert-files (or/c (listof path-string?) #f)]
                         [server-suggest-auth-file path-string?]
-                        [client-cert-file (or/c path-string? false/c)]
-                        [client-key-file (or/c path-string? false/c)]
+                        [client-cert-file (or/c path-string? #f)]
+                        [client-key-file (or/c path-string? #f)]
                         [client-root-cert-files (listof path-string?)])
          unit?]{
 

--- a/pkgs/net-doc/net/scribblings/tcp.scrbl
+++ b/pkgs/net-doc/net/scribblings/tcp.scrbl
@@ -22,34 +22,27 @@ See also @racket[tcp-redirect] and @racket[make-ssl-tcp@].
 
 @defsignature[tcp^ ()]{
 
-@defproc[(tcp-listen [port-no (and/c exact-nonnegative-integer?
-                                     (integer-in 0 65535))]
+@defproc[(tcp-listen [port-no (integer-in 0 65535)]
                      [max-allow-wait exact-nonnegative-integer? 4]
                      [reuse? any/c #f]
-                     [hostname (or/c string? false/c) #f])
+                     [hostname (or/c string? #f) #f])
          @#,sigelem[tcp^ tcp-listener?]]{
 
 Like @racket[tcp-listen] from @racketmodname[racket/tcp].}
 
 @defproc[(tcp-connect [hostname string?]
-                      [port-no (and/c exact-nonnegative-integer?
-                                     (integer-in 1 65535))]
-                      [local-hostname (or/c string? false/c) #f]
-                      [local-port-no (or/c (and/c exact-nonnegative-integer?
-                                                  (integer-in 1 65535))
-                                           false/c)
+                      [port-no (integer-in 1 65535)]
+                      [local-hostname (or/c string? #f) #f]
+                      [local-port-no (or/c (integer-in 1 65535) #f)
                                      #f])
           (values input-port? output-port?)]{
 
 Like @racket[tcp-connect] from @racketmodname[racket/tcp].}
 
 @defproc[(tcp-connect/enable-break [hostname string?]
-                      [port-no (and/c exact-nonnegative-integer?
-                                     (integer-in 1 65535))]
-                      [local-hostname (or/c string? false/c) #f]
-                      [local-port-no (or/c (and/c exact-nonnegative-integer?
-                                                  (integer-in 1 65535))
-                                           false/c)])
+                      [port-no (integer-in 1 65535)]
+                      [local-hostname (or/c string? #f) #f]
+                      [local-port-no (or/c (integer-in 1 65535) #f)])
           (values input-port? output-port?)]{
 
 Like @racket[tcp-connect/enable-break] from @racketmodname[racket/tcp].}

--- a/pkgs/net-doc/net/scribblings/uri-codec.scrbl
+++ b/pkgs/net-doc/net/scribblings/uri-codec.scrbl
@@ -120,7 +120,7 @@ Decode a string encoded using the
 @tt{application/x-www-form-urlencoded} encoding rules.}
 
 
-@defproc[(alist->form-urlencoded [alist (listof (cons/c symbol? (or/c false/c string?)))])
+@defproc[(alist->form-urlencoded [alist (listof (cons/c symbol? (or/c #f string?)))])
          string?]{
 
 Encode an association list using the
@@ -131,7 +131,7 @@ separator used in the result.}
 
 
 @defproc[(form-urlencoded->alist [str string])
-         (listof (cons/c symbol? (or/c false/c string?)))]{
+         (listof (cons/c symbol? (or/c #f string?)))]{
 
 Decode a string encoded using the
 @tt{application/x-www-form-urlencoded} encoding rules into an
@@ -142,7 +142,7 @@ that separators are parsed in the input.}
 
 
 @defparam[current-alist-separator-mode mode 
-          (one-of/c 'amp 'semi 'amp-or-semi 'semi-or-amp)]{
+          (or/c 'amp 'semi 'amp-or-semi 'semi-or-amp)]{
 
 A parameter that determines the separator used/recognized between
 associations in @racket[form-urlencoded->alist],

--- a/pkgs/net-doc/net/scribblings/url.scrbl
+++ b/pkgs/net-doc/net/scribblings/url.scrbl
@@ -39,14 +39,14 @@ re-exported by @racketmodname[net/url] and @racketmodname[net/url-string].}
 @; ----------------------------------------
 
 
-@defstruct[url ([scheme (or/c false/c string?)]
-                [user (or/c false/c string?)]
-                [host (or/c false/c string?)]
-                [port (or/c false/c exact-nonnegative-integer?)]
+@defstruct[url ([scheme (or/c #f string?)]
+                [user (or/c #f string?)]
+                [host (or/c #f string?)]
+                [port (or/c #f exact-nonnegative-integer?)]
                 [path-absolute? boolean?]
                 [path (listof path/param?)]
-                [query (listof (cons/c symbol? (or/c false/c string?)))]
-                [fragment (or/c false/c string?)])]{
+                [query (listof (cons/c symbol? (or/c #f string?)))]
+                [fragment (or/c #f string?)])]{
 
 The basic structure for all URLs, which is explained in RFC 3986
 @cite["RFC3986"]. The following diagram illustrates the parts:
@@ -583,7 +583,7 @@ where a pattern is one of:
 
 @defproc[(proxy-server-for
           [url-schm string?]
-          [dest-host-name (or/c false/c string?) #f])
+          [dest-host-name (or/c #f string?) #f])
          (or/c (list/c string? string? (integer-in 0 65535)) #f)]{
 
 Returns the proxy server entry for the combination of @racket[url-schm]
@@ -598,7 +598,7 @@ and @racket[host], or @racket[#f] if no proxy is to be used.}
 @defproc[(http-sendrecv/url [u url?]
                             [#:method method (or/c bytes? string? symbol?) #"GET"]
                             [#:headers headers (listof (or/c bytes? string?)) empty]
-                            [#:data data (or/c false/c bytes? string? data-procedure/c) #f]
+                            [#:data data (or/c #f bytes? string? data-procedure/c) #f]
                             [#:content-decode decodes (listof symbol?) '(gzip deflate)])
          (values bytes? (listof bytes?) input-port?)]{
 

--- a/pkgs/racket-doc/dynext/dynext.scrbl
+++ b/pkgs/racket-doc/dynext/dynext.scrbl
@@ -44,7 +44,7 @@ directories are added automatically.}
 
 @defparam[current-extension-compiler 
           compiler
-          (or/c path-string? false/c)]{
+          (or/c path-string? #f)]{
 
 A parameter that determines the executable for the compiler. 
 
@@ -131,7 +131,7 @@ and without non-@racket["-D"] flags.}
 
 @defparam[compile-variant
           variant-symbol
-          (one-of/c 'normal 'cgc '3m)]{
+          (or/c 'normal 'cgc '3m)]{
 
 A parameter that indicates the target for compilation, where
 @racket['normal] is an alias for the result of @racket[(system-type
@@ -140,7 +140,7 @@ A parameter that indicates the target for compilation, where
 
 @subsection{Helper functions}
 
-@defproc[(use-standard-compiler (name (apply one-of/c (get-standard-compilers)))) any]{
+@defproc[(use-standard-compiler (name (apply or/c (get-standard-compilers)))) any]{
 
 Sets the parameters described in @secref["compile-params"] for a
 particular known compiler. The acceptable names are
@@ -204,7 +204,7 @@ destination extension filename.}
 
 @defparam[current-extension-linker
           linker
-          (or/c path-string? false/c)]{
+          (or/c path-string? #f)]{
 
 A parameter that determines the executable used as a linker.
 
@@ -283,7 +283,7 @@ resulting file to be loaded via @racket[load-extension].  Defaults to
 
 @defparam[link-variant
           variant-symbol
-          (one-of/c 'normal 'cgc '3m)]{
+          (or/c 'normal 'cgc '3m)]{
 
 A parameter that indicates the target for linking, where
 @racket['normal] is an alias for the result of @racket[(system-type
@@ -292,7 +292,7 @@ A parameter that indicates the target for linking, where
 
 @subsection{Helper Functions}
 
-@defproc[(use-standard-linker (name (one-of/c 'cc 'gcc 'msvc 'borland 'cw)))
+@defproc[(use-standard-linker (name (or/c 'cc 'gcc 'msvc 'borland 'cw)))
          void?]{
 
 Sets the parameters described in @secref["link-params"] for a
@@ -357,7 +357,7 @@ Appends the platform-standard dynamic-extension file suffix to
 
 @defproc[(extract-base-filename/ss (s path-string?) 
                                    (program any/c #f))
-         (or/c path? false/c)]{
+         (or/c path? #f)]{
 
 Strips the Racket file suffix from @racket[s] and returns a stripped
 path. The recognized suffixes are the ones reported by
@@ -371,7 +371,7 @@ Unlike the other functions below, when @racket[program] is not
 
 @defproc[(extract-base-filename/c (s path-string?) 
                                   (program any/c #f)) 
-         (or/c path? false/c)]{
+         (or/c path? #f)]{
 
 Strips the Racket file suffix from @racket[s] and
 returns a stripped path. If @racket[s] is not a Racket file name and
@@ -379,17 +379,17 @@ returns a stripped path. If @racket[s] is not a Racket file name and
 not a Racket file and @racket[program] is @racket[#f], @racket[#f] is
 returned.}
 
-@defproc[(extract-base-filename/kp (s path-string?) (program any/c #f)) (or/c path? false/c)]{
+@defproc[(extract-base-filename/kp (s path-string?) (program any/c #f)) (or/c path? #f)]{
 
 Same as @racket[extract-base-filename/c], but for constant-pool
 files.}
 
-@defproc[(extract-base-filename/o (s path-string?) (program any/c #f)) (or/c path? false/c)]{
+@defproc[(extract-base-filename/o (s path-string?) (program any/c #f)) (or/c path? #f)]{
 
 Same as @racket[extract-base-filename/c], but for compiled-object
 files.}
 
-@defproc[(extract-base-filename/ext (s path-string?) (program any/c #f)) (or/c path? false/c)]{
+@defproc[(extract-base-filename/ext (s path-string?) (program any/c #f)) (or/c path? #f)]{
 
 Same as @racket[extract-base-filename/c], but for extension files.}
 

--- a/pkgs/racket-doc/file/scribblings/gzip.scrbl
+++ b/pkgs/racket-doc/file/scribblings/gzip.scrbl
@@ -23,7 +23,7 @@ is the name of the file to compress. If the file named by
 
 @defproc[(gzip-through-ports [in input-port?]
                              [out output-port?]
-                             [orig-filename (or/c string? false/c)]
+                             [orig-filename (or/c string? #f)]
                              [timestamp exact-integer?])
          void?]{
 

--- a/pkgs/racket-doc/file/scribblings/ico.scrbl
+++ b/pkgs/racket-doc/file/scribblings/ico.scrbl
@@ -21,7 +21,7 @@ otherwise.}
 @deftogether[(
 @defproc[(ico-width [ico ico?]) exact-positive-integer?]
 @defproc[(ico-height [ico ico?]) exact-positive-integer?]
-@defproc[(ico-depth [ico ico?]) (one-of/c 1 2 4 8 16 24 32)]
+@defproc[(ico-depth [ico ico?]) (or/c 1 2 4 8 16 24 32)]
 )]{
 
 Returns the width or height of an icon in pixels, or the depth in bits per
@@ -109,7 +109,7 @@ Returns the bytes of a PNG encoding for an icon in PNG format (see
 @defproc[(argb->ico [width (integer-in 1 256)]
                     [height (integer-in 1 256)]
                     [bstr bytes?]
-                    [#:depth depth (one-of/c 1 2 4 8 24 32) 32])
+                    [#:depth depth (or/c 1 2 4 8 24 32) 32])
          ico?]{
 
 Converts an ARGB byte string (in the same format as from

--- a/pkgs/racket-doc/scribblings/foreign/com-auto.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/com-auto.scrbl
@@ -83,7 +83,7 @@ produces a @tech{ProgID} with its version.}
 
 
 @defproc[(com-create-instance [clsid-or-progid (or/c clsid? string?)]
-                              [where (or/c (one-of/c 'local 'remote) string?) 'local])
+                              [where (or/c 'local 'remote string?) 'local])
          com-object?]{
 
   Returns an instance of the @tech{COM class} specified by

--- a/pkgs/racket-doc/scribblings/foreign/pointers.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/pointers.scrbl
@@ -92,7 +92,7 @@ in a pointer.  The same operation could be performed using
             any]
            [(ptr-ref [cptr cpointer?]
                      [type ctype?]
-                     [abs-tag (one-of/c 'abs)]
+                     [abs-tag 'abs]
                      [offset exact-nonnegative-integer?])
             any]
            [(ptr-set! [cptr cpointer?]
@@ -106,7 +106,7 @@ in a pointer.  The same operation could be performed using
             void?]
            [(ptr-set! [cptr cpointer?]
                       [type ctype?]
-                      [abs-tag (one-of/c 'abs)]
+                      [abs-tag 'abs]
                       [offset exact-nonnegative-integer?]
                       [val any/c])
             void?])]{
@@ -212,11 +212,11 @@ see @|InsideRacket|.
                                       ctype?) 
                                 @#,elem{absent}]
                  [cptr cpointer? @#,elem{absent}]
-                 [mode (one-of/c 'raw 'atomic 'nonatomic 'tagged
-                                 'atomic-interior 'interior
-                                 'stubborn 'uncollectable 'eternal)
+                 [mode (or/c 'raw 'atomic 'nonatomic 'tagged
+                             'atomic-interior 'interior
+                             'stubborn 'uncollectable 'eternal)
                        @#,elem{absent}]
-                 [fail-mode (one-of/c 'failok) @#,elem{absent}])
+                 [fail-mode 'failok @#,elem{absent}])
          cpointer?]{
 
 Allocates a memory block of a specified size using a specified

--- a/pkgs/racket-doc/scribblings/foreign/types.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/types.scrbl
@@ -1314,9 +1314,9 @@ results.
 @defproc[(make-cstruct-type [types (non-empty-listof ctype?)]
                             [abi (or/c #f 'default 'stdcall 'sysv) #f]
                             [alignment (or/c #f 1 2 4 8 16) #f]
-                            [malloc-mode (one-of/c 'raw 'atomic 'nonatomic 'tagged
-                                                    'atomic-interior 'interior
-                                                    'stubborn 'uncollectable 'eternal)
+                            [malloc-mode (or/c 'raw 'atomic 'nonatomic 'tagged
+                                               'atomic-interior 'interior
+                                               'stubborn 'uncollectable 'eternal)
                                          'atomic])
          ctype?]{
 
@@ -1344,9 +1344,9 @@ allocation mode is @emph{not} used for an argument to a
 
 @defproc[(_list-struct [#:alignment alignment (or/c #f 1 2 4 8 16) #f] 
                        [#:malloc-mode malloc-mode
-                                      (one-of/c 'raw 'atomic 'nonatomic 'tagged
-                                                'atomic-interior 'interior
-                                                'stubborn 'uncollectable 'eternal)
+                                      (or/c 'raw 'atomic 'nonatomic 'tagged
+                                            'atomic-interior 'interior
+                                            'stubborn 'uncollectable 'eternal)
                                       'atomic]
                        [type ctype?] ...+)
          ctype?]{
@@ -1374,9 +1374,9 @@ below for a more efficient approach.
                               #:define-unsafe)]
          #:contracts ([offset-expr exact-integer?]
                       [alignment-expr (or/c #f 1 2 4 8 16)]
-                      [malloc-mode-expr (one-of/c 'raw 'atomic 'nonatomic 'tagged
-                                                  'atomic-interior 'interior
-                                                  'stubborn 'uncollectable 'eternal)]
+                      [malloc-mode-expr (or/c 'raw 'atomic 'nonatomic 'tagged
+                                              'atomic-interior 'interior
+                                              'stubborn 'uncollectable 'eternal)]
                       [prop-expr struct-type-property?])]{
 
 Defines a new C struct type, but unlike @racket[_list-struct], the

--- a/pkgs/racket-doc/scribblings/guide/contracts/general-function.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/contracts/general-function.scrbl
@@ -613,7 +613,7 @@ glance, this appears to suggest a contract that assigns a
 @racketblock[
 (->* () 
      #:rest (listof any/c)
-     (or/c number? false/c))
+     (or/c number? #f))
 ]
 This contract, however, says that the function must accept @emph{any}
 number of arguments, not a @emph{specific} but
@@ -631,7 +631,7 @@ because the given function accepts only one argument.
   [n-step
    (->i ([proc (inits)
           (and/c (unconstrained-domain-> 
-                  (or/c false/c number?))
+                  (or/c #f number?))
                  (λ (f) (procedure-arity-includes? 
                          f 
                          (length inits))))]

--- a/pkgs/racket-doc/scribblings/raco/api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/api.scrbl
@@ -31,7 +31,7 @@ through a Racket API.}
 
 @defproc[((compile-zos [expr any/c] [#:module? module? any/c #f] [#:verbose? verbose? any/c #f]) 
           [racket-files (listof path-string?)]
-          [dest-dir (or/c path-string? false/c (one-of/c 'auto))])
+          [dest-dir (or/c path-string? #f 'auto)])
          void?]{
 
 Supplying just @racket[expr] returns a compiler that is initialized
@@ -284,7 +284,7 @@ the files that it compiles and produces. The default is @racket[#f].}
 A @racket[#t] value for the parameter causes the compiler to print
 verbose messages about its operations. The default is @racket[#f].}
 
-@defparam[compile-subcollections cols (one-of/c #t #f)]{
+@defboolparam[compile-subcollections on?]{
 
 A parameter that specifies whether sub-collections are compiled by
 @racket[compile-collection-zos].  The default is @racket[#t].}

--- a/pkgs/racket-doc/scribblings/raco/bundle-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/bundle-api.scrbl
@@ -36,8 +36,8 @@ Archive creation fails if @racket[dist-file] exists.}
 
 
 @defproc[(bundle-put-file-extension+style+filters)
-         (values (or/c string? false/c)
-                 (listof (one-of/c 'packages 'enter-packages))
+         (values (or/c string? #f)
+                 (listof (or/c 'packages 'enter-packages))
                  (listof (list/c string? string?)))]{
 
 Returns three values suitable for use as the @racket[extension],

--- a/pkgs/racket-doc/scribblings/raco/dist-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/dist-api.scrbl
@@ -18,7 +18,7 @@ perform the same work as @exec{raco distribute}.}
                                 [exec-files (listof path-string?)]
                                 [#:executables? executables? any/c #t]
                                 [#:relative-base relative-base (or/c path-string? #f) #f]
-                                [#:collects-path path (or/c false/c (and/c path-string? relative-path?)) #f]
+                                [#:collects-path path (or/c #f (and/c path-string? relative-path?)) #f]
                                 [#:copy-collects dirs (listof path-string?) null])
          void?]{
 

--- a/pkgs/racket-doc/scribblings/raco/exe-api.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe-api.scrbl
@@ -45,9 +45,9 @@ parameter is true.
 
 @defproc[(create-embedding-executable [dest path-string?]
                                [#:modules mod-list 
-                                         (listof (or/c (list/c (or/c symbol? (one-of/c #t #f)) 
+                                         (listof (or/c (list/c (or/c symbol? #f #t)
                                                                (or/c module-path? path?))
-                                                       (list/c (or/c symbol? (one-of/c #t #f)) 
+                                                       (list/c (or/c symbol? #f #t)
                                                                (or/c module-path? path?)
                                                                (listof symbol?))))]
                                [#:early-literal-expressions early-literal-sexps
@@ -394,9 +394,9 @@ have been applied as needed to refer to the existing file).
 @defproc[(make-embedding-executable [dest path-string?]
                                [mred? any/c]
                                [verbose? any/c]
-                               [mod-list (listof (or/c (list/c (or/c symbol? (one-of/c #t #f)) 
+                               [mod-list (listof (or/c (list/c (or/c symbol? #f #t)
                                                                (or/c module-path? path?))
-                                                       (list/c (or/c symbol? (one-of/c #t #f)) 
+                                                       (list/c (or/c symbol? #f #t)
                                                                (or/c module-path? path?)
                                                                (listof symbol?))))]
                                [literal-files (listof path-string?)]
@@ -404,7 +404,7 @@ have been applied as needed to refer to the existing file).
                                [cmdline (listof string?)]
                                [aux (listof (cons/c symbol? any/c)) null]
                                [launcher? any/c #f]
-                               [variant (one-of/c 'cgc '3m'cs) (system-type 'gc)]
+                               [variant (or/c 'cgc '3m 'cs) (system-type 'gc)]
                                [collects-path (or/c #f
                                                     path-string? 
                                                     (listof path-string?))
@@ -415,9 +415,9 @@ Old (keywordless) interface to @racket[create-embedding-executable].}
 
 
 @defproc[(write-module-bundle [verbose? any/c]
-                               [mod-list (listof (or/c (list/c (or/c symbol? (one-of/c #t #f)) 
+                               [mod-list (listof (or/c (list/c (or/c symbol? #f #t)
                                                                (or/c module-path? path?))
-                                                       (list/c (or/c symbol? (one-of/c #t #f)) 
+                                                       (list/c (or/c symbol? #f #t)
                                                                (or/c module-path? path?)
                                                                (listof symbol?))))]
                               [literal-files (listof path-string?)]
@@ -450,8 +450,8 @@ Mac OS when @racket[mred?] is @racket[#t], @racket[#f] otherwise.}
 
 
 @defproc[(embedding-executable-put-file-extension+style+filters [mred? any/c])
-         (values (or/c string? false/c)
-                 (listof (one-of/c 'packages 'enter-packages))
+         (values (or/c string? #f)
+                 (listof (or/c 'packages 'enter-packages))
                  (listof (list/c string? string?)))]{
 
 Returns three values suitable for use as the @racket[extension],

--- a/pkgs/racket-doc/scribblings/raco/launcher.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/launcher.scrbl
@@ -360,8 +360,8 @@ Like @racket[gracket-launcher-add-suffix], but for Racket launchers.}
 
 
 @defproc[(gracket-launcher-put-file-extension+style+filters)
-         (values (or/c string? false/c)
-                 (listof (one-of/c 'packages 'enter-packages))
+         (values (or/c string? #f)
+                 (listof (or/c 'packages 'enter-packages))
                  (listof (list/c string? string?)))]{
 
 Returns three values suitable for use as the @racket[extension],
@@ -375,8 +375,8 @@ string indicating a required extension for the directory name. }
 
 
 @defproc[(racket-launcher-put-file-extension+style+filters)
-         (values (or/c string? false/c)
-                 (listof (one-of/c 'packages 'enter-packages))
+         (values (or/c string? #f)
+                 (listof (or/c 'packages 'enter-packages))
                  (listof (list/c string? string?)))]{
 
 Like @racket[gracket-launcher-get-file-extension+style+filters], but for
@@ -388,8 +388,8 @@ Racket launchers.}
 @defproc[(mred-launcher-is-actually-directory?) boolean?]
 @defproc[(mred-launcher-add-suffix [path-string? path]) path?]
 @defproc[(mred-launcher-put-file-extension+style+filters)
-         (values (or/c string? false/c)
-                 (listof (one-of/c 'packages 'enter-packages))
+         (values (or/c string? #f)
+                 (listof (or/c 'packages 'enter-packages))
                  (listof (list/c string? string?)))]
 )]{
 
@@ -404,8 +404,8 @@ Backward-compatible aliases for
 @defproc[(mzscheme-launcher-is-actually-directory?) boolean?]
 @defproc[(mzscheme-launcher-add-suffix [path-string? path]) path?]
 @defproc[(mzscheme-launcher-put-file-extension+style+filters)
-         (values (or/c string? false/c)
-                 (listof (one-of/c 'packages 'enter-packages))
+         (values (or/c string? #f)
+                 (listof (or/c 'packages 'enter-packages))
                  (listof (list/c string? string?)))]
 )]{
 

--- a/pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -187,7 +187,7 @@ implements the compilation and dependency management used by
 @defproc[(make-compilation-manager-load/use-compiled-handler 
           [delete-zos-when-rkt-file-does-not-exist? any/c #f]
           [#:security-guard security-guard (or/c security-guard? #f) #f])
-         (path? (or/c symbol? false/c) . -> . any)]{
+         (path? (or/c symbol? #f) . -> . any)]{
 
 Returns a procedure suitable as a value for the
 @racket[current-load/use-compiled] parameter. The returned procedure

--- a/pkgs/racket-doc/scribblings/raco/plt.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/plt.scrbl
@@ -348,7 +348,7 @@ making @filepath{.plt} archives.}
             [#:collections collection-list (listof path-string?) null]
             [#:plt-relative? plt-relative? any/c #f]
             [#:at-plt-home? at-plt-home? any/c #f]
-            [#:test-plt-dirs dirs (or/c (listof path-string?) false/c) #f]
+            [#:test-plt-dirs dirs (or/c (listof path-string?) #f) #f]
             [#:requires mod-and-version-list
                         (listof (listof path-string?)
                                 (listof exact-integer?))
@@ -460,7 +460,7 @@ making @filepath{.plt} archives.}
                 [#:as-path as-path path-string? path]
                 (output output-port?)
                 (filter (path-string? . -> . boolean?))
-                (file-mode (symbols 'file 'file-replace))) void?]{
+                (file-mode (or/c 'file 'file-replace))) void?]{
    Called by @racket[pack] to write one directory/file @racket[path] to the
    output port @racket[output] using the filter procedure @racket[filter]
    (see @racket[pack] for a description of @racket[filter]). The @racket[path]

--- a/pkgs/racket-doc/scribblings/raco/unpack.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/unpack.scrbl
@@ -94,7 +94,7 @@ while the second will refer to the main installation.}
                                                  (list/c (or/c 'collects 'doc 'lib 'include)
                                                          path-string?))
                                            input-port? 
-                                           (one-of/c 'file 'file-replace) 
+                                           (or/c 'file 'file-replace)
                                            any/c 
                                            . -> . any/c))]
                            [initial-value any/c])

--- a/pkgs/racket-doc/scribblings/reference/chaperones.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/chaperones.scrbl
@@ -793,7 +793,8 @@ an extra argument as with @racket[impersonate-procedure*].
                            [orig-proc (or/c struct-accessor-procedure?
                                             struct-mutator-procedure?
                                             struct-type-property-accessor-procedure?
-                                            (one-of/c struct-info))]
+                                            (lambda (proc)
+                                              (eq? proc struct-info)))]
                            [redirect-proc (or/c procedure? #f)] ... ...
                            [prop impersonator-property?]
                            [prop-val any/c] ... ...)

--- a/pkgs/racket-doc/scribblings/reference/syntax-util.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax-util.scrbl
@@ -117,7 +117,7 @@ creates pattern variable definitions for the pattern variables of
 
 @section{Error reporting}
 
-@defparam[current-syntax-context stx (or/c syntax? false/c)]{
+@defparam[current-syntax-context stx (or/c syntax? #f)]{
 
 The current contextual syntax object, defaulting to @racket[#f].  It
 determines the special form name that prefixes syntax errors created
@@ -162,7 +162,7 @@ different due to renaming, prefixing, etc).
 @section{Recording disappeared uses}
 
 @defparam[current-recorded-disappeared-uses ids
-          (or/c (listof identifier?) false/c)]{
+          (or/c (listof identifier?) #f)]{
 
 Parameter for tracking disappeared uses. Tracking is ``enabled'' when
 the parameter has a non-false value. This is done automatically by

--- a/pkgs/racket-doc/scribblings/reference/unsafe-undefined.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/unsafe-undefined.scrbl
@@ -33,7 +33,7 @@ See above for important constraints on the use of @racket[unsafe-undefined].}
 
 
 @defproc[(check-not-unsafe-undefined [v any/c] [sym symbol?])
-         (and/c any/c (not/c (one-of/c unsafe-undefined)))]{
+         any/c]{
 
 Checks whether @racket[v] is @racket[unsafe-undefined], and raises
 @racket[exn:fail:contract:variable] in that case with an error message
@@ -42,7 +42,7 @@ initialization.''  If @racket[v] is not @racket[unsafe-undefined],
 then @racket[v] is returned.}
 
 @defproc[(check-not-unsafe-undefined/assign [v any/c] [sym symbol?])
-         (and/c any/c (not/c (one-of/c unsafe-undefined)))]{
+         any/c]{
 
 The same as @racket[check-not-unsafe-undefined], except that the error
 message (if any) is along the lines of ``@racket[sym]: undefined;

--- a/pkgs/racket-doc/syntax/scribblings/keyword.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/keyword.scrbl
@@ -65,7 +65,7 @@ times in the input occurs multiple times in the options list.
 
 @defproc[(parse-keyword-options [stx syntax?]
                                 [table #, @techlink{keyword-table}]
-                                [#:context ctx (or/c false/c syntax?) #f]
+                                [#:context ctx (or/c #f syntax?) #f]
                                 [#:no-duplicates? no-duplicates? boolean? #f]
                                 [#:incompatible incompatible (listof (listof keyword?)) '()]
                                 [#:on-incompatible incompatible-handler
@@ -172,7 +172,7 @@ of @racket[parse-keyword-options].
 
 @defproc[(parse-keyword-options/eol [stx syntax?]
                                 [table #, @techlink{keyword-table}]
-                                [#:context ctx (or/c false/c syntax?) #f]
+                                [#:context ctx (or/c #f syntax?) #f]
                                 [#:no-duplicates? no-duplicates? boolean? #f]
                                 [#:incompatible incompatible (listof (list keyword? keyword?)) '()]
                                 [#:on-incompatible incompatible-handler
@@ -239,13 +239,13 @@ in @racket[options], the @racket[default] value is returned.
 
 
 
-@defproc[(check-identifier [stx syntax?] [ctx (or/c false/c syntax?)]) identifier?]{
+@defproc[(check-identifier [stx syntax?] [ctx (or/c #f syntax?)]) identifier?]{
 
 A @techlink{check-procedure} that accepts only identifiers.
 
 }
 
-@defproc[(check-expression [stx syntax?] [ctx (or/c false/c syntax?)]) syntax?]{
+@defproc[(check-expression [stx syntax?] [ctx (or/c #f syntax?)]) syntax?]{
 
 A @techlink{check-procedure} that accepts any non-keyword term. It does
 not actually check that the term is a valid expression.
@@ -253,7 +253,7 @@ not actually check that the term is a valid expression.
 }
 
 @defproc[((check-stx-listof [check #, @techlink{check-procedure}])
-          [stx syntax?] [ctx (or/c false/c syntax?)])
+          [stx syntax?] [ctx (or/c #f syntax?)])
          (listof any/c)]{
 
 Lifts a @techlink{check-procedure} to accept syntax lists of whatever the
@@ -261,13 +261,13 @@ original procedure accepted.
 
 }
 
-@defproc[(check-stx-string [stx syntax?] [ctx (or/c false/c syntax?)]) syntax?]{
+@defproc[(check-stx-string [stx syntax?] [ctx (or/c #f syntax?)]) syntax?]{
 
 A @techlink{check-procedure} that accepts syntax strings.
 
 }
 
-@defproc[(check-stx-boolean [stx syntax?] [ctx (or/c false/c syntax?)])
+@defproc[(check-stx-boolean [stx syntax?] [ctx (or/c #f syntax?)])
          syntax?]{
 
 A @techlink{check-procedure} that accepts syntax booleans.

--- a/pkgs/racket-doc/syntax/scribblings/modcode.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/modcode.scrbl
@@ -18,8 +18,8 @@
                           [#:roots roots (listof (or/c path-string? 'same)) (current-compiled-file-roots)]
                           [#:compile compile-proc0 (any/c . -> . any) compile] 
                           [compile-proc (any/c . -> . any) compile-proc0] 
-                          [#:extension-handler ext-proc0 (or/c false/c (path? boolean? . -> . any)) #f]
-                          [ext-proc (or/c false/c (path? boolean? . -> . any)) ext-proc0]
+                          [#:extension-handler ext-proc0 (or/c #f (path? boolean? . -> . any)) #f]
+                          [ext-proc (or/c #f (path? boolean? . -> . any)) ext-proc0]
                           [#:notify notify-proc (any/c . -> . any) void]
                           [#:source-reader read-syntax-proc 
                                         (any/c input-port? . -> . (or/c syntax? eof-object?)) 

--- a/pkgs/racket-doc/syntax/scribblings/modread.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/modread.scrbl
@@ -12,8 +12,8 @@ values.}
 
 @defproc[(check-module-form [stx (or/c syntax? eof-object?)] 
                             [expected-module-sym symbol?]
-                            [source-v (or/c string? false/c)])
-         (or/c syntax? false/c)]{
+                            [source-v (or/c string? #f)])
+         (or/c syntax? #f)]{
 
 Inspects @racket[stx] to check whether evaluating it will declare a
 module---at least if @racket[module] is bound in the top-level to

--- a/pkgs/racket-doc/syntax/scribblings/readerr.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/readerr.scrbl
@@ -7,10 +7,10 @@
 
 @defproc[(raise-read-error [msg-string string?] 
                            [source any/c]
-                           [line (or/c exact-positive-integer? false/c)]
-                           [col (or/c exact-nonnegative-integer? false/c)]
-                           [pos (or/c exact-positive-integer? false/c)]
-                           [span (or/c exact-nonnegative-integer? false/c)]
+                           [line (or/c exact-positive-integer? #f)]
+                           [col (or/c exact-nonnegative-integer? #f)]
+                           [pos (or/c exact-positive-integer? #f)]
+                           [span (or/c exact-nonnegative-integer? #f)]
                            [#:extra-srclocs extra-srclocs (listof srcloc?) '()]) 
          any]{
 
@@ -35,10 +35,10 @@ was discovered.}
 
 @defproc[(raise-read-eof-error [msg-string string?] 
                                [source any/c]
-                               [line (or/c exact-positive-integer? false/c)]
-                               [col (or/c exact-nonnegative-integer? false/c)]
-                               [pos (or/c exact-positive-integer? false/c)]
-                               [span (or/c exact-nonnegative-integer? false/c)]) 
+                               [line (or/c exact-positive-integer? #f)]
+                               [col (or/c exact-nonnegative-integer? #f)]
+                               [pos (or/c exact-positive-integer? #f)]
+                               [span (or/c exact-nonnegative-integer? #f)])
          any]{
 
 Like @racket[raise-read-error], but raises @racket[exn:fail:read:eof]

--- a/pkgs/racket-doc/syntax/scribblings/struct.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/struct.scrbl
@@ -7,7 +7,7 @@
 
 @defproc[(parse-define-struct [stx syntax?] [orig-stx syntax?]) 
          (values identifier?
-                 (or/c identifier? false/c)
+                 (or/c identifier? #f)
                  (listof identifier?)
                  syntax?)]{
 
@@ -24,7 +24,7 @@ expression.}
                              [#:constructor-name ctr-name (or/c identifier? #f) #f]
 			     [omit-sel? boolean?]
 			     [omit-set? boolean?]
-			     [src-stx (or/c syntax? false/c) #f])
+			     [src-stx (or/c syntax? #f) #f])
           (listof identifier?)]{
 
 Generates the names bound by @racket[define-struct] given an
@@ -91,8 +91,8 @@ Like @racket[build-struct-generation], but given the names produced by
                                    [omit-sel? boolean?]
                                    [omit-set? boolean?]
                                    [base-name (or/c identifier? boolean?)]
-                                   [base-getters (listof (or/c identifier? false/c))]
-                                   [base-setters (listof (or/c identifier? false/c))])
+                                   [base-getters (listof (or/c identifier? #f))]
+                                   [base-setters (listof (or/c identifier? #f))])
 	 any]{
 
 Takes mostly the same arguments as @racket[build-struct-names], plus a parent
@@ -119,7 +119,7 @@ See @secref[#:doc refman]{structinfo}.}
 
 @defproc[(generate-struct-declaration [orig-stx syntax?] 
                                       [name-id identifier?]
-                                      [super-id-or-false (or/c identifier? false/c)]
+                                      [super-id-or-false (or/c identifier? #f)]
                                       [field-id-list (listof identifier?)]
                                       [current-context any/c]
 				      [make-make-struct-type procedure?]

--- a/pkgs/racket-doc/xml/xml.scrbl
+++ b/pkgs/racket-doc/xml/xml.scrbl
@@ -34,14 +34,14 @@ It does not interpret namespaces either.
 
 @section{Datatypes}
 
-@defstruct[location ([line (or/c false/c exact-nonnegative-integer?)]
-                     [char (or/c false/c exact-nonnegative-integer?)]
+@defstruct[location ([line (or/c #f exact-nonnegative-integer?)]
+                     [char (or/c #f exact-nonnegative-integer?)]
                      [offset exact-nonnegative-integer?])]{
 
 Represents a location in an input stream. The offset is a character offset unless @racket[xml-count-bytes] is @racket[#t], in which case it is a byte offset.}
 
 @defthing[location/c contract?]{
- Equivalent to @racket[(or/c location? symbol? false/c)].
+ Equivalent to @racket[(or/c location? symbol? #f)].
 }
 
 @defstruct[source ([start location/c]
@@ -65,7 +65,7 @@ Represents an externally defined DTD.}
 
 @defstruct[document-type ([name symbol?]
                           [external external-dtd?]
-                          [inlined false/c])]{
+                          [inlined #f])]{
 
 Represents a document type.}
 
@@ -83,7 +83,7 @@ Represents a processing instruction.}
 }
 
 @defstruct[prolog ([misc (listof misc/c)]
-                   [dtd (or/c document-type false/c)]
+                   [dtd (or/c document-type #f)]
                    [misc2 (listof misc/c)])]{
 Represents a document prolog. 
 }
@@ -439,7 +439,7 @@ or otherwise escaping. Results from the leaves are combined with
   @history[#:added "8.0.0.12"]
 }
 
-@defparam[empty-tag-shorthand shorthand (or/c (one-of/c 'always 'never) (listof symbol?))]{
+@defparam[empty-tag-shorthand shorthand (or/c 'always 'never (listof symbol?))]{
 
 A parameter that determines whether output functions should use the
 @litchar{<}@nonterm{tag}@litchar{/>} tag notation instead of


### PR DESCRIPTION
##### Checklist
- [x] documentation

### Description of change
This commit mainly updates `false/c` to `#f` and `one-of/c` to `or/c`. A few contracts are also simplified/corrected as I happen to have noticed them.