### PR TITLE
`make pb-fetch` for Building `racket/src`

### DIFF
--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -78,6 +78,7 @@ Quick instructions:
  From this directory (where the `configure` file is), run the following
  commands:
 
+   make --directory=../../ pb-fetch
    mkdir build
    cd build
    ../configure


### PR DESCRIPTION
### Description of change
<!-- Please provide a description of the change here. -->

Adds a reference to `make pb-fetch` in `racket/src/readme.txt`, which is required to successfully build `racket/src`.