### PR TITLE
adjust build stamp for development and snapshots

### DIFF
--- a/main.zuo
+++ b/main.zuo
@@ -355,6 +355,10 @@
   (define (as-is token vm)
     (check-mode "in-place")
     (base token vm)
+    (racket (find-racket vm)
+            (list "-U" "-G" (path-only build-config.rktd)
+                  (at-source "racket/src/pkgs-config.rkt")
+                  "--maybe-update-stamp"))
     (setup vm))
 
   (define (in-place token vm [also? #f] [setup-extra-args ""])
@@ -392,6 +396,7 @@
     (racket vars
             (list "-U" "-G" (path-only build-config.rktd)
                   (at-source "racket/src/pkgs-config.rkt")
+                  "--pkgs-catalog"
                   default-src-catalog
                   (lookup 'SRC_CATALOG)))
     (racket vars
@@ -456,9 +461,8 @@
   (define (server-from-base token [options-in (hash)])
     (check-mode "server")
     (make-build/site.rkt)
-    (update-stamp.txt)
-
     (define options (add-server-compile-machine options-in))
+    (update-stamp.txt options)
 
     ;; Create a copy of `SRC_CATALOG', so that we snapshot checksums, and
     ;; start building from it. The packages are installed in user scope,
@@ -524,26 +528,25 @@
                            "(machine)")
                        build/site.rkt)))
   
-  (define (update-stamp.txt)
+  (define (update-stamp.txt options)
     (define given-stamp (lookup 'BUILD_STAMP))
     (define stamp
       (cond
         [(not (equal? given-stamp ""))
          given-stamp]
         [else
-         (define (shell-result . cmds)
-           (define p (shell cmds (hash 'stdout 'pipe)))
-           (define r (fd-read (hash-ref p 'stdout) eof))
-           (process-wait (hash-ref p 'process))
-           (unless (= 0 (process-status (hash-ref p 'process)))
-             (error "failed" cmds))
-           (car (string-split r "\n")))
-         (~a
-          (shell-result "date" (string->shell "+%Y%m%d"))
-          (if (directory-exists? (at-source ".git"))
-              (~a "-"
-                  (shell-result "git log -1 --pretty=format:%h"))
-              ""))]))
+         (define cmds
+           (list (find-built-racket options)
+                 (at-source "racket/src/pkgs-config.rkt")
+                 "--display-auto-stamp"))
+         (define p
+           (apply racket/process (append cmds (list (hash 'stdout 'pipe)))))
+         (define r
+           (fd-read (hash-ref p 'stdout) eof))
+         (process-wait (hash-ref p 'process))
+         (unless (= 0 (process-status (hash-ref p 'process)))
+           (error "failed" cmds))
+         (car (string-split r "\n"))]))
     (display-to-file (~a stamp "\n") (at-source "build/stamp.txt") :truncate))
 
   (define (server-cache-config options)

--- a/racket/src/pkgs-config.rkt
+++ b/racket/src/pkgs-config.rkt
@@ -1,13 +1,42 @@
 #lang racket/base
 (require racket/cmdline
          racket/format
-         racket/path
+         racket/pretty
+         racket/port
+         racket/string
+         racket/date
+         racket/system
          racket/file)
 
-;; Adjust the configuration to consult a catalog that is
-;; expected to map some packages to directory links.
-
-;; Used by the top-level Makefile in the main Racket repository.
+(module+ main
+  (command-line
+   #:usage-help
+   "Used by the top-level Makefile in the main Racket repository."
+   "If no <option> is provided, does nothing."
+   #:once-any
+   [("--pkgs-catalog")
+    default-src-catalog src-catalog
+    ("Configure a development build to consult first a local catalog,"
+     "which is expected to map packages in this repository to directory links,"
+     "next <src-catalog>, and then <default-src-catalog> (if different) before"
+     "falling back to the built-in default catalog."
+     "If a config.rktd file is created, also set its installation-name,"
+     "build-stamp, default-scope, interactive-file, and"
+     "gui-interactive-file to values suitable for development from Git."
+     "If a config.rktd file already exists, check its catalog configuration"
+     "and potentially update its build stamp as with `--maybe-update-stamp`.")
+    (pkgs-catalog default-src-catalog src-catalog)]
+   [("--maybe-update-stamp")
+    ("Update the build stamp if and only if a config.rktd file already"
+     "exists and indicates that its build stamp was previously generated"
+     "by this script.")
+    (maybe-update-stamp)]
+   [("--display-auto-stamp")
+    ("Display to standard output an automatic build stamp (in the same style"
+     "as above) followed by a newline. Used by `distro-build`.")
+    (displayln (auto-stamp))]
+   #:args ()
+   (void)))
 
 (define config-dir-path (build-path "racket" "etc"))
 (define config-file-path (build-path config-dir-path "config.rktd"))
@@ -15,24 +44,21 @@
 (define catalog-relative-path (build-path 'up "share" "pkgs-catalog"))
 (define catalog-relative-path-str (path->string catalog-relative-path))
 
-(define-values (default-src-catalog src-catalog)
-  (command-line
-   #:args
-   (default-src-catalog src-catalog)
-   (values default-src-catalog src-catalog)))
+(define (write-config config)
+  (call-with-atomic-output-file config-file-path
+    (λ (out _tmp)
+      (pretty-write config out))))
 
-(define src-catalog-is-default?
-  (equal? src-catalog default-src-catalog))
-
-(when (file-exists? config-file-path)
-  (call-with-input-file*
-   config-file-path
-   (lambda (i)
-     (define r (read i))
-     (define l (hash-ref r 'catalogs #f))
+(define (pkgs-catalog default-src-catalog src-catalog)
+  (define src-catalog-is-default?
+    (equal? src-catalog default-src-catalog))
+  (cond
+    [(file-exists? config-file-path)
+     (define config (file->value config-file-path))
+     (define l (hash-ref config 'catalogs #f))
      (define starts-as-expected?
        (and (list? l)
-            ((length l) . >= . 1)
+            (pair? l)
             (equal? (car l) catalog-relative-path-str)))
      (define has-src-catalog?
        (or (and src-catalog-is-default?
@@ -55,29 +81,95 @@
                   "")
               (if (not starts-as-expected?)
                   catalog-relative-path-str
-                  src-catalog))))))
+                  src-catalog)))
+     (update-stamp-if-auto config)]
+    [else
+     (printf "Writing ~a\n" config-file-path)
+     (make-directory* config-dir-path)
+     (write-config (hash 'catalogs
+                         (cons catalog-relative-path-str
+                               (if src-catalog-is-default?
+                                   '(#f)
+                                   (list src-catalog #f)))
+                         'installation-name
+                         "development"
+                         'default-scope
+                         "installation"
+                         'automatic-development-build-stamp?
+                         #t
+                         'build-stamp
+                         (auto-stamp)
+                         'interactive-file
+                         'racket/interactive
+                         'gui-interactive-file
+                         'racket/gui/interactive))]))
 
-(unless (file-exists? config-file-path)
-  (printf "Writing ~a\n" config-file-path)
-  (let-values ([(base name dir?) (split-path config-file-path)])
-    (when (path? base) (make-directory* base)))
-  (call-with-output-file*
-   config-file-path
-   (lambda (o)
-     (write (hash 'catalogs
-                  (cons catalog-relative-path-str
-                        (append
-                         (if src-catalog-is-default?
-                             '()
-                             (list src-catalog))
-                         (list #f)))
-                  'installation-name
-                  "development"
-                  'default-scope
-                  "installation"
-                  'interactive-file
-                  'racket/interactive
-                  'gui-interactive-file
-                  'racket/gui/interactive)
-            o)
-     (newline o))))
+(define (maybe-update-stamp)
+  (when (file-exists? config-file-path)
+    (update-stamp-if-auto (file->value config-file-path))))
+
+(define (update-stamp-if-auto config)
+  (when (hash-ref config 'automatic-development-build-stamp? #f)
+    (printf "Updating build-stamp in ~a\n" config-file-path)
+    (write-config (hash-set config 'build-stamp (auto-stamp)))))
+
+(define (auto-stamp)
+  (cond
+    [(format-current-commit)
+     => (λ (desc)
+          (~a (today) "-" desc))]
+    [else
+     (today)]))
+
+(define (today)
+  ;; Use Racket instead of:
+  ;;  - `date +%Y-%m-%d` to handle SOURCE_DATA_EPOCH and to avoid
+  ;;     portability complications.
+  ;;  - `git log -1 --pretty=%cs` because the date for snapshot
+  ;;     builds should be updated even on days with no commits here.
+  ;;     Users can still choose the commit date instead via e.g.
+  ;;     `SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)`.
+  (define env
+    (getenv "SOURCE_DATE_EPOCH"))
+  (define date
+    (if (and (non-empty-string? env)
+             (not (regexp-match? #px"\\D" env)))
+        (seconds->date (string->number env) #f)
+        (current-date)))
+  (parameterize ([date-display-format 'iso-8601])
+    (date->string date)))
+
+(define (format-current-commit)
+  (let/ec return
+    (define git-cmd
+      (or (find-executable-path "git")
+          (find-executable-path "git.exe")
+          (and (eq? 'macosx (system-type))
+               (find-executable-path "/opt/local/bin/git"))))
+    (unless (and git-cmd
+                 (parameterize ([current-output-port (open-output-nowhere)]
+                                [current-input-port (open-input-string "")]
+                                ;; failure here just means we are not in a git tree,
+                                ;; so discard error messages
+                                [current-error-port (open-output-nowhere)])
+                   (with-handlers ([exn:fail? (λ (e) #f)])
+                     (system* git-cmd "rev-parse" "--git-dir"))))
+      (return #f))
+    (define (git . args)
+      ;; failure here means something is likely wrong, so pass through stderr,
+      ;; but don't break the build
+      (define o (open-output-string))
+      (or (and (parameterize ([current-output-port o]
+                              [current-input-port (open-input-string "")])
+                 (apply system* git-cmd args))
+               (let ([s (string-trim (get-output-string o))])
+                 (and (non-empty-string? s) s)))
+          (return #f)))
+    (~a (git "log" "-1" "--abbrev=10" "--pretty=format:%h")
+        (or (for/or ([state '("broken" "dirty")]
+                     [mark '("-broken" "*")])
+              (define desc
+                (git "describe" "--always" "--long" (~a "--" state)))
+              (and (string-suffix? desc state)
+                   mark))
+            ""))))


### PR DESCRIPTION
This is a first cut at adding enhancements to build stamps like those previously done by DrRacket, as discussed in https://github.com/racket/racket/pull/4847. It seems to work, but I have not tested with `distro-build` yet, and I'd also like people to have a chance to weigh in on the content of the build stamps. 

The change for snapshots is fairly simple: instead of e.g. `20231203-4f7eb34066`, these are now formatted as `2023-12-03-4f7eb34066`. I also considered `2023-12-03(4f7eb34066)`, which would be closer to what DrRacket used to do, but the stamps end up in urls like https://users.cs.utah.edu/plt/snapshots/20231215-396fa983c4/ and https://plt.cs.northwestern.edu/snapshots/20231214-396fa983c4/, so it seemed better to stick with characters that should never need to be escaped.

For development builds, the stamp is set only under the same circumstances as when `installation-name` is set to `development`. I noticed that `make base` is **not** one of those circumstances. This behavior is documented in the sense that:

https://github.com/racket/racket/blob/5b3f530e690f2268d607477760a5dbdcdb6b82e8/pkgs/racket-build-guide/build.scrbl#L183-L191

only specifies the behavior for `make` and `make in-place`, but I don't think there's anything documenting that these things don't happen with `make base`, and it's a difference from `make in-place PKGS=`. It surprised me, though it may make sense.

I did arrange to update an old automatically-generated the stamp even when previously the `config.rktd` file would have been unchanged, e.g. with `make as-is`.

For the content of the stamp, in development mode:

 1. If `git` is unavailable or the source is not a Git working tree (e.g. if it was created with `git archive`), the stamp is `2023-12-16-development`, using the build date.
 2. With Git, the basic format is something like `2023-12-16-example-119156e17d`, which consists of:
      - The date of the current commit, or the build date if the commit date somehow can't be found;
      - A tag or branch name, if available; and
      - The abbreviated commit hash.
 3. If there are uncommitted changes to tracked files, the stamp is further extended with `changed` and the build date, so e.g. `2023-12-16-example-359ec98455-changed-2024-01-01`.

I'm concerned that the last case is a bit too long. On the other hand, I find all of those pieces of information useful, and I find it more self-explanatory than the cryptic letter between `/` and `)` previously used by DrRacket.

Currently `make as-is` fails if the `config.rktd` file does not exist, which doesn't seem ideal.

I also don't love the current overloading of the `pkgs-config.rkt` script in general.