### PR TITLE
add `CFLAGS+=...` handling to `configure`

### DIFF
--- a/racket/src/README.txt
+++ b/racket/src/README.txt
@@ -183,8 +183,10 @@ Detailed instructions:
 
          env CC=cc [here]configure
 
-    To add an include path, be sure to use CPPFLAGS="-I..." instead of
-    CFLAGS="-I...". The CPPFLAGS variable controls C pre-processing,
+    Use CFLAGS+=.... to add to CFLAGS instead of replacing the default,
+    and `+=` also works for the variables CPPFLAGS, LDFLAGS, and LIBS.
+    To add an include path, be sure to use CPPFLAGS+="-I..." instead of
+    CFLAGS+="-I...". The CPPFLAGS variable controls C pre-processing,
     which includes C compilation, and the Racket build normally uses
     the C pre-processor directly for some parts of the build.
 

--- a/racket/src/ac/add_c_flags.m4
+++ b/racket/src/ac/add_c_flags.m4
@@ -1,0 +1,22 @@
+
+# The "filter_add.sh" script is inserted into autoconf output just
+# before the generated configure script handles arguments. The
+# configure script later handles the variables potentially built up
+# here, adding contents to the default or initially configured flag
+# sets.
+
+if test "$CPPFLAGS_ADD" != "" ; then
+   CPPFLAGS="$CPPFLAGS $CPPFLAGS_ADD"
+fi
+
+if test "$CFLAGS_ADD" != "" ; then
+   CFLAGS="$CFLAGS $CFLAGS_ADD"
+fi
+
+if test "$LDFLAGS_ADD" != "" ; then
+   LDFLAGS="$LDFLAGS $LDFLAGS_ADD"
+fi
+
+if test "$LIBS_ADD" != "" ; then
+   LIBS="$LIBS $LIBS_ADD"
+fi

--- a/racket/src/ac/filter_add.sh
+++ b/racket/src/ac/filter_add.sh
@@ -1,0 +1,25 @@
+# Added to the front of an autoconf script to handle
+# `CFLAGS+=...` and similar additions, athering the
+# content into vabiables like `CFLAGS_ADD` and removing
+# them from autoconf's view
+
+for arg do
+    shift
+    case $arg in
+        CFLAGS+=*)
+            CFLAGS_ADD="${CFLAGS_ADD} "`echo $arg | sed -e 's/^CFLAGS+=//'`
+            ;;
+        CPPFLAGS+=*)
+            CPPFLAGS_ADD="${CPPFLAGS_ADD} "`echo $arg | sed -e 's/^CPPFLAGS+=//'`
+            ;;
+        LDFLAGS+=*)
+            LDFLAGS_ADD="${LDFLAGS_ADD} "`echo $arg | sed -e 's/^LDFLAGS+=//'`
+            ;;
+        LIBS+=*)
+            LIBS_ADD="${LIBS_ADD} "`echo $arg | sed -e 's/^LIBS+=//'`
+            ;;
+        *)
+            set -- "$@" "$arg"
+            ;;
+    esac
+done

--- a/racket/src/ac/make-configure
+++ b/racket/src/ac/make-configure
@@ -28,6 +28,8 @@ exit 0
 ;; In addition, we want none of the feature-selection flags
 ;;  (such as --enable-mac64) to be passed to sub-configures,
 ;;  so we adjust the script to strip them away.
+;; Finally, we want to support `CFLAGS+=...` to add to `CFLAGS`
+;;  instead of replacing the default arguments.
 
 (define skip-rxs
   (map (lambda (s)
@@ -47,10 +49,29 @@ exit 0
          ;;  localedir - converted to "appsdir"
         )))
 
