### PR TITLE
Avoid calling path->pkg repeatedly when it is unlikely to be necessary.

### DIFF
--- a/pkgs/racket-index/setup/scribble.rkt
+++ b/pkgs/racket-index/setup/scribble.rkt
@@ -27,8 +27,8 @@
          scribble/xref
          syntax/modcollapse
          racket/place
-         pkg/lib
-         pkg/strip
+         (only-in pkg/lib path->pkg)
+         (only-in pkg/strip fixup-local-redirect-reference)
          openssl/sha1
          compiler/compilation-path
          (prefix-in u: net/url)
@@ -59,7 +59,6 @@
                                  flags
                                  under-main?
                                  via-search?
-                                 pkg?
                                  category
                                  out-count
                                  name
@@ -184,48 +183,50 @@
                                   (apply validate i)))
                            infos)])
            (and (not (memq #f infos)) infos))))
-  (define ((get-docs main-dirs) i rec)
-    (let* ([pre-s (and i (i 'scribblings (λ () #f)))]
-           [s (validate-scribblings-infos pre-s)]
-           [dir (directory-record-path rec)])
-      (if s
-          (map (lambda (d)
-                 (let* ([flags (cadr d)]
-                        [under-main?
-                         (and (not (memq 'user-doc-root flags))
-                              (not (memq 'user-doc flags))
-                              (or (memq 'main-doc flags)
-                                  (hash-ref main-dirs dir #f)))])
-                   (define src (simplify-path (build-path dir (car d)) #f))
-                   (define name (cadddr d))
-                   (define dest (doc-path dir name flags under-main?))
-                   (define via-search? (and under-main?
-                                            (not (or (equal? (find-doc-dir) dest)
-                                                     (let-values ([(base name dir?) (split-path dest)])
-                                                       (equal? (path->directory-path (find-doc-dir))
-                                                               base))))))
-                   (make-doc dir
-                             (let ([spec (directory-record-spec rec)])
-                               (list* (car spec)
-                                      (car d)
-                                      (if (eq? 'planet (car spec))
-                                          (list (append (cdr spec)
-                                                        (list (directory-record-maj rec)
-                                                              (list '= (directory-record-min rec)))))
-                                          (cdr spec))))
-                             src
-                             dest
-                             flags under-main? via-search? (and (path->pkg src) #t)
-                             (caddr d)
-                             (list-ref d 4)
-                             (if (path? name) (path-element->string name) name)
-                             (list-ref d 5))))
-               s)
-          (begin (setup-printf
-                  "WARNING"
-                  "bad 'scribblings info: ~e from: ~e" 
-                  pre-s dir)
-                 null))))
+  (define (get-docs main-dirs)
+    (define doc-dir (find-doc-dir))
+    (lambda (i rec)
+      (let* ([pre-s (and i (i 'scribblings (λ () #f)))]
+	     [s (validate-scribblings-infos pre-s)]
+	     [dir (directory-record-path rec)])
+	(if s
+	    (map (lambda (d)
+		   (let* ([flags (cadr d)]
+			  [under-main?
+			   (and (not (memq 'user-doc-root flags))
+				(not (memq 'user-doc flags))
+				(or (memq 'main-doc flags)
+				    (hash-ref main-dirs dir #f)))])
+		     (define src (simplify-path (build-path dir (car d)) #f))
+		     (define name (cadddr d))
+		     (define dest (doc-path dir name flags under-main?))
+		     (define via-search? (and under-main?
+					      (not (or (equal? (find-doc-dir) dest)
+						       (let-values ([(base name dir?) (split-path dest)])
+							 (equal? (path->directory-path (find-doc-dir))
+								 base))))))
+		     (make-doc dir
+			       (let ([spec (directory-record-spec rec)])
+				 (list* (car spec)
+					(car d)
+					(if (eq? 'planet (car spec))
+					    (list (append (cdr spec)
+							  (list (directory-record-maj rec)
+								(list '= (directory-record-min rec)))))
+					    (cdr spec))))
+			       src
+			       dest
+			       flags under-main? via-search?
+			       (caddr d)
+			       (list-ref d 4)
+			       (if (path? name) (path-element->string name) name)
+			       (list-ref d 5))))
+		 s)
+	    (begin (setup-printf
+		    "WARNING"
+		    "bad 'scribblings info: ~e from: ~e" 
+		    pre-s dir)
+		   null)))))
   (log-setup-info "getting documents")
   (define docs
     (sort
@@ -1717,3 +1718,9 @@
     (build-path base root)]
    [else
     (reroot-path base root)]))
+
+
+(define path-pkg-cache (make-hash))
+
+(define (doc-pkg? doc)
+  (and (path->pkg (doc-src-file doc) #:cache path-pkg-cache) #t))

--- a/racket/collects/pkg/main.rkt
+++ b/racket/collects/pkg/main.rkt
@@ -315,6 +315,7 @@
                       (clone-to-package-name clone 'update)]
                      [else
                       ;; In a package directory?
+		      ;; This is the only call to path->pkg so not worth a cache
                       (define pkg (path->pkg (current-directory)))
                       (if pkg
                           (begin

--- a/racket/collects/setup/private/cc-struct.rkt
+++ b/racket/collects/setup/private/cc-struct.rkt
@@ -1,7 +1,11 @@
 #lang racket/base
 
-(provide (struct-out cc))
+(require racket/promise)
+
+(provide (struct-out cc) cc-name)
 
 (define-struct cc
-  (collection path name info parent-cc omit-root info-root info-path info-path-mode shadowing-policy main?)
+  (collection path name* info parent-cc omit-root info-root info-path info-path-mode shadowing-policy main?)
   #:inspector #f)
+
+(define (cc-name v) (force (cc-name* v)))


### PR DESCRIPTION
This saves about 5 seconds on my machine when building with no documents (eg `raco setup racket/private`).

I did not try to memoize the resulting `path->pkg` computation. Storing a promise in a serializable struct won't work, and making the struct mutable seemed like a bad idea. 