### PR TITLE
Add `equal-always?` variant of `case`

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.11.1.7")
+(define version "8.11.1.8")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -14,6 +14,7 @@
                      racket/provide
                      racket/package
                      racket/splicing
+                     racket/case
                      racket/runtime-path
                      racket/lazy-require
                      (only-in compiler/cm-accomplice
@@ -2547,6 +2548,24 @@ in @math{O(log N)} time for @math{N} @racket[datum]s.
 (classify #\1)
 (classify #\!)
 ]}
+
+@subsection[#:tag "case/equal"]{Variants of @racket[case]}
+
+@note-lib-only[racket/case]
+
+@history[#:added "8.11.1.8"]
+
+@deftogether[(
+@defform[(case/equal val-expr case-clause ...)]
+@defform[(case/equal-always val-expr case-clause ...)]
+@defform[(case/eq val-expr case-clause ...)]
+@defform[(case/eqv val-expr case-clause ...)]
+)]{
+
+Like @racket[case], but using @racket[equal?], @racket[equal-always?],
+@racket[eq?], or @racket[eqv?] for comparing the result of
+@racket[val-expr] to the literals in the @racket[case-clause]s. The
+@racket[case/equal] form is equivalent to @racket[case].}
 
 @;------------------------------------------------------------------------
 @section[#:tag "define"]{Definitions: @racket[define], @racket[define-syntax], ...}

--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -4,7 +4,8 @@
 (Section 'syntax)
 
 (require syntax/srcloc
-         syntax/strip-context)
+         syntax/strip-context
+         racket/case)
 
 ;; ----------------------------------------
 
@@ -347,6 +348,28 @@
 			[(bye) 'a]
 			[(hello) (values 10 9)]
 			[else #f])))
+(test "none" 'case/equal-always (case/equal-always (string-append "a" "b")
+                                                   (("ab" "ac") "a")
+                                                   (else "none")))
+(test "a" 'case/equal-always (case/equal-always (string->immutable-string (string-append "a" "b"))
+                                                (("ab" "ac") "a")
+                                                (else "none")))
+(test 'composite 'case/eqv (case/eqv (* 2 3)
+                                     ((2 3 5 7) 'prime)
+                                     ((1 4 6 8 9) 'composite)))
+(test "none" 'case/eqv (case/eqv (string->immutable-string
+                                  (string-append "a" (if (zero? (random 1)) "b" "_")))
+                                 (("ab" "ac") "a")
+                                 (else "none")))
+(test "a" 'case/eqv (case/eqv (datum-intern-literal (string-append "a" "b"))
+                              (("ab" "ac") "a")
+                              (else "none")))
+(test "2^100" 'case/eqv (case/eqv (expt 2 (if (zero? (random 1)) 100 0))
+                                  ((1267650600228229401496703205376) "2^100")
+                                  (else "none")))
+(test "none" 'case/eq (case/eq (expt 2 (if (zero? (random 1)) 100 0))
+                               ((1267650600228229401496703205376) "2^100")
+                               (else "none")))
 (error-test #'(cond [(values 1 2) 8]) arity?)
 (error-test #'(case (values 1 2) [(a) 8]) arity?)
 (syntax-test #'(case 1 []) #rx"ill-formed clause")
@@ -359,6 +382,10 @@
 (syntax-test #'(case 1 [(y) 5] [(x)]) #rx"missing expression after datum sequence")
 (syntax-test #'(case 1 [(x) . 8]) #rx"illegal use of `.'")
 (syntax-test #'(case 1 [(x) 10] . 9) #rx"illegal use of `.'")
+(syntax-test #'(case/equal 1 []) #rx"ill-formed clause")
+(syntax-test #'(case/equal-always 1 []) #rx"ill-formed clause")
+(syntax-test #'(case/eq 1 []) #rx"ill-formed clause")
+(syntax-test #'(case/eqv 1 []) #rx"ill-formed clause")
 
 ;; test larger `case' dispatches to trigger for binary-search
 ;; and hash-table-based dispatch:

--- a/racket/collects/racket/case.rkt
+++ b/racket/collects/racket/case.rkt
@@ -1,0 +1,19 @@
+#lang racket/base
+(require (for-syntax racket/base)
+         (submod "private/case.rkt" make-case))
+
+(provide case/equal
+         case/equal-always
+         case/eq
+         case/eqv)
+
+;; equivalent to `case`:
+(define-syntax case/equal
+  (make-case #'equal?))
+
+(define-syntax case/equal-always
+  (make-case #'equal-always?))
+(define-syntax case/eq
+  (make-case #'eq?))
+(define-syntax case/eqv
+  (make-case #'eqv?))

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 11
 #define MZSCHEME_VERSION_Z 1
-#define MZSCHEME_VERSION_W 7
+#define MZSCHEME_VERSION_W 8
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
Currently undocumented; requires `else` clause, does not specially handle trivial situations. Intended only for use in Rhombus to fix:

racket/rhombus-prototype#417.

Could be changed to be public with a bit more code duplication and/or abstraction.