### PR TITLE
net/sendurl: fix various errors and revamp the doc

### DIFF
--- a/pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -79,35 +79,29 @@ above.}
 }
 
 @defparam[external-browser cmd browser-preference?]{
-
-A parameter that can hold a procedure to override how a browser is
-started, or @racket[#f] to use the default platform-dependent command.
-
-On Unix, the command that is used depends on the @racket['external-browser]
-preference.  It's recommended not to use this preference, but to rely on
-@tt{xdg-open}.  If the preference is unset, @racket[send-url] uses the first
-of the browsers from @racket[unix-browser-list] for which the executable is
-found.  Otherwise, the preference should hold a symbol indicating a known
-browser (from the @racket[unix-browser-list]), or it a pair of a prefix and
-a suffix string that are concatenated around the @racket[url] string to make
-up a shell command to run.  In addition, the @racket[external-browser]
-paremeter can be set to one of these values, and @racket[send-url] will use
-it instead of the preference value.
-
-Note that the URL is encoded to make it work inside shell double-quotes:
-URLs can still hold characters like @litchar{#}, @litchar{?}, and
-@litchar{&}, so if the @racket[external-browser] is set to a pair of
-prefix/suffix strings, they should use double quotes around the url.
-
-If the preferred or default browser can't be launched,
-@racket[send-url] fails. See @racket[get-preference] and
-@racket[put-preferences] for details on setting preferences.}
+A parameter that can hold a browser preference to override how a browser is
+started for @racket[send-url]. See @racket[browser-preference?] for details.}
 
 @defproc[(browser-preference? [a any/c]) boolean?]{
 
 Returns @racket[#t] if @racket[v] is a valid browser preference,
-@racket[#f] otherwise. See @racket[external-browser] for more
-information.}
+@racket[#f] otherwise. A valid browser preference is either:
+
+@itemlist[
+  @item{The value @racket[#f], which fallbacks to the next preference method.}
+  @item{A @racket[procedure?] that accepts a URL string.
+        This value is not allowed for the @racket['external-browser] preference.}
+  @item{A symbol in @racket[browser-list] that indicates a browser to use.}
+  @item{A pair of strings to be concatenated with a URL string to form a shell command to run.
+        The first string is the command prefix and the second string is the command suffix.
+        This method requires extra care:
+
+        @itemlist[
+          @item{The URL can hold characters like @litchar{#}, @litchar{?}, and
+                @litchar{&}, so the pair of strings should place double quotes around the URL.}
+          @item{The URL should be encoded to make it work inside shell double-quotes,
+                so the default value of @racket[escape?] in @racket[send-url] should be used.}]}]}
+
 @defthing[browser-list (listof symbol?)]{
 
 A list of symbols representing executable names that may be tried

--- a/pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -16,7 +16,10 @@ browser preference is set.
          void?]{
 
 Opens @racket[str], which represents a URL, in a platform-specific
-manner. For some platforms and configurations, the
+manner.
+In particular, the first value in @racket[browser-list] will determine
+which browser will be used to open the URL.
+For some platforms and configurations, the
 @racket[separate-window?] parameter determines if the browser creates
 a new window to display the URL or not.
 
@@ -27,9 +30,16 @@ backslashes, non-ASCII characters, and non-graphic characters. Note
 that escaping does not affect already-encoded characters in
 @racket[str].
 
-On all platforms, the @racket[external-browser] parameter can be set to a
-procedure to override the above behavior, and the procedure will be
-called with the URL @racket[str].}
+There are two ways to override the above behavior: the @racket[external-browser] parameter and
+the @racket['external-browser] preference.
+A valid setting for both the @racket[external-browser] parameter and the @racket['external-browser] preference
+must satisfy @racket[browser-preference?], with a restriction that
+the setting for the @racket['external-browser] preference cannot be a procedure.
+The @racket[external-browser] parameter takes priority over @racket['external-browser] preference:
+the preference is only used when @racket[(external-browser)] is @racket[#f].
+See @racket[put-preferences] for details on setting preferences.
+
+On Unix, it's recommended to not override the default behavior, but to rely on @tt{xdg-open} in @racket[browser-list].}
 
 @defproc[(send-url/file [path path-string?] [separate-window? any/c #t]
                         [#:fragment fragment (or/c string? #f) #f]
@@ -88,7 +98,7 @@ Returns @racket[#t] if @racket[v] is a valid browser preference,
 @racket[#f] otherwise. A valid browser preference is either:
 
 @itemlist[
-  @item{The value @racket[#f], which fallbacks to the next preference method.}
+  @item{The value @racket[#f], which falls back to the next preference method.}
   @item{A @racket[procedure?] that accepts a URL string.
         This value is not allowed for the @racket['external-browser] preference.}
   @item{A symbol in @racket[browser-list] that indicates a browser to use.}

--- a/pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -20,8 +20,6 @@ manner. For some platforms and configurations, the
 @racket[separate-window?] parameter determines if the browser creates
 a new window to display the URL or not.
 
-On Mac OS, @racket[send-url] calls @racket[send-url/mac].
-
 If @racket[escape?] is true, then @racket[str] is escaped (by UTF-8
 encoding followed by ``%'' encoding) to avoid dangerous shell
 characters: single quotes, double quotes, backquotes, dollar signs,

--- a/pkgs/net-doc/net/scribblings/sendurl.scrbl
+++ b/pkgs/net-doc/net/scribblings/sendurl.scrbl
@@ -108,10 +108,19 @@ If the preferred or default browser can't be launched,
 Returns @racket[#t] if @racket[v] is a valid browser preference,
 @racket[#f] otherwise. See @racket[external-browser] for more
 information.}
+@defthing[browser-list (listof symbol?)]{
+
+A list of symbols representing executable names that may be tried
+in order by @racket[send-url]. The @racket[send-url] function
+internally includes information on how to launch each executable with
+a URL.
+
+@history[#:added "7.5.0.10"]}
 
 @defthing[unix-browser-list (listof symbol?)]{
 
-A list of symbols representing Unix executable names that may be tried
-in order by @racket[send-url]. The @racket[send-url] function
-internally includes information on how to launch each executable with
-a URL.}
+@deprecated[#:what "value" @racket[browser-list]]
+
+The same as @racket[browser-list].
+
+@history[#:changed "7.5.0.10" @elem{Changed the value to be an alias of @racket[browser-list].}]}

--- a/pkgs/net-lib/net/sendurl.rkt
+++ b/pkgs/net-lib/net/sendurl.rkt
@@ -4,7 +4,8 @@
 #lang racket/base
 
 (require racket/system racket/file racket/promise racket/port
-         racket/contract racket/promise json)
+         racket/contract racket/promise
+         (for-syntax racket/base))
 
 (provide send-url send-url/file send-url/contents
          browser-list external-browser
@@ -57,7 +58,7 @@
 
 ;; Backwards compatibility
 
-(define unix-browser-list browser-list)
+(define-syntax unix-browser-list (make-rename-transformer #'browser-list))
 
 ;; : any -> bool
 (define (custom-browser? x)

--- a/pkgs/net-lib/net/sendurl.rkt
+++ b/pkgs/net-lib/net/sendurl.rkt
@@ -156,7 +156,7 @@
     (with-output-to-file temp #:exists 'truncate
       (lambda () (display contents)))
     (when delete-at (thread (lambda () (sleep delete-at) (delete-file temp))))
-    (send-url/file temp)))
+    (send-url/file temp separate-window? #:fragment fragment #:query query)))
 
 (define (send-url/simple url [separate-window? separate-by-default?])
   ;; in cases where a browser was uninstalled, we might get a preference that


### PR DESCRIPTION
This PR is a follow up of #2900. The PR in particular:

1. Delays the evaluation of browser-list properly by avoiding its
   eager evaluation in unix-browser-list.
2. Marks unix-browser-list as deprecated in the doc,
   and documents browser-list.
3. Corrects the description for the Mac platform
   (send-url/mac is no longer used by send-url).
4. Reorganizes the doc to make it clearer.
5. Gives an advice on how to use send-url with command prefix and suffix
6. Passes arguments of send-url/contents to send-url/file correctly
   (This is really a follow-up for c44e2cea9e).