### PR TITLE
rktio: support ICU as iconv alternative, e.g. for Windows

### DIFF
--- a/racket/src/rktio/rktio.h
+++ b/racket/src/rktio/rktio.h
@@ -1206,7 +1206,7 @@ intptr_t rktio_convert(rktio_t *rktio,
                        rktio_converter_t *cvt,
                        char **in, intptr_t *in_left,
                        char **out, intptr_t *out_left);
-/* Converts some bytes, following the icon protocol: each consumed by
+/* Converts some bytes, following the iconv protocol: each consumed by
    increments `*in` and decrements `*in_left`, and each produced by
    increments `*out` and decrements `*out_left`. In case of an error,
    the result is `RKTIO_CONVERT_ERROR` and the last error is set to

--- a/racket/src/rktio/rktio_config.h.in
+++ b/racket/src/rktio/rktio_config.h.in
@@ -60,6 +60,11 @@ typedef unsigned long long rktio_uint64_t;
 
 /* In case iconv is not available: */
 #undef RKTIO_NO_ICONV
+#ifdef RKTIO_SYSTEM_WINDOWS
+# define RKTIO_ICU_DLL
+#else
+# define RKTIO_NO_ICONV
+#endif
 
 /* Fields of struct dirent */
 #undef HAVE_DIRENT_NAMLEN

--- a/racket/src/rktio/rktio_config.h.in
+++ b/racket/src/rktio/rktio_config.h.in
@@ -60,10 +60,11 @@ typedef unsigned long long rktio_uint64_t;
 
 /* In case iconv is not available: */
 #undef RKTIO_NO_ICONV
+#undef RKTIO_NO_ICU /* HACK HACK HACK for testing */
 #ifdef RKTIO_SYSTEM_WINDOWS
 # define RKTIO_ICU_DLL
-#else
-# define RKTIO_NO_ICONV
+/* #else */
+/* # define RKTIO_NO_ICU */
 #endif
 
 /* Fields of struct dirent */


### PR DESCRIPTION
This PR aims to support ICU as an alternative to `iconv` in rktio to implement [byte converters](https://docs.racket-lang.org/reference/bytestrings.html#%28def._%28%28quote._~23~25kernel%29._bytes-open-converter%29%29).

Windows does not have iconv, so Racket currently distributes `libiconv-2.dll` in platform-specific packages like `racket-win32-x86_64-3` that are part of even the minimal Racket distribution. Building and distributing third-party C libraries is no fun. However, while looking into https://github.com/racket/racket/issues/4277, I discovered that [Windows has provided ICU](https://learn.microsoft.com/en-us/windows/win32/intl/international-components-for-unicode--icu-) as a supported system DLL since the Windows 10 Creators Update (1703), released in 2017. This appears to mean that all Windows versions in "mainstream support" from Microsoft include ICU.[^1]

[^1]: As explained in a comment in the code, in this PR I'm actually targeting Windows 10 version 1903, which avoids some per-thread initialization needed in earlier versions. The only earlier version of Windows still in mainstream support appears to be version 1809 (Enterprise LTSC 2019), for which [mainstream support ends in January](https://learn.microsoft.com/en-us/lifecycle/products/windows-10-enterprise-ltsc-2019).

My hope is that by using the OS-provided ICU, we can stop distributing `libiconv-2.dll` for minimal Racket on Windows.

The functionality may be useful in other contexts, too: for example, it seems Android has either no iconv or a very rudimentary iconv (vid. e.g. https://github.com/racket/racket/commit/8a087040128fad352a3b86cc94073a2e9585921c), but [Android provides ICU](https://developer.android.com/guide/topics/resources/internationalization#icu4c) as a system library.

I intend to contribute a similar patch to Chez Scheme, but I've found it easier to start with rktio.

# Open Design Questions

 1. I have not added any support to `configure` yet. I think the behavior should be:

     - On Windows, automatically enable ICU if `AC_CHECK_HEADER([icu.h])` finds it. To support building in older environments, don't build ICU support if the header is not found. To support running on older Windows versions, dynamically load `icu.dll` with `LoadLibraryW`/`GetProcAddress`. This means no linking flags are needed.
     - On other platforms, enable ICU only if specifically requested. If it is requested, find the appropriate flags either with [`AX_CHECK_ICU`](https://www.gnu.org/software/autoconf-archive/ax_check_icu.html) or by using `pkg-config` directly.

    But native Windows builds do not use Autoconf, and I'm not sure how to do the equivalent of `AC_CHECK_HEADER([icu.h])`. (I cannot overstate the extent to which I am not a Windows person&mdash;perhaps ironically, I have only tested this so far on GNU/Linux.) The simplest thing to do would probably be to omit the check and require an explicit `--disable-icu` (`/disableICU`?) to build in old Windows environments.

 2. If both iconv and ICU are enabled and found, currently ICU is used. That's certainly debatable. On non-Windows platforms, it seems to make sense because enabling ICU would be an explicit choice. On Windows, one consideration is that an iconv DLL might (sometimes?) end up being installed as a dependency of `racket/draw` (see https://github.com/racket/libs/commit/8ba7a8704b8052d297299be7f875e6a8b12364e1) or for some other reason, and having that change the behavior of `bytes-open-converter` seems worth avoiding.

 3. Currently, this change is entirely contained within the C code of rktio, with no change to the interface exposed to Racket. I could imagine ways of exposing more. The possibility I'd most strongly consider is adding a function to report whether iconv or ICU is being used. If there were a reason to want such a thing,  it would be possible to expose the new `rktio_iconv_converter_open` and `rktio_icu_converter_open` so they could both be used if both are available. If there were a desire to support `dlopen`ing ICU on non-Windows platforms, that might be a reason to drive more from the Racket side.

 4. There might be a better `ICU_BUF_SIZE`.

 5. If we want to stop distributing `libiconv-2.dll` for minimal Racket, there would need to be changes to the native library packages, which I have not attempted. That can (and probably should!) be done as a second step, though.

    As a compatibility consideration, I looked into the encoding names recognized by ICU compared to GNU libiconv. (The documentation is already clear that the supported encodings are system-dependent, so this is an extra level of scrutiny.) Both ICU and GNU libiconv recognize multiple aliases for some encodings. For most of the encodings supported by GNU libiconv (with `--enable-extra-encodings`), at least one alias is also listed by ICU. There are [some encodings](https://github.com/LiberalArtist/icuiconv/blob/8c5acb287bdd2966f356bed9bd67e5f9fa067734/encodings/missing-encodings.ss) for which that is not the case, though. I suspect these encodings are also supported by ICU under different names, and a sufficiently motivated person could fill in a translation table. Some of them might even be recognized by the matching functions in the ICU API: I only checked for exact matches.
