### PR TITLE
CS: allow more error adjustment of primitives

### DIFF
--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -2450,6 +2450,12 @@
 (err/rt-test (raise-arguments-error 'f "invalid" 'x 5) exn:fail:contract? #rx"raise-arguments-error:")
 (err/rt-test (raise-arguments-error 'f "invalid" "x" 5 "y") exn:fail:contract? #rx"raise-arguments-error:")
 
+(err/rt-test (raise-arguments-error* "f" 'mars "invalid") exn:fail:contract? #rx"raise-arguments-error\\*:")
+(err/rt-test (raise-arguments-error* 'f 'mars 'invalid) exn:fail:contract? #rx"raise-arguments-error\\*:")
+(err/rt-test (raise-arguments-error* 'f 'mars "invalid" "x") exn:fail:contract? #rx"raise-arguments-error\\*:")
+(err/rt-test (raise-arguments-error* 'f 'mars "invalid" 'x 5) exn:fail:contract? #rx"raise-arguments-error\\*:")
+(err/rt-test (raise-arguments-error* 'f 'mars "invalid" "x" 5 "y") exn:fail:contract? #rx"raise-arguments-error\\*:")
+
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 ;; continuations
 

--- a/pkgs/racket-test-core/tests/racket/error.rktl
+++ b/pkgs/racket-test-core/tests/racket/error.rktl
@@ -122,12 +122,32 @@
                        (values (case (and (eq? realm 'racket/primitive)
                                           ctc)
                                  [("number?") "number/c"]
+                                 [("exact-nonnegative-integer?") "nonneg-int/c"]
+                                 [("(integer-in 0 (sub1 (expt 2 (stencil-vector-mask-width))))")
+                                  "valid-stencil-vector-mask/c"]
                                  [else ctc])
                                'mars))]
                     [else #f]))])
   (test-error-match #rx"expected: number/c" (+ 'a 'b))
+  (test-error-match #rx"expected: number[?]" (raise-argument-error 'plus "number?" 'a))
 
-  (test-error-match #rx"expected: number[?]" (raise-argument-error 'plus "number?" 'a)))
+  (test-error-match #rx"expected: nonneg-int/c"
+                    (vector-ref #(1 2 3) 'not-nonneg-int))
+  (test-error-match #rx"expected: nonneg-int/c"
+                    (vector-set! (make-vector 3) 'not-nonneg-int 0))
+  (test-error-match #rx"expected: exact-nonngative-integer[?]"
+                    (raise-argument-error 'vector-add "exact-nonngative-integer?" 'not-nonneg-int))
+
+  (test-error-match #rx"expected: valid-stencil-vector-mask/c"
+                    (stencil-vector 'invalid))
+  (test-error-match #rx"expected: valid-stencil-vector-mask/c"
+                    (stencil-vector-update (stencil-vector 0) 'invalid 0))
+  (test-error-match #rx"expected: valid-stencil-vector-mask/c"
+                    (stencil-vector-update (stencil-vector 0) 0 'invalid))
+  (test-error-match #rx"expected:.+integer-in 0.+sub1.+expt 2.+stencil-vector-mask-width"
+                    (raise-argument-error 'stencil-vector-add
+                                          "(integer-in 0 (sub1 (expt 2 (stencil-vector-mask-width))))"
+                                          'invalid)))
 
 (parameterize ([current-error-message-adjuster
                 (lambda (mode)

--- a/racket/src/cs/rumble/error-rewrite.ss
+++ b/racket/src/cs/rumble/error-rewrite.ss
@@ -143,8 +143,11 @@
                                                 "  " what ": ~s")
                                  irritants)))]
      [else
-      (format-error-values (string-append "contract violation\n"
-                                          "  expected: exact-nonnegative-integer?\n"
+      (format-error-values (string-append "contract violation\n  expected: "
+                                          (error-contract->adjusted-string
+                                           "exact-nonnegative-integer?"
+                                           primitive-realm)
+                                          "\n"
                                           "  given: ~s\n"
                                           "  argument position: 2nd\n"
                                           "  first argument...:\n"
@@ -170,13 +173,16 @@
         (and (eq? who 'stencil-vector-update)
              (or (equal? str invalid-removal-mask)
                  (equal? str invalid-addition-mask))))
-    (format-error-values (string-append "contract violation\n"
-                                        "  expected: (integer-in 0 (sub1 (expt 2 (stencil-vector-mask-width))))\n"
+    (format-error-values (string-append "contract violation\n  expected: "
+                                        (error-contract->adjusted-string
+                                         "(integer-in 0 (sub1 (expt 2 (stencil-vector-mask-width))))"
+                                         primitive-realm)
+                                        "\n"
                                         (cond
                                           [(equal? str invalid-removal-mask) "  argument position: 2nd\n"]
                                           [(equal? str invalid-addition-mask) "  argument position: 3rd\n"]
                                           [else ""])
-                                        "  given: ~s\n")
+                                        "  given: ~s")
                          irritants)]
    [(or (equal? str "mask ~s does not match given number of items ~s")
         (equal? str "addition mask ~s does not match given number of items ~s"))

--- a/racket/src/cs/rumble/error.ss
+++ b/racket/src/cs/rumble/error.ss
@@ -174,7 +174,7 @@
           [(string? (car more))
            (cond
              [(null? (cdr more))
-              (raise-arguments-error 'raise-arguments-error
+              (raise-arguments-error e-who
                                      "missing value after field string"
                                      "string"
                                      (car more))]
@@ -187,7 +187,7 @@
                                          (error-value->string val))))
                     (loop (cddr more)))])]
           [else
-           (raise-argument-error 'raise-arguments-error "string?" (car more))])))
+           (raise-argument-error e-who "string?" (car more))])))
      realm)
     (current-continuation-marks))))
 


### PR DESCRIPTION
Add some missing calls to `error-contract->adjusted-string`.  Also fix the name of `raise-arguments-error*` (when *it* raises).