### PR TITLE
regexp: more consistent contract checking in `regexp-replace{,*}`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -326,7 +326,7 @@ the start of the input or of a line.}
 @;------------------------------------------------------------------------
 @section{Regexp Matching}
 
-@defproc[(regexp-match [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match [pattern (or/c regexp? byte-regexp? string? bytes?)]
                        [input (or/c string? bytes? path? input-port?)]
                        [start-pos exact-nonnegative-integer? 0]
                        [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -441,7 +441,7 @@ bytes. To avoid such interleaving, use @racket[regexp-match-peek]
 ]}
 
 
-@defproc[(regexp-match* [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match* [pattern (or/c regexp? byte-regexp? string? bytes?)]
                         [input (or/c string? bytes? path? input-port?)]
                         [start-pos exact-nonnegative-integer? 0]
                         [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -512,7 +512,7 @@ return @emph{only} the separators, making such uses equivalent to
 ]}
 
 
-@defproc[(regexp-try-match [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-try-match [pattern (or/c regexp? byte-regexp? string? bytes?)]
                            [input input-port?]
                            [start-pos exact-nonnegative-integer? 0]
                            [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -531,7 +531,7 @@ peeked (and therefore pulled into memory) before the match succeeds or
 fails.}
 
 
-@defproc[(regexp-match-positions [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-positions [pattern (or/c regexp? byte-regexp? string? bytes?)]
                                  [input (or/c string? bytes? path? input-port?)]
                                  [start-pos exact-nonnegative-integer? 0]
                                  [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -587,7 +587,7 @@ a tail of @racket[input-prefix].
 (regexp-match-positions #rx"(?<=(.))." "a" 0 #f #f (string->bytes/utf-8 "\u3BB"))
 ]}
 
-@defproc[(regexp-match-positions* [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-positions* [pattern (or/c regexp? byte-regexp? string? bytes?)]
                                   [input (or/c string? bytes? path? input-port?)]
                                   [start-pos exact-nonnegative-integer? 0]
                                   [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -614,7 +614,7 @@ inferred from the resulting matches.
 }
 
 
-@defproc[(regexp-match? [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match? [pattern (or/c regexp? byte-regexp? string? bytes?)]
                         [input (or/c string? bytes? path? input-port?)]
                         [start-pos exact-nonnegative-integer? 0]
                         [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -631,7 +631,7 @@ match succeeds, @racket[#f] otherwise.
 ]}
 
 
-@defproc[(regexp-match-exact? [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-exact? [pattern (or/c regexp? byte-regexp? string? bytes?)]
                               [input (or/c string? bytes? path?)])
           boolean?]{
 
@@ -665,7 +665,7 @@ lower precedence than alternation; the regular expression without it,
 ]}
 
 
-@defproc[(regexp-match-peek [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-peek [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -695,7 +695,7 @@ information if another process meanwhile reads from
 ]}
 
 
-@defproc[(regexp-match-peek-positions [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-peek-positions [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -713,7 +713,7 @@ bytes from @racket[input] instead of reading them, and with a
 @racket[progress] argument like @racket[regexp-match-peek].}
 
 
-@defproc[(regexp-match-peek-immediate [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-peek-immediate [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -728,7 +728,7 @@ match fails if not-yet-available characters might be used to match
 @racket[pattern].}
 
 
-@defproc[(regexp-match-peek-positions-immediate [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-peek-positions-immediate [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -748,7 +748,7 @@ used to match @racket[pattern].}
 
 
 @defproc[(regexp-match-peek-positions*
-                            [pattern (or/c string? bytes? regexp? byte-regexp?)]
+                            [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -764,7 +764,7 @@ used to match @racket[pattern].}
 Like @racket[regexp-match-peek-positions], but returns multiple matches like
 @racket[regexp-match-positions*].}
 
-@defproc[(regexp-match/end [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match/end [pattern (or/c regexp? byte-regexp? string? bytes?)]
                        [input (or/c string? bytes? path? input-port?)]
                        [start-pos exact-nonnegative-integer? 0]
                        [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -789,7 +789,7 @@ the first match. In that case, use @racket[regexp-max-lookbehind]
 to determine an appropriate value for @racket[count].}
 
 @deftogether[(
-@defproc[(regexp-match-positions/end [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-positions/end [pattern (or/c regexp? byte-regexp? string? bytes?)]
                                   [input (or/c string? bytes? path? input-port?)]
                                   [start-pos exact-nonnegative-integer? 0]
                                   [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -798,7 +798,7 @@ to determine an appropriate value for @racket[count].}
          (values (listof (cons/c exact-nonnegative-integer?
                                  exact-nonnegative-integer?))
                  (or/c #f bytes?))]
-@defproc[(regexp-match-peek-positions/end [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-peek-positions/end [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -813,7 +813,7 @@ to determine an appropriate value for @racket[count].}
                                       #f)))
                 #f)
           (or/c #f bytes?))]
-@defproc[(regexp-match-peek-positions-immediate/end [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-match-peek-positions-immediate/end [pattern (or/c regexp? byte-regexp? string? bytes?)]
                             [input input-port?]
                             [start-pos exact-nonnegative-integer? 0]
                             [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -836,7 +836,7 @@ like @racket[regexp-match/end].}
 @;------------------------------------------------------------------------
 @section{Regexp Splitting}
 
-@defproc[(regexp-split [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-split [pattern (or/c regexp? byte-regexp? string? bytes?)]
                        [input (or/c string? bytes? input-port?)]
                        [start-pos exact-nonnegative-integer? 0]
                        [end-pos (or/c exact-nonnegative-integer? #f) #f]
@@ -877,7 +877,7 @@ an end-of-file if @racket[input] is an input port).
 @;------------------------------------------------------------------------
 @section{Regexp Substitution}
 
-@defproc[(regexp-replace [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-replace [pattern (or/c regexp? byte-regexp? string? bytes?)]
                          [input (or/c string? bytes?)]
                          [insert (or/c string? bytes?
                                        (string? string? ... . -> . string?)
@@ -945,7 +945,7 @@ before the @litchar{\}. For example, the Racket constant
 (display (regexp-replace #rx"x" "12x4x6" "\\\\"))
 ]}
 
-@defproc[(regexp-replace* [pattern (or/c string? bytes? regexp? byte-regexp?)]
+@defproc[(regexp-replace* [pattern (or/c regexp? byte-regexp? string? bytes?)]
                           [input (or/c string? bytes?)]
                           [insert (or/c string? bytes?
                                         (string? string? ... . -> . string?)
@@ -987,7 +987,7 @@ string or the stream up to an end-of-file.
 @defproc[(regexp-replaces [input (or/c string? bytes?)]
                           [replacements
                            (listof
-                            (list/c (or/c string? bytes? regexp? byte-regexp?)
+                            (list/c (or/c regexp? byte-regexp? string? bytes?)
                                     (or/c string? bytes?
                                         (string? string? ... . -> . string?)
                                         (bytes? bytes? ... . -> . bytes?))))])

--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -1444,6 +1444,16 @@
 (test "hello world" regexp-replace* #px"o" "ohello world" "" 0 3)
 (test "hell world" regexp-replace* #px"o" "ohello world" "" 0 6)
 
+(let ([rx #rx"regexp-replace: contract violation.+expected:.+or/c regexp\\? byte-regexp\\? string\\? bytes\\?"])
+  (err/rt-test (regexp-replace 'not-regexp "string" "rep") exn:fail:contract? rx)
+  (err/rt-test (regexp-replace 'not-regexp "string" "rep" #"ipre") exn:fail:contract? rx))
+
+(let ([rx #rx"regexp-replace\\*: contract violation.+expected:.+or/c regexp\\? byte-regexp\\? string\\? bytes\\?"])
+  (err/rt-test (regexp-replace* 'not-regexp "string" "rep") exn:fail:contract? rx)
+  (err/rt-test (regexp-replace* 'not-regexp "string" "rep" 1) exn:fail:contract? rx)
+  (err/rt-test (regexp-replace* 'not-regexp "string" "rep" 1 2) exn:fail:contract? rx)
+  (err/rt-test (regexp-replace* 'not-regexp "string" "rep" 1 2 #"ipre") exn:fail:contract? rx))
+
 ;; Test weird port offsets:
 (define (test-weird-offset regexp-match regexp-match-positions)
   (test #f regexp-match "e" (open-input-string ""))

--- a/racket/src/bc/src/regexp.c
+++ b/racket/src/bc/src/regexp.c
@@ -5794,6 +5794,7 @@ static Scheme_Object *gen_replace(const char *name, int argc, Scheme_Object *arg
       if (SCHEME_CHAR_STRINGP(argv[1])) {
 	scheme_contract_error(name, "cannot replace a string with a byte string",
                               "string-matching regexp", 1, argv[0],
+                              "string", 1, argv[1],
                               "byte string", 1, argv[2],
                               NULL);
       }

--- a/racket/src/cs/schemified/regexp.scm
+++ b/racket/src/cs/schemified/regexp.scm
@@ -8940,147 +8940,153 @@
        (regexp-replace*_0 rx_0 orig-in_0 insert_0 prefix5_0))))))
 (define do-regexp-replace
   (lambda (who_0 rx-in_0 orig-in_0 insert_0 prefix_0 all?_0)
-    (let ((string-mode?_0
-           (if (let ((or-part_0 (string? rx-in_0)))
-                 (if or-part_0 or-part_0 (1/regexp? rx-in_0)))
-             (string? orig-in_0)
-             #f)))
-      (let ((in_0
-             (if (if (not string-mode?_0) (string? orig-in_0) #f)
-               (string->bytes/utf-8 orig-in_0)
-               orig-in_0)))
+    (let ((rx_0
+           (if (rx:regexp? rx-in_0)
+             rx-in_0
+             (if (string? rx-in_0)
+               (make-regexp who_0 rx-in_0 #f #f #f)
+               (if (bytes? rx-in_0)
+                 (make-regexp who_0 rx-in_0 #f #t #f)
+                 (raise-argument-error
+                  who_0
+                  "(or/c regexp? byte-regexp? string? bytes?)"
+                  rx-in_0))))))
+      (begin
+        (if (let ((or-part_0 (string? orig-in_0)))
+              (if or-part_0 or-part_0 (bytes? orig-in_0)))
+          (void)
+          (raise-argument-error who_0 "(or/c string? bytes?)" orig-in_0))
         (begin
-          (if (if string-mode?_0
-                string-mode?_0
-                (if (let ((or-part_0 (bytes? rx-in_0)))
-                      (if or-part_0 or-part_0 (1/byte-regexp? rx-in_0)))
-                  (let ((or-part_0 (string? orig-in_0)))
-                    (if or-part_0 or-part_0 (bytes? orig-in_0)))
-                  #f))
-            (if (let ((or-part_0 (string? insert_0)))
-                  (if or-part_0
-                    or-part_0
-                    (let ((or-part_1 (bytes? insert_0)))
-                      (if or-part_1 or-part_1 (procedure? insert_0)))))
-              (void)
-              (raise-argument-error
-               who_0
-               "(or/c string? bytes? procedure?)"
-               insert_0))
-            (void))
-          (begin
-            (if string-mode?_0
-              (if (bytes? insert_0)
+          (if (let ((or-part_0 (string? insert_0)))
+                (if or-part_0
+                  or-part_0
+                  (let ((or-part_1 (bytes? insert_0)))
+                    (if or-part_1 or-part_1 (procedure? insert_0)))))
+            (void)
+            (raise-argument-error
+             who_0
+             "(or/c string? bytes? procedure?)"
+             insert_0))
+          (let ((string-mode?_0
+                 (if (let ((or-part_0 (string? rx-in_0)))
+                       (if or-part_0 or-part_0 (1/regexp? rx-in_0)))
+                   (string? orig-in_0)
+                   #f)))
+            (begin
+              (if (if string-mode?_0 (bytes? insert_0) #f)
                 (raise-arguments-error
                  who_0
                  "cannot replace a string with a byte string"
+                 "string-matching regexp"
+                 rx-in_0
+                 "string"
+                 orig-in_0
                  "byte string"
                  insert_0)
                 (void))
-              (void))
-            (let ((rx_0
-                   (if (string? rx-in_0)
-                     (make-regexp who_0 rx-in_0 #f #f #f)
-                     (if (bytes? rx-in_0)
-                       (make-regexp who_0 rx-in_0 #f #t #f)
-                       rx-in_0))))
-              (let ((ins_0
-                     (if (if (not string-mode?_0) (string? insert_0) #f)
-                       (string->bytes/utf-8 insert_0)
-                       insert_0)))
-                (let ((need-lookbehind_0 (rx:regexp-max-lookbehind rx_0)))
-                  (letrec*
-                   ((loop_0
-                     (|#%name|
-                      loop
-                      (lambda (search-pos_0 get-list?_0)
-                        (begin
-                          (let ((use-prefix_0
-                                 (if (< search-pos_0 need-lookbehind_0)
-                                   prefix_0
-                                   #f)))
-                            (let ((in-start_0
-                                   (if use-prefix_0
-                                     0
-                                     (max
-                                      0
-                                      (- search-pos_0 need-lookbehind_0)))))
-                              (let ((poss_0
-                                     (drive-regexp-match.1
-                                      #f
-                                      #f
-                                      #f
-                                      #f
-                                      #f
-                                      'positions
-                                      #f
-                                      #f
-                                      search-pos_0
-                                      who_0
-                                      rx_0
-                                      in_0
-                                      in-start_0
-                                      #f
-                                      #f
-                                      prefix_0)))
-                                (let ((recur_0
-                                       (|#%name|
-                                        recur
-                                        (lambda ()
-                                          (begin
-                                            (let ((end_0 (cdar poss_0)))
-                                              (if (= (caar poss_0) end_0)
-                                                (if (=
-                                                     end_0
-                                                     (chytes-length in_0))
-                                                  null
-                                                  (let ((app_0
-                                                         (subchytes
-                                                          in_0
-                                                          end_0
-                                                          (add1 end_0))))
-                                                    (cons
-                                                     app_0
-                                                     (loop_0
-                                                      (add1 end_0)
-                                                      #t))))
-                                                (loop_0 end_0 #t))))))))
-                                  (if (not poss_0)
-                                    (let ((result_0
-                                           (if (zero? search-pos_0)
-                                             in_0
-                                             (subchytes in_0 search-pos_0))))
-                                      (if get-list?_0
-                                        (list result_0)
-                                        result_0))
-                                    (let ((pre_0
-                                           (subchytes
-                                            in_0
-                                            search-pos_0
-                                            (caar poss_0))))
-                                      (let ((new_0
-                                             (replacements
-                                              who_0
+              (let ((in_0
+                     (if (if (not string-mode?_0) (string? orig-in_0) #f)
+                       (string->bytes/utf-8 orig-in_0)
+                       orig-in_0)))
+                (let ((ins_0
+                       (if (if (not string-mode?_0) (string? insert_0) #f)
+                         (string->bytes/utf-8 insert_0)
+                         insert_0)))
+                  (let ((need-lookbehind_0 (rx:regexp-max-lookbehind rx_0)))
+                    (letrec*
+                     ((loop_0
+                       (|#%name|
+                        loop
+                        (lambda (search-pos_0 get-list?_0)
+                          (begin
+                            (let ((use-prefix_0
+                                   (if (< search-pos_0 need-lookbehind_0)
+                                     prefix_0
+                                     #f)))
+                              (let ((in-start_0
+                                     (if use-prefix_0
+                                       0
+                                       (max
+                                        0
+                                        (- search-pos_0 need-lookbehind_0)))))
+                                (let ((poss_0
+                                       (drive-regexp-match.1
+                                        #f
+                                        #f
+                                        #f
+                                        #f
+                                        #f
+                                        'positions
+                                        #f
+                                        #f
+                                        search-pos_0
+                                        who_0
+                                        rx_0
+                                        in_0
+                                        in-start_0
+                                        #f
+                                        #f
+                                        prefix_0)))
+                                  (let ((recur_0
+                                         (|#%name|
+                                          recur
+                                          (lambda ()
+                                            (begin
+                                              (let ((end_0 (cdar poss_0)))
+                                                (if (= (caar poss_0) end_0)
+                                                  (if (=
+                                                       end_0
+                                                       (chytes-length in_0))
+                                                    null
+                                                    (let ((app_0
+                                                           (subchytes
+                                                            in_0
+                                                            end_0
+                                                            (add1 end_0))))
+                                                      (cons
+                                                       app_0
+                                                       (loop_0
+                                                        (add1 end_0)
+                                                        #t))))
+                                                  (loop_0 end_0 #t))))))))
+                                    (if (not poss_0)
+                                      (let ((result_0
+                                             (if (zero? search-pos_0)
+                                               in_0
+                                               (subchytes in_0 search-pos_0))))
+                                        (if get-list?_0
+                                          (list result_0)
+                                          result_0))
+                                      (let ((pre_0
+                                             (subchytes
                                               in_0
-                                              poss_0
-                                              ins_0
-                                              prefix_0)))
-                                        (if all?_0
-                                          (let ((result_0
-                                                 (list*
-                                                  pre_0
-                                                  new_0
-                                                  (recur_0))))
-                                            (if get-list?_0
-                                              result_0
-                                              (apply chytes-append result_0)))
-                                          (chytes-append
-                                           pre_0
-                                           new_0
-                                           (subchytes
-                                            in_0
-                                            (cdar poss_0))))))))))))))))
-                   (loop_0 0 #f)))))))))))
+                                              search-pos_0
+                                              (caar poss_0))))
+                                        (let ((new_0
+                                               (replacements
+                                                who_0
+                                                in_0
+                                                poss_0
+                                                ins_0
+                                                prefix_0)))
+                                          (if all?_0
+                                            (let ((result_0
+                                                   (list*
+                                                    pre_0
+                                                    new_0
+                                                    (recur_0))))
+                                              (if get-list?_0
+                                                result_0
+                                                (apply
+                                                 chytes-append
+                                                 result_0)))
+                                            (chytes-append
+                                             pre_0
+                                             new_0
+                                             (subchytes
+                                              in_0
+                                              (cdar poss_0))))))))))))))))
+                     (loop_0 0 #f))))))))))))
 (define replacements
   (lambda (who_0 in_0 poss_0 insert_0 prefix_0)
     (if (procedure? insert_0)
@@ -9118,7 +9124,10 @@
           (if (chytes? in_0 a_0)
             (void)
             (raise-result-error
-             who_0
+             (string->symbol
+              (string-append
+               (symbol->immutable-string who_0)
+               " (calling given filter procedure)"))
              (if (bytes? in_0) "bytes?" "string?")
              a_0))
           a_0))


### PR DESCRIPTION
Right now, contract checking in `regexp-replace{,*}` is inconsistent across implementations.  For example, the CS implementation tries to defer some checking but fails.  Make contract checking more eager in the CS and general implementation.  Also clean up the general implementation.

Fix #4633.