### PR TITLE
match: add hash-pattern-optimized?

### DIFF
--- a/pkgs/racket-test/tests/match/hash-table-tests.rkt
+++ b/pkgs/racket-test/tests/match/hash-table-tests.rkt
@@ -3,10 +3,22 @@
 (provide hash-table-tests)
 
 (require racket/match
-         rackunit)
+         rackunit
+         syntax/parse/define
+         racket/stxparam
+         (only-in racket/match/runtime hash-pattern-optimized?)
+         (for-syntax racket/base))
+
+(define-syntax-parse-rule (test-suite-hash-table tcase ...)
+  (test-suite "Tests for hash tables"
+    (test-suite "optimization on"
+      tcase ...)
+    (test-suite "optimization off"
+      (syntax-parameterize ([hash-pattern-optimized? #f])
+        tcase ...))))
 
 (define hash-table-tests
-  (test-suite "Test for hash tables"
+  (test-suite-hash-table
     (test-case "non hash"
       (check-equal? (match 1
                       [(hash* [3 x]) x]

--- a/racket/collects/racket/match/runtime.rkt
+++ b/racket/collects/racket/match/runtime.rkt
@@ -13,6 +13,7 @@
          mlist? mlist->list
          syntax-srclocs
 
+         ;; hash pattern
          undef
          user-def
          undef?
@@ -20,7 +21,8 @@
 
          (struct-out hash-state)
          hash-state-closed?
-         hash-state-residue)
+         hash-state-residue
+         hash-pattern-optimized?)
 
 (define match-prompt-tag (make-continuation-prompt-tag 'match)) 
 
@@ -130,3 +132,8 @@
      (for ([k (in-list acc-keys)])
        (hash-remove! ht* k))
      ht*]))
+
+;; If true, optimize the hash pattern as follows:
+;; - Generate simplified code for the open mode
+;; - Treat #:rest _ as the open mode
+(define-syntax-parameter hash-pattern-optimized? #t)


### PR DESCRIPTION
This PR adds a syntax parameter hash-pattern-optimized? which can be used to control hash pattern optimization.
It is not meant to be used by Racket users.
Rather, it is used for testing to make sure that the behavior in the general case and the specialized case are the same.