### PR TITLE
Reduce memory footprint of net/http-client

### DIFF
--- a/racket/collects/ffi/unsafe/define.rkt
+++ b/racket/collects/ffi/unsafe/define.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 
-(require (for-syntax syntax/parse
+(require (for-syntax syntax/parse/pre
                      racket/base)
          ffi/unsafe)
 

--- a/racket/collects/net/platform-ssl.rkt
+++ b/racket/collects/net/platform-ssl.rkt
@@ -20,8 +20,10 @@
 (define-predicate-stubs
   (osx-ssl-output-port? _p)
   (osx-old-openssl?)
-  (win32-ssl-port? _p)
-  (win32-ssl-available?))
+  (win32-ssl-port? _p))
+
+(provide win32-ssl-available?)
+(define win32-ssl-available? #f)
 
 (define-syntax (define-stubs stx)
   (syntax-case stx ()

--- a/racket/collects/net/platform-ssl.rkt
+++ b/racket/collects/net/platform-ssl.rkt
@@ -1,0 +1,68 @@
+#lang racket/base
+
+(require (for-syntax racket/base
+                     setup/cross-system)
+         racket/runtime-path)
+
+;; Unifies osx-ssl.rkt and win32-ssl.rkt, without loading either module
+;; on platforms where they wouldn't work.
+
+(define-runtime-module-path-index osx-ssl.rkt "osx-ssl.rkt")
+(define-runtime-module-path-index win32-ssl.rkt "win32-ssl.rkt")
+
+(define-syntax (define-predicate-stubs stx)
+  (syntax-case stx ()
+    [(_ (id . args) ...)
+     #'(begin
+         (provide id ...)
+         (define (id . args) #f) ...)]))
+
+(define-predicate-stubs
+  (osx-ssl-output-port? _p)
+  (osx-old-openssl?)
+  (win32-ssl-port? _p)
+  (win32-ssl-available?))
+
+(define-syntax (define-stubs stx)
+  (syntax-case stx ()
+    [(_ (id . args) ...)
+     #'(begin
+         (provide id ...)
+         (define (id . args)
+           (error 'id "not available"))
+         ...)]))
+
+(define-stubs
+  (osx-ssl-connect _host _port [_protocol 'auto])
+  (osx-ssl-abandon-port _p)
+  (win32-ssl-connect _host _port [_protocol 'auto])
+  (win32-ssl-abandon-port _p)
+  (ports->win32-ssl-ports _i _o
+                          #:encrypt [_protocol 'auto]
+                          #:hostname [_hostname #f]))
+
+(define-syntax (define-platform-ssl-procedures stx)
+  (syntax-case stx ()
+    [(_ triple ...)
+     (let ([by-platform (for/hasheqv ([triple-stx (in-list (syntax-e #'(triple ...)))])
+                          (values (syntax->datum (car (syntax-e triple-stx))) triple-stx))])
+       (define target-system-stx
+         (hash-ref by-platform (cross-system-type) #f))
+       (if target-system-stx
+           (syntax-case target-system-stx ()
+             [{_ mod-expr (export-id ...)}
+              #'(begin
+                  (let ([mod mod-expr])
+                    (set! export-id (dynamic-require mod 'export-id)) ...))])
+           #'(begin)))]))
+
+(define-platform-ssl-procedures
+  {macosx osx-ssl.rkt (osx-ssl-connect
+                       osx-ssl-abandon-port
+                       osx-ssl-output-port?
+                       osx-old-openssl?)}
+  {windows win32-ssl.rkt (win32-ssl-connect
+                          win32-ssl-abandon-port
+                          ports->win32-ssl-ports
+                          win32-ssl-port?
+                          win32-ssl-available?)})

--- a/racket/collects/net/uri-codec.rkt
+++ b/racket/collects/net/uri-codec.rkt
@@ -83,7 +83,7 @@ See more in PR8831.
 ;; Draws inspiration from encode-decode.scm by Kurt Normark and a code
 ;; sample provided by Eli Barzilay
 
-(require racket/string racket/list)
+(require racket/string)
 
 (provide uri-encode                         uri-decode
          uri-path-segment-encode            uri-path-segment-decode

--- a/racket/collects/net/url-connect.rkt
+++ b/racket/collects/net/url-connect.rkt
@@ -4,8 +4,7 @@
                     [tcp-connect plain-tcp-connect]
                     [tcp-abandon-port plain-tcp-abandon-port])
          openssl
-         "win32-ssl.rkt"
-         "osx-ssl.rkt")
+         "platform-ssl.rkt")
 
 (provide (all-defined-out))
 

--- a/racket/collects/net/url-exception.rkt
+++ b/racket/collects/net/url-exception.rkt
@@ -1,7 +1,6 @@
 #lang racket/base
-(require racket/string
-         racket/contract/base
-         racket/list)
+
+(require racket/contract/base)
 
 (define-struct (url-exception exn:fail) ())
 (define (-url-exception? x)

--- a/racket/collects/net/url-string.rkt
+++ b/racket/collects/net/url-string.rkt
@@ -1,10 +1,11 @@
 #lang racket/base
-(require racket/string
-         racket/contract/base
+
+(require racket/contract/base
          racket/list
-         "url-structs.rkt"
+         racket/string
+         "uri-codec.rkt"
          "url-exception.rkt"
-         "uri-codec.rkt")
+         "url-structs.rkt")
 
 ;; To do:
 ;;   Handle HTTP/file errors.

--- a/racket/collects/net/url.rkt
+++ b/racket/collects/net/url.rkt
@@ -8,7 +8,6 @@
          racket/tcp
          (prefix-in hc: "http-client.rkt")
          (only-in "url-connect.rkt" current-https-protocol)
-         "uri-codec.rkt"
          "url-string.rkt"
          (only-in "url-exception.rkt" make-url-exception))
 

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -23,11 +23,10 @@ TO DO:
 |#
 
 #lang racket/base
+
 (require (rename-in racket/contract/base [-> c->])
          ffi/unsafe
-         ffi/unsafe/define
          ffi/unsafe/atomic
-         ffi/unsafe/alloc
          ffi/unsafe/global
          ffi/file
          ffi/unsafe/custodian


### PR DESCRIPTION
This change reduces some of the imports in `net-lib` and makes it so that `win32-ssl.rkt` doesn't have to be loaded on non-Windows platforms and vice-versa for `osx-ssl.rkt` and non-macOS platforms, improving the memory footprint of `net/http-client` by about 5MB.

Before this change:

```
$ racket -l racket/base -e '(define s (current-memory-use)) (require net/http-client) (- (current-memory-use) s)' | awk '{print $1/1024/1024}'
30.8346
```

After:

```
$ racket -l racket/base -e '(define s (current-memory-use)) (require net/http-client) (- (current-memory-use) s)' | awk '{print $1/1024/1024}'
25.5956
```