+;; Keep "#!" line first:
+(displayln (read-line))
+
+(define (insert-filter_add)
+ (newline)
+ (call-with-input-file
+  "filter_add.sh"
+  (lambda (i)
+   (let loop ()
+    (let ([l (read-line i)])
+     (unless (eof-object? l)
+      (displayln l)
+      (loop))))))
+ (newline))
+
 (let loop ()
   (let ([l (read-line)])
     (unless (eof-object? l)
       (cond
+       [(regexp-match #rx"for ac_option" l)
+        (insert-filter_add)
+        (displayln l)
+        (loop)]
        [(ormap (lambda (rx)
                  (regexp-match rx l))
                skip-rxs)
@@ -85,6 +106,13 @@ exit 0
           (displayln "  --appsdir=DIR           .desktop files [EPREFIX/share/applications]")]
          [else
           (displayln (regexp-replace* #rx"locale" l "apps"))])
+        (loop)]
+       [(regexp-match #rx"Usage: .*[[]VAR=VALUE[]][.][.][.]" l)
+        (displayln (string-append l " [VAR+=VALUE]..."))
+        (loop)]
+       [(regexp-match #rx"See below for descriptions of some of the useful variables" l)
+        (displayln l)
+        (displayln "Use += with CFLAGS, CPPFLAGS, LDFLAGS, or LIBS to add to the variable.")
         (loop)]
        [else
         ;; Copy

--- a/racket/src/bc/configure
+++ b/racket/src/bc/configure
@@ -917,6 +917,33 @@ mandir='${datarootdir}/man'
 
 ac_prev=
 ac_dashdash=
+
+# Added to the front of an autoconf script to handle
+# `CFLAGS+=...` and similar additions, athering the
+# content into vabiables like `CFLAGS_ADD` and removing
+# them from autoconf's view
+
+for arg do
+    shift
+    case $arg in
+        CFLAGS+=*)
+            CFLAGS_ADD="${CFLAGS_ADD} "`echo $arg | sed -e 's/^CFLAGS+=//'`
+            ;;
+        CPPFLAGS+=*)
+            CPPFLAGS_ADD="${CPPFLAGS_ADD} "`echo $arg | sed -e 's/^CPPFLAGS+=//'`
+            ;;
+        LDFLAGS+=*)
+            LDFLAGS_ADD="${LDFLAGS_ADD} "`echo $arg | sed -e 's/^LDFLAGS+=//'`
+            ;;
+        LIBS+=*)
+            LIBS_ADD="${LIBS_ADD} "`echo $arg | sed -e 's/^LIBS+=//'`
+            ;;
+        *)
+            set -- "$@" "$arg"
+            ;;
+    esac
+done
+
 for ac_option
 do
   # If the previous option needs an argument, assign it.
@@ -1407,10 +1434,11 @@ if test "$ac_init_help" = "long"; then
   cat <<_ACEOF
 \`configure' configures this package to adapt to many kinds of systems.
 
-Usage: $0 [OPTION]... [VAR=VALUE]...
+Usage: $0 [OPTION]... [VAR=VALUE]... [VAR+=VALUE]...
 
 To assign environment variables (e.g., CC, CFLAGS...), specify them as
 VAR=VALUE.  See below for descriptions of some of the useful variables.
+Use += with CFLAGS, CPPFLAGS, LDFLAGS, or LIBS to add to the variable.
 
 Defaults for the options are specified in brackets.
 
@@ -3563,6 +3591,9 @@ WINDRES=windres
 DLLTOOL=dlltool
 
 PREFLAGS="$CPPFLAGS"
+if test "$CPPFLAGS_ADD" != "" ; then
+   PREFLAGS="$PREFLAGS $CPPFLAGS_ADD"
+fi
 COPY_NEW_CFLAGS_TO_CPPFLAGS=yes
 
 OWN_LIBFFI="ON"
@@ -4027,6 +4058,33 @@ See \`config.log' for more details" "$LINENO" 5; }
 $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
 set X $ac_compile
 ac_compiler=$2
+
+# Added to the front of an autoconf script to handle
+# `CFLAGS+=...` and similar additions, athering the
+# content into vabiables like `CFLAGS_ADD` and removing
+# them from autoconf's view
+
+for arg do
+    shift
+    case $arg in
+        CFLAGS+=*)
+            CFLAGS_ADD="${CFLAGS_ADD} "`echo $arg | sed -e 's/^CFLAGS+=//'`
+            ;;
+        CPPFLAGS+=*)
+            CPPFLAGS_ADD="${CPPFLAGS_ADD} "`echo $arg | sed -e 's/^CPPFLAGS+=//'`
+            ;;
+        LDFLAGS+=*)
+            LDFLAGS_ADD="${LDFLAGS_ADD} "`echo $arg | sed -e 's/^LDFLAGS+=//'`
+            ;;
+        LIBS+=*)
+            LIBS_ADD="${LIBS_ADD} "`echo $arg | sed -e 's/^LIBS+=//'`
+            ;;
+        *)
+            set -- "$@" "$arg"
+            ;;
+    esac
+done
+
 for ac_option in --version -v -V -qversion; do
   { { ac_try="$ac_compiler $ac_option >&5"
 case "(($ac_try" in
@@ -4805,6 +4863,30 @@ if test "$ARFLAGS" = '' ; then
   ARFLAGS=rc
 fi
 SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} AR_FLAGS="'"'"${ARFLAGS}"'"'
+
+
+# The "filter_add.sh" script is inserted into autoconf output just
+# before the generated configure script handles arguments. The
+# configure script later handles the variables potentially built up
+# here, adding contents to the default or initially configured flag
+# sets.
+
+if test "$CPPFLAGS_ADD" != "" ; then
+   CPPFLAGS="$CPPFLAGS $CPPFLAGS_ADD"
+fi
+
+if test "$CFLAGS_ADD" != "" ; then
+   CFLAGS="$CFLAGS $CFLAGS_ADD"
+fi
+
+if test "$LDFLAGS_ADD" != "" ; then
+   LDFLAGS="$LDFLAGS $LDFLAGS_ADD"
+fi
+
+if test "$LIBS_ADD" != "" ; then
+   LIBS="$LIBS $LIBS_ADD"
+fi
+
 
 is_gmake=`make -v no-such-target-we-hope 2>&1 | grep "GNU Make"`
 

--- a/racket/src/bc/configure.ac
+++ b/racket/src/bc/configure.ac
@@ -271,6 +271,9 @@ WINDRES=windres
 DLLTOOL=dlltool
 
 PREFLAGS="$CPPFLAGS"
+if test "$CPPFLAGS_ADD" != "" ; then
+   PREFLAGS="$PREFLAGS $CPPFLAGS_ADD"
+fi
 COPY_NEW_CFLAGS_TO_CPPFLAGS=yes
 
 OWN_LIBFFI="ON"
@@ -433,6 +436,8 @@ if test "$ARFLAGS" = '' ; then
   ARFLAGS=rc
 fi
 SUB_CONFIGURE_EXTRAS="${SUB_CONFIGURE_EXTRAS} AR_FLAGS="'"'"${ARFLAGS}"'"'
+
+m4_include(../ac/add_c_flags.m4)
 
 is_gmake=`make -v no-such-target-we-hope 2>&1 | grep "GNU Make"`
 

--- a/racket/src/cs/c/build.zuo
+++ b/racket/src/cs/c/build.zuo
@@ -680,6 +680,7 @@
                                                                     (add-scheme-kernel-config
                                                                      (adjust-linking-config config)))
                                                                    'm m
+                                                                   'relativeBootFiles "yes"
                                                                    ;; these are for Windows:
                                                                    'runtimeAs "static"
                                                                    'linkAs "exe"

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -878,6 +878,33 @@ mandir='${datarootdir}/man'
 
 ac_prev=
 ac_dashdash=
+
+# Added to the front of an autoconf script to handle
+# `CFLAGS+=...` and similar additions, athering the
+# content into vabiables like `CFLAGS_ADD` and removing
+# them from autoconf's view
+
+for arg do
+    shift
+    case $arg in
+        CFLAGS+=*)
+            CFLAGS_ADD="${CFLAGS_ADD} "`echo $arg | sed -e 's/^CFLAGS+=//'`
+            ;;
+        CPPFLAGS+=*)
+            CPPFLAGS_ADD="${CPPFLAGS_ADD} "`echo $arg | sed -e 's/^CPPFLAGS+=//'`
+            ;;
+        LDFLAGS+=*)
+            LDFLAGS_ADD="${LDFLAGS_ADD} "`echo $arg | sed -e 's/^LDFLAGS+=//'`
+            ;;
+        LIBS+=*)
+            LIBS_ADD="${LIBS_ADD} "`echo $arg | sed -e 's/^LIBS+=//'`
+            ;;
+        *)
+            set -- "$@" "$arg"
+            ;;
+    esac
+done
+
 for ac_option
 do
   # If the previous option needs an argument, assign it.
@@ -1368,10 +1395,11 @@ if test "$ac_init_help" = "long"; then
   cat <<_ACEOF
 \`configure' configures this package to adapt to many kinds of systems.
 
-Usage: $0 [OPTION]... [VAR=VALUE]...
+Usage: $0 [OPTION]... [VAR=VALUE]... [VAR+=VALUE]...
 
 To assign environment variables (e.g., CC, CFLAGS...), specify them as
 VAR=VALUE.  See below for descriptions of some of the useful variables.
+Use += with CFLAGS, CPPFLAGS, LDFLAGS, or LIBS to add to the variable.
 
 Defaults for the options are specified in brackets.
 
@@ -2387,6 +2415,7 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
 
 
 ac_config_headers="$ac_config_headers cs_config.h"
@@ -3677,6 +3706,33 @@ See \`config.log' for more details" "$LINENO" 5; }
 $as_echo "$as_me:${as_lineno-$LINENO}: checking for C compiler version" >&5
 set X $ac_compile
 ac_compiler=$2
+
+# Added to the front of an autoconf script to handle
+# `CFLAGS+=...` and similar additions, athering the
+# content into vabiables like `CFLAGS_ADD` and removing
+# them from autoconf's view
+
+for arg do
+    shift
+    case $arg in
+        CFLAGS+=*)
+            CFLAGS_ADD="${CFLAGS_ADD} "`echo $arg | sed -e 's/^CFLAGS+=//'`
+            ;;
+        CPPFLAGS+=*)
+            CPPFLAGS_ADD="${CPPFLAGS_ADD} "`echo $arg | sed -e 's/^CPPFLAGS+=//'`
+            ;;
+        LDFLAGS+=*)
+            LDFLAGS_ADD="${LDFLAGS_ADD} "`echo $arg | sed -e 's/^LDFLAGS+=//'`
+            ;;
+        LIBS+=*)
+            LIBS_ADD="${LIBS_ADD} "`echo $arg | sed -e 's/^LIBS+=//'`
+            ;;
+        *)
+            set -- "$@" "$arg"
+            ;;
+    esac
+done
+
 for ac_option in --version -v -V -qversion; do
   { { ac_try="$ac_compiler $ac_option >&5"
 case "(($ac_try" in
@@ -4158,6 +4214,30 @@ ac_cpp='$CPP $CPPFLAGS'
 ac_compile='$CC -c $CFLAGS $CPPFLAGS conftest.$ac_ext >&5'
 ac_link='$CC -o conftest$ac_exeext $CFLAGS $CPPFLAGS $LDFLAGS conftest.$ac_ext $LIBS >&5'
 ac_compiler_gnu=$ac_cv_c_compiler_gnu
+
+
+
+# The "filter_add.sh" script is inserted into autoconf output just
+# before the generated configure script handles arguments. The
+# configure script later handles the variables potentially built up
+# here, adding contents to the default or initially configured flag
+# sets.
+
+if test "$CPPFLAGS_ADD" != "" ; then
+   CPPFLAGS="$CPPFLAGS $CPPFLAGS_ADD"
+fi
+
+if test "$CFLAGS_ADD" != "" ; then
+   CFLAGS="$CFLAGS $CFLAGS_ADD"
+fi
+
+if test "$LDFLAGS_ADD" != "" ; then
+   LDFLAGS="$LDFLAGS $LDFLAGS_ADD"
+fi
+
+if test "$LIBS_ADD" != "" ; then
+   LIBS="$LIBS $LIBS_ADD"
+fi
 
 
 # If using gcc, we'll want all warnings

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -5,6 +5,7 @@
 #################################################################
 
 AC_INIT([embed-boot.rkt])
+
 AC_CONFIG_HEADERS([cs_config.h])
 
 AC_CONFIG_AUX_DIR(../../lt)
@@ -198,6 +199,8 @@ ENABLE_EXTRA_CHECKS=no
 m4_include(../ac/sdk_ios.m4)
 
 AC_PROG_CC
+
+m4_include(../ac/add_c_flags.m4)
 
 m4_include(../ac/is_gcc.m4)
 


### PR DESCRIPTION
I've often wanted a way to add to `CFLAGS` without replacing whatever it would otherwise use or default to. There doesn't seem to be a common way to do this on the command line with `configure` or with more modern build systems. (Pointers welcome if I've overlooked something.) But `CFLAGS+=....` seems like a natural and easy-to-remember way of doing this,  andit worked out well for a use case in Chez Scheme. I think it makes sense to add here, even though it means hacking the output of `autoconf` a little more than we already do.