### PR TITLE
remove vacuous `let-values` from `splicing-syntax-parameterize`

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/class.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/class.scrbl
@@ -989,47 +989,45 @@ thus can only be used, for methods where no Beta-style augmentation has taken
 place. The following example shows this difference:
 
 @racketblock[
+(define/contract glutton%
+  (class/c (override [eat (->m edible/c void?)]))
+  (class animal%
+    (super-new)
+    (inherit eat)
+    (define/public (gulp food-list)
+      (for ([f food-list])
+        (eat f)))))
 (define/contract sloppy-eater%
   (class/c [eat (->m edible/c edible/c)])
-  (begin
-    (define/contract glutton%
-      (class/c (override [eat (->m edible/c void?)]))
-      (class animal%
-        (super-new)
-        (inherit eat)
-        (define/public (gulp food-list)
-          (for ([f food-list])
-            (eat f)))))
-    (class glutton%
-      (super-new)
-      (inherit-field size)
-      (define/override (eat f)
-        (let ([food-size (get-field size f)])
-          (set! size (/ food-size 2))
-          (set-field! size f (/ food-size 2))
-          f)))))]
+  (class glutton%
+    (super-new)
+    (inherit-field size)
+    (define/override (eat f)
+      (let ([food-size (get-field size f)])
+        (set! size (/ food-size 2))
+        (set-field! size f (/ food-size 2))
+        f))))]
 
 @interaction-eval[
 #:eval class-eval
+(define/contract glutton%
+  (class/c (override [eat (->m edible/c void?)]))
+  (class animal%
+    (super-new)
+    (inherit eat)
+    (define/public (gulp food-list)
+      (for ([f food-list])
+        (eat f)))))
 (define/contract sloppy-eater%
   (class/c [eat (->m edible/c edible/c)])
-  (begin
-    (define/contract glutton%
-      (class/c (override [eat (->m edible/c void?)]))
-      (class animal%
-        (super-new)
-        (inherit eat)
-        (define/public (gulp food-list)
-          (for ([f food-list])
-            (eat f)))))
-    (class glutton%
-      (super-new)
-      (inherit-field size)
-      (define/override (eat f)
-        (let ([food-size (get-field size f)])
-          (set! size (/ food-size 2))
-          (set-field! size f (/ food-size 2))
-          f)))))]
+  (class glutton%
+    (super-new)
+    (inherit-field size)
+    (define/override (eat f)
+      (let ([food-size (get-field size f)])
+        (set! size (/ food-size 2))
+        (set-field! size f (/ food-size 2))
+        f))))]
 
 @interaction[
 #:eval class-eval

--- a/racket/collects/racket/private/stxparam.rkt
+++ b/racket/collects/racket/private/stxparam.rkt
@@ -9,7 +9,7 @@
   (#%provide (for-syntax do-syntax-parameterize)
              let-local-keys)
 
-  (define-for-syntax (do-syntax-parameterize stx letrec-syntaxes-id empty-body-ok? keep-ids?)
+  (define-for-syntax (do-syntax-parameterize stx finish-k)
     (syntax-case stx ()
       [(-syntax-parameterize ([id val] ...) body ...)
        (let ([ids (syntax->list #'(id ...))])
@@ -41,35 +41,37 @@
 		"duplicate binding"
 		stx
 		dup)))
-           (unless empty-body-ok?
-             (when (null? (syntax-e #'(body ...)))
-               (raise-syntax-error
-                #f
-                "missing body expression(s)"
-                stx)))
-           (with-syntax ([letrec-syntaxes letrec-syntaxes-id]
-                         [(kept-id ...) (if keep-ids?
-                                            #'(id ...)
-                                            '())])
-             (syntax/loc stx
-               (letrec-syntaxes ([(gen-id) (wrap-parameter-value 'who/must-be-renamer val)]
-                                 ...)
-                 kept-id ...
-                 (let-local-keys ([local-key gen-id] ...)
-                   body ...))))))]))
-  
+           (if finish-k
+               (finish-k #'(id ...)
+                         #'(gen-id ...)
+                         #'((wrap-parameter-value 'who/must-be-renamer val) ...)
+                         #'([local-key gen-id] ...)
+                         #'(body ...))
+               (begin
+                 (when (null? (syntax-e #'(body ...)))
+                   (raise-syntax-error
+                    #f
+                    "missing body expression(s)"
+                    stx))
+                 (syntax/loc stx
+                   (letrec-syntaxes+values
+                       ([(gen-id) (wrap-parameter-value 'who/must-be-renamer val)] ...)
+                       ()
+                     (let-local-keys ([local-key gen-id] ...)
+                       (let-values () body ...))))))))]))
+
   (define-syntax (let-local-keys stx)
     (if (eq? 'expression (syntax-local-context))
         (let-values ([(expr opaque-expr)
                       (syntax-case stx ()
-                        [(_ ([local-key id] ...) body ...)
+                        [(_ ([local-key id] ...) expr)
                          (with-continuation-mark
                           current-parameter-environment
                           (extend-parameter-environment
                            (current-parameter-environment)
                            #'([local-key id] ...))
                           (syntax-local-expand-expression
-                           #'(let-values () body ...)
+                           #'expr
                            #t))])])
           opaque-expr)
         (with-syntax ([stx stx])

--- a/racket/collects/racket/stxparam.rkt
+++ b/racket/collects/racket/stxparam.rkt
@@ -41,4 +41,4 @@
                   key)))))]))
 
   (define-syntax (syntax-parameterize stx)
-    (do-syntax-parameterize stx #'letrec-syntaxes #f #f)))
+    (do-syntax-parameterize stx #f)))


### PR DESCRIPTION
In the `define-values` case, the expansion can end up with a vacuous `let-values` even though no definition context is needed.  Remove this `let-values` and clean up the expansion code.

An example in the Guide wasn’t supposed to work, but accidentally worked due to this.