### PR TITLE
pkg migrate: supply a list of available versions when none is supplied

### DIFF
--- a/pkgs/racket-doc/pkg/scribblings/lib.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/lib.scrbl
@@ -475,6 +475,14 @@ The package lock must be held; see @racket[with-pkg-lock].
 @history[#:changed "6.4.0.14" @elem{Added the @racket[#:dry-run] argument.}]}
 
 
+@defproc[(pkg-migrate-available-versions) (listof string?)]{
+
+Returns a list of versions that are suitable as arguments to
+@racket[pkg-migrate].
+
+@history[#:added "8.11.1.7"]}
+
+
 @defproc[(pkg-catalog-show [names (listof string?)]
                            [#:all? all? boolean? #f]
                            [#:only-names? only-names? boolean? #f]

--- a/racket/collects/pkg/lib.rkt
+++ b/racket/collects/pkg/lib.rkt
@@ -181,6 +181,8 @@
                         #:force-strip? boolean?
                         #:dry-run? boolean?)
         (or/c #f 'skip (listof (or/c path-string? (non-empty-listof path-string?)))))]
+  [pkg-migrate-available-versions
+   (-> (listof string?))]
   [pkg-catalog-show
    (->* ((listof string?))
         (#:all? boolean?

--- a/racket/collects/pkg/main.rkt
+++ b/racket/collects/pkg/main.rkt
@@ -4,6 +4,7 @@
          racket/format
          racket/path
          racket/splicing
+         racket/string
          raco/command-name
          setup/dirs
          net/url
@@ -479,7 +480,18 @@
              install-force-flags ...
              dry-run-flags ...
              job-flags ...
-             #:args (from-version)
+             #:args ([from-version #f])
+             (unless from-version
+               (define versions (pkg-migrate-available-versions))
+               ((pkg-error 'migrate) (string-append
+                                      "expected <from-version> to migrate from"
+                                      (cond
+                                        [(null? versions) ", but none are available"]
+                                        [else
+                                         (string-join (cons
+                                                       "\n  available versions:"
+                                                       versions)
+                                                      "\n   ")]))))
              (call-with-package-scope
               'migrate
               scope scope-dir installation user #f #f #f #f

--- a/racket/collects/pkg/private/migrate.rkt
+++ b/racket/collects/pkg/private/migrate.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require racket/match
          net/url
+         setup/dirs
          "../path.rkt"
          "config.rkt"
          "lock.rkt"
@@ -12,7 +13,8 @@
          "dirs.rkt"
          "print.rkt")
 
-(provide pkg-migrate)
+(provide pkg-migrate
+         pkg-migrate-available-versions)
 
 (define (pkg-migrate from-version
                      #:all-platforms? [all-platforms? #f]
@@ -88,3 +90,12 @@
                     #:dry-run? dry-run?)
        (unless quiet?
          (printf "Packages migrated~a\n" (dry-run-explain dry-run?))))))
+
+(define (pkg-migrate-available-versions)
+  (define d (find-system-path 'addon-dir))
+  (for/list ([p (in-list (directory-list d))]
+             #:when (let ([p (build-path d p "pkgs" "pkgs.rktd")])
+                      (file-exists? p))
+             #:unless (equal? (path-element->string p)
+                              (get-installation-name)))
+    (path-element->string p)))


### PR DESCRIPTION
A new `pkg-migrate-available-versions` function makes this list available programmatically.

The implementation of `pkg-migrate-available-versions` is from `gui-pkg-manager`, so that package could change to use this copy.