### PR TITLE
some cleanups to `racket/generator`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1569,8 +1569,7 @@ values from the generator.
 
   When not in the @tech{dynamic extent} of a @racket[generator],
   @racket[infinite-generator], or @racket[in-generator] body,
-  @racket[yield] raises @racket[exn:fail] after evaluating its
-  @racket[expr]s.
+  @racket[yield] raises @racket[exn:fail:contract].
 
   @examples[#:eval generator-eval
     (define my-generator (generator () (yield 1) (yield 2 3 4)))
@@ -1607,7 +1606,7 @@ values from the generator.
               ([maybe-arity code:blank
                             (code:line #:arity arity-k)])]{
   Produces a @tech{sequence} that encapsulates the @tech{generator}
-  formed by @racket[(generator () body ...+)]. The values produced by
+  formed by @racket[(generator () body ...)]. The values produced by
   the generator form the elements of the sequence, except for the last
   value produced by the generator (i.e., the values produced by
   returning).

--- a/pkgs/racket-test-core/tests/racket/generator.rktl
+++ b/pkgs/racket-test-core/tests/racket/generator.rktl
@@ -12,7 +12,7 @@
 (test #f generator? error)
 
 (define (exn-yield? e)
-  (and (exn:fail? e)
+  (and (exn:fail:contract? e)
        ;; the old yield raised arity errors when given anything but a single
        ;; argument (outside of a generator expression), contrary to the spec
        ;; (yield v ...)
@@ -49,6 +49,12 @@
   (test '(1 2 3) 'parameterized-yield
         (for/list ([x (in-generator (helper 0) (helper 1) (helper 2))])
                   x)))
+
+(test '(gen inf-gen) 'inferred-name
+      (list (let ([gen (generator () #f)])
+              (object-name gen))
+            (let ([inf-gen (infinite-generator #f)])
+              (object-name inf-gen))))
 
 (let ([g (lambda () (generator () (yield 1) (yield 2) (yield 3)))])
   (let ([g (g)]) (test '(1 2 3) list (g) (g) (g)))

--- a/racket/collects/racket/generator.rkt
+++ b/racket/collects/racket/generator.rkt
@@ -1,13 +1,13 @@
 #lang racket/base
 
-(require (for-syntax racket/base)
-         racket/control)
+(require (for-syntax racket/base
+                     syntax/name))
 
 (provide yield generator generator-state in-generator infinite-generator
          sequence->generator sequence->repeated-generator
          generator?)
 
-;; (require racket/stxparam racket/splicing)
+;; (require racket/control racket/stxparam racket/splicing)
 
 ;; (define-syntax-parameter yield
 ;;   (lambda (stx)
@@ -42,108 +42,115 @@
     (define (generator) (cont))
     generator))
 
-(define current-yielder
-  (make-parameter
-   (lambda _
-     (error 'yield "must be called in the context of a generator"))
-   #f
-   'current-yielder))
+(define current-generator
+  (make-parameter #f #f 'current-generator))
 
-(define yield
-  (case-lambda [()  ((current-yielder))]
-               [(v) ((current-yielder) v)]
-               [vs  (apply (current-yielder) vs)]))
+(define (yield . vs)
+  (define self (current-generator))
+  (unless self
+    (raise-arguments-error 'yield
+                           "must be called in the context of a generator"))
+  (call-with-composable-continuation
+   (lambda (cont)
+     (suspended-generator! self cont)
+     (apply abort-current-continuation yield-tag vs))
+   yield-tag))
 
 (define yield-tag (make-continuation-prompt-tag 'yield))
 
 (define-syntax (generator stx)
   (syntax-case stx ()
-    [(_ formals body0 body ...) 
-     (if (let loop ([formals #'formals])
-           (cond
-            [(null? formals) #t]
-            [(identifier? formals) #t]
-            [(syntax? formals) (loop (syntax-e formals))]
-            [(pair? formals) (and (identifier? (car formals))
-                                  (loop (cdr formals)))]
-            [else #f]))
-         #'(create-generator (let ([generator
-                                    (lambda formals
-                                      body0 body ...)])
-                               generator))
-         (raise-syntax-error
-          #f
-          "bad syntax for formal initial arguments"
-          stx
-          #'formals))]
-    [_ (if (identifier? stx)
-           (raise-syntax-error #f "bad syntax"  stx)
-           (raise-syntax-error
-            #f
-            (format "use does not have the form (~a formals body ...)"
-                    (syntax-e (car (syntax-e stx))))
-            stx))]))
+    [(_ formals body0 body ...)
+     (let ()
+       (syntax-case #'formals ()
+         [(arg ... . rest-arg)
+          (and (andmap identifier? (syntax->list #'(arg ...)))
+               (or (identifier? #'rest-arg)
+                   (null? (syntax-e #'rest-arg))))
+          (void)]
+         [_
+          (raise-syntax-error #f "bad syntax for formals" stx #'formals)])
+       (define name
+         (or (syntax-local-infer-name stx)
+             'generator))
+       #`(create-generator '#,name
+                           #,(syntax-property
+                              (syntax/loc stx
+                                (lambda formals body0 body ...))
+                              'inferred-name name)
+                           #f))]))
 
-(define (create-generator start)
-  (let ([state 'fresh])
-    (define (yielder . vs)
-      (set! state 'suspended)
-      (call/cc (lambda (k)
-                 (set! cont k)
-                 (apply abort-current-continuation yield-tag vs))
-               yield-tag))
-    (define (cont . init-formals)
-      (set! state 'running)
-      (call-with-values
-          (lambda ()
-            (apply start init-formals))
-        ;; get here only on at the end of the generator
-        (lambda rs
-          (set! cont (lambda () (set! state 'done) (apply values rs)))
-          (cont))))
-    (define (call-cont vs)
-      (call-with-continuation-prompt
-       (lambda ()
-         (parameterize ([current-yielder yielder])
-           (apply cont vs)))
-       yield-tag
-       values))
-    (define (err [what "send a value to"])
-      (raise-arguments-error 'generator 
-                             (format "cannot ~a a ~a generator" what state)
-                             "generator" self))
-    (define generator
-      (case-lambda
-        [()  (if (eq? state 'running)
-               (err "call")
-               (begin (set! state 'running) (call-cont null)))]
-        ;; yield-tag means return the state (see `generator-state' below)
-        [(x) (cond [(eq? x yield-tag) state]
-                   [(memq state '(suspended running fresh))
-                    (set! state 'running)
-                    (call-cont (list x))]
-                   [else (err)])]
-        [xs  (if (memq state '(suspended running fresh))
-               (begin (set! state 'running) (call-cont xs))
-               (err))]))
-    (define self (make-generator generator))
-    self))
+(define-syntax (infinite-generator stx)
+  (syntax-case stx ()
+    [(_ body0 body ...)
+     (let ()
+       (define name
+         (or (syntax-local-infer-name stx)
+             'infinite-generator))
+       #`(create-generator '#,name
+                           (letrec ([loop #,(syntax-property
+                                             (syntax/loc stx
+                                               (lambda () body0 body ... (loop)))
+                                             'inferred-name name)])
+                             loop)
+                           #t))]))
 
-(define-struct generator (proc)
-  #:property prop:procedure 0
+(define (create-generator name start loop?)
+  (define (fresh-cont self . vs)
+    (define (start-thunk)
+      (parameterize ([current-generator self])
+        (apply start vs)))
+    (running-generator! self)
+    (call-with-continuation-prompt
+     (if loop?
+         start-thunk
+         (lambda ()
+           (call-with-values start-thunk
+             ;; get here only at the end of non-infinite generator
+             (lambda rs
+               (done-generator! self rs)
+               (apply values rs)))))
+     yield-tag
+     values))
+  (make-generator name fresh-cont 'fresh))
+
+(define (apply-generator-cont self . vs)
+  (apply (generator-cont self) self vs))
+
+(struct generator (name [cont #:mutable] [state #:mutable])
+  #:constructor-name make-generator
+  #:property prop:object-name (struct-field-index name)
+  #:property prop:procedure apply-generator-cont
   #:omit-define-syntaxes)
 
-;; Get the state -- this is a hack: uses yield-tag as a hidden value that makes
-;; the generator return its state.  Protect against grabbing this tag (eg, with
-;; (generator-state values)) by inspecting the result (so it can still be
-;; deceived, but that will be harmless).
-(define (generator-state g)
-  (if (generator? g)
-      (g yield-tag)
-      (raise-argument-error 'generator-state "generator?" g)))
+(define (running-generator! self)
+  (define (running-cont self . _)
+    (raise-arguments-error 'generator
+                           "cannot resume a running generator"
+                           "generator" self))
+  (set-generator-cont! self running-cont)
+  (set-generator-state! self 'running))
 
-(define-syntax-rule (infinite-generator body0 body ...)
-  (generator () (let loop () body0 body ... (loop))))
+(define (suspended-generator! self cont)
+  (define (suspended-cont self . vs)
+    (running-generator! self)
+    (call-with-continuation-prompt
+     (lambda ()
+       (apply cont vs))
+     yield-tag
+     values))
+  (set-generator-cont! self suspended-cont)
+  (set-generator-state! self 'suspended))
+
+(define (done-generator! self rs)
+  (define done-cont
+    (case-lambda
+      [(_) (apply values rs)]
+      [(self . _) (raise-arguments-error 'generator
+                                         "cannot send values to a done generator"
+                                         "generator" self)]))
+  (set-generator-cont! self done-cont)
+  (set-generator-state! self 'done))
 
 (define stop-value (gensym 'stop-value))
 
@@ -177,12 +184,12 @@
                   (lambda () stop?)))]
            [else
             (define vars (generate-temporaries (build-list real-arity values)))
-            (define stops (build-list real-arity (lambda (i) #'stop-value)))
+            (define fs (build-list (sub1 real-arity) (lambda (_) #'#f)))
             (with-syntax ([(x ...) vars]
                           [x0 (car vars)]
-                          [(stop ...) stops])
+                          [(f ...) fs])
               #'(in-producer
-                  (generator () body0 body ... (values stop ...))
+                  (generator () body0 body ... (values stop-value f ...))
                   (lambda (x ...) (eq? x0 stop-value))))]))])))
 
 (define-sequence-syntax in-generator
@@ -198,7 +205,7 @@
   (generator () (for ([i sequence]) (yield i))))
 
 (define (sequence->repeated-generator sequence)
-  (sequence->generator (in-cycle sequence)))
+  (infinite-generator (for ([i sequence]) (yield i))))
 
 #|
 ;; examples


### PR DESCRIPTION
- Raise `exn:fail:contract` in `yield`;
- Use composable continuations in `generator`;
- Implement `prop:object-name` for `generator`;
- Replace `generator-state` with a proper accessor;
- Don’t `call-with-values` in `infinite-generator`;
- Simplify the overall implementation of `generator`.