### PR TITLE
Fix some expander typos

### DIFF
--- a/racket/src/expander/common/performance.rkt
+++ b/racket/src/expander/common/performance.rkt
@@ -14,7 +14,7 @@
 ;; the path `(list key-expr ...)`. Times for a path
 ;; are included in the times for the path's prefixes, but
 ;; not for any other path. When regions that are nested
-;; dynamically, time accumlates only for the most nested
+;; dynamically, time accumulates only for the most nested
 ;; region.
 ;;
 ;; For example,

--- a/racket/src/expander/compile/module.rkt
+++ b/racket/src/expander/compile/module.rkt
@@ -203,7 +203,7 @@
                                                     (hash-ref phase-to-link-extra-inspectorsss phase #f)))))))
    
    ;; Assemble the declaration linking unit, which includes linking
-   ;; information for each phase, is instanted once for a module
+   ;; information for each phase, is instantiated once for a module
    ;; declaration, and is shared among instances
    (define declaration-linklet
      (and serializable?

--- a/racket/src/expander/eval/module.rkt
+++ b/racket/src/expander/eval/module.rkt
@@ -127,7 +127,7 @@
          ;; Dummy callback to avoid retaining anything:
          void))
 
-   ;; At this point, we've prepared everything anout the module that we
+   ;; At this point, we've prepared everything about the module that we
    ;; can while staying independent of a specific declaration or
    ;; specific instance. If we have a hash key for this module, we can
    ;; stash `declare-this-module` for potential reuse later.

--- a/racket/src/expander/expand/require.rkt
+++ b/racket/src/expander/expand/require.rkt
@@ -257,7 +257,7 @@
     (syntax-e id)))
 
 (define (same-scopes? a b)
-  ;; chocie of phase 0 is arbitrary:
+  ;; choice of phase 0 is arbitrary:
   (equal? (syntax-scope-set a 0)
           (syntax-scope-set b 0)))
 


### PR DESCRIPTION
This fixes a few typos I noticed while reading through the expander.