### PR TITLE
fix FFI identifier convention for camelCase

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/define.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/define.scrbl
@@ -1,5 +1,8 @@
 #lang scribble/doc
-@(require "utils.rkt" (for-label ffi/unsafe/define ffi/unsafe/alloc))
+@(require "utils.rkt"
+          (for-label ffi/unsafe/define
+                     ffi/unsafe/alloc
+                     ffi/unsafe/define/conventions))
 
 @title{Defining Bindings}
 
@@ -144,25 +147,62 @@ that converts one identifier to another.
 @defidform[convention:hyphen->underscore]{
 
  A convention that converts hyphens in an identifier to
- underscores. For example, the identifier
- @racket[gtk-rc-parse] will transform to @racket[gkt_rc_parse].
+ underscores.
+ For example, the identifier @racket[underscore-variable] will
+ transform to @racket[underscore_variable].
 
 @racketblock[
-  (define-ffi-definer define-gtk gtk-lib
+  (define-ffi-definer define-unlib underscore-lib
     #:make-c-id convention:hyphen->underscore)
- (define-gtk gtk-rc-parse (_fun _path -> _void))]
+  (define-unlib underscore-variable (_fun -> _void))
+]
+
+}
+
+@defidform[convention:hyphen->camelCase]{
+
+ Similar to @racket[convention:hyphen->underscore], but
+ converts the identifier to ``camelCase,'' following the
+ @racket[string-downcase] and @racket[string-titlecase] functions.
+ For example, the identifier @racket[camel-case-variable]
+ (or even @racket[cAmeL-CAsE-vaRiaBlE]) will
+ transform to @racket[camelCaseVariable].
+
+@racketblock[
+  (define-ffi-definer define-calib camel-lib
+    #:make-c-id convention:hyphen->camelCase)
+  (define-calib camel-case-variable (_fun -> _void))
+]
+
+@history[#:added "8.11.1.8"]
+}
+
+@defidform[convention:hyphen->PascalCase]{
+
+ Like @racket[convention:hyphen->camelCase], but
+ converts the identifier to ``PascalCase,'' following the
+ @racket[string-titlecase] function.
+ For example, the identifier @racket[pascal-case-variable]
+ (or even @racket[paSCaL-CAsE-vaRiaBlE]) will
+ transform to @racket[PascalCaseVariable].
+
+@racketblock[
+  (define-ffi-definer define-palib pascal-lib
+    #:make-c-id convention:hyphen->PascalCase)
+  (define-palib pascal-case-variable (_fun -> _void))
+]
+
+@history[#:added "8.11.1.8"]
 }
 
 @defidform[convention:hyphen->camelcase]{
-                                         
- Similar to @racket[convention:hyphen->underscore], but
- converts the identifier to camel case instead, following the
- @racket[string-titlecase] function. For example, the
- identifier @racket[camelCaseVariable] will transform to
- @racket[came-case-variable].
- 
- @racketblock[
- (define-ffi-definer define-calib camel-lib
-   #:make-c-id convention:hyphen->camelcase)
- (define-calib camel-case-variable (_fun -> _void))]
+
+ @deprecated[#:what "convention"
+             @racket[convention:hyphen->PascalCase]]{
+  This convention unfortunately converts to ``PascalCase'' as opposed
+  to what its name suggests.
+ }
+
+@history[#:changed "8.11.1.8" @elem{Deprecated due to the wrong
+           behavior.}]
 }

--- a/pkgs/racket-test-core/tests/racket/foreign-test.c
+++ b/pkgs/racket-test-core/tests/racket/foreign-test.c
@@ -423,3 +423,15 @@ X int callback_hungry(int (*f)(void*)) {
   char use_stack_space[10000];
   return f(use_stack_space);
 }
+
+X void underscore_variable() {
+  return;
+}
+
+X void camelCaseVariable() {
+  return;
+}
+
+X void PascalCaseVariable() {
+  return;
+}

--- a/pkgs/racket-test-core/tests/racket/foreign-test.rktl
+++ b/pkgs/racket-test-core/tests/racket/foreign-test.rktl
@@ -1610,16 +1610,34 @@
 ;; ----------------------------------------
 
 (let ()
-  (unless (eq? (system-type) 'windows)
-    (define-ffi-definer define-test-lib test-lib
-      #:make-c-id convention:hyphen->underscore)
-    (define-test-lib check-multiple-of-ten
-      (_fun #:save-errno 'posix _int -> _int))
-    (test 0 check-multiple-of-ten 40)
-    (test -1 check-multiple-of-ten 42)
-    (test 2 saved-errno)
-    (saved-errno 5)
-    (test 5 saved-errno)))
+  (define-ffi-definer define-test-lib test-lib
+    #:make-c-id convention:hyphen->underscore)
+  (define-test-lib underscore-variable (_fun -> _void))
+  (test (void) underscore-variable))
+
+(let ()
+  (define-ffi-definer define-test-lib test-lib
+    #:make-c-id convention:hyphen->camelCase)
+  (define-test-lib camel-case-variable (_fun -> _void))
+  (test (void) camel-case-variable)
+  (define-test-lib cAmeL-CAsE-vaRiaBlE (_fun -> _void))
+  (test (void) cAmeL-CAsE-vaRiaBlE))
+
+(let ()
+  (define-ffi-definer define-test-lib test-lib
+    #:make-c-id convention:hyphen->PascalCase)
+  (define-test-lib pascal-case-variable (_fun -> _void))
+  (test (void) pascal-case-variable)
+  (define-test-lib paSCaL-CAsE-vaRiaBlE (_fun -> _void))
+  (test (void) paSCaL-CAsE-vaRiaBlE))
+
+(let ()
+  (define-ffi-definer define-test-lib test-lib
+    #:make-c-id convention:hyphen->camelcase)
+  (define-test-lib pascal-case-variable (_fun -> _void))
+  (test (void) pascal-case-variable)
+  (define-test-lib paSCaL-CAsE-vaRiaBlE (_fun -> _void))
+  (test (void) paSCaL-CAsE-vaRiaBlE))
 
 (let ()
   (define-ffi-definer define-test-lib test-lib)

--- a/racket/collects/ffi/unsafe/define/conventions.rkt
+++ b/racket/collects/ffi/unsafe/define/conventions.rkt
@@ -1,16 +1,37 @@
 #lang racket/base
 
 (provide convention:hyphen->underscore
+         convention:hyphen->camelCase
+         convention:hyphen->PascalCase
+         ;; deprecated
          convention:hyphen->camelcase)
 (require (for-syntax racket/base
-                     racket/syntax
-                     racket/string))
+                     racket/symbol))
+
+(define-for-syntax (id->string id)
+  (symbol->immutable-string (syntax-e id)))
+
+(define-for-syntax (string->id orig-id str)
+  (datum->syntax orig-id (string->symbol str) orig-id))
 
 (define-syntax (convention:hyphen->underscore id)
-  (format-id id (string-replace (symbol->string (syntax-e id)) "-" "_")))
+  (define str (id->string id))
+  (string->id id (regexp-replace* #rx"-" str "_")))
 
-(define-syntax (convention:hyphen->camelcase id)
-  (define str (symbol->string (syntax-e id)))
-  (format-id id
-             (apply string-append
-                    (map string-titlecase (string-split str "-")))))
+(define-for-syntax (id->strings/hyphen id)
+  (regexp-split #rx"-" (id->string id)))
+
+(define-syntax (convention:hyphen->camelCase id)
+  (define strs (id->strings/hyphen id))
+  (string->id id (apply string-append
+                        (string-downcase (car strs))
+                        (map string-titlecase (cdr strs)))))
+
+(define-syntaxes (convention:hyphen->PascalCase
+                  convention:hyphen->camelcase)
+  (let ()
+    (define (t id)
+      (define strs (id->strings/hyphen id))
+      (string->id id (apply string-append
+                            (map string-titlecase strs))))
+    (values t t)))


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [x] tests included
- [x] documentation

### Description of change
Previously, `convention:hyphen->camelcase` had the wrong behavior, that is, that of the newly added `convention:hyphen->PascalCase`.  Deprecate `convention:hyphen->camelcase` and add `convention:hyphen->{camelCase,PascalCase}`.

Fix #1971.