### PR TITLE
CS: fix behavior of `regexp-max-lookbehind`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -321,7 +321,13 @@ example, the pattern @litchar{(?<=abc)d} consults three bytes
 preceding a matching @litchar{d}, while @litchar{e(?<=a..)d} consults
 two bytes before a matching @litchar{ed}. A @litchar{^} pattern may
 consult a preceding byte to determine whether the current position is
-the start of the input or of a line.}
+the start of the input or of a line.
+
+@examples[
+(regexp-max-lookbehind #rx#"(?<=abc)d")
+(regexp-max-lookbehind #rx#"e(?<=a..)d")
+(regexp-max-lookbehind #rx"^")
+]}
 
 @;------------------------------------------------------------------------
 @section{Regexp Matching}

--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -1687,6 +1687,18 @@
 (arity-test regexp-replace 3 4)
 (arity-test regexp-replace* 3 6)
 
+(test 3 regexp-max-lookbehind #rx#"(?<=abc)d")
+(test 2 regexp-max-lookbehind #rx#"e(?<=a..)d")
+(test 2 regexp-max-lookbehind #rx#"(?:a|ab)(?<!a..)d")
+(test 1 regexp-max-lookbehind #rx"^")
+(test 1 regexp-max-lookbehind #px"\\b")
+(test 0 regexp-max-lookbehind #rx"$")
+(test 0 regexp-max-lookbehind #rx".")
+(let ([rx #rx"regexp-max-lookbehind: contract violation.*expected:.+or/c.+regexp[?].+byte-regexp[?]"])
+  (err/rt-test (regexp-max-lookbehind "string") exn:fail:contract? rx)
+  (err/rt-test (regexp-max-lookbehind #"bytes") exn:fail:contract? rx)
+  (err/rt-test (regexp-max-lookbehind 'obviously-not-regexp) exn:fail:contract? rx))
+
 (test #t procedure? car)
 (test #f procedure? 'car)
 (test #t procedure? (lambda (x) (* x x)))

--- a/racket/src/cs/schemified/regexp.scm
+++ b/racket/src/cs/schemified/regexp.scm
@@ -3707,7 +3707,9 @@
                                                                        app_1
                                                                        (max
                                                                         max-lb_0
-                                                                        lb1_0)))))
+                                                                        (-
+                                                                         lb1_0
+                                                                         min-len_0))))))
                                                                  (args
                                                                   (raise-binding-result-arity-error
                                                                    3
@@ -9349,7 +9351,7 @@
            (void)
            (raise-argument-error
             'regexp-max-lookbehind
-            "(or regexp? byte-regexp?)"
+            "(or/c regexp? byte-regexp?)"
             rx_0))
          (rx:regexp-max-lookbehind rx_0))))))
 (define no-prefix #vu8())

--- a/racket/src/regexp/analyze/validate.rkt
+++ b/racket/src/regexp/analyze/validate.rkt
@@ -38,10 +38,10 @@
         (define-values (min1 max1 lb1) (validate (rx:alts-rx1 rx)))
         (define-values (min2 max2 lb2) (validate (rx:alts-rx2 rx)))
         (values (min min1 min2) (max max1 max2) (max lb1 lb2))]
-       [(rx:sequence? rx)       
+       [(rx:sequence? rx)
         (for/fold ([min-len 0] [max-len 0] [max-lb 0]) ([rx (in-list (rx:sequence-rxs rx))])
           (define-values (min1 max1 lb1) (validate rx))
-          (values (+ min-len min1) (+ max-len max1) (max max-lb lb1)))]
+          (values (+ min-len min1) (+ max-len max1) (max max-lb (- lb1 min-len))))]
        [(rx:group? rx)
         (define-values (min1 max1 lb1) (validate (rx:group-rx rx)))
         (set! group-sizes (hash-set group-sizes (rx:group-number rx) min1))

--- a/racket/src/regexp/main.rkt
+++ b/racket/src/regexp/main.rkt
@@ -52,7 +52,7 @@
 (define/who (regexp-max-lookbehind rx)
   (check who
          #:test (or (regexp? rx) (byte-regexp? rx))
-         #:contract "(or regexp? byte-regexp?)"
+         #:contract "(or/c regexp? byte-regexp?)"
          rx)
   (rx:regexp-max-lookbehind rx))
 


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [x] tests included
- [x] documentation

### Description of change
For a lookbehind somewhere in the middle, the maximum lookbehind should take the minimum number of bytes after the starting position into account.  This commit fixes this behavior.

Also fix the contract string and add test cases.

Fix #4840.