### PR TITLE
change `chaperone-treelist` to support state-passing and more operations

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.12.0.10")
+(define version "8.12.0.11")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -62,6 +62,20 @@ This operation takes @math{O(N log N)} time to construct a treelist of
 (treelist 1 "a" 'apple)
 ]}
 
+@defproc[(make-treelist [size exact-nonnegative-integer?] [v any/c]) treelist?]{
+
+ Returns a @tech{treelist} with size @racket[size], where
+ every element is @racket[v].
+ This operation takes @math{O(log N)} time to construct a
+ treelist of @math{N} elements.
+
+ @examples[
+ #:eval the-eval
+ (make-treelist 0 'pear)
+ (make-treelist 3 'pear)
+ ]
+
+@history[#:added "8.12.0.11"]}
 
 @deftogether[(
 @defproc[(treelist-empty? [tl treelist?]) boolean?]

--- a/pkgs/racket-test-core/tests/racket/treelist.rktl
+++ b/pkgs/racket-test-core/tests/racket/treelist.rktl
@@ -38,6 +38,19 @@
                       [m '(1 -1)])
         (* i m)))
 
+(test (make-treelist 0 567) "make-treelist 0" (treelist))
+(test (eq? (make-treelist 0 567) (treelist)) "eq make-treelist" #t)
+(test (make-treelist 1 #f) "make-treelist 1" (treelist #f))
+(test (make-treelist 2 #f) "make-treelist 2" (treelist #f #f))
+(test (equal? (make-treelist 100 #f) (vector->treelist (make-vector 100 #f))) "make-treelist 100" #t)
+(test (equal? (make-treelist 100 'other) (vector->treelist (make-vector 100 'other))) "make-treelist 100" #t)
+(test (equal? (make-treelist 101 #f) (vector->treelist (make-vector 101 #f))) "make-treelist 101" #t)
+(test (equal? (make-treelist 1000 #f) (vector->treelist (make-vector 1000 #f))) "make-treelist 1000" #t)
+(test (equal? (make-treelist 1001 #f) (vector->treelist (make-vector 1001 #f))) "make-treelist 1001" #t)
+(test (equal? (make-treelist 10000 #f) (vector->treelist (make-vector 10000 #f))) "make-treelist 10000" #t)
+(test (equal? (make-treelist 10001 #f) (vector->treelist (make-vector 10001 #f))) "make-treelist 10001" #t)
+(test (equal? (make-treelist 12321 #f) (vector->treelist (make-vector 12321 #f))) "make-treelist 12321" #t)
+
 (define-syntax-rule (test-bad (op arg ...))
   (err/rt-test (op arg ...) exn:fail:contract? (regexp (string-append "^"
                                                                       (regexp-quote (symbol->string 'op))

--- a/pkgs/racket-test/tests/racket/contract/treelist.rkt
+++ b/pkgs/racket-test/tests/racket/contract/treelist.rkt
@@ -101,16 +101,139 @@
               'pos
               'neg))
   (test/spec-passed
-   'treelist/c5
+   'treelist/c8
    '(contract (treelist/c (-> integer? integer?) #:lazy? #t)
               (treelist (λ (x) #f))
               'pos
               'neg))
   (test/pos-blame
-   'treelist/c6
+   'treelist/c9
    '((treelist-first
       (contract (treelist/c (-> integer? integer?) #:lazy? #t)
                 (treelist (λ (x) #f))
                 'pos
                 'neg))
-     1)))
+     1))
+  (test/pos-blame
+   'treelist/c10
+   '(treelist-ref
+     (treelist-append
+      (contract (treelist/c number? #:lazy? #t #:flat? #f)
+                (treelist "one")
+                'pos 'neg)
+      (contract (treelist/c number? #:lazy? #t #:flat? #f)
+                (treelist #t)
+                'something 'else))
+     0))
+  (test/pos-blame
+   'treelist/c11
+   '(treelist-ref
+     (treelist-append
+      (contract (treelist/c number? #:lazy? #t #:flat? #f)
+                (treelist "one")
+                'something 'else)
+      (contract (treelist/c number? #:lazy? #t #:flat? #f)
+                (treelist #t)
+                'pos 'neg))
+     1))
+
+  ;; tests that make sure that
+  ;; the contract does not get put
+  ;; onto newly added things in the treelist
+  (test/spec-passed/result
+   'treelist/c-add.set
+   '(treelist-ref
+     (treelist-set
+      (contract
+       (treelist/c number? #:lazy? #t #:flat? #f)
+       (treelist 1 2 3)
+       'pos
+       'neg)
+      0
+      "abc")
+     0)
+   "abc")
+  (test/spec-passed/result
+   'treelist/c-add.insert
+   '(treelist-ref
+     (treelist-insert
+      (contract
+       (treelist/c number? #:lazy? #t #:flat? #f)
+       (treelist 1 2 3)
+       'pos
+       'neg)
+      2
+      "abc")
+     2)
+   "abc")
+  (test/spec-passed/result
+   'treelist/c-add.append
+   '(let ([t
+           (treelist-append
+            (contract
+             (treelist/c number? #:lazy? #t #:flat? #f)
+             (treelist 1 2 3)
+             'pos
+             'neg)
+            (treelist "abc" "def" "ghi"))])
+      (list (treelist-ref t 3)
+            (treelist-ref t 4)
+            (treelist-ref t 5)))
+   (list "abc" "def" "ghi"))
+  (test/spec-passed/result
+   'treelist/c-add.prepend
+   '(let ([t
+           (treelist-append
+            (treelist "abc" "def" "ghi")
+            (contract
+             (treelist/c number? #:lazy? #t #:flat? #f)
+             (treelist 1 2 3)
+             'pos
+             'neg))])
+      (list (treelist-ref t 0)
+            (treelist-ref t 1)
+            (treelist-ref t 2)))
+   (list "abc" "def" "ghi"))
+  (test/spec-passed/result
+   'treelist/c-add.delete
+   '(let ([t
+           (treelist-append
+            (treelist-delete
+             (contract
+              (treelist/c number? #:lazy? #t #:flat? #f)
+              (treelist 1 2 3)
+              'pos
+              'neg)
+             0)
+            (treelist "abc"))])
+      (treelist-ref t 2))
+   "abc")
+  (test/spec-passed/result
+   'treelist/c-add.take
+   '(let ([t
+           (treelist-append
+            (treelist-take
+             (contract
+              (treelist/c number? #:lazy? #t #:flat? #f)
+              (treelist 1 2 3)
+              'pos
+              'neg)
+             2)
+            (treelist "abc"))])
+      (treelist-ref t 2))
+   "abc")
+  (test/spec-passed/result
+   'treelist/c-add.drop
+   '(let ([t
+           (treelist-append
+            (treelist-drop
+             (contract
+              (treelist/c number? #:lazy? #t #:flat? #f)
+              (treelist 1 2 3)
+              'pos
+              'neg)
+             1)
+            (treelist "abc"))])
+      (treelist-ref t 2))
+   "abc")
+  )

--- a/racket/collects/racket/contract/private/treelist.rkt
+++ b/racket/collects/racket/contract/private/treelist.rkt
@@ -118,18 +118,20 @@
       (define blame+neg-party (cons blame neg-party))
       (chaperone-treelist
        val
-       #:state #f
+       #:state (make-treelist (treelist-length val) #t)
        #:ref (λ (tl i val state)
-               (with-contract-continuation-mark
-                 blame+neg-party
-                 (ln+blame val neg-party)))
-       #:set (λ (tl i val state) (values val state))
-       #:insert (λ (tl i val state) (values val state))
-       #:prepend (λ (tl1 tl2 state) (values tl1 state))
-       #:append (λ (tl1 tl2 state) (values tl2 state))
-       #:delete (λ (tl i state) state)
-       #:take (λ (tl n state) state)
-       #:drop (λ (tl n state) state)
+               (if (treelist-ref state i)
+                   (with-contract-continuation-mark
+                       blame+neg-party
+                     (ln+blame val neg-party))
+                   val))
+       #:set (λ (tl i val state) (values val (treelist-set state i #f)))
+       #:insert (λ (tl i val state) (values val (treelist-insert state i #f)))
+       #:append (λ (tl1 tl2 state) (values tl2 (treelist-append state (make-treelist (treelist-length tl2) #f))))
+       #:prepend (λ (tl1 tl2 state) (values tl1 (treelist-append (make-treelist (treelist-length tl2) #f) state)))
+       #:delete (λ (tl i state) (treelist-delete state i))
+       #:take (λ (tl n state) (treelist-take state n))
+       #:drop (λ (tl n state) (treelist-drop state n))
        impersonator-prop:contracted ctc
        impersonator-prop:blame blame))))
 

--- a/racket/collects/racket/contract/private/treelist.rkt
+++ b/racket/collects/racket/contract/private/treelist.rkt
@@ -118,13 +118,18 @@
       (define blame+neg-party (cons blame neg-party))
       (chaperone-treelist
        val
-       (λ (tl i val)
-         (with-contract-continuation-mark
-             blame+neg-party
-           (ln+blame val neg-party)))
-       (λ (tl i val) val)
-       (λ (tl i val) val)
-       (λ (tl1 tl2) tl2)
+       #:state #f
+       #:ref (λ (tl i val state)
+               (with-contract-continuation-mark
+                 blame+neg-party
+                 (ln+blame val neg-party)))
+       #:set (λ (tl i val state) (values val state))
+       #:insert (λ (tl i val state) (values val state))
+       #:prepend (λ (tl1 tl2 state) (values tl1 state))
+       #:append (λ (tl1 tl2 state) (values tl2 state))
+       #:delete (λ (tl i state) state)
+       #:take (λ (tl n state) state)
+       #:drop (λ (tl n state) state)
        impersonator-prop:contracted ctc
        impersonator-prop:blame blame))))
 

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 12
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 10
+#define MZSCHEME_VERSION_W 11
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
Thread a "state" value through interposition procedures for `chaperone-treelist` and family. On each operation that produces an updated treelist, the updated state is associated with the chaperoned result, so that interposition procedures can track the evolution of the wrapped treelist as needed (with no dependence on mutable state).

Previously, operations that remove elements for a treelist had no interposition procedures, but new ones have been added so that they get the opportunity to update the state.

This is a backward-incomptible change within the development sequence, but on the grounds that treelists are new and experimental, anyway.
