### PR TITLE
Add build stamp to `--version` output

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/config.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/config.scrbl
@@ -233,7 +233,11 @@ directory}:
  @item{@indexed-racket['build-stamp] --- a string that identifies a build,
        which can be used to augment the Racket version number to more
        specifically identify the build. An empty string is normally
-       appropriate for a release build.}
+       appropriate for a release build. The default @racket{banner}
+       also shows the build stamp when non-empty.}
+
+       @history[#:changed "8.11.1.7" @elem{Added build stamp to
+                                           @racket{banner}.}]
 
  @item{@indexed-racket['absolute-installation?] --- a boolean that is
        @racket[#t] if the installation uses absolute path names,

--- a/racket/src/bc/cmdline.inc
+++ b/racket/src/bc/cmdline.inc
@@ -1227,19 +1227,6 @@ static int run_from_cmd_line(int argc, char *_argv[],
 
   if (no_init_ns)
     init_ns = 0;
-
-  if (show_vers) {
-#ifndef RACKET_CMD_LINE  
-    if (!use_repl
-#ifdef CMDLINE_STDIO_FLAG
-	|| alternate_rep
-#endif
-	)
-#endif
-      PRINTF("%s", BANNER);
-
-   CMDLINE_FFLUSH(stdout);
-  }
 #endif /* DONT_PARSE_COMMAND_LINE */
 
   if (!syslog_level) {
@@ -1406,6 +1393,34 @@ static int run_from_cmd_line(int argc, char *_argv[],
   if (!skip_coll_dirs)
     scheme_init_collection_paths_post_config(global_env, collects_paths_l, collects_paths_r, config_table);
   scheme_init_compiled_roots_config(global_env, compiled_paths, config_table);
+
+  {
+    Scheme_Object *build_stamp;
+    build_stamp = scheme_hash_tree_get((Scheme_Hash_Tree *)config_table, scheme_intern_symbol("build-stamp"));
+    if (build_stamp) {
+      char *s;
+      intptr_t s_len;
+      s = scheme_display_to_string(build_stamp, &s_len);
+      if (s_len) {
+        scheme_set_build_stamp(s);
+      }
+    }
+  }
+
+#ifndef DONT_PARSE_COMMAND_LINE
+  if (show_vers) {
+#ifndef RACKET_CMD_LINE
+    if (!use_repl
+#ifdef CMDLINE_STDIO_FLAG
+        || alternate_rep
+#endif
+        )
+#endif
+      PRINTF("%s", BANNER);
+
+    CMDLINE_FFLUSH(stdout);
+  }
+#endif
 
   scheme_seal_parameters();
 

--- a/racket/src/bc/include/scheme.h
+++ b/racket/src/bc/include/scheme.h
@@ -1941,6 +1941,7 @@ MZ_EXTERN void scheme_set_stdio_makers(Scheme_Stdio_Maker_Proc in,
 
 
 MZ_EXTERN void scheme_set_banner(char *s);
+MZ_EXTERN void scheme_set_build_stamp(char *s);
 MZ_EXTERN Scheme_Object *scheme_set_exec_cmd(char *s);
 MZ_EXTERN Scheme_Object *scheme_set_run_cmd(char *s);
 MZ_EXTERN void scheme_set_collects_path(Scheme_Object *p);

--- a/racket/src/cs/main.sps
+++ b/racket/src/cs/main.sps
@@ -793,7 +793,10 @@
        (set-collects-dir! init-collects-dir)])
      (set-config-dir! init-config-dir)
      (let* ([config (read-installation-configuration-table)]
-            [name (get-installation-name config)])
+            [name (get-installation-name config)]
+            [build-stamp (or (hash-ref config 'build-stamp #f) "")])
+       (unless (equal? build-stamp "")
+         (set-build-stamp! build-stamp))
        (unless (eq? init-collects-dir 'disable)
          (current-library-collection-links
           (find-library-collection-links config name))
@@ -929,14 +932,15 @@
          (when (and n (exact-nonnegative-integer? n))
            (set-schedule-quantum! n)))))
 
-   (when version?
-     (display (banner)))
    (call/cc ; Chez Scheme's `call/cc`, used here to escape from the Racket-thread engine loop
     (lambda (entry-point-k)
       (call-in-main-thread
        (lambda ()
          (initialize-exit-handler!)
          (initialize-place!)
+
+         (when version?
+           (display (banner)))
 
          (when (and make? (not (null? compiled-file-paths)))
            (|#%app|

--- a/racket/src/cs/rumble.sls
+++ b/racket/src/cs/rumble.sls
@@ -1,6 +1,7 @@
 (library (rumble)
   (export version
           banner
+          set-build-stamp! ; not exported to Racket
 
           null eof void void?
 

--- a/racket/src/cs/rumble/version.ss
+++ b/racket/src/cs/rumble/version.ss
@@ -38,4 +38,12 @@
                    (loop 0)]))]))]))))))
 
 (define (version) (extract-version-string))
-(define (banner) (string-append "Welcome to Racket v" (version) " [cs].\n"))
+
+(define build-stamp #f)
+(define (set-build-stamp! stamp)
+  (set! build-stamp stamp))
+
+(define (banner)
+  (if build-stamp
+      (string-append-immutable "Welcome to Racket v" (version) "-" build-stamp " [cs].\n")
+      (string-append-immutable "Welcome to Racket v" (version) " [cs].\n")))


### PR DESCRIPTION
This adds the build stamp value to Racket's `banner` and `--version` output when the value is non-empty. This is helpful as a quick and easy way to distinguish snapshot builds and verify the build date. This matches the behaviour of other compilers which often indicate a detailed version with a date or commit hash for development / snapshot builds.