### PR TITLE
Key filter val filter

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -1005,4 +1005,34 @@ one for the result.
 
 @history[#:added "7.9.0.1"]}
 
+
+@defproc[(hash-filter-values [ht hash?] [pred procedure?])
+         hash?]{
+
+Filters a hash table by applying a predicate to it's values.
+
+@examples[
+#:eval the-eval
+(hash-filter-values (for/hash ([num '(1 2 3 4 5)]) (values num (add1 num))) (λ (v) (< v 3)))
+(hash-filter-values (make-hash) (λ (v) (< v 3)))
+]
+
+@history[#:added "8.11.1"]
+}
+
+
+@defproc[(hash-filter-keys [ht hash?] [pred procedure?])
+         hash?]{
+
+Filters a hash table by applying a predicate to it's keys.
+
+@examples[
+#:eval the-eval
+(hash-filter-keys (for/hash ([num '(1 2 3 4 5)]) (values num 0)) (λ (k) (< k 3)))
+(hash-filter-keys (make-hash) (λ (k) (< k 3)))
+]
+
+@history[#:added "8.11.1"]
+}
+
 @(close-eval the-eval)

--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -1040,36 +1040,80 @@ depends on both the key and value meeting the criteria defined by @racket[pred].
                (λ (k v) (and (not (number? k)) (number? v) (> v 1))))
 ]
 
-@history[#:added "8.12.0.6"]
+@history[#:added "8.12.0.9"]
 }
-
-@defproc[(hash-filter-values [ht hash?] [pred procedure?])
-         hash?]{
-
-Filters a hash table by applying a predicate to it's values.
-
-@examples[
-#:eval the-eval
-(hash-filter-values (for/hash ([num '(1 2 3 4 5)]) (values num (add1 num))) (λ (v) (< v 3)))
-(hash-filter-values (make-hash) (λ (v) (< v 3)))
-]
-
-@history[#:added "8.11.1"]
-}
-
 
 @defproc[(hash-filter-keys [ht hash?] [pred procedure?])
          hash?]{
 
-Filters a hash table by applying a predicate to it's keys.
+Filters the @racket[hash?] @racket[ht] based on a predicate @racket[pred] applied to its keys.
+This function constructs a new hash table that includes only those key-value pairs
+from the input @racket[ht] for which the predicate @racket[pred] returns true when
+applied to the keys. Similar to @racket[hash-filter-values], the output hash table
+maintains the mutability and key comparator of the input hash table, ensuring that
+the structural and operational properties of the original hash are retained.
 
 @examples[
-#:eval the-eval
-(hash-filter-keys (for/hash ([num '(1 2 3 4 5)]) (values num 0)) (λ (k) (< k 3)))
-(hash-filter-keys (make-hash) (λ (k) (< k 3)))
+  #:eval the-eval
+  ;; Filtering keys less than 3 from a hash table
+  (hash-filter-keys (for/hash ([num '(1 2 3 4 5)]) (values num 0)) (λ (k) (< k 3)))
+
+  ;; Filtering keys from an empty hash table
+  (hash-filter-keys (make-hash) (λ (k) (< k 3)))
+
+  ;; Filtering with eq? hash table
+  (hash-filter-keys (make-hasheq '([#f . "false"] [#t . "true"])) (λ (k) (eq? k #t)))
+
+  ;; Filtering lists as keys
+  (hash-filter-keys (hash (list 1 2) 'pair (vector 3 4) 'vector) list?)
+
+  ;; Filtering keys of mixed types: numbers and strings
+  (hash-filter-keys (hash "one" 1 2 "two" "three" 3) (lambda (k) (number? k)))
+
+  ;; Filtering keys that are symbols
+  (hash-filter-keys (hash 'apple "fruit" 'carrot "vegetable" "banana" "fruit")
+                    (lambda (k) (symbol? k)))
 ]
 
-@history[#:added "8.11.1"]
+@history[#:added "8.12.0.9"]
+}
+
+
+@defproc[(hash-filter-values [ht hash?] [pred procedure?])
+         hash?]{
+
+Filters the @racket[hash?] @racket[ht] based on a predicate @racket[pred] applied to its values.
+This function returns a new hash table containing only the key-value pairs for which
+the predicate @racket[pred] returns true when applied to the values of @racket[ht].
+The resulting hash table retains the mutability and the key comparison predicate
+(e.g., @racket[eq?], @racket[eqv?], @racket[equal-always?], @racket[equal?]) of the input
+hash table @racket[ht]. This ensures that the characteristics of the input hash are preserved
+in the output, allowing for a seamless transition between different types of hash tables.
+
+@examples[
+   #:eval the-eval
+   ;; Filtering values less than 3
+   (hash-filter-values (for/hash ([num '(1 2 3 4 5)]) (values num num)) (λ (v) (< v 3)))
+
+   ;; Filtering values from an empty hash table
+   (hash-filter-values (make-hash) (λ (v) (< v 3)))
+
+   ;; Filtering with eqv? hash table
+   (hash-filter-values (make-hasheqv '([1 . "one"] [2 . "two"])) (λ (v) (eqv? v "two")))
+
+   ;; Filtering values of mixed types: strings and numbers
+   (hash-filter-values (hash 'one "1" 'two 2 'three "3") (lambda (v) (string? v)))
+
+   ;; Filtering values to include only vectors
+   (hash-filter-values (hash 'list (list 1 2 3) 'vector #(4 5 6) 'string "hello")
+                       (lambda (v) (vector? v)))
+
+   ;; Filtering based on complex values (hash tables and lists)
+   (hash-filter-values (hash 'nested-hash (hash 'a 1 'b 2) 'nested-list (list 'x 'y 'z))
+                       (lambda (v) (hash? v)))
+ ]
+
+@history[#:added "8.12.0.9"]
 }
 
 @(close-eval the-eval)

--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -1005,6 +1005,43 @@ one for the result.
 
 @history[#:added "7.9.0.1"]}
 
+@defproc[(hash-filter [ht hash?] [pred (-> any/c any/c boolean?)])
+         hash?]{
+
+Filters the @racket[hash?] @racket[ht] based on a predicate @racket[pred] applied to both its keys and values.
+This function constructs a new hash table that includes only those key-value pairs
+from the input @racket[ht] for which the predicate @racket[pred] returns true when
+applied simultaneously to the keys and values of @racket[ht]. The output hash table
+retains the mutability and the key comparison predicate (e.g., @racket[eqv?],
+@racket[equal-always?], @racket[equal?]) of the input hash table @racket[ht], ensuring that
+the structural and operational properties of the original hash are preserved
+in the output. This allows for nuanced filtering where the inclusion of a key-value pair
+depends on both the key and value meeting the criteria defined by @racket[pred].
+
+@examples[
+  #:eval the-eval
+  ;; Filtering key-value pairs where the key is less than 3 and value is even
+  (hash-filter (for/hash ([num '(1 2 3 4 5)]) (values num (* num 2)))
+               (λ (k v) (and (< k 3) (even? v))))
+
+  ;; Filtering key-value pairs from an empty hash table
+  (hash-filter (make-hash) (λ (k v) (< k 3)))
+
+  ;; Filtering with eq? hash table based on specific key-value conditions
+  (hash-filter (make-hasheq '([#f . "false"] [#t . "true"]))
+               (λ (k v) (and (eq? k #t) (string=? v "true"))))
+
+  ;; Filtering key-value pairs where the key is a list and the value is a symbol
+  (hash-filter (hash (list 1 2) 'pair (vector 3 4) 'vector)
+               (λ (k v) (and (list? k) (symbol? v))))
+
+  ;; Filtering key-value pairs of mixed types based on custom logic
+  (hash-filter (hash "one" 1 2 "two" "three" 3)
+               (λ (k v) (and (not (number? k)) (number? v) (> v 1))))
+]
+
+@history[#:added "8.12.0.6"]
+}
 
 @defproc[(hash-filter-values [ht hash?] [pred procedure?])
          hash?]{

--- a/pkgs/racket-doc/scribblings/reference/hashes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/hashes.scrbl
@@ -1008,15 +1008,16 @@ one for the result.
 @defproc[(hash-filter [ht hash?] [pred (-> any/c any/c boolean?)])
          hash?]{
 
-Filters the @racket[hash?] @racket[ht] based on a predicate @racket[pred] applied to both its keys and values.
-This function constructs a new hash table that includes only those key-value pairs
-from the input @racket[ht] for which the predicate @racket[pred] returns true when
-applied simultaneously to the keys and values of @racket[ht]. The output hash table
-retains the mutability and the key comparison predicate (e.g., @racket[eqv?],
-@racket[equal-always?], @racket[equal?]) of the input hash table @racket[ht], ensuring that
-the structural and operational properties of the original hash are preserved
-in the output. This allows for nuanced filtering where the inclusion of a key-value pair
-depends on both the key and value meeting the criteria defined by @racket[pred].
+Filters the @racket[hash?] @racket[ht] based on a predicate
+@racket[pred] applied to both its keys and values. This function
+constructs a new hash table that includes only those key-value pairs
+from the input @racket[ht] for which the predicate @racket[pred]
+returns true when applied simultaneously to the keys and values of
+@racket[ht]. The output hash table retains the mutability and the key
+comparison predicate (e.g., @racket[eqv?], @racket[equal-always?],
+@racket[equal?]) of the input hash table @racket[ht], ensuring that
+the structural and operational properties of the original hash are
+preserved in the output.
 
 @examples[
   #:eval the-eval
@@ -1082,13 +1083,13 @@ the structural and operational properties of the original hash are retained.
 @defproc[(hash-filter-values [ht hash?] [pred procedure?])
          hash?]{
 
-Filters the @racket[hash?] @racket[ht] based on a predicate @racket[pred] applied to its values.
-This function returns a new hash table containing only the key-value pairs for which
-the predicate @racket[pred] returns true when applied to the values of @racket[ht].
-The resulting hash table retains the mutability and the key comparison predicate
-(e.g., @racket[eq?], @racket[eqv?], @racket[equal-always?], @racket[equal?]) of the input
-hash table @racket[ht]. This ensures that the characteristics of the input hash are preserved
-in the output, allowing for a seamless transition between different types of hash tables.
+Filters the @racket[hash?] @racket[ht] based on a predicate
+@racket[pred] applied to its values.  This function returns a new hash
+table containing only the key-value pairs for which the predicate
+@racket[pred] returns true when applied to the values of @racket[ht].
+The resulting hash table retains the mutability and the key comparison
+predicate (e.g., @racket[eq?], @racket[eqv?], @racket[equal-always?],
+@racket[equal?]) of the input hash table @racket[ht].
 
 @examples[
    #:eval the-eval

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -123,8 +123,110 @@
          #hash([one . 1] [two . 2] [three . 3] [four . 4]))
         h))
 
-(test #hash([1 . 0] [2 . 0])
-      hash-filter-keys #hash([1 . 0] [2 . 0] [3 . 0] [4 . 0] [5 . 0]) (λ (k) (< k 3)))
+;; ----------------------------------------
+;; hash-filter, hash-filter-key, and hash-filter-value:
+
+;; Filtering where key is a string and value is 1
+(test (hash "one" 1)
+      hash-filter
+      (hash "one" 1 "two" 2 "three" 3)
+      (λ (k v) (and (string? k) (= v 1))))
+
+;; Filtering where value is "vegetable" and key is a symbol
+(test (hash 'carrot "vegetable")
+      hash-filter
+      (hash 'apple "fruit" 'carrot "vegetable" 'banana "fruit")
+      (λ (k v) (and (symbol? k) (string=? v "vegetable"))))
+
+;; Filtering by key-value pairs where key is a list of numbers and value is a symbol
+(test (hash (list 1 2) 'number-list)
+      hash-filter
+      (hash (list 1 2) 'number-list (list "a" "b") 'letter-list (list 3 4) 'another-number-list)
+      (λ (k v) (and (list? k) (number? (car k)) (symbol? v))))
+
+;; Filtering by key-value pairs where the value is in the list ["hot", "cold"] and key is a symbol
+(test (hash 'summer "hot" 'winter "cold")
+      hash-filter
+      (hash 'spring "warm" 'summer "hot" 'autumn "cool" 'winter "cold")
+      (λ (k v) (and (symbol? k) (member v '("hot" "cold")))))
+
+;; Filtering by key-value pairs where the key is boolean
+(test (hash #t 'truth #f 'falsehood)
+      hash-filter
+      (hash #t 'truth #f 'falsehood 'unknown 'mystery)
+      (λ (k _) (boolean? k)))
+
+;; Filtering by key-value pairs with eq? comparator
+(test (hasheq #t "true")
+      hash-filter
+      (hasheq #f "false" #t "true")
+      (λ (k v) (and (eq? k #t) (string=? v "true"))))
+
+;; Filtering by key-value pairs with eqv? comparator
+(test (hasheqv 2 "two")
+      hash-filter
+      (hasheqv 1 "one" 2 "two")
+      (λ (k v) (and (eqv? k 2) (string=? v "two"))))
+
+;; Mutable hash with equal-always?: filtering by key-value pairs
+(test (make-hashalw (list (cons 'pear "fruit")))
+      hash-filter
+      (make-hashalw (list (cons 'apple "not-fruit") (cons 'pear "fruit")))
+      (λ (k v) (and (equal-always? k 'pear) (string=? v "fruit"))))
+
+;; Immutable hash with equal-always?: filtering by key-value pairs
+(test (make-immutable-hashalw (list (cons 'cherry "fruit")))
+      hash-filter
+      (make-immutable-hashalw (list (cons 'apple "not-fruit") (cons 'cherry "fruit")))
+      (λ (k v) (and (equal-always? k 'cherry) (string=? v "fruit"))))
+
+;; Filtering by key-value pairs in an immutable hash table
+(test (hash (list 1 2) 'pair)
+      hash-filter
+      (hash (list 1 2) 'pair #(3 4) 'vector)
+      (λ (k v) (and (list? k) (symbol? v))))
+
+;; Filtering by key-value pairs in a mutable hash table
+(test (make-hash (list (cons 'b 2)))
+      hash-filter
+      (make-hash (list (cons 'a 1) (cons 'b 2)))
+      (λ (_ v) (> v 1)))
+
+;; Ephemerons with equal comparator
+(test (make-ephemeron-hash (list (cons 'grape "fruit")))
+      hash-filter
+      (make-ephemeron-hash (list (cons 'grape "fruit") (cons 'lettuce "vegetable")))
+      (λ (k v) (and (equal? k 'grape) (string=? v "fruit"))))
+
+;; Ephemerons with eqv comparator
+(test (make-ephemeron-hasheqv (list (cons 3.14 "pi")))
+      hash-filter
+      (make-ephemeron-hasheqv (list (cons 3.14 "pi") (cons 2.71 "e")))
+      (λ (k v) (and (eqv? k 3.14) (string=? v "pi"))))
+
+;; Filtering by key-value pairs in an ephemeron hash table with equal-always?
+(test (make-ephemeron-hashalw (list (cons (list 'a) "list-a")))
+      hash-filter
+      (make-ephemeron-hashalw (list (cons (list 'a) "list-a") (cons (list 'b) "list-b")))
+      (λ (k v) (and (equal? k (list 'a)) (string=? v "list-a"))))
+
+;; Weak hashes with equal comparator
+(test (make-weak-hash (list (cons 'melon "fruit")))
+      hash-filter
+      (make-weak-hash (list (cons 'melon "fruit") (cons 'cucumber "vegetable")))
+      (λ (k v) (and (equal? k 'melon) (string=? v "fruit"))))
+
+;; Weak hashes with eqv comparator
+(test (make-weak-hasheqv (list (cons 1.618 "golden")))
+      hash-filter
+      (make-weak-hasheqv (list (cons 1.618 "golden") (cons 0.618 "silver")))
+      (λ (k v) (and (eqv? k 1.618) (string=? v "golden"))))
+
+;; Filtering by key-value pairs in a weak hash table with equal-always?
+(test (make-weak-hashalw (list (cons 'apple "fruit")))
+      hash-filter
+      (make-weak-hashalw (list (cons 'apple "fruit") (cons 'carrot "vegetable")))
+      (λ (k v) (and (equal-always? k 'apple) (string=? v "fruit"))))
 
 ;; filtering by key with strings
 (test (hash "one" 1)
@@ -180,6 +282,66 @@
       hash-filter-values
       (make-hash (list (cons 'a 1) (cons 'b 2)))
       (λ (v) (> v 1)))
+
+;; Ephemerons: filtering by key
+(test (make-ephemeron-hash (list (cons 'a "ephemeron-a")))
+      hash-filter-keys
+      (make-ephemeron-hash (list (cons 'a "ephemeron-a") (cons 'b "ephemeron-b")))
+      (λ (k) (equal? k 'a)))
+
+;; Ephemerons: filtering by value
+(test (make-ephemeron-hash (list (cons 'b "ephemeron-b")))
+      hash-filter-values
+      (make-ephemeron-hash (list (cons 'a "ephemeron-a") (cons 'b "ephemeron-b")))
+      (λ (v) (string=? v "ephemeron-b")))
+
+;; Weak hashes: filtering by key
+(test (make-weak-hash (list (cons 'apple "fruit")))
+      hash-filter-keys
+      (make-weak-hash (list (cons 'apple "fruit") (cons 'carrot "vegetable")))
+      (λ (k) (symbol? k)))
+
+;; Weak hashes: filtering by value
+(test (make-weak-hash (list (cons 'carrot "vegetable")))
+      hash-filter-values
+      (make-weak-hash (list (cons 'apple "fruit") (cons 'carrot "vegetable")))
+      (λ (v) (string=? v "vegetable")))
+
+;; Ephemerons with eqv?: filtering by key
+(test (make-ephemeron-hasheqv (list (cons 1.0 "one")))
+      hash-filter-keys
+      (make-ephemeron-hasheqv (list (cons 1.0 "one") (cons 2.0 "two")))
+      (λ (k) (eqv? k 1.0)))
+
+;; Weak hashes with eqv?: filtering by value
+(test (make-weak-hasheqv (list (cons 'number 2.0)))
+      hash-filter-values
+      (make-weak-hasheqv (list (cons 'number 2.0) (cons 'string "two")))
+      (λ (v) (eqv? v 2.0)))
+
+;; Ephemeron with equal-always?: filtering by key
+(test (make-ephemeron-hashalw (list (cons (list 'a) "list-a")))
+      hash-filter-keys
+      (make-ephemeron-hashalw (list (cons (list 'a) "list-a") (cons (list 'b) "list-b")))
+      (λ (k) (equal? k (list 'a))))
+
+;; Ephemeron with equal-always?: filtering by value
+(test (make-ephemeron-hashalw (list (cons 'unique (vector 1 2 3))))
+      hash-filter-values
+      (make-ephemeron-hashalw (list (cons 'unique (vector 1 2 3)) (cons 'common (vector 4 5 6))))
+      (λ (v) (equal? v (vector 1 2 3))))
+
+;; Weak hash with equal-always?: filtering by key
+(test (make-weak-hashalw (list (cons 'apple "fruit")))
+      hash-filter-keys
+      (make-weak-hashalw (list (cons 'apple "fruit") (cons 'carrot "vegetable")))
+      (λ (k) (equal-always? k 'apple)))
+
+;; Weak hash with equal-always?: filtering by value
+(test (make-weak-hashalw (list (cons 'carrot "vegetable")))
+      hash-filter-values
+      (make-weak-hashalw (list (cons 'apple "fruit") (cons 'carrot "vegetable")))
+      (λ (v) (equal-always? v "vegetable")))
 
 (let ()
   (struct a (n m)

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -123,6 +123,18 @@
          #hash([one . 1] [two . 2] [three . 3] [four . 4]))
         h))
 
+(test #hash([1 . 0] [2 . 0])
+      hash-filter-keys #hash([1 . 0] [2 . 0] [3 . 0] [4 . 0] [5 . 0]) (λ (k) (< k 3)))
+
+(test #hash()
+      hash-filter-keys #hash() (λ (k) (< k 5)))
+
+(test #hash([1 . 2])
+      hash-filter-values #hash((1 . 2) (2 . 3) (3 . 4) (4 . 5) (5 . 6)) (λ (v) (< v 3)))
+
+(test #hash()
+      hash-filter-values #hash() (λ (v) (< v 5)))
+
 (let ()
   (struct a (n m)
           #:property

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -3,7 +3,7 @@
 
 (Section 'hash)
 
-(require racket/hash)
+(require racket/hash (only-in racket list? number? null? symbol? eq? eqv?))
 
 ;; ----------------------------------------
 ;; Hash-key sorting:

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -178,7 +178,7 @@
 ;; mutable
 (test #hash(['b . 2])
       hash-filter-values
-      '#hash((['a . 1] ['b . 2]))
+      '#hash(['a . 1] ['b . 2])
       (λ (v) (> v 1)))
 
 (let ()

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -132,8 +132,54 @@
 (test #hash([1 . 2])
       hash-filter-values #hash((1 . 2) (2 . 3) (3 . 4) (4 . 5) (5 . 6)) (λ (v) (< v 3)))
 
-(test #hash()
-      hash-filter-values #hash() (λ (v) (< v 5)))
+;; filtering by key with number lists
+(test #hash([(list 1 2) . 'number-list])
+      hash-filter-keys
+      #hash([(list 1 2) . 'number-list] [(list "a" "b") . 'letter-list])
+      (λ (k) (list? k) (number? (car k))))
+
+;; filtering by value with membership in list
+(test #hash(['summer . "hot"] ['winter . "cold"])
+      hash-filter-values
+      #hash(['spring . "warm"] ['summer . "hot"] ['autumn . "cool"] ['winter . "cold"])
+      (λ (v) (member v '("hot" "cold"))))
+
+;; filtering by key with booleans
+(test #hash([#t . 'truth] [#f . 'falsehood])
+      hash-filter-keys
+      #hash([#t . 'truth] [#f . 'falsehood] ['unknown . 'mystery])
+      (λ (k) (boolean? k)))
+
+;; filtering by value with non-empty lists containing symbols
+(test #hash(['nested-list . (list 'a 'b 'c)])
+      hash-filter-values
+      #hash(['flat-list . (list 1 2 3)] ['nested-list . (list 'a 'b 'c)] ['empty-list . '()])
+      (λ (v) (and (list? v) (not (null? v)) (symbol? (car v)))))
+
+;; test alternate equal implementations and for mutability
+;; eq
+(test #hash([#t . "true"])
+      hash-filter-keys
+      #hasheq([#f . "false"] [#t . "true"])
+      (λ (k) (eq? k #t)))
+
+;;eqv
+(test #hash([2 . "two"])
+      hash-filter-values
+      #hasheqv([1 . "one"] [2 . "two"])
+      (λ (v) (eqv? v "two")))
+
+;; immutable
+(test #hash([(list 1 2) . 'pair])
+      hash-filter-keys
+      #hash([(list 1 2) . pair] [#(3 4) . vector])
+      list?)
+
+;; mutable
+(test #hash(['b . 2])
+      hash-filter-values
+      '#hash((['a . 1] ['b . 2]))
+      (λ (v) (> v 1)))
 
 (let ()
   (struct a (n m)

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -139,7 +139,7 @@
       (λ (k v) (and (symbol? k) (string=? v "vegetable"))))
 
 ;; Filtering by key-value pairs where key is a list of numbers and value is a symbol
-(test (hash (list 1 2) 'number-list)
+(test (hash (list 3 4) 'another-number-list (list 1 2) 'number-list)
       hash-filter
       (hash (list 1 2) 'number-list (list "a" "b") 'letter-list (list 3 4) 'another-number-list)
       (λ (k v) (and (list? k) (number? (car k)) (symbol? v))))
@@ -298,7 +298,7 @@
 ;; Weak hashes: filtering by key
 (test (make-weak-hash (list (cons 'apple "fruit")))
       hash-filter-keys
-      (make-weak-hash (list (cons 'apple "fruit") (cons 'carrot "vegetable")))
+      (make-weak-hash (list (cons 'apple "fruit") (cons "carrot" "vegetable")))
       (λ (k) (symbol? k)))
 
 ;; Weak hashes: filtering by value

--- a/pkgs/racket-test-core/tests/racket/hash.rktl
+++ b/pkgs/racket-test-core/tests/racket/hash.rktl
@@ -133,7 +133,7 @@
       (λ (k) (string=? k "one")))
 
 ;; filtering by value with strings
-(test (hash 'apple "fruit" 'banana "fruit")
+(test (hash 'carrot "vegetable")
       hash-filter-values
       (hash 'apple "fruit" 'carrot "vegetable" 'banana "fruit")
       (λ (v) (string=? v "vegetable")))

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -67,7 +67,7 @@
   (cond
     [(immutable? ht)
      (for/fold ([ht ht]) ([(k v) (in-immutable-hash ht)]
-                          #:when (not (pred k v)))
+                          #:unless (pred k v))
        (hash-remove ht k))]
     [else
      (define new-ht (hash-copy-clear ht))

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -1,7 +1,5 @@
 #lang racket/base
-(require racket/contract/base
-         (only-in racket/function curry)
-         (only-in racket/list flatten))
+(require racket/contract/base)
 
 (define ((hash-duplicate-error name) key value1 value2)
   (error name "duplicate values for key ~e: ~e and ~e" key value1 value2))

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -64,30 +64,14 @@
         res)))
 
 (define (hash-filter ht pred)
-  (define constructor
-    (match (map (λ (f) (f ht)) (list immutable? hash-ephemeron? hash-weak? hash-eq? hash-eqv? hash-equal-always?))
-      ;; Ephemerons
-      [(list _ #t _ #t _ _) make-ephemeron-hasheq]
-      [(list _ #t _ _ #t _) make-ephemeron-hasheqv]
-      [(list _ #t _ _ _ #t) make-ephemeron-hashalw]
-      [(list _ #t _ _ _ _) make-ephemeron-hash]
-      ;; Weak Hashes
-      [(list _ _ #t #t _ _) make-weak-hasheq]
-      [(list _ _ #t _ #t _) make-weak-hasheqv]
-      [(list _ _ #t _ _ #t) make-weak-hashalw]
-      [(list _ _ #t _ _ _) make-weak-hash]
-      ;; Immutable Hashes
-      [(list #t _ _ #t _ _) make-immutable-hasheq]
-      [(list #t _ _ _ #t _) make-immutable-hasheqv]
-      [(list #t _ _ _ _ #t) make-immutable-hashalw]
-      [(list #t _ _ _ _ _) make-immutable-hash]
-      ;; Mutable Hashes
-      [(list _ _ _ #t _ _) make-hasheq]
-      [(list _ _ _ _ #t _) make-hasheqv]
-      [(list _ _ _ _ _ #t) make-hashalw]
-      ;; mutable hash with equal? comparator
-      [_ make-hash]))
-  (constructor (for/list ([(k v) (in-hash ht)] #:when (pred k v)) (cons k v))))
+  (cond [(immutable? ht)
+         (for ([(k v) (in-hash ht)])
+           (when (not (pred k v))
+             (set! ht (hash-remove ht k))))]
+        [else
+         (for ([(k v) (in-hash ht)])
+           (when (not (pred k v))
+             (hash-remove! ht k)))]))
 
 (define (hash-filter-keys ht pred)
   (hash-filter ht (lambda (k _) (pred k))))

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -63,6 +63,12 @@
                     (combine/key k v (hash-ref hm k))))
         res)))
 
+(define (hash-filter-values ht pred)
+  (for/hash ([(k v) (in-hash ht)] #:when (pred v)) (values k v)))
+
+(define (hash-filter-keys ht pred)
+  (for/hash ([(k v) (in-hash ht)] #:when (pred k)) (values k v)))
+
 (provide/contract
  [hash-union (->* [(and/c hash? immutable?)]
                   [#:combine
@@ -84,4 +90,6 @@
                         #:combine/key
                         (-> any/c any/c any/c any/c)]
                        #:rest (listof hash?)
-                       (and/c hash? immutable?))])
+                       (and/c hash? immutable?))]
+ [hash-filter-values (-> (hash? procedure?) hash?)]
+ [hash-filter-keys (-> (hash? procedure?) hash?)])

--- a/racket/collects/racket/hash.rkt
+++ b/racket/collects/racket/hash.rkt
@@ -71,7 +71,8 @@
         [else
          (for ([(k v) (in-hash ht)])
            (when (not (pred k v))
-             (hash-remove! ht k)))]))
+             (hash-remove! ht k)))])
+  ht)
 
 (define (hash-filter-keys ht pred)
   (hash-filter ht (lambda (k _) (pred k))))


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Feature
- [x] tests included
- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->

This change adds the following 2 functions to `racket/hash`:
- `hash-filter-keys`: given a hash table and a predicate, return a hash table where the predicate is true for the input hash tables keys
- `hash-filter-values`: the same as for keys, but applies the predicate to the input hash tables values

This is my first contribution to `racket/hash`, please let me know if I am missing anything or if there are broader guidelines for contributing that are applicable here