### PR TITLE
add pregexp-quote

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.11.1.8")
+(define version "8.11.1.9")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/reference/regexps.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/regexps.scrbl
@@ -60,7 +60,7 @@ or both byte regexps.
 
 A literal or printed @tech{regexp value} starts with @litchar{#rx} or
 @litchar{#px}. @see-read-print["regexp"]{regular expressions} Regexp
-values produced by the default reader are @tech{interned} in 
+values produced by the default reader are @tech{interned} in
 @racket[read-syntax] mode.
 
 On the @tech[#:doc '(lib "scribblings/guide/guide.scrbl")]{BC} variant of Racket,
@@ -311,6 +311,15 @@ case-insensitively.
 (regexp-match "." "apple.scm")
 (regexp-match (regexp-quote ".") "apple.scm")
 ]}
+
+@defproc*[([(pregexp-quote [str string?] [case-sensitive? any/c #t]) string?]
+           [(pregexp-quote [bstr bytes?] [case-sensitive? any/c #t]) bytes?])]{
+
+Like @racket[regexp-quote], but intended for use with @racket[pregexp].
+Escapes all non-alphanumeric, non-underscore characters in the input.
+
+@history[#:added "8.11.1.9"]
+}
 
 @defproc[(regexp-max-lookbehind [pattern (or/c regexp? byte-regexp?)])
          exact-nonnegative-integer?]{

--- a/pkgs/racket-test/tests/racket/pregexp.rkt
+++ b/pkgs/racket-test/tests/racket/pregexp.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(require rackunit)
+
+(check-equal?
+ (regexp-quote "ab-cd")
+ "ab\\-cd")
+
+(let ([re (pregexp (pregexp-quote "-"))])
+  (check-true (regexp-match-exact? re "-"))
+  (check-false (regexp-match-exact? re "a")))
+
+(let ([re (pregexp (format "[~a]" (pregexp-quote ")-;")))])
+  (for ([s (in-list '(")" "-" ";"))])
+    (check-true (regexp-match-exact? re s)))
+  ;; '8' is situated between ')' and ';' on the ASCII table, but it
+  ;; _shouldn't_ match the pregexp if '-' was escaped correctly.
+  (check-false (regexp-match-exact? re "8")))

--- a/racket/collects/racket/private/string.rkt
+++ b/racket/collects/racket/private/string.rkt
@@ -2,6 +2,7 @@
 
   (provide real->decimal-string
            regexp-quote
+           pregexp-quote
            regexp-replace-quote
            regexp-match*
            regexp-match-positions*
@@ -41,17 +42,35 @@
   (define regexp-quote-chars:s #rx"[][.*?+|(){}\\$^]")
   (define regexp-quote-chars:b #rx#"[][.*?+|(){}\\$^]")
 
-  (define (regexp-quote s [case-sens? #t])
+  (define (do-regexp-quote who pat:b pat:s s case-sens?)
     (let* ([b? (cond [(bytes? s) #t]
                      [(string? s) #f]
-                     [else (raise-argument-error 'regexp-quote
-                                                 "(or/c string? bytes?)" s)])]
+                     [else (raise-argument-error who "(or/c string? bytes?)" s)])]
            [s (if b?
-                (regexp-replace* regexp-quote-chars:b s #"\\\\&")
-                (regexp-replace* regexp-quote-chars:s s "\\\\&"))])
+                  (regexp-replace* pat:b s #"\\\\&")
+                  (regexp-replace* pat:s s "\\\\&"))])
       (cond [case-sens? s]
             [b?   (bytes-append #"(?i:" s #")")]
             [else (string-append "(?i:" s ")")])))
+
+  (define (regexp-quote s [case-sens? #t])
+    (do-regexp-quote
+     'regexp-quote
+     regexp-quote-chars:b
+     regexp-quote-chars:s
+     s
+     case-sens?))
+
+  (define pregexp-quote-chars:s #rx"[^0-9A-Za-z_]")
+  (define pregexp-quote-chars:b #rx#"[^0-9A-Za-z_]")
+
+  (define (pregexp-quote s [case-sens? #t])
+    (do-regexp-quote
+     'pregexp-quote
+     pregexp-quote-chars:b
+     pregexp-quote-chars:s
+     s
+     case-sens?))
 
   (define (regexp-replace-quote s)
     (cond [(bytes?  s) (regexp-replace* #rx#"[&\\]" s #"\\\\&")]

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 11
 #define MZSCHEME_VERSION_Z 1
-#define MZSCHEME_VERSION_W 8
+#define MZSCHEME_VERSION_W 9
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
Adds `pregexp-quote`, an analog of `regexp-quote` for `pregexp` values that works like Perl's `quotemeta`.