### PR TITLE
Correct duplicate word typo

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/interaction-info.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/interaction-info.scrbl
@@ -21,7 +21,7 @@ Instead of providing configuration information directly, the
 @racket[current-interaction-info] parameter specifies a module to
 load, a exported function to call, and data to pass as an argument to
 the exported function. The result of that function should be another
-one that accepts two arguments: a symbol a symbol indicating the kind
+one that accepts two arguments: a symbol indicating the kind
 of information requested (as defined by external tools), and a default
 value that normally should be returned if the symbol is not
 recognized.


### PR DESCRIPTION
##### Checklist
- [x] documentation

### Description of change
Correct duplicate word typo
