### PR TITLE
doc: The `'ptr_ptr->save` protocol has 2 arguments, not 3.

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/collect-callback.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/collect-callback.scrbl
@@ -38,8 +38,8 @@ icon.}
  (*)(void*, void*, void*)}.}
 
  @item{@racket['ptr_ptr->save] corresponds to @cpp{void* (*)(void*,
- void*, void*)}, but the result is recorded as the current ``save''
- value. The current ``save'' value starts as @cpp{NULL}.}
+ void*)}, but the result is recorded as the current ``save'' value.
+ The current ``save'' value starts as @cpp{NULL}.}
 
  @item{@racket['save!_ptr->void] corresponds to @cpp{void (*)(void*,
  void*)}, but only if the current ``save'' value is not a @cpp{NULL}


### PR DESCRIPTION
##### Checklist

- [x] documentation

### Description of change

The `'ptr_ptr->save` protocol of `unsafe-add-collect-callbacks` was described in the documentation as corresponding to the signature `void* (*)(void*, void*, void*)`. I've corrected this to `void* (*)(void*, void*)`, which is evidently the signature in use by [relevant code in BC's thread.c](https://github.com/rocketnia/racket/blob/d4b4626ad1b4b82e468467a18508893c7476b256/racket/src/bc/src/thread.c#L9152C1-L9160C29) and [relevant code in CS's memory.ss](https://github.com/rocketnia/racket/blob/d4b4626ad1b4b82e468467a18508893c7476b256/racket/src/cs/rumble/memory.ss#L604C1-L605C71).