### PR TITLE
LoongArch64 Support

### DIFF
--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -4703,6 +4703,10 @@ case "$MACH_HOST_CPU" in
     MACH="${thread_prefix}rv64${MACH_OS}"
     pb_machine_name="${thread_prefix}pb64l"
     ;;
+  loongarch64*)
+    MACH="${thread_prefix}la64${MACH_OS}"
+    pb_machine_name="${thread_prefix}pb64l"
+    ;;
 esac
 
 if test "${MACH}" = "" ; then
@@ -4801,6 +4805,9 @@ if test "${build_os}_${build_cpu}" != "${host_os}_${host_cpu}" ; then
       ;;
     riscv64*)
       BUILD_MACH="${BUILD_THREAD_PREFIX}rv64${BUILD_OS}"
+      ;;
+    loongarch64*)
+      BUILD_MACH="${BUILD_THREAD_PREFIX}la64${BUILD_OS}"
       ;;
     *)
       echo "unknown build CPU"

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -429,6 +429,10 @@ case "$MACH_HOST_CPU" in
     MACH="${thread_prefix}rv64${MACH_OS}"
     pb_machine_name="${thread_prefix}pb64l"
     ;;
+  loongarch64*)
+    MACH="${thread_prefix}la64${MACH_OS}"
+    pb_machine_name="${thread_prefix}pb64l"
+    ;;
 esac
 
 if test "${MACH}" = "" ; then
@@ -527,6 +531,9 @@ if test "${build_os}_${build_cpu}" != "${host_os}_${host_cpu}" ; then
       ;;
     riscv64*)
       BUILD_MACH="${BUILD_THREAD_PREFIX}rv64${BUILD_OS}"
+      ;;
+    loongarch64*)
+      BUILD_MACH="${BUILD_THREAD_PREFIX}la64${BUILD_OS}"
       ;;
     *)
       echo "unknown build CPU"

--- a/racket/src/cs/rumble/system.ss
+++ b/racket/src/cs/rumble/system.ss
@@ -47,7 +47,8 @@
     [(a6le ta6le i3le ti3le
            arm32le tarm32le arm64le tarm64le
            ppc32le tppc32le
-           rv64le trv64le)
+           rv64le trv64le
+	   la64le tla64le)
      'linux]
     [(i3gnu ti3gnu)
      'gnu-hurd]
@@ -111,6 +112,8 @@
      'ppc]
     [(rv64le trv64le)
      'riscv64]
+    [(la64le tla64le)
+     'loongarch64]
     [(pb tpb
          pb64l tpb64l pb64b tpb64b
          pb32l tpb32l pb32b tpb32b)

--- a/racket/src/rktboot/config.rkt
+++ b/racket/src/rktboot/config.rkt
@@ -52,6 +52,7 @@
       [("arm") "arm32"]
       [("ppc") "ppc32"]
       [("riscv64") "rv64"]
+      [("loongarch64") "la64"]
       [("unknown") #f] ; pb machine types
       [else #f]))
   (define os

--- a/racket/src/rktboot/machine-def.rkt
+++ b/racket/src/rktboot/machine-def.rkt
@@ -26,6 +26,7 @@
                                      [(regexp-match? #rx"^t?arm64" target-machine) "arm64"]
                                      [(regexp-match? #rx"^t?ppc32" target-machine) "ppc32"]
                                      [(regexp-match? #rx"^t?rv64" target-machine) "rv64"]
+                                     [(regexp-match? #rx"^t?la64" target-machine) "la64"]
                                      [(regexp-match? #rx"^t?pb" target-machine) "pb"]
                                      [else (error "machine.def: cannot infer architecture")]))]
                [s (regexp-replace* #rx"[$][(]Mend[)]" s


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [x] tests included
- [ ] documentation

### Description of change
<!-- Please provide a description of the change here. -->

This PR adds LoongArch64 support. Machine type is `[t]la64le`, and architecture is `loongarch64`.

No new tests are needed. Existing arch-dependent tests are modified to account for `loongarch64`.