### PR TITLE
Add `get-failure-result` to racket/function

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -3667,7 +3667,7 @@ currently being checked.
 
 @defthing[failure-result/c contract?]{
   A contract that describes the failure result arguments of procedures
-  such as @racket[hash-ref].
+  such as @racket[hash-ref]. See also @racket[get-failure-result].
 
   Equivalent to @racket[(if/c procedure? (-> any) any/c)].
 

--- a/pkgs/racket-doc/scribblings/reference/procedures.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/procedures.scrbl
@@ -904,5 +904,20 @@ arguments that procedures with arity @racket[b] accept.
 
 }
 
+@defproc[(get-failure-result [v failure-result/c]) any]{
+
+If @racket[v] is a procedure, it is applied in @tech{tail position} to zero
+arguments to produce a result. Otherwise, @racket[v] is returned.
+
+@racket[get-failure-result] can be used to extract the value of failure result
+arguments passed to procedures such as @racket[hash-ref].
+
+@mz-examples[#:eval fun-eval
+(eval:check (get-failure-result 1) 1)
+(eval:check (get-failure-result (lambda () 2)) 2)
+(get-failure-result (lambda () (values 3 4)))]
+
+@history[#:added "8.11.1.4"]}
+
 
 @close-eval[fun-eval]

--- a/pkgs/racket-test/tests/racket/bool.rkt
+++ b/pkgs/racket-test/tests/racket/bool.rkt
@@ -1,5 +1,5 @@
 #lang racket/base
-(require racket/bool racket/function rackunit)
+(require racket/bool rackunit)
 
 (check-true true)
 (check-false false)
@@ -41,13 +41,3 @@
 (check-equal? (xor 11 #f) 11)
 (check-equal? (xor #f 22) 22)
 (check-equal? (xor #f #f) #f)
-
-(check-true ((conjoin) 'x #:y 'z)) ; no function
-(check-true ((conjoin integer? exact?) 1))
-(check-false ((conjoin integer? exact?) 1.0))
-(check-false ((conjoin integer? exact?) 0.5))
-
-(check-false ((disjoin) 'x #:y 'z)) ; no function
-(check-true ((disjoin integer? exact?) 1))
-(check-true ((disjoin integer? exact?) 1/2))
-(check-false ((disjoin integer? exact?) 0.5))

--- a/pkgs/racket-test/tests/racket/function.rkt
+++ b/pkgs/racket-test/tests/racket/function.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+(require racket/function rackunit)
+
+(check-true ((conjoin) 'x #:y 'z)) ; no function
+(check-true ((conjoin integer? exact?) 1))
+(check-false ((conjoin integer? exact?) 1.0))
+(check-false ((conjoin integer? exact?) 0.5))
+
+(check-false ((disjoin) 'x #:y 'z)) ; no function
+(check-true ((disjoin integer? exact?) 1))
+(check-true ((disjoin integer? exact?) 1/2))
+(check-false ((disjoin integer? exact?) 0.5))
+
+(check-equal? (get-failure-result #f) #f)
+(check-equal? (get-failure-result #t) #t)
+(check-equal? (get-failure-result 'hello) 'hello)
+(check-equal? (get-failure-result (λ () #f)) #f)
+(check-equal? (get-failure-result (λ () #t)) #t)
+(check-equal? (get-failure-result (λ () 'hello)) 'hello)
+(check-exn exn:fail:contract? (λ () (get-failure-result (λ (x) x))))

--- a/racket/collects/racket/function.rkt
+++ b/racket/collects/racket/function.rkt
@@ -9,6 +9,7 @@
          curry   curryr
          conjoin disjoin
          negate
+         get-failure-result
          (all-from-out racket/private/arity))
 
 (define (identity x) x)
@@ -48,6 +49,15 @@
       [(1) (lambda (x) (not (f x)))]
       [(2) (lambda (x y) (not (f x y)))]
       [else (compose1 not f)]))) ; keyworded or more args => just compose
+
+(define (get-failure-result v)
+  (if (procedure? v)
+      (if (procedure-arity-includes? v 0)
+          (v)
+          (raise-argument-error 'get-failure-result
+                                "a procedure that accepts 0 non-keyword arguments"
+                                v))
+      v))
 
 (define (make-curry right?)
   ; arity-mask? -> (or/c exact-nonnegative-integer? +inf.0 #f)


### PR DESCRIPTION
This adds a very simple function named `get-failure-result` to `racket/function`. It is essentially just

```racket
(define (get-failure-result v)
  (if (procedure? v) (v) v))
```

except that the version in this PR also includes an explicit arity check.

Since this function is so simple, the convenience it affords is obviously extremely minor. Still, I’ve written it so many times that it feels worth putting somewhere, especially since we already have `failure-result/c`.