### PR TITLE
regexp: fix contract violation in `regexp-replace*`

### DIFF
--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -1421,6 +1421,18 @@
 
 (test "ap0p0le" regexp-replace* #rx"p" "apple" "\\0\\$0")
 
+(test "allle" regexp-replace* #rx"p" "apple" "l" 1)
+(test "allle" regexp-replace* #rx"p" "apple" "l" 1 3)
+(test "allle" regexp-replace* #rx"p" "apple" "l" 1 3 #"a")
+
+(test #"allle" regexp-replace* #rx#"p" "apple" #"l" 1)
+(test #"allle" regexp-replace* #rx#"p" "apple" #"l" 1 3)
+(test #"allle" regexp-replace* #rx#"p" "apple" #"l" 1 3 #"a")
+
+(test #"allle" regexp-replace* #rx#"p" #"apple" #"l" 1)
+(test #"allle" regexp-replace* #rx#"p" #"apple" #"l" 1 3)
+(test #"allle" regexp-replace* #rx#"p" #"apple" #"l" 1 3 #"a")
+
 ;; Test sub-matches with procedure replace (second example by synx)
 (test "myCERVEZA myMI Mi"
       regexp-replace* "([Mm])i ([a-zA-Z]*)" "mi cerveza Mi Mi Mi"

--- a/racket/collects/racket/private/string.rkt
+++ b/racket/collects/racket/private/string.rkt
@@ -532,11 +532,19 @@
                                #f #f #f
                                ;; flags
                                #t #f))
-                (apply
-                 (if (bytes? buf) bytes-append string-append)
-                 (cond [(and (= start 0) (not end)) r]
-                       [(not end) (cons (sub string 0 start) r)]
-                       [else `(,(sub string 0 start) ,@r ,(sub string end #f))]))]))])
+
+                (let-values ([(app sub)
+                              (if (bytes? buf)
+                                  (values bytes-append subbytes)
+                                  (values string-append substring))])
+                  (apply app
+                         (let* ([r (if end
+                                       (append r (list (sub buf end)))
+                                       r)]
+                                [r (if (eqv? start 0)
+                                       r
+                                       (cons (sub buf 0 start) r))])
+                           r)))]))])
       regexp-replace*))
 
   ;; Returns all the matches for the pattern in the string, optionally


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [x] tests included

### Description of change
More specifically, the contract violation happens in the general implementation.  I’m surprised that this hasn’t been reported yet.