### PR TITLE
Skip let-values arity check in unsafe mode.

### DIFF
--- a/racket/src/cs/schemified/io.scm
+++ b/racket/src/cs/schemified/io.scm
@@ -2264,8 +2264,7 @@
         (void)
         (call-with-values
          (lambda () (procedure-keywords f_0))
-         (case-lambda
-          ((required-keywords_0 optional-keywords_0)
+         (lambda (required-keywords_0 optional-keywords_0)
            (let ((app_0
                   (if (pair? required-keywords_0)
                     (string-append
@@ -2367,8 +2366,7 @@
                                            app_5
                                            (loop_0 (cdr ls_1))))))))))
                                (loop_0 ls_0)))))
-                           null))))))))))
-          (args (raise-binding-result-arity-error 2 args))))))))
+                           null)))))))))))))))
 (define gen-map
   (lambda (f_0 ls_0)
     (begin
@@ -5133,8 +5131,7 @@
              #f
              0
              #f))
-          (case-lambda
-           ((used-bytes_0 got-chars_0 state_0)
+          (lambda (used-bytes_0 got-chars_0 state_0)
             (if (eq? state_0 'error)
               #f
               (if just-length?15_0
@@ -5151,8 +5148,7 @@
                      str_0
                      0
                      #f)
-                    str_0)))))
-           (args (raise-binding-result-arity-error 3 args)))))))))
+                    str_0)))))))))))
 (define utf-8-encode!
   (lambda (in-str_0 in-start_0 in-end_0 out-bstr_0 out-start_0 out-end_0)
     (letrec*
@@ -5504,8 +5500,7 @@
                          #f
                          0
                          skip25_0)))
-                    (case-lambda
-                     ((initial-used-bytes_0 initial-got-chars_0 state_0)
+                    (lambda (initial-used-bytes_0 initial-got-chars_0 state_0)
                       (if (eq? state_0 'error)
                         #f
                         (if (eq? state_0 'continues)
@@ -5531,8 +5526,7 @@
                                     str_0
                                     0
                                     1)))
-                               (case-lambda
-                                ((used-bytes_0 got-chars_0 new-state_0)
+                               (lambda (used-bytes_0 got-chars_0 new-state_0)
                                  (if (eq? new-state_0 'error)
                                    #f
                                    (if (let ((or-part_0
@@ -5545,12 +5539,8 @@
                                      (if get-index?21_0
                                        (+ initial-used-bytes_0 start27_0)
                                        (string-ref str_0 0))
-                                     #f)))
-                                (args
-                                 (raise-binding-result-arity-error 3 args))))))
-                          #f)))
-                     (args
-                      (raise-binding-result-arity-error 3 args))))))))))))))
+                                     #f))))))
+                          #f))))))))))))))
 (define 1/bytes-utf-8-ref
   (let ((bytes-utf-8-ref_0
          (|#%name|
@@ -5743,15 +5733,13 @@
                   str47_0)
                  (call-with-values
                   (lambda () (utf-8-encode! str47_0 start49_0 end50_0 #f 0 #f))
-                  (case-lambda
-                   ((used-chars_0 got-bytes_0 status_0)
+                  (lambda (used-chars_0 got-bytes_0 status_0)
                     (if just-length?44_0
                       got-bytes_0
                       (let ((bstr_0 (make-bytes got-bytes_0)))
                         (begin
                           (utf-8-encode! str47_0 start49_0 end50_0 bstr_0 0 #f)
-                          bstr_0))))
-                   (args (raise-binding-result-arity-error 3 args)))))))))))))
+                          bstr_0))))))))))))))
 (define 1/string->bytes/utf-8
   (let ((string->bytes/utf-8_0
          (|#%name|
@@ -6401,8 +6389,7 @@
                                       #f
                                       0
                                       #f)))
-                                 (case-lambda
-                                  ((used-bytes_0 got-chars_0 new-state_0)
+                                 (lambda (used-bytes_0 got-chars_0 new-state_0)
                                    (let ((delta-chars_0
                                           (-
                                            got-chars_0
@@ -6442,11 +6429,7 @@
                                             app_0
                                             app_1
                                             (keep-aborts_0 new-state_0)
-                                            #f))))))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    3
-                                    args)))))))))
+                                            #f))))))))))))
                       (if (= i_0 end_0)
                         (if (zero? span_0)
                           (begin
@@ -6944,8 +6927,7 @@
                   (begin
                     (call-with-values
                      (lambda () (poll-commit-liveness reqs_0 resps_0))
-                     (case-lambda
-                      ((live-reqs_0 new-resps_0)
+                     (lambda (live-reqs_0 new-resps_0)
                        (let ((live-resps_0 (drop-abandoned new-resps_0)))
                          (let ((app_0
                                 (handle-evt
@@ -7058,8 +7040,9 @@
                                                      fold-var_1
                                                      rest_0))))
                                               fold-var_0))))))
-                                     (for-loop_0 null live-resps_0)))))))))))
-                      (args (raise-binding-result-arity-error 2 args)))))))))
+                                     (for-loop_0
+                                      null
+                                      live-resps_0)))))))))))))))))
              (loop_0 '() '())))))))))
 (define poll-commit-liveness
   (lambda (reqs_0 resps_0)
@@ -8620,11 +8603,9 @@
                 (call-with-values
                  (lambda ()
                    (make-pipe-ends limit24_0 input-name25_0 output-name26_0))
-                 (case-lambda
-                  ((ip_0 op_0)
+                 (lambda (ip_0 op_0)
                    (let ((app_0 (finish-port/count ip_0)))
-                     (values app_0 (finish-port/count op_0))))
-                  (args (raise-binding-result-arity-error 2 args))))))))))
+                     (values app_0 (finish-port/count op_0)))))))))))
     (|#%name|
      make-pipe
      (case-lambda
@@ -10532,8 +10513,7 @@
              src-start669_0
              src-end670_0
              1))
-          (case-lambda
-           ((v*_0 start*_0 stop*_0 step*_0)
+          (lambda (v*_0 start*_0 stop*_0 step*_0)
             (letrec*
              ((for-loop_0
                (|#%name|
@@ -10556,8 +10536,7 @@
                                   (void))
                                 (if newline?_0 (values) (next-k-proc_0)))))))
                       (values)))))))
-             (for-loop_0 start*_0)))
-           (args (raise-binding-result-arity-error 4 args))))
+             (for-loop_0 start*_0))))
          (void))))))
 (define temp21.1
   (|#%name|
@@ -12851,8 +12830,7 @@
                          str15_0
                          start16_0
                          temp95_0)))
-                    (case-lambda
-                     ((used-bytes_0 got-chars_0 state_0)
+                    (lambda (used-bytes_0 got-chars_0 state_0)
                       (let ((actually-used-bytes_0
                              (-
                               used-bytes_0
@@ -12922,8 +12900,9 @@
                                                       str15_0
                                                       start_0
                                                       temp111_1))))))))
-                                       (case-lambda
-                                        ((used-bytes_1 got-chars_1 new-state_0)
+                                       (lambda (used-bytes_1
+                                                got-chars_1
+                                                new-state_0)
                                          (if (zero? got-chars_1)
                                            (let ((app_0 (+ skip-k_0 v_1)))
                                              (loop_0
@@ -12995,11 +12974,7 @@
                                                         discard-bytes_0))))
                                                  (values
                                                   (+ total-chars_0 got-chars_1)
-                                                  actually-used-bytes_1))))))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          3
-                                          args)))))))))))
+                                                  actually-used-bytes_1))))))))))))))
                            (let ((app_0 (+ skip5_0 (- v_0 consumed-v_0))))
                              (let ((app_1 (+ start16_0 got-chars_0)))
                                (loop_0
@@ -13020,9 +12995,9 @@
                                bstr_0
                                0
                                (- actually-used-bytes_0 consumed-v_0)))
-                            (values got-chars_0 actually-used-bytes_0)))))
-                     (args
-                      (raise-binding-result-arity-error 3 args))))))))))))))
+                            (values
+                             got-chars_0
+                             actually-used-bytes_0))))))))))))))))
 (define do-read-string!.1
   (|#%name|
    do-read-string!
@@ -13050,8 +13025,7 @@
              str27_0
              start28_0
              end29_0))
-          (case-lambda
-           ((v_0 used-bytes_0)
+          (lambda (v_0 used-bytes_0)
             (if (not (exact-integer? v_0))
               v_0
               (if (= v_0 amt_0)
@@ -13082,8 +13056,7 @@
                                   str27_0
                                   temp126_1
                                   end29_0)))))
-                         (case-lambda
-                          ((v_1 used-bytes_1)
+                         (lambda (v_1 used-bytes_1)
                            (if (eof-object? v_1)
                              got_0
                              (let ((new-got_0 (+ got_0 v_1)))
@@ -13091,11 +13064,10 @@
                                  amt_0
                                  (loop_0
                                   new-got_0
-                                  (+ total-used-bytes_0 used-bytes_1))))))
-                          (args
-                           (raise-binding-result-arity-error 2 args)))))))))
-                 (loop_0 v_0 used-bytes_0)))))
-           (args (raise-binding-result-arity-error 2 args)))))))))
+                                  (+
+                                   total-used-bytes_0
+                                   used-bytes_1))))))))))))
+                 (loop_0 v_0 used-bytes_0)))))))))))
 (define read-char-via-read-byte.1
   (|#%name|
    read-char-via-read-byte
@@ -13110,8 +13082,7 @@
                (integer->char b_0)
                (call-with-values
                 (lambda () (utf-8-decode-byte b_0 0 0))
-                (case-lambda
-                 ((accum_0 remaining_0 state_0)
+                (lambda (accum_0 remaining_0 state_0)
                   (if (eq? state_0 'error)
                     '#\xfffd
                     (letrec*
@@ -13127,8 +13098,9 @@
                                 (call-with-values
                                  (lambda ()
                                    (utf-8-decode-byte b_1 accum_1 remaining_1))
-                                 (case-lambda
-                                  ((next-accum_0 next-remaining_0 state_1)
+                                 (lambda (next-accum_0
+                                          next-remaining_0
+                                          state_1)
                                    (if (eq? state_1 'complete)
                                      (begin
                                        (letrec*
@@ -13153,13 +13125,8 @@
                                        (loop_0
                                         (fx+ 1 skip-k_0)
                                         next-accum_0
-                                        next-remaining_0))))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    3
-                                    args)))))))))))
-                     (loop_0 0 accum_0 remaining_0))))
-                 (args (raise-binding-result-arity-error 3 args))))))))))))
+                                        next-remaining_0))))))))))))
+                     (loop_0 0 accum_0 remaining_0)))))))))))))
 (define read-a-char.1
   (|#%name|
    read-a-char
@@ -13716,16 +13683,14 @@
         (let ((special_0
                (call-with-values
                 (lambda () (1/port-next-location in_0))
-                (case-lambda
-                 ((line_0 col_0 pos_0)
+                (lambda (line_0 col_0 pos_0)
                   (let ((app_0 (if col_0 (+ col_0 delta_0) #f)))
                     (|#%app|
                      v_0
                      source-name_0
                      line_0
                      app_0
-                     (if pos_0 (+ pos_0 delta_0) #f))))
-                 (args (raise-binding-result-arity-error 3 args))))))
+                     (if pos_0 (+ pos_0 delta_0) #f)))))))
           (if special-wrap_0 (|#%app| special-wrap_0 special_0) special_0)))
       v_0)))
 (define special-wrap-for-peek?
@@ -15141,8 +15106,7 @@
                       dest_0
                       dest-start_0
                       dest-end_0)))))))
-         (case-lambda
-          ((in-consumed_0 out-produced_0 status_0)
+         (lambda (in-consumed_0 out-produced_0 status_0)
            (values
             in-consumed_0
             out-produced_0
@@ -15150,8 +15114,7 @@
               29
               (if (eq? status_0 'aborts)
                 30
-                (if (eq? status_0 'continues) 28 #f)))))
-          (args (raise-binding-result-arity-error 3 args))))))))
+                (if (eq? status_0 'continues) 28 #f))))))))))
 (define utf-8-ish-reencode!.1
   (|#%name|
    utf-8-ish-reencode!
@@ -16458,12 +16421,8 @@
                               dest-start-pos10_0
                               dest-end-pos_0
                               6))
-                           (case-lambda
-                            ((bstr_0 used_0 status_0) (values bstr_0 status_0))
-                            (args
-                             (raise-binding-result-arity-error
-                              3
-                              args)))))))))))))))
+                           (lambda (bstr_0 used_0 status_0)
+                             (values bstr_0 status_0))))))))))))))
     (|#%name|
      bytes-convert-end
      (case-lambda
@@ -16555,8 +16514,7 @@
                         use-dest-bstr_1
                         use-dest-start-pos_0
                         use-dest-end-pos_0))
-                     (case-lambda
-                      ((in-consumed_0 out-produced_0 err_0)
+                     (lambda (in-consumed_0 out-produced_0 err_0)
                        (if (if (eqv? err_0 28)
                              (if (not dest-bstr_0) (not dest-end-pos_0) #f)
                              #f)
@@ -16604,8 +16562,7 @@
                                       'continues
                                       (if (eqv? err_0 31)
                                         'error
-                                        'complete))))))))))
-                      (args (raise-binding-result-arity-error 3 args)))))))))
+                                        'complete))))))))))))))))
              (loop_0
               use-dest-bstr_0
               src-start-pos_0
@@ -16671,8 +16628,7 @@
                   start_0
                   end_0
                   1))
-               (case-lambda
-                ((v*_0 start*_0 stop*_0 step*_0)
+               (lambda (v*_0 start*_0 stop*_0 step*_0)
                  (let ((start_1 0))
                    (let ((end_1 len_0))
                      (let ((inc_0 4))
@@ -16731,8 +16687,7 @@
                                           (unsafe-fx+ idx_0 1)
                                           (+ pos_0 inc_0))))
                                      (values)))))))
-                            (for-loop_0 start*_1 start_2))))))))
-                (args (raise-binding-result-arity-error 4 args))))
+                            (for-loop_0 start*_1 start_2)))))))))
               (void))
             (begin
               (call-with-values
@@ -16743,8 +16698,7 @@
                   start_0
                   end_0
                   1))
-               (case-lambda
-                ((v*_0 start*_0 stop*_0 step*_0)
+               (lambda (v*_0 start*_0 stop*_0 step*_0)
                  (let ((start_1 0))
                    (let ((end_1 len_0))
                      (let ((inc_0 4))
@@ -16803,8 +16757,7 @@
                                           (unsafe-fx+ idx_0 1)
                                           (+ pos_0 inc_0))))
                                      (values)))))))
-                            (for-loop_0 start*_1 start_2))))))))
-                (args (raise-binding-result-arity-error 4 args))))
+                            (for-loop_0 start*_1 start_2)))))))))
               (void)))
           bstr_0)))))
 (define finish_1919
@@ -16994,8 +16947,7 @@
                                      (call-with-values
                                       (lambda ()
                                         (1/bytes-convert c_0 in-bstr_0 pos_0))
-                                      (case-lambda
-                                       ((bstr_0 in-used_0 status_0)
+                                      (lambda (bstr_0 in-used_0 status_0)
                                         (if (eq? status_0 'complete)
                                           (if (eqv? pos_0 0)
                                             bstr_0
@@ -17030,11 +16982,7 @@
                                                      bstr_0
                                                      (cons
                                                       err-bstr_0
-                                                      r_0)))))))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         3
-                                         args)))))))))
+                                                      r_0)))))))))))))))
                               (loop_0 0))))
                          (lambda ()
                            (let ((c_1 c_0))
@@ -17119,8 +17067,7 @@
                                    (call-with-values
                                     (lambda ()
                                       (1/bytes-convert c_0 in-bstr8_0 pos_0))
-                                    (case-lambda
-                                     ((bstr_0 in-used_0 status_0)
+                                    (lambda (bstr_0 in-used_0 status_0)
                                       (if (eq? status_0 'complete)
                                         (if (eqv? pos_0 0)
                                           (1/bytes->string/utf-8 bstr_0)
@@ -17155,11 +17102,7 @@
                                                    bstr_0
                                                    (cons
                                                     err-bstr_0
-                                                    r_0)))))))))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       3
-                                       args)))))))))
+                                                    r_0)))))))))))))))
                             (loop_0 0)))
                          (lambda ()
                            (let ((c_1 c_0))
@@ -17284,8 +17227,7 @@
     (if (string? s_0)
       (call-with-values
        (lambda () (begin (values s_0 (unsafe-string-length s_0))))
-       (case-lambda
-        ((vec_0 len_0)
+       (lambda (vec_0 len_0)
          (letrec*
           ((for-loop_0
             (|#%name|
@@ -17303,8 +17245,7 @@
                          (for-loop_0 result_1 (unsafe-fx+ 1 pos_0))
                          result_1)))
                    result_0))))))
-          (for-loop_0 #t 0)))
-        (args (raise-binding-result-arity-error 2 args))))
+          (for-loop_0 #t 0))))
       #f)))
 (define string->path$1
   (|#%name|
@@ -17333,8 +17274,7 @@
         (void))
       (call-with-values
        (lambda () (begin (values s_0 (unsafe-string-length s_0))))
-       (case-lambda
-        ((vec_0 len_0)
+       (lambda (vec_0 len_0)
          (letrec*
           ((for-loop_0
             (|#%name|
@@ -17353,8 +17293,7 @@
                          (void))
                        (for-loop_0 (unsafe-fx+ 1 pos_0))))
                    (values)))))))
-          (for-loop_0 0)))
-        (args (raise-binding-result-arity-error 2 args))))
+          (for-loop_0 0))))
       (void))))
 (define check-path-bytes
   (lambda (who_0 s_0)
@@ -17364,8 +17303,7 @@
         (void))
       (call-with-values
        (lambda () (begin (values s_0 (unsafe-bytes-length s_0))))
-       (case-lambda
-        ((vec_0 len_0)
+       (lambda (vec_0 len_0)
          (letrec*
           ((for-loop_0
             (|#%name|
@@ -17384,8 +17322,7 @@
                          (void))
                        (for-loop_0 (unsafe-fx+ 1 pos_0))))
                    (values)))))))
-          (for-loop_0 0)))
-        (args (raise-binding-result-arity-error 2 args))))
+          (for-loop_0 0))))
       (void))))
 (define check-path-argument
   (lambda (who_0 p_0)
@@ -17481,8 +17418,7 @@
                                                            fn_0
                                                            (unsafe-string-length
                                                             fn_0))))
-                                                      (case-lambda
-                                                       ((vec_0 len_1)
+                                                      (lambda (vec_0 len_1)
                                                         (call-with-values
                                                          (lambda ()
                                                            (let ((vec_1
@@ -17492,8 +17428,7 @@
                                                                 vec_1
                                                                 (unsafe-bytes-length
                                                                  vec_1)))))
-                                                         (case-lambda
-                                                          ((vec_1 len_2)
+                                                         (lambda (vec_1 len_2)
                                                            (let ((vec_2 vec_0)
                                                                  (len_3 len_1))
                                                              (letrec*
@@ -17565,15 +17500,7 @@
                                                               (for-loop_1
                                                                #t
                                                                0
-                                                               0))))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))
+                                                               0)))))))
                                                    (let ((or-part_0
                                                           (= len_0 fn-len_0)))
                                                      (if or-part_0
@@ -17602,11 +17529,10 @@
                                                                    fn-len_0
                                                                    #f
                                                                    1))
-                                                                (case-lambda
-                                                                 ((v*_0
-                                                                   start*_0
-                                                                   stop*_0
-                                                                   step*_0)
+                                                                (lambda (v*_0
+                                                                         start*_0
+                                                                         stop*_0
+                                                                         step*_0)
                                                                   (letrec*
                                                                    ((for-loop_1
                                                                      (|#%name|
@@ -17651,11 +17577,7 @@
                                                                             result_1))))))
                                                                    (for-loop_1
                                                                     #t
-                                                                    start*_0)))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   4
-                                                                   args))))))))))
+                                                                    start*_0))))))))))
                                                    #f)
                                                  #f))))
                                         (values result_1))))
@@ -17694,14 +17616,12 @@
   (lambda (bstr_0)
     (call-with-values
      (lambda () (parse-backslash-backslash-questionmark bstr_0))
-     (case-lambda
-      ((kind_0
-        drive-end-pos_0
-        orig-drive-end-pos_0
-        clean-start-pos_0
-        add-sep-pos_0)
-       kind_0)
-      (args (raise-binding-result-arity-error 5 args))))))
+     (lambda (kind_0
+              drive-end-pos_0
+              orig-drive-end-pos_0
+              clean-start-pos_0
+              add-sep-pos_0)
+       kind_0))))
 (define parse-backslash-backslash-questionmark
   (lambda (bstr_0)
     (if (not (backslash-backslash-questionmark? bstr_0))
@@ -18052,11 +17972,10 @@
                                                                             j_5)
                                                                            #f
                                                                            1))
-                                                                        (case-lambda
-                                                                         ((v*_0
-                                                                           start*_0
-                                                                           stop*_0
-                                                                           step*_0)
+                                                                        (lambda (v*_0
+                                                                                 start*_0
+                                                                                 stop*_0
+                                                                                 step*_0)
                                                                           (letrec*
                                                                            ((for-loop_0
                                                                              (|#%name|
@@ -18095,11 +18014,7 @@
                                                                                     result_0))))))
                                                                            (for-loop_0
                                                                             #t
-                                                                            start*_0)))
-                                                                         (args
-                                                                          (raise-binding-result-arity-error
-                                                                           4
-                                                                           args))))))
+                                                                            start*_0))))))
                                                                  j_5
                                                                  #f)
                                                                (loop_2
@@ -18157,10 +18072,12 @@
     (if (backslash-backslash-questionmark? bstr_0)
       (call-with-values
        (lambda () (parse-backslash-backslash-questionmark bstr_0))
-       (case-lambda
-        ((kind_0 drive-len_0 orig-drive-len_0 clean-start-pos_0 add-sep-pos_0)
-         (subbytes bstr_0 0 drive-len_0))
-        (args (raise-binding-result-arity-error 5 args))))
+       (lambda (kind_0
+                drive-len_0
+                orig-drive-len_0
+                clean-start-pos_0
+                add-sep-pos_0)
+         (subbytes bstr_0 0 drive-len_0)))
       (let ((c3_0 (parse-unc.1 #f #f bstr_0 0)))
         (if c3_0
           (subbytes bstr_0 0 c3_0)
@@ -18211,16 +18128,14 @@
   (lambda (bstr_0)
     (call-with-values
      (lambda () (parse-backslash-backslash-questionmark bstr_0))
-     (case-lambda
-      ((kind_0
-        drive-end-pos_0
-        orig-drive-end-pos_0
-        clean-start-pos_0
-        add-sep-pos_0)
+     (lambda (kind_0
+              drive-end-pos_0
+              orig-drive-end-pos_0
+              clean-start-pos_0
+              add-sep-pos_0)
        (if (eq? kind_0 'rel)
          (subbytes bstr_0 (if (eqv? (unsafe-bytes-ref bstr_0 8) 92) 9 8))
-         bstr_0))
-      (args (raise-binding-result-arity-error 5 args))))))
+         bstr_0)))))
 (define check-path-test-argument
   (lambda (who_0 p_0)
     (if (let ((or-part_0 (1/path? p_0)))
@@ -20036,8 +19951,7 @@
              (if (call-with-values
                   (lambda ()
                     (begin (values str_0 (unsafe-string-length str_0))))
-                  (case-lambda
-                   ((vec_0 len_0)
+                  (lambda (vec_0 len_0)
                     (let ((start_0 0))
                       (let ((vec_1 vec_0) (len_1 len_0))
                         (begin
@@ -20068,8 +19982,7 @@
                                            (+ pos_1 1))
                                           result_1)))
                                     result_0))))))
-                           (for-loop_0 #t 0 start_0))))))
-                   (args (raise-binding-result-arity-error 2 args))))
+                           (for-loop_0 #t 0 start_0)))))))
                (if (if for-keyword?11_0
                      for-keyword?11_0
                      (if for-type?9_0
@@ -20093,8 +20006,7 @@
                        (call-with-values
                         (lambda ()
                           (begin (values str_0 (unsafe-string-length str_0))))
-                        (case-lambda
-                         ((vec_0 len_0)
+                        (lambda (vec_0 len_0)
                           (letrec*
                            ((for-loop_0
                              (|#%name|
@@ -20117,8 +20029,7 @@
                                            (unsafe-fx+ 1 pos_0))
                                           result_1)))
                                     result_0))))))
-                           (for-loop_0 #f 0)))
-                         (args (raise-binding-result-arity-error 2 args))))))
+                           (for-loop_0 #f 0))))))
                  (let ((len_0 (string-length str_0)))
                    (apply
                     string-append
@@ -20375,8 +20286,7 @@
                       (call-with-values
                        (lambda ()
                          (begin (values v_1 (unsafe-vector-length v_1))))
-                       (case-lambda
-                        ((vec_0 len_0)
+                       (lambda (vec_0 len_0)
                          (letrec*
                           ((for-loop_0
                             (|#%name|
@@ -20401,8 +20311,7 @@
                                                  fuel_3)))
                                            (next-k-proc_0 fuel_4)))))
                                    fuel_3))))))
-                          (for-loop_0 fuel_2 0)))
-                        (args (raise-binding-result-arity-error 2 args)))))
+                          (for-loop_0 fuel_2 0)))))
                     #f)
                   (if (if (box? v_1) (config-get config_0 1/print-box) #f)
                     (if (not print-graph?_0)
@@ -20640,8 +20549,7 @@
                                                    v_1
                                                    (unsafe-vector-length
                                                     v_1))))
-                                              (case-lambda
-                                               ((vec_0 len_0)
+                                              (lambda (vec_0 len_0)
                                                 (letrec*
                                                  ((for-loop_0
                                                    (|#%name|
@@ -20672,11 +20580,7 @@
                                                                 1
                                                                 pos_0))))
                                                           unquoted?_0))))))
-                                                 (for-loop_0 #f 0)))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args))))))
+                                                 (for-loop_0 #f 0))))))
                                         (done!_0 v_1 unquoted?_0)))
                                     (if (if (box? v_1)
                                           (config-get config_0 1/print-box)
@@ -20871,9 +20775,8 @@
                                                                         vec_0
                                                                         (unsafe-vector-length
                                                                          vec_0)))))
-                                                                 (case-lambda
-                                                                  ((vec_0
-                                                                    len_0)
+                                                                 (lambda (vec_0
+                                                                          len_0)
                                                                    (letrec*
                                                                     ((for-loop_0
                                                                       (|#%name|
@@ -20907,11 +20810,7 @@
                                                                              unquoted?_0))))))
                                                                     (for-loop_0
                                                                      #f
-                                                                     0)))
-                                                                  (args
-                                                                   (raise-binding-result-arity-error
-                                                                    2
-                                                                    args))))))
+                                                                     0))))))
                                                            (if or-part_0
                                                              or-part_0
                                                              (if (eq? mode_1 0)
@@ -23454,12 +23353,11 @@
                                      (lambda ()
                                        (parse-backslash-backslash-questionmark
                                         bstr_0))
-                                     (case-lambda
-                                      ((kind_0
-                                        drive-len_0
-                                        orig-drive-len_0
-                                        clean-start-pos_0
-                                        add-sep-pos_0)
+                                     (lambda (kind_0
+                                              drive-len_0
+                                              orig-drive-len_0
+                                              clean-start-pos_0
+                                              add-sep-pos_0)
                                        (let ((or-part_0 (eq? kind_0 'abs)))
                                          (let ((abs?_0
                                                 (if or-part_0
@@ -23472,11 +23370,7 @@
                                               (just-backslashes-after?
                                                bstr_0
                                                drive-len_0)
-                                              #f)))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        5
-                                        args))))
+                                              #f))))))
                                     (let ((c1_0 (parse-unc.1 #f #f bstr_0 0)))
                                       (if c1_0
                                         (combine_0
@@ -23558,8 +23452,7 @@
          (backslash-backslash-questionmark-dot-ups-end
           bstr_0
           (unsafe-bytes-length bstr_0)))
-       (case-lambda
-        ((dots-end_0 literal-start_0)
+       (lambda (dots-end_0 literal-start_0)
          (let ((app_0 (extract-dot-ups bstr_0 8 (if dots-end_0 dots-end_0 8))))
            (append
             app_0
@@ -23567,8 +23460,7 @@
              #t
              keep-trailing-separator?_0
              bstr_0
-             literal-start_0))))
-        (args (raise-binding-result-arity-error 2 args))))
+             literal-start_0)))))
       (extract-separate-parts.1 #f keep-trailing-separator?_0 bstr_0 0))))
 (define as-bytes
   (lambda (p_0)
@@ -23582,8 +23474,7 @@
     (call-with-values
      (lambda ()
        (unsafe-normalise-inputs unsafe-bytes-length bstr_0 drive-len_0 #f 1))
-     (case-lambda
-      ((v*_0 start*_0 stop*_0 step*_0)
+     (lambda (v*_0 start*_0 stop*_0 step*_0)
        (letrec*
         ((for-loop_0
           (|#%name|
@@ -23601,15 +23492,13 @@
                        (for-loop_0 result_1 (unsafe-fx+ idx_0 1))
                        result_1)))
                  result_0))))))
-        (for-loop_0 #t start*_0)))
-      (args (raise-binding-result-arity-error 4 args))))))
+        (for-loop_0 #t start*_0))))))
 (define just-backslashes-after?
   (lambda (bstr_0 drive-len_0)
     (call-with-values
      (lambda ()
        (unsafe-normalise-inputs unsafe-bytes-length bstr_0 drive-len_0 #f 1))
-     (case-lambda
-      ((v*_0 start*_0 stop*_0 step*_0)
+     (lambda (v*_0 start*_0 stop*_0 step*_0)
        (letrec*
         ((for-loop_0
           (|#%name|
@@ -23626,8 +23515,7 @@
                          (for-loop_0 result_2 (unsafe-fx+ idx_0 1))
                          result_2))))
                  result_0))))))
-        (for-loop_0 #t start*_0)))
-      (args (raise-binding-result-arity-error 4 args))))))
+        (for-loop_0 #t start*_0))))))
 (define drive?
   (lambda (s_0)
     (if (starting-point? s_0)
@@ -23846,8 +23734,11 @@
     (if (backslash-backslash-questionmark? bstr_0)
       (call-with-values
        (lambda () (parse-backslash-backslash-questionmark bstr_0))
-       (case-lambda
-        ((kind_0 drive-len_0 orig-drive-len_0 clean-start-pos_0 add-sep_0)
+       (lambda (kind_0
+                drive-len_0
+                orig-drive-len_0
+                clean-start-pos_0
+                add-sep_0)
          (if (if (eq? kind_0 'abs) #t (eq? kind_0 'unc))
            (let ((app_0
                   (1/reverse
@@ -23878,8 +23769,7 @@
               (backslash-backslash-questionmark-dot-ups-end
                bstr_0
                (unsafe-bytes-length bstr_0)))
-            (case-lambda
-             ((dots-end_0 literal-start_0)
+            (lambda (dots-end_0 literal-start_0)
               (let ((app_0
                      (1/reverse
                       (extract-separate-parts.1
@@ -23898,9 +23788,7 @@
                       unsafe-undefined
                       kind_0
                       bstr_0
-                      temp72_0))))))
-             (args (raise-binding-result-arity-error 2 args))))))
-        (args (raise-binding-result-arity-error 5 args))))
+                      temp72_0))))))))))
       (let ((c3_0 (parse-unc.1 #f #f bstr_0 0)))
         (if c3_0
           (call-with-values
@@ -23909,8 +23797,7 @@
                     (let ((temp77_0 (subbytes bstr_0 0 c3_0)))
                       (extract-separate-parts.1 #f #f temp77_0 0))))
                (let ((app_0 (car l_0))) (values app_0 (cadr l_0)))))
-           (case-lambda
-            ((machine_0 volume_0)
+           (lambda (machine_0 volume_0)
              (let ((app_0
                     (1/reverse
                      (let ((temp79_0
@@ -23931,8 +23818,7 @@
                      unsafe-undefined
                      'unc
                      unc-bstr_0
-                     unc-len_0))))))
-            (args (raise-binding-result-arity-error 2 args))))
+                     unc-len_0)))))))
           (if (bytes=? #vu8(46) bstr_0)
             (let ((temp87_0 #vu8(92 92 63 92 82 69 76)))
               (make-starting-point.1 #t #f #vu8() unsafe-undefined 'rel temp87_0 7))
@@ -24277,12 +24163,11 @@
                 (call-with-values
                  (lambda ()
                    (parse-backslash-backslash-questionmark (path-bytes p_0)))
-                 (case-lambda
-                  ((kind_0
-                    drive-len_0
-                    orig-drive-len_0
-                    clean-start-pos_0
-                    sep-bstr_0)
+                 (lambda (kind_0
+                          drive-len_0
+                          orig-drive-len_0
+                          clean-start-pos_0
+                          sep-bstr_0)
                    (if clean-start-pos_0
                      (return_0
                       (clean-double-slashes.1
@@ -24296,8 +24181,7 @@
                         (backslash-backslash-questionmark-dot-ups-end
                          bstr_0
                          (unsafe-bytes-length bstr_0)))
-                      (case-lambda
-                       ((dots-end_0 literal-start_0)
+                      (lambda (dots-end_0 literal-start_0)
                         (let ((new-bstr_0
                                (clean-double-slashes.1
                                 #t
@@ -24334,9 +24218,7 @@
                                     #vu8(92)
                                     (subbytes
                                      new-bstr_0
-                                     literal-start_0)))))))))
-                       (args (raise-binding-result-arity-error 2 args))))))
-                  (args (raise-binding-result-arity-error 5 args))))
+                                     literal-start_0)))))))))))))
                 (let ((c1_0 (parse-unc.1 #f #f bstr_0 0)))
                   (if c1_0
                     (return_0
@@ -24432,8 +24314,7 @@
                           to-backslash-from2_0
                           #f
                           1))
-                       (case-lambda
-                        ((v*_0 start*_0 stop*_0 step*_0)
+                       (lambda (v*_0 start*_0 stop*_0 step*_0)
                          (letrec*
                           ((for-loop_0
                             (|#%name|
@@ -24454,8 +24335,7 @@
                                             (unsafe-fx+ idx_0 1))
                                            result_2))))
                                    result_0))))))
-                          (for-loop_0 #f start*_0)))
-                        (args (raise-binding-result-arity-error 4 args)))))))
+                          (for-loop_0 #f start*_0)))))))
                  #f)
              bstr5_0
              (let ((new-bstr_0
@@ -24628,8 +24508,7 @@
                  #f)
              (call-with-values
               (lambda () (parse-//?-drive bstr_0))
-              (case-lambda
-               ((//?-kind_0 //?-drive-end_0 //?-orig-drive-end_0)
+              (lambda (//?-kind_0 //?-drive-end_0 //?-orig-drive-end_0)
                 (if //?-kind_0
                   (if (let ((or-part_0 (eq? //?-kind_0 'rel)))
                         (if or-part_0 or-part_0 (eq? //?-kind_0 'red)))
@@ -24676,8 +24555,7 @@
                        #f
                        #f
                        #f
-                       p3_0)))))
-               (args (raise-binding-result-arity-error 3 args))))
+                       p3_0))))))
              (if (if (>= (unsafe-bytes-length bstr_0) 2)
                    (if (drive-letter? (unsafe-bytes-ref bstr_0 0))
                      (eq? (unsafe-bytes-ref bstr_0 1) 58)
@@ -24759,8 +24637,7 @@
                                   (loop_0 (sub1 i_0) #t))
                                 (loop_0 (sub1 i_0) ends-sep?_0)))))))))
                    (loop_0 (sub1 len_0) #f)))
-                (case-lambda
-                 ((split-pos_0 ends-sep?_0)
+                (lambda (split-pos_0 ends-sep?_0)
                   (if (not split-pos_0)
                     (if (let ((or-part_0
                                (is-sep?
@@ -24781,12 +24658,10 @@
                           len_0
                           0
                           convention_0))
-                       (case-lambda
-                        ((name_0 is-dir?_0)
+                       (lambda (name_0 is-dir?_0)
                          (if explode?11_0
                            (list name_0)
-                           (values 'relative name_0 is-dir?_0)))
-                        (args (raise-binding-result-arity-error 2 args)))))
+                           (values 'relative name_0 is-dir?_0)))))
                     (call-with-values
                      (lambda ()
                        (let ((temp72_0 (add1 split-pos_0)))
@@ -24797,8 +24672,7 @@
                           len_0
                           temp72_0
                           convention_0)))
-                     (case-lambda
-                      ((name_0 is-dir?_0)
+                     (lambda (name_0 is-dir?_0)
                        (if (zero? split-pos_0)
                          (let ((base_0
                                 (if (eq? (unsafe-bytes-ref bstr_0 0) '#\x2f)
@@ -24817,8 +24691,7 @@
                                (if (= len_1 drive-end6_0)
                                  keep-drive-end_0
                                  len_1))))
-                          (case-lambda
-                           ((exposed-bstr_0 exposed-len_0)
+                          (lambda (exposed-bstr_0 exposed-len_0)
                             (if explode?11_0
                               (cons
                                name_0
@@ -24837,10 +24710,10 @@
                                      (path1.1
                                       (subbytes exposed-bstr_0 0 exposed-len_0)
                                       convention_0)))
-                                (values base_0 name_0 is-dir?_0))))
-                           (args (raise-binding-result-arity-error 2 args))))))
-                      (args (raise-binding-result-arity-error 2 args))))))
-                 (args (raise-binding-result-arity-error 2 args))))))))))))
+                                (values
+                                 base_0
+                                 name_0
+                                 is-dir?_0)))))))))))))))))))
 (define split-tail.1
   (|#%name|
    split-tail
@@ -24892,10 +24765,12 @@
   (lambda (bstr_0)
     (call-with-values
      (lambda () (parse-backslash-backslash-questionmark bstr_0))
-     (case-lambda
-      ((kind_0 drive-len_0 orig-drive-len_0 clean-start-pos_0 add-sep-pos_0)
-       (values kind_0 drive-len_0 orig-drive-len_0))
-      (args (raise-binding-result-arity-error 5 args))))))
+     (lambda (kind_0
+              drive-len_0
+              orig-drive-len_0
+              clean-start-pos_0
+              add-sep-pos_0)
+       (values kind_0 drive-len_0 orig-drive-len_0)))))
 (define parse-//-drive (lambda (bstr_0) (parse-unc.1 #f #f bstr_0 0)))
 (define split-reld.1
   (|#%name|
@@ -24914,15 +24789,13 @@
                     (if (eqv? (unsafe-bytes-ref bstr_0 (sub1 len_0)) 92)
                       (values (sub1 len_0) #t)
                       (values len_0 #f))))
-                (case-lambda
-                 ((len_0 is-dir?_0)
+                (lambda (len_0 is-dir?_0)
                   (call-with-values
                    (lambda ()
                      (backslash-backslash-questionmark-dot-ups-end
                       bstr_0
                       len_0))
-                   (case-lambda
-                    ((dots-end_0 literal-start_0)
+                   (lambda (dots-end_0 literal-start_0)
                      (if (< literal-start_0 len_0)
                        (letrec*
                         ((loop_0
@@ -25037,9 +24910,7 @@
                              'windows)
                             'up
                             #t)
-                           (values 'relative 'up #t)))))
-                    (args (raise-binding-result-arity-error 2 args)))))
-                 (args (raise-binding-result-arity-error 2 args)))))))))
+                           (values 'relative 'up #t)))))))))))))
         (explode-loop_0 bstr32_0))))))
 (define 1/path->directory-path
   (|#%name|
@@ -25138,10 +25009,8 @@
                                  (backslash-backslash-questionmark-dot-ups-end
                                   bstr_0
                                   len_0))
-                               (case-lambda
-                                ((dots-end_0 literal-start_0) dots-end_0)
-                                (args
-                                 (raise-binding-result-arity-error 2 args)))))
+                               (lambda (dots-end_0 literal-start_0)
+                                 dots-end_0)))
                              #f)
                            #f)))
                      (unixish-path-directory-path?_0))
@@ -25371,8 +25240,7 @@
   (lambda (bstr_0)
     (call-with-values
      (lambda () (parse-backslash-backslash-questionmark bstr_0))
-     (case-lambda
-      ((kind_0 drive-len_0 orig-drive-len_0 clean-start-pos_0 sep-bstr_0)
+     (lambda (kind_0 drive-len_0 orig-drive-len_0 clean-start-pos_0 sep-bstr_0)
        (if (not kind_0)
          #f
          (if (if (fx= (unsafe-bytes-ref bstr_0 4) 82)
@@ -25386,8 +25254,7 @@
                  (begin
                    (call-with-values
                     (lambda () (1/split-path p_0))
-                    (case-lambda
-                     ((base-dir_0 name_0 dir?_0)
+                    (lambda (base-dir_0 name_0 dir?_0)
                       (if (symbol? name_0)
                         'non-simple
                         (let ((new-accum_0 (cons name_0 accum_0)))
@@ -25414,11 +25281,9 @@
                                            rebuilt-p_0))))
                                     (if (bytes=? bstr_0 rebuilt-bstr_0)
                                       'simple
-                                      'non-simple)))))))))
-                     (args (raise-binding-result-arity-error 3 args)))))))))
+                                      'non-simple)))))))))))))))
             (loop_0 (path1.1 bstr_0 'windows) '() #f))
-           'non-simple)))
-      (args (raise-binding-result-arity-error 5 args))))))
+           'non-simple))))))
 (define unc-without-trailing-separator?
   (lambda (p_0)
     (let ((bstr_0 (path-bytes p_0)))
@@ -25430,8 +25295,11 @@
       (let ((len_0 (unsafe-bytes-length bstr_0)))
         (call-with-values
          (lambda () (parse-backslash-backslash-questionmark bstr_0))
-         (case-lambda
-          ((kind_0 drive-len_0 orig-drive-len_0 clean-start-pos_0 sep-bstr_0)
+         (lambda (kind_0
+                  drive-len_0
+                  orig-drive-len_0
+                  clean-start-pos_0
+                  sep-bstr_0)
            (let ((special-element?_0
                   (|#%name|
                    special-element?
@@ -25562,8 +25430,7 @@
                           (backslash-backslash-questionmark-dot-ups-end
                            bstr_0
                            len_0))
-                        (case-lambda
-                         ((dots-end_0 literal-start_0)
+                        (lambda (dots-end_0 literal-start_0)
                           (if (no-special-in-content?_0
                                unsafe-undefined
                                literal-start_0)
@@ -25576,10 +25443,8 @@
                                 app_0
                                 (subbytes bstr_0 literal-start_0)))
                              'windows)
-                            p_0))
-                         (args (raise-binding-result-arity-error 2 args))))
-                       p_0)))))))
-          (args (raise-binding-result-arity-error 5 args))))))))
+                            p_0)))
+                       p_0))))))))))))
 (define normalize-backslash-backslash-unc
   (lambda (bstr_0)
     (if (if (eqv? (unsafe-bytes-ref bstr_0 4) 85)
@@ -27837,9 +27702,8 @@
                                                                   (lambda ()
                                                                     (make-init-offset+file-position
                                                                      user-init-position5_0))
-                                                                  (case-lambda
-                                                                   ((init-offset_0
-                                                                     file-position_0)
+                                                                  (lambda (init-offset_0
+                                                                           file-position_0)
                                                                     (let ((buffer-mode_0
                                                                            (if user-buffer-mode6_0
                                                                              (make-buffer-mode.1
@@ -27966,11 +27830,7 @@
                                                                               0
                                                                               0
                                                                               #f
-                                                                              'block)))))))
-                                                                   (args
-                                                                    (raise-binding-result-arity-error
-                                                                     2
-                                                                     args))))))))))))))))))))))))))))))))))))
+                                                                              'block))))))))))))))))))))))))))))))))))))))))
     (|#%name|
      make-input-port
      (case-lambda
@@ -28444,10 +28304,9 @@
                                                               bstr_0)
                                                              start_0
                                                              end_0)))
-                                                        (case-lambda
-                                                         ((imm-bstr_0
-                                                           imm-start_0
-                                                           imm-end_0)
+                                                        (lambda (imm-bstr_0
+                                                                 imm-start_0
+                                                                 imm-end_0)
                                                           (let ((r_0
                                                                  (let ((enable-break?_1
                                                                         (if (not
@@ -28497,11 +28356,7 @@
                                                                    imm-start_0
                                                                    imm-end_0
                                                                    non-block/buffer?_0)
-                                                                  r_0)))))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           3
-                                                           args))))))))))
+                                                                  r_0))))))))))))
                                               (let ((get-write-evt_0
                                                      (|#%name|
                                                       get-write-evt
@@ -28530,10 +28385,9 @@
                                                                   (-
                                                                    end_0
                                                                    start_0)))))
-                                                           (case-lambda
-                                                            ((imm-bstr_0
-                                                              imm-start_0
-                                                              imm-end_0)
+                                                           (lambda (imm-bstr_0
+                                                                    imm-start_0
+                                                                    imm-end_0)
                                                              (begin
                                                                (unsafe-end-atomic)
                                                                (let ((r_0
@@ -28556,11 +28410,7 @@
                                                                     r_0
                                                                     imm-start_0
                                                                     imm-end_0
-                                                                    #t)))))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args)))))))))
+                                                                    #t)))))))))))
                                                 (let ((write-out-special_0
                                                        (|#%name|
                                                         write-out-special
@@ -28611,9 +28461,8 @@
                                                        (lambda ()
                                                          (make-init-offset+file-position
                                                           user-init-position6_0))
-                                                       (case-lambda
-                                                        ((init-offset_0
-                                                          file-position_0)
+                                                       (lambda (init-offset_0
+                                                                file-position_0)
                                                          (let ((buffer-mode_0
                                                                 (if user-buffer-mode7_0
                                                                   (make-buffer-mode.1
@@ -28674,11 +28523,7 @@
                                                                  evt9_0
                                                                  #f
                                                                  #f
-                                                                 #f))))))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args))))))))))))))))))))))))))))))
+                                                                 #f)))))))))))))))))))))))))))))))))
     (|#%name|
      make-output-port
      (case-lambda
@@ -29196,15 +29041,12 @@
                                           #f
                                           0
                                           #f))
-                                       (case-lambda
-                                        ((used-bytes_0 got-chars_0 new-state_0)
+                                       (lambda (used-bytes_0
+                                                got-chars_0
+                                                new-state_0)
                                          (if (utf-8-state? new-state_0)
                                            (loop_0 (add1 offset_0) new-state_0)
-                                           #t))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          3
-                                          args))))
+                                           #t)))
                                       #f))))))
                              (loop_0 0 #f)))))
                       #f)))))))))
@@ -29934,8 +29776,7 @@
                                                  (hash-iterate-key+value
                                                   ctime-hash_0
                                                   i_0))
-                                               (case-lambda
-                                                ((key_0 value_0)
+                                               (lambda (key_0 value_0)
                                                  (let ((new-hash_1
                                                         (let ((new-hash_1
                                                                (hash-set
@@ -29948,11 +29789,7 @@
                                                     new-hash_1
                                                     (hash-iterate-next
                                                      ctime-hash_0
-                                                     i_0))))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args))))
+                                                     i_0)))))
                                               new-hash_0))))))
                                      (for-loop_0
                                       main-hash_0
@@ -30392,16 +30229,11 @@
                                       target_0
                                       (call-with-values
                                        (lambda () (1/split-path new-base_0))
-                                       (case-lambda
-                                        ((base-dir_0 name_0 dir?_0)
+                                       (lambda (base-dir_0 name_0 dir?_0)
                                          (path->complete-path.1
                                           #t
                                           target_0
-                                          base-dir_0))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          3
-                                          args)))))))
+                                          base-dir_0))))))
                                (begin
                                  (if (hash-ref seen_0 from-base_0 #f)
                                    (raise
@@ -30425,18 +30257,17 @@
                                  (values
                                   from-base_0
                                   (hash-set seen_0 from-base_0 #t))))))
-                         (case-lambda
-                          ((from-base_0 new-seen_0)
+                         (lambda (from-base_0 new-seen_0)
                            (call-with-values
                             (lambda () (1/split-path from-base_0))
-                            (case-lambda
-                             ((next-base_0 name_0 dir?_0)
+                            (lambda (next-base_0 name_0 dir?_0)
                               (if (not next-base_0)
                                 (loop_0 (cdr l_1) from-base_0 '() new-seen_0)
-                                (loop_0 (cdr l_1) next-base_0 '() new-seen_0)))
-                             (args
-                              (raise-binding-result-arity-error 3 args)))))
-                          (args (raise-binding-result-arity-error 2 args))))))
+                                (loop_0
+                                 (cdr l_1)
+                                 next-base_0
+                                 '()
+                                 new-seen_0))))))))
                     (let ((app_0 (cdr l_1)))
                       (loop_0
                        app_0
@@ -30462,8 +30293,7 @@
       (not
        (call-with-values
         (lambda () (begin (values s_0 (unsafe-bytes-length s_0))))
-        (case-lambda
-         ((vec_0 len_0)
+        (lambda (vec_0 len_0)
           (letrec*
            ((for-loop_0
              (|#%name|
@@ -30478,8 +30308,7 @@
                           (for-loop_0 result_1 (unsafe-fx+ 1 pos_0))
                           result_1)))
                     result_0))))))
-           (for-loop_0 #f 0)))
-         (args (raise-binding-result-arity-error 2 args)))))
+           (for-loop_0 #f 0)))))
       #f)))
 (define bytes-environment-variable-name?
   (lambda (k_0)
@@ -30809,16 +30638,12 @@
                                                                            (|#%app|
                                                                             rktio_free
                                                                             v_0)))))))))
-                                                             (case-lambda
-                                                              ((key_0 val_0)
+                                                             (lambda (key_0
+                                                                      val_0)
                                                                (hash-set
                                                                 table_2
                                                                 key_0
-                                                                val_0))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                2
-                                                                args))))))
+                                                                val_0)))))
                                                        (values table_3))))
                                                 (for-loop_0
                                                  table_3
@@ -31274,8 +31099,7 @@
                                           end_0)))))))
                                (loop_0 (unsafe-bytes-length bstr_0)))
                               1))
-                           (case-lambda
-                            ((v*_0 start*_0 stop*_0 step*_0)
+                           (lambda (v*_0 start*_0 stop*_0 step*_0)
                              (let ((start_0 0))
                                (let ((v*_1 v*_0)
                                      (start*_1 start*_0)
@@ -31321,15 +31145,11 @@
                                                     (+ pos_0 1))
                                                    result_1)))
                                              result_0))))))
-                                    (for-loop_0 #f start*_1 start_0))))))
-                            (args
-                             (raise-binding-result-arity-error 4 args)))))))))
+                                    (for-loop_0 #f start*_1 start_0))))))))))))
                (call-with-values
                 (lambda () (1/split-path p10_0))
-                (case-lambda
-                 ((base_0 name_0 dir?_0)
-                  (if (symbol? base_0) (if (1/path? name_0) name_0 #f) #f))
-                 (args (raise-binding-result-arity-error 3 args))))
+                (lambda (base_0 name_0 dir?_0)
+                  (if (symbol? base_0) (if (1/path? name_0) name_0 #f) #f)))
                #f)))
          #f)))))
 (define path-element? (lambda (p_0) (if (path-element-clean.1 #t p_0) #t #f)))
@@ -31352,8 +31172,7 @@
         (if (eq? 'windows convention_0)
           (if (call-with-values
                (lambda () (begin (values bstr_0 (unsafe-bytes-length bstr_0))))
-               (case-lambda
-                ((vec_0 len_0)
+               (lambda (vec_0 len_0)
                  (letrec*
                   ((for-loop_0
                     (|#%name|
@@ -31371,8 +31190,7 @@
                                    (for-loop_0 result_2 (unsafe-fx+ 1 pos_0))
                                    result_2))))
                            result_0))))))
-                  (for-loop_0 #f 0)))
-                (args (raise-binding-result-arity-error 2 args))))
+                  (for-loop_0 #f 0))))
             (bad-element_0)
             (void))
           (void))
@@ -31477,8 +31295,7 @@
     (let ((surrogate-count_0
            (call-with-values
             (lambda () (begin (values s_0 (unsafe-string-length s_0))))
-            (case-lambda
-             ((vec_0 len_0)
+            (lambda (vec_0 len_0)
               (letrec*
                ((for-loop_0
                  (|#%name|
@@ -31495,15 +31312,13 @@
                                    (values n_1))))
                             (for-loop_0 n_1 (unsafe-fx+ 1 pos_0))))
                         n_0))))))
-               (for-loop_0 0 0)))
-             (args (raise-binding-result-arity-error 2 args))))))
+               (for-loop_0 0 0))))))
       (let ((bstr_0
              (make-bytes (fx* 2 (fx+ (string-length s_0) surrogate-count_0)))))
         (begin
           (call-with-values
            (lambda () (begin (values s_0 (unsafe-string-length s_0))))
-           (case-lambda
-            ((vec_0 len_0)
+           (lambda (vec_0 len_0)
              (letrec*
               ((for-loop_0
                 (|#%name|
@@ -31554,8 +31369,7 @@
                                   (values pos_2))))
                            (for-loop_0 pos_2 (unsafe-fx+ 1 pos_1))))
                        pos_0))))))
-              (for-loop_0 0 0)))
-            (args (raise-binding-result-arity-error 2 args))))
+              (for-loop_0 0 0))))
           bstr_0)))))
 (define big-endian? (system-big-endian?))
 (define utf-16-decode
@@ -31572,8 +31386,7 @@
                    (if big-endian? 0 1)
                    len_0
                    2))
-                (case-lambda
-                 ((v*_0 start*_0 stop*_0 step*_0)
+                (lambda (v*_0 start*_0 stop*_0 step*_0)
                   (letrec*
                    ((for-loop_0
                      (|#%name|
@@ -31590,8 +31403,7 @@
                                        (values n_1))))
                                 (for-loop_0 n_1 (+ idx_0 2))))
                             n_0))))))
-                   (for-loop_0 0 start*_0)))
-                 (args (raise-binding-result-arity-error 4 args)))))))
+                   (for-loop_0 0 start*_0)))))))
         (let ((str_0
                (make-string
                 (fx- (unsafe-fxrshift len_0 1) surrogate-count_0))))
@@ -31761,8 +31573,7 @@
                              (if (eqv? pos_0 0) "" '(""))
                              (call-with-values
                               (lambda () (1/bytes-convert c_0 in-bstr_0 pos_0))
-                              (case-lambda
-                               ((bstr_0 in-used_0 status_0)
+                              (lambda (bstr_0 in-used_0 status_0)
                                 (begin
                                   (unsafe-start-atomic)
                                   (begin
@@ -31796,11 +31607,7 @@
                                                   (list*
                                                    ls_0
                                                    err-s_0
-                                                   r_0)))))))))))
-                               (args
-                                (raise-binding-result-arity-error
-                                 3
-                                 args))))))))))
+                                                   r_0))))))))))))))))))
                     (loop_0 0)))
                  (lambda ()
                    (let ((c_1 c_0))
@@ -31960,8 +31767,7 @@
                            (call-with-values
                             (lambda ()
                               (1/bytes-convert c1_0 in-bstr1_0 pos1_0 end1_0))
-                            (case-lambda
-                             ((bstr1_0 in-used1_0 status1_0)
+                            (lambda (bstr1_0 in-used1_0 status1_0)
                               (call-with-values
                                (lambda ()
                                  (1/bytes-convert
@@ -31969,8 +31775,7 @@
                                   in-bstr2_0
                                   pos2_0
                                   end2_0))
-                               (case-lambda
-                                ((bstr2_0 in-used2_0 status2_0)
+                               (lambda (bstr2_0 in-used2_0 status2_0)
                                  (let ((new-pos1_0 (+ in-used1_0 pos1_0)))
                                    (let ((new-pos2_0 (+ in-used2_0 pos2_0)))
                                      (let ((done1?_0 (= new-pos1_0 end1_0)))
@@ -32083,11 +31888,9 @@
                                                     pos1_0
                                                     pos2_0
                                                     app_0
-                                                    (+ pos2_0 len_0))))))))))))
-                                (args
-                                 (raise-binding-result-arity-error 3 args)))))
-                             (args
-                              (raise-binding-result-arity-error 3 args)))))))))
+                                                    (+
+                                                     pos2_0
+                                                     len_0))))))))))))))))))))
                     (loop_0
                      0
                      0
@@ -33560,25 +33363,19 @@
                                                   topic_0)
                                                  topic-ceiling-level_0))
                                                #f))))
-                                        (case-lambda
-                                         ((max-level_1 topic-max-level_1)
+                                        (lambda (max-level_1 topic-max-level_1)
                                           (begin-unsafe
                                            (begin
                                              (for-loop_0
                                               max-level_1
                                               topic-max-level_1
-                                              rest_0))))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args))))))))
+                                              rest_0)))))))))
                                (values max-level_0 topic-max-level_0)))))))
                       (for-loop_0
                        old-max-level_0
                        old-topic-max-level_0
                        lst_0)))))
-               (case-lambda
-                ((max-level_0 topic-max-level_0)
+               (lambda (max-level_0 topic-max-level_0)
                  (let ((c1_0
                         (if (let ((or-part_0
                                    (begin-unsafe
@@ -33698,8 +33495,7 @@
                                    (void))
                                  (vector-set! cache_0 0 topic_0)
                                  (vector-set! cache_0 1 topic-max-level_0)))))
-                         (void))))))
-                (args (raise-binding-result-arity-error 2 args)))))))))
+                         (void))))))))))))
        (loop_0 logger_0 'debug 'none 'debug 'none)))))
 (define logger-all-levels
   (lambda (logger_0)
@@ -33732,27 +33528,16 @@
                                            r_0
                                            topics_1
                                            default-level_1))
-                                        (case-lambda
-                                         ((topics_2 default-level_2)
-                                          (values topics_2 default-level_2))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args)))))
-                                     (case-lambda
-                                      ((topics_2 default-level_2)
+                                        (lambda (topics_2 default-level_2)
+                                          (values topics_2 default-level_2))))
+                                     (lambda (topics_2 default-level_2)
                                        (for-loop_0
                                         topics_2
                                         default-level_2
-                                        rest_0))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args))))))
+                                        rest_0)))))
                                 (values topics_1 default-level_1)))))))
                        (for-loop_0 topics_0 'none lst_0)))))
-                (case-lambda
-                 ((new-topics_0 new-default-level_0)
+                (lambda (new-topics_0 new-default-level_0)
                   (let ((next-default-level_0
                          (level-max
                           (level-min new-default-level_0 max-default-level_0)
@@ -33770,11 +33555,9 @@
                            next-default-level_0
                            max-default-level_1
                            parent-logger_0))
-                        (values new-topics_0 next-default-level_0)))))
-                 (args (raise-binding-result-arity-error 2 args)))))))))
+                        (values new-topics_0 next-default-level_0)))))))))))
         (loop_0 hash2610 'none 'debug logger_0)))
-     (case-lambda
-      ((topics_0 default-level_0)
+     (lambda (topics_0 default-level_0)
        (let ((app_0 (level->user-representation default-level_0)))
          (list*
           app_0
@@ -33812,8 +33595,7 @@
                              fold-var_1
                              (hash-iterate-next topics_0 i_0))))
                         fold-var_0))))))
-               (for-loop_0 null (hash-iterate-first topics_0)))))))))
-      (args (raise-binding-result-arity-error 2 args))))))
+               (for-loop_0 null (hash-iterate-first topics_0))))))))))))
 (define make-root-logger (lambda () (create-logger.1 #f 'none #f)))
 (define cell.1$6 (unsafe-make-place-local (make-root-logger)))
 (define unsafe-root-logger (lambda () (unsafe-place-local-ref cell.1$6)))
@@ -34376,8 +34158,7 @@
                                          #f)
                                      (call-with-values
                                       (lambda () (1/split-path (host-> fn_0)))
-                                      (case-lambda
-                                       ((base_0 name_0 dir_0)
+                                      (lambda (base_0 name_0 dir_0)
                                         (let ((base-fn_0
                                                (->host
                                                 base_0
@@ -34390,11 +34171,7 @@
                                              (unsafe-place-local-ref cell.1)
                                              base-fn_0
                                              (unsafe-place-local-ref
-                                              cell.1$5)))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         3
-                                         args))))
+                                              cell.1$5))))))
                                      (begin (unsafe-start-atomic) file-rfc_0)))
                                  file-rfc_0)))
                           (if (vector? rfc_0)
@@ -34924,8 +34701,7 @@
                        'subprocess
                        "(or/c path-string? #f 'new subprocess?)"
                        group/command_0)))))
-              (case-lambda
-               ((group_0 command_0 exact/args_0)
+              (lambda (group_0 command_0 exact/args_0)
                 (call-with-values
                  (lambda ()
                    (if (if (pair? exact/args_0)
@@ -34933,8 +34709,7 @@
                          #f)
                      (values #t (cdr exact/args_0))
                      (values #f exact/args_0)))
-                 (case-lambda
-                  ((exact?_0 args_0)
+                 (lambda (exact?_0 args_0)
                    (begin
                      (begin
                        (letrec*
@@ -35303,9 +35078,7 @@
                                                                                 sp_0
                                                                                 in_0
                                                                                 out_0
-                                                                                err_0))))))))))))))))))))))))))))))))
-                  (args (raise-binding-result-arity-error 2 args)))))
-               (args (raise-binding-result-arity-error 3 args)))))))))))
+                                                                                err_0))))))))))))))))))))))))))))))))))))))))))
 (define 1/subprocess-wait
   (|#%name|
    subprocess-wait
@@ -37106,8 +36879,7 @@
   (lambda (s_0)
     (call-with-values
      (lambda () (begin (values s_0 (unsafe-string-length s_0))))
-     (case-lambda
-      ((vec_0 len_0)
+     (lambda (vec_0 len_0)
        (letrec*
         ((for-loop_0
           (|#%name|
@@ -37123,8 +36895,7 @@
                             (values v_1))))
                      (for-loop_0 v_1 (unsafe-fx+ 1 pos_0))))
                  v_0))))))
-        (for-loop_0 0 0)))
-      (args (raise-binding-result-arity-error 2 args))))))
+        (for-loop_0 0 0))))))
 (define finish_2442
   (make-struct-type-install-properties
    '(udp)
@@ -37637,8 +37408,7 @@
                              rktio_socket_peer_address
                              (unsafe-place-local-ref cell.1)
                              fd_0))))))
-                   (case-lambda
-                    ((local-address_0 peer-address_0)
+                   (lambda (local-address_0 peer-address_0)
                      (let ((local-address-bytes_0
                             (if (not (vector? local-address_0))
                               (|#%app| rktio_to_bytes_list local-address_0 2)
@@ -37703,8 +37473,7 @@
                                             0)))
                                        (values
                                         local-hostname_0
-                                        peer-hostname_0)))))))))))
-                    (args (raise-binding-result-arity-error 2 args)))))))))))
+                                        peer-hostname_0)))))))))))))))))))
     (|#%name|
      tcp-addresses
      (case-lambda
@@ -39468,25 +39237,21 @@
             (|#%app| proc_0 self_0 #f)
             (call-with-values
              (lambda () (|#%app| proc_0 self_0 #f))
-             (case-lambda
-              ((vals_0 evt_0)
+             (lambda (vals_0 evt_0)
                (if vals_0
                  (values vals_0 #f)
                  (if (eq? evt_0 self_0)
                    (call-with-values
                     (lambda () (|#%app| proc_0 self_0 poll-ctx_0))
-                    (case-lambda
-                     ((vals_1 evt_1)
+                    (lambda (vals_1 evt_1)
                       (begin
                         (if vals_1
                           (sandman-poll-ctx-merge-timeout
                            poll-ctx_0
                            (current-inexact-monotonic-milliseconds))
                           (void))
-                        (values #f self_0)))
-                     (args (raise-binding-result-arity-error 2 args))))
-                   (values #f evt_0))))
-              (args (raise-binding-result-arity-error 2 args)))))))))))
+                        (values #f self_0))))
+                   (values #f evt_0))))))))))))
 (define 1/unsafe-poll-ctx-fd-wakeup
   (|#%name|
    unsafe-poll-ctx-fd-wakeup
@@ -39870,8 +39635,7 @@
        (if in_0
          (values #f (dup-fd (fd-port-fd in_0) void "stdin dup"))
          (reverse-pipe void "stdin pipe")))
-     (case-lambda
-      ((parent-in-fd_0 child-in-fd_0)
+     (lambda (parent-in-fd_0 child-in-fd_0)
        (let ((clean-in_0
               (|#%name|
                clean-in
@@ -39893,8 +39657,7 @@
             (if out_0
               (values #f (dup-fd (fd-port-fd out_0) clean-in_0 "stdout dup"))
               (pipe clean-in_0 "stdout pipe")))
-          (case-lambda
-           ((parent-out-fd_0 child-out-fd_0)
+          (lambda (parent-out-fd_0 child-out-fd_0)
             (let ((clean-out+in_0
                    (|#%name|
                     clean-out+in
@@ -39919,8 +39682,7 @@
                     #f
                     (dup-fd (fd-port-fd err_0) clean-out+in_0 "stderr dup"))
                    (pipe clean-out+in_0 "stderr pipe")))
-               (case-lambda
-                ((parent-err-fd_0 child-err-fd_0)
+               (lambda (parent-err-fd_0 child-err-fd_0)
                  (let ((app_0
                         (if parent-in-fd_0
                           (let ((temp2_0 "place-in"))
@@ -39954,10 +39716,7 @@
                         #f)
                       child-in-fd_0
                       child-out-fd_0
-                      child-err-fd_0))))
-                (args (raise-binding-result-arity-error 2 args))))))
-           (args (raise-binding-result-arity-error 2 args))))))
-      (args (raise-binding-result-arity-error 2 args))))))
+                      child-err-fd_0)))))))))))))
 (define dup-fd
   (lambda (fd_0 cleanup_0 during_0)
     (let ((new-fd_0 (|#%app| rktio_dup (unsafe-place-local-ref cell.1) fd_0)))
@@ -40013,16 +39772,13 @@
           (void))
         (call-with-values
          (lambda () (|#%app| rktio_pipe_results p_0))
-         (case-lambda
-          ((in_0 out_0) (begin (|#%app| rktio_free p_0) (values in_0 out_0)))
-          (args (raise-binding-result-arity-error 2 args))))))))
+         (lambda (in_0 out_0)
+           (begin (|#%app| rktio_free p_0) (values in_0 out_0))))))))
 (define reverse-pipe
   (lambda (cleanup_0 during_0)
     (call-with-values
      (lambda () (pipe cleanup_0 during_0))
-     (case-lambda
-      ((in_0 out_0) (values out_0 in_0))
-      (args (raise-binding-result-arity-error 2 args))))))
+     (lambda (in_0 out_0) (values out_0 in_0)))))
 (define io-place-init!
   (lambda (in-fd_0 out-fd_0 err-fd_0 cust_0 plumber_0)
     (begin

--- a/racket/src/cs/schemified/regexp.scm
+++ b/racket/src/cs/schemified/regexp.scm
@@ -554,8 +554,7 @@
         (void)
         (call-with-values
          (lambda () (procedure-keywords f_0))
-         (case-lambda
-          ((required-keywords_0 optional-keywords_0)
+         (lambda (required-keywords_0 optional-keywords_0)
            (let ((app_0
                   (if (pair? required-keywords_0)
                     (string-append
@@ -657,8 +656,7 @@
                                            app_5
                                            (loop_0 (cdr ls_1))))))))))
                                (loop_0 ls_0)))))
-                           null))))))))))
-          (args (raise-binding-result-arity-error 2 args))))))))
+                           null)))))))))))))))
 (define gen-map
   (lambda (f_0 ls_0)
     (begin
@@ -864,10 +862,7 @@
                                                    (for-loop_1 (+ pos_0 1)))
                                                  (values)))))))
                                         (for-loop_1 start_1)))))))
-                             (case-lambda
-                              (() (for-loop_0 rest_0))
-                              (args
-                               (raise-binding-result-arity-error 0 args))))))
+                             (lambda () (for-loop_0 rest_0)))))
                         (values)))))))
                (for-loop_0 range_0)))
             (void)
@@ -2438,8 +2433,7 @@
                (if (eqv? tmp_1 '#\x5e)
                  (values #t (+ pos_0 2))
                  (values #f (add1 pos_0))))))
-         (case-lambda
-          ((cat-negated?_0 next-pos_0)
+         (lambda (cat-negated?_0 next-pos_0)
            (call-with-values
             (lambda ()
               (letrec*
@@ -2465,8 +2459,7 @@
                                    (cons (chytes-ref$1 s_0 pos_1) accum_0)))
                               (loop_0 app_0 (add1 pos_1)))))))))))
                (loop_0 null next-pos_0)))
-            (case-lambda
-             ((l_0 pos2_0)
+            (lambda (l_0 pos2_0)
               (let ((categories_0
                      (let ((tmp_1 (list->bytes l_0)))
                        (let ((index_0
@@ -2549,9 +2542,7 @@
                    (rx:unicode-categories12.1
                     categories_0
                     (not (xor prop-negated?_0 cat-negated?_0)))
-                   pos2_0))))
-             (args (raise-binding-result-arity-error 2 args)))))
-          (args (raise-binding-result-arity-error 2 args))))
+                   pos2_0)))))))
         (let ((fmt_0 "expected `{` after `\\~a`"))
           (let ((args_0 (list (integer->char p-c_0))))
             (let ((fmt_1 fmt_0))
@@ -2609,10 +2600,8 @@
         (if (eqv? tmp_0 '#\x5e)
           (call-with-values
            (lambda () (parse-range s_0 (add1 pos_0) config_0))
-           (case-lambda
-            ((range_0 pos2_0)
-             (values (range-invert range_0 (chytes-limit s_0)) pos2_0))
-            (args (raise-binding-result-arity-error 2 args))))
+           (lambda (range_0 pos2_0)
+             (values (range-invert range_0 (chytes-limit s_0)) pos2_0)))
           (parse-range s_0 pos_0 config_0))))))
 (define parse-range
   (lambda (s_0 pos_0 config_0)
@@ -2721,8 +2710,7 @@
                               "misplaced hyphen within square brackets in pattern")
                              (call-with-values
                               (lambda () (parse-class s6_0 pos2_0 config8_0))
-                              (case-lambda
-                               ((success?_0 range1_0 pos3_0)
+                              (lambda (success?_0 range1_0 pos3_0)
                                 (begin
                                   (if success?_0
                                     (void)
@@ -2745,9 +2733,7 @@
                                        range2_0
                                        s6_0
                                        temp39_0
-                                       config8_0)))))
-                               (args
-                                (raise-binding-result-arity-error 3 args)))))
+                                       config8_0)))))))
                            (let ((temp44_0 (add1 pos2_0)))
                              (parse-range-rest/span.1
                               must-span-from2_0
@@ -2774,8 +2760,7 @@
                             #f)
                         (parse-posix-char-class s6_0 (add1 pos7_0))
                         (values #f #f #f)))
-                    (case-lambda
-                     ((success?_0 range1_0 pos2_0)
+                    (lambda (success?_0 range1_0 pos2_0)
                       (if success?_0
                         (let ((range2_0
                                (range-union
@@ -2796,8 +2781,7 @@
                            range5_0
                            s6_0
                            temp62_0
-                           config8_0))))
-                     (args (raise-binding-result-arity-error 3 args))))
+                           config8_0)))))
                    (let ((temp66_0 (chytes-ref$1 s6_0 pos7_0)))
                      (let ((temp69_0 (add1 pos7_0)))
                        (let ((temp66_1 temp66_0))
@@ -2864,8 +2848,7 @@
        (let ((config_0 (make-parse-config.1 #f px?1_0 'regexp)))
          (call-with-values
           (lambda () (parse-regexp.1 unsafe-undefined p3_0 0 config_0))
-          (case-lambda
-           ((rx_0 pos_0)
+          (lambda (rx_0 pos_0)
             (let ((pos_1 pos_0))
               (let ((tmp_0
                      (if (let ((app_0 pos_1)) (= app_0 (chytes-length$1 p3_0)))
@@ -2879,8 +2862,8 @@
                     (values
                      rx_0
                      app_0
-                     (unbox (parse-config-references?-box config_0))))))))
-           (args (raise-binding-result-arity-error 2 args)))))))))
+                     (unbox
+                      (parse-config-references?-box config_0))))))))))))))
 (define parse-regexp.1
   (|#%name|
    parse-regexp
@@ -2896,8 +2879,7 @@
                 parse-regexp5_0)))
          (call-with-values
           (lambda () (parse-pces s7_0 pos8_0 config9_0))
-          (case-lambda
-           ((rxs_0 pos2_0)
+          (lambda (rxs_0 pos2_0)
             (let ((tmp_0
                    (if (= pos2_0 (chytes-length$1 s7_0))
                      'eos
@@ -2906,15 +2888,12 @@
                 (call-with-values
                  (lambda ()
                    (|#%app| parse-regexp_0 s7_0 (add1 pos2_0) config9_0))
-                 (case-lambda
-                  ((rx_0 pos3_0)
+                 (lambda (rx_0 pos3_0)
                    (values
                     (let ((app_0 (rx-sequence rxs_0)))
                       (rx-alts app_0 rx_0 (chytes-limit s7_0)))
-                    pos3_0))
-                  (args (raise-binding-result-arity-error 2 args))))
-                (values (rx-sequence rxs_0) pos2_0))))
-           (args (raise-binding-result-arity-error 2 args)))))))))
+                    pos3_0)))
+                (values (rx-sequence rxs_0) pos2_0))))))))))
 (define parse-regexp/maybe-empty
   (lambda (s_0 pos_0 config_0)
     (let ((tmp_0
@@ -2930,8 +2909,7 @@
       (values null pos_0)
       (call-with-values
        (lambda () (parse-pce s_0 pos_0 config_0))
-       (case-lambda
-        ((rx_0 pos2_0)
+       (lambda (rx_0 pos2_0)
          (let ((tmp_0
                 (if (= pos2_0 (chytes-length$1 s_0))
                   'eos
@@ -2942,16 +2920,13 @@
                (values (list rx_0) pos2_0)
                (call-with-values
                 (lambda () (parse-pces s_0 pos2_0 config_0))
-                (case-lambda
-                 ((rxs_0 pos3_0) (values (cons rx_0 rxs_0) pos3_0))
-                 (args (raise-binding-result-arity-error 2 args))))))))
-        (args (raise-binding-result-arity-error 2 args)))))))
+                (lambda (rxs_0 pos3_0)
+                  (values (cons rx_0 rxs_0) pos3_0)))))))))))
 (define parse-pce
   (lambda (s_0 pos_0 config_0)
     (call-with-values
      (lambda () (parse-atom s_0 pos_0 config_0))
-     (case-lambda
-      ((rx_0 pos2_0)
+     (lambda (rx_0 pos2_0)
        (let ((tmp_0
               (if (= pos2_0 (chytes-length$1 s_0))
                 'eos
@@ -2959,30 +2934,23 @@
          (if (eqv? tmp_0 '#\x2a)
            (call-with-values
             (lambda () (parse-non-greedy s_0 (add1 pos2_0) config_0))
-            (case-lambda
-             ((non-greedy?_0 pos3_0)
-              (values (rx:repeat4.1 rx_0 0 +inf.0 non-greedy?_0) pos3_0))
-             (args (raise-binding-result-arity-error 2 args))))
+            (lambda (non-greedy?_0 pos3_0)
+              (values (rx:repeat4.1 rx_0 0 +inf.0 non-greedy?_0) pos3_0)))
            (if (eqv? tmp_0 '#\x2b)
              (call-with-values
               (lambda () (parse-non-greedy s_0 (add1 pos2_0) config_0))
-              (case-lambda
-               ((non-greedy?_0 pos3_0)
-                (values (rx:repeat4.1 rx_0 1 +inf.0 non-greedy?_0) pos3_0))
-               (args (raise-binding-result-arity-error 2 args))))
+              (lambda (non-greedy?_0 pos3_0)
+                (values (rx:repeat4.1 rx_0 1 +inf.0 non-greedy?_0) pos3_0)))
              (if (eqv? tmp_0 '#\x3f)
                (call-with-values
                 (lambda () (parse-non-greedy s_0 (add1 pos2_0) config_0))
-                (case-lambda
-                 ((non-greedy?_0 pos3_0)
-                  (values (rx:maybe5.1 rx_0 non-greedy?_0) pos3_0))
-                 (args (raise-binding-result-arity-error 2 args))))
+                (lambda (non-greedy?_0 pos3_0)
+                  (values (rx:maybe5.1 rx_0 non-greedy?_0) pos3_0)))
                (if (eqv? tmp_0 '#\x7b)
                  (if (parse-config-px? config_0)
                    (call-with-values
                     (lambda () (parse-integer 0 s_0 (add1 pos2_0) config_0))
-                    (case-lambda
-                     ((n1_0 pos3_0)
+                    (lambda (n1_0 pos3_0)
                       (let ((tmp_1
                              (if (= pos3_0 (chytes-length$1 s_0))
                                'eos
@@ -2991,8 +2959,7 @@
                           (call-with-values
                            (lambda ()
                              (parse-integer 0 s_0 (add1 pos3_0) config_0))
-                           (case-lambda
-                            ((n2_0 pos4_0)
+                           (lambda (n2_0 pos4_0)
                              (let ((tmp_2
                                     (if (= pos4_0 (chytes-length$1 s_0))
                                       'eos
@@ -3008,45 +2975,34 @@
                                        s_0
                                        (add1 pos4_0)
                                        config_0))
-                                    (case-lambda
-                                     ((non-greedy?_0 pos5_0)
+                                    (lambda (non-greedy?_0 pos5_0)
                                       (values
                                        (rx:repeat4.1
                                         rx_0
                                         n1_0
                                         n2*_0
                                         non-greedy?_0)
-                                       pos5_0))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args)))))
+                                       pos5_0))))
                                  (parse-error
                                   s_0
                                   pos3_0
                                   config_0
-                                  "expected digit or `}` to end repetition specification started with `{`"))))
-                            (args (raise-binding-result-arity-error 2 args))))
+                                  "expected digit or `}` to end repetition specification started with `{`")))))
                           (if (eqv? tmp_1 '#\x7d)
                             (call-with-values
                              (lambda ()
                                (parse-non-greedy s_0 (add1 pos3_0) config_0))
-                             (case-lambda
-                              ((non-greedy?_0 pos4_0)
+                             (lambda (non-greedy?_0 pos4_0)
                                (values
                                 (rx:repeat4.1 rx_0 n1_0 n1_0 non-greedy?_0)
-                                pos4_0))
-                              (args
-                               (raise-binding-result-arity-error 2 args))))
+                                pos4_0)))
                             (parse-error
                              s_0
                              pos3_0
                              config_0
-                             "expected digit, `,`, or `}' for repetition specification started with `{`")))))
-                     (args (raise-binding-result-arity-error 2 args))))
+                             "expected digit, `,`, or `}' for repetition specification started with `{`"))))))
                    (values rx_0 pos2_0))
-                 (values rx_0 pos2_0)))))))
-      (args (raise-binding-result-arity-error 2 args))))))
+                 (values rx_0 pos2_0))))))))))
 (define parse-non-greedy
   (lambda (s_0 pos_0 config_0)
     (let ((tmp_0
@@ -3086,10 +3042,8 @@
           (if (eqv? tmp_0 '#\x5b)
             (call-with-values
              (lambda () (parse-range/not s_0 (add1 pos_0) config_0))
-             (case-lambda
-              ((range_0 pos2_0)
-               (values (rx-range range_0 (chytes-limit s_0)) pos2_0))
-              (args (raise-binding-result-arity-error 2 args))))
+             (lambda (range_0 pos2_0)
+               (values (rx-range range_0 (chytes-limit s_0)) pos2_0)))
             (if (eqv? tmp_0 '#\x2e)
               (let ((rx_0
                      (if (parse-config-multi-line? config_0)
@@ -3145,8 +3099,7 @@
                     (call-with-values
                      (lambda ()
                        (parse-regexp/maybe-empty s_0 (add1 pos2_0) config_0))
-                     (case-lambda
-                      ((rx_0 pos3_0)
+                     (lambda (rx_0 pos3_0)
                        (let ((post-num-groups_0
                               (begin-unsafe
                                (unbox
@@ -3162,8 +3115,7 @@
                                     (needs-backtrack? rx_0))))))
                            (values
                             app_0
-                            (check-close-paren s_0 pos3_0 config_0)))))
-                      (args (raise-binding-result-arity-error 2 args)))))
+                            (check-close-paren s_0 pos3_0 config_0)))))))
                   (if (eqv? tmp_1 '#\x28)
                     (parse-conditional s_0 (add1 pos2_0) config_0)
                     (if (if (eqv? tmp_1 '#\x69)
@@ -3177,8 +3129,7 @@
                                 (eqv? tmp_1 '#\x3a)))))
                       (call-with-values
                        (lambda () (parse-mode s_0 pos2_0 config_0))
-                       (case-lambda
-                        ((config2_0 pos3_0)
+                       (lambda (config2_0 pos3_0)
                          (let ((tmp_2
                                 (if (= pos3_0 (chytes-length$1 s_0))
                                   'eos
@@ -3190,21 +3141,17 @@
                                  s_0
                                  (add1 pos3_0)
                                  config2_0))
-                              (case-lambda
-                               ((rx_0 pos4_0)
+                              (lambda (rx_0 pos4_0)
                                 (values
                                  rx_0
-                                 (check-close-paren s_0 pos4_0 config2_0)))
-                               (args
-                                (raise-binding-result-arity-error 2 args))))
+                                 (check-close-paren s_0 pos4_0 config2_0))))
                              (parse-error
                               s_0
                               pos3_0
                               config2_0
                               (string-append
                                "expected `:` or another mode after `(?` and a mode sequence;\n"
-                               " a mode is `i`, `-i`, `m`, `-m`, `s`, or `-s`")))))
-                        (args (raise-binding-result-arity-error 2 args))))
+                               " a mode is `i`, `-i`, `m`, `-m`, `s`, or `-s`"))))))
                       (parse-look s_0 pos2_0 config_0)))))))
           (let ((group-number_0
                  (begin-unsafe
@@ -3215,11 +3162,11 @@
                 s_0
                 pos_0
                 (config-group-number+1 config_0)))
-             (case-lambda
-              ((rx_0 pos2_0)
+             (lambda (rx_0 pos2_0)
                (let ((app_0 (begin-unsafe (rx:group3.1 rx_0 group-number_0))))
-                 (values app_0 (check-close-paren s_0 pos2_0 config_0))))
-              (args (raise-binding-result-arity-error 2 args))))))))))
+                 (values
+                  app_0
+                  (check-close-paren s_0 pos2_0 config_0)))))))))))
 (define parse-look
   (lambda (s_0 pos2_0 config_0)
     (let ((pre-num-groups_0
@@ -3237,30 +3184,26 @@
           (if (eqv? tmp_0 '#\x3d)
             (call-with-values
              (lambda () (parse-regexp/maybe-empty s_0 (add1 pos2_0) config_0))
-             (case-lambda
-              ((rx_0 pos3_0)
+             (lambda (rx_0 pos3_0)
                (let ((app_0
                       (rx:lookahead7.1
                        rx_0
                        #t
                        pre-num-groups_0
                        (span-num-groups_0))))
-                 (values app_0 (check-close-paren s_0 pos3_0 config_0))))
-              (args (raise-binding-result-arity-error 2 args))))
+                 (values app_0 (check-close-paren s_0 pos3_0 config_0)))))
             (if (eqv? tmp_0 '#\x21)
               (call-with-values
                (lambda ()
                  (parse-regexp/maybe-empty s_0 (add1 pos2_0) config_0))
-               (case-lambda
-                ((rx_0 pos3_0)
+               (lambda (rx_0 pos3_0)
                  (let ((app_0
                         (rx:lookahead7.1
                          rx_0
                          #f
                          pre-num-groups_0
                          (span-num-groups_0))))
-                   (values app_0 (check-close-paren s_0 pos3_0 config_0))))
-                (args (raise-binding-result-arity-error 2 args))))
+                   (values app_0 (check-close-paren s_0 pos3_0 config_0)))))
               (if (eqv? tmp_0 '#\x3c)
                 (let ((pos2+_0 (add1 pos2_0)))
                   (let ((tmp_1
@@ -3281,8 +3224,7 @@
                             s_0
                             (add1 pos2+_0)
                             config_0))
-                         (case-lambda
-                          ((rx_0 pos3_0)
+                         (lambda (rx_0 pos3_0)
                            (let ((app_0
                                   (rx:lookbehind8.1
                                    rx_0
@@ -3293,8 +3235,7 @@
                                    (span-num-groups_0))))
                              (values
                               app_0
-                              (check-close-paren s_0 pos3_0 config_0))))
-                          (args (raise-binding-result-arity-error 2 args))))
+                              (check-close-paren s_0 pos3_0 config_0)))))
                         (if (eqv? tmp_1 '#\x21)
                           (call-with-values
                            (lambda ()
@@ -3302,8 +3243,7 @@
                               s_0
                               (add1 pos2+_0)
                               config_0))
-                           (case-lambda
-                            ((rx_0 pos3_0)
+                           (lambda (rx_0 pos3_0)
                              (let ((app_0
                                     (rx:lookbehind8.1
                                      rx_0
@@ -3314,8 +3254,7 @@
                                      (span-num-groups_0))))
                                (values
                                 app_0
-                                (check-close-paren s_0 pos3_0 config_0))))
-                            (args (raise-binding-result-arity-error 2 args))))
+                                (check-close-paren s_0 pos3_0 config_0)))))
                           (begin-unsafe
                            (parse-error
                             s_0
@@ -3334,8 +3273,7 @@
            (begin-unsafe (unbox (parse-config-group-number-box config_0)))))
       (call-with-values
        (lambda () (parse-test s_0 pos_0 config_0))
-       (case-lambda
-        ((tst_0 pos2_0)
+       (lambda (tst_0 pos2_0)
          (let ((tst-span-num-groups_0
                 (-
                  (begin-unsafe
@@ -3343,8 +3281,7 @@
                  tst-pre-num-groups_0)))
            (call-with-values
             (lambda () (parse-pces s_0 pos2_0 config_0))
-            (case-lambda
-             ((pces_0 pos3_0)
+            (lambda (pces_0 pos3_0)
               (let ((tmp_0
                      (if (= pos3_0 (chytes-length$1 s_0))
                        'eos
@@ -3359,8 +3296,7 @@
                   (if (eqv? tmp_0 '#\x7c)
                     (call-with-values
                      (lambda () (parse-pces s_0 (add1 pos3_0) config_0))
-                     (case-lambda
-                      ((pces2_0 pos4_0)
+                     (lambda (pces2_0 pos4_0)
                        (let ((tmp_1
                               (if (= pos4_0 (chytes-length$1 s_0))
                                 'eos
@@ -3386,8 +3322,7 @@
                               s_0
                               pos4_0
                               config_0
-                              "expected `)` to close `(?(...)...` after second branch")))))
-                      (args (raise-binding-result-arity-error 2 args))))
+                              "expected `)` to close `(?(...)...` after second branch"))))))
                     (if (eqv? tmp_0 '#\x29)
                       (let ((app_0
                              (rx-conditional
@@ -3397,9 +3332,7 @@
                               tst-pre-num-groups_0
                               tst-span-num-groups_0)))
                         (values app_0 (add1 pos3_0)))
-                      (void))))))
-             (args (raise-binding-result-arity-error 2 args))))))
-        (args (raise-binding-result-arity-error 2 args)))))))
+                      (void)))))))))))))
 (define parse-test
   (lambda (s_0 pos_0 config_0)
     (let ((tmp_0
@@ -3421,8 +3354,7 @@
                 (set-box! (parse-config-references?-box config_0) #t)
                 (call-with-values
                  (lambda () (parse-integer 0 s_0 pos_0 config_0))
-                 (case-lambda
-                  ((n_0 pos3_0)
+                 (lambda (n_0 pos3_0)
                    (begin
                      (if (if (< pos3_0 (chytes-length$1 s_0))
                            (= (chytes-ref$1 s_0 pos3_0) 41)
@@ -3434,8 +3366,7 @@
                         config_0
                         "expected `)` after `(?(` followed by digits"))
                      (let ((app_0 (rx:reference10.1 n_0 #f)))
-                       (values app_0 (add1 pos3_0)))))
-                  (args (raise-binding-result-arity-error 2 args)))))
+                       (values app_0 (add1 pos3_0)))))))
               (parse-error
                s_0
                pos_0
@@ -3494,12 +3425,10 @@
             (set-box! (parse-config-references?-box config_0) #t)
             (call-with-values
              (lambda () (parse-integer 0 s_0 pos2_0 config_0))
-             (case-lambda
-              ((n_0 pos3_0)
+             (lambda (n_0 pos3_0)
                (values
                 (rx:reference10.1 n_0 (parse-config-case-sensitive? config_0))
-                pos3_0))
-              (args (raise-binding-result-arity-error 2 args)))))
+                pos3_0))))
           (if (if (parse-config-px? config_0)
                 (let ((or-part_0 (if (>= c2_0 97) (<= c2_0 122) #f)))
                   (if or-part_0 or-part_0 (if (>= c2_0 65) (<= c2_0 90) #f)))
@@ -3513,16 +3442,14 @@
                     (values 'not-word-boundary (add1 pos2_0))
                     (call-with-values
                      (lambda () (parse-class s_0 pos2_0 config_0))
-                     (case-lambda
-                      ((success?_0 range_0 pos3_0)
+                     (lambda (success?_0 range_0 pos3_0)
                        (if success?_0
                          (values (rx-range range_0 (chytes-limit s_0)) pos3_0)
                          (parse-error
                           s_0
                           pos2_0
                           config_0
-                          "illegal alphabetic escape")))
-                      (args (raise-binding-result-arity-error 3 args))))))))
+                          "illegal alphabetic escape"))))))))
             (values c2_0 (add1 pos2_0))))))))
 (define parse-mode
   (lambda (s_0 pos_0 config_0)
@@ -3642,27 +3569,17 @@
                                      (call-with-values
                                       (lambda ()
                                         (validate_0 (rx:alts-rx_2265 rx_1)))
-                                      (case-lambda
-                                       ((min1_0 max1_0 lb1_0)
+                                      (lambda (min1_0 max1_0 lb1_0)
                                         (call-with-values
                                          (lambda ()
                                            (validate_0 (rx:alts-rx_1912 rx_1)))
-                                         (case-lambda
-                                          ((min2_0 max2_0 lb2_0)
+                                         (lambda (min2_0 max2_0 lb2_0)
                                            (let ((app_0 (min min1_0 min2_0)))
                                              (let ((app_1 (max max1_0 max2_0)))
                                                (values
                                                 app_0
                                                 app_1
-                                                (max lb1_0 lb2_0)))))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            3
-                                            args)))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         3
-                                         args))))
+                                                (max lb1_0 lb2_0))))))))
                                      (if (rx:sequence? rx_1)
                                        (let ((lst_0 (rx:sequence-rxs rx_1)))
                                          (begin
@@ -3690,10 +3607,9 @@
                                                                 (lambda ()
                                                                   (validate_0
                                                                    rx_2))
-                                                                (case-lambda
-                                                                 ((min1_0
-                                                                   max1_0
-                                                                   lb1_0)
+                                                                (lambda (min1_0
+                                                                         max1_0
+                                                                         lb1_0)
                                                                   (let ((app_0
                                                                          (+
                                                                           min-len_0
@@ -3709,36 +3625,22 @@
                                                                         max-lb_0
                                                                         (-
                                                                          lb1_0
-                                                                         min-len_0))))))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   3
-                                                                   args)))))
-                                                             (case-lambda
-                                                              ((min-len_1
-                                                                max-len_1
-                                                                max-lb_1)
+                                                                         min-len_0))))))))
+                                                             (lambda (min-len_1
+                                                                      max-len_1
+                                                                      max-lb_1)
                                                                (values
                                                                 min-len_1
                                                                 max-len_1
-                                                                max-lb_1))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                3
-                                                                args)))))
-                                                          (case-lambda
-                                                           ((min-len_1
-                                                             max-len_1
-                                                             max-lb_1)
+                                                                max-lb_1))))
+                                                          (lambda (min-len_1
+                                                                   max-len_1
+                                                                   max-lb_1)
                                                             (for-loop_0
                                                              min-len_1
                                                              max-len_1
                                                              max-lb_1
-                                                             rest_0))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             3
-                                                             args))))))
+                                                             rest_0)))))
                                                      (values
                                                       min-len_0
                                                       max-len_0
@@ -3748,8 +3650,7 @@
                                          (call-with-values
                                           (lambda ()
                                             (validate_0 (rx:group-rx rx_1)))
-                                          (case-lambda
-                                           ((min1_0 max1_0 lb1_0)
+                                          (lambda (min1_0 max1_0 lb1_0)
                                             (begin
                                               (set! group-sizes_0
                                                 (let ((app_0 group-sizes_0))
@@ -3757,11 +3658,7 @@
                                                    app_0
                                                    (rx:group-number rx_1)
                                                    min1_0)))
-                                              (values min1_0 max1_0 lb1_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             3
-                                             args))))
+                                              (values min1_0 max1_0 lb1_0))))
                                          (if (rx:repeat? rx_1)
                                            (let ((old-depends-sizes_0
                                                   depends-sizes_0))
@@ -3772,8 +3669,7 @@
                                                 (lambda ()
                                                   (validate_0
                                                    (rx:repeat-rx rx_1)))
-                                                (case-lambda
-                                                 ((min1_0 max1_0 lb1_0)
+                                                (lambda (min1_0 max1_0 lb1_0)
                                                   (begin
                                                     (if (zero? min1_0)
                                                       (might-be-empty-error_0)
@@ -3798,44 +3694,36 @@
                                                        (*
                                                         max1_0
                                                         (rx:repeat-max rx_1))
-                                                       lb1_0))))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   3
-                                                   args))))))
+                                                       lb1_0)))))))
                                            (if (rx:maybe? rx_1)
                                              (call-with-values
                                               (lambda ()
                                                 (validate_0
                                                  (rx:maybe-rx rx_1)))
-                                              (case-lambda
-                                               ((min1_0 max1_0 lb1_0)
-                                                (values 0 max1_0 lb1_0))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 3
-                                                 args))))
+                                              (lambda (min1_0 max1_0 lb1_0)
+                                                (values 0 max1_0 lb1_0)))
                                              (if (rx:conditional? rx_1)
                                                (call-with-values
                                                 (lambda ()
                                                   (validate_0
                                                    (rx:conditional-tst rx_1)))
-                                                (case-lambda
-                                                 ((min0_0 max0_0 lb0_0)
+                                                (lambda (min0_0 max0_0 lb0_0)
                                                   (call-with-values
                                                    (lambda ()
                                                      (validate_0
                                                       (rx:conditional-rx_2162
                                                        rx_1)))
-                                                   (case-lambda
-                                                    ((min1_0 max1_0 lb1_0)
+                                                   (lambda (min1_0
+                                                            max1_0
+                                                            lb1_0)
                                                      (call-with-values
                                                       (lambda ()
                                                         (validate_0
                                                          (rx:conditional-rx_2328
                                                           rx_1)))
-                                                      (case-lambda
-                                                       ((min2_0 max2_0 lb2_0)
+                                                      (lambda (min2_0
+                                                               max2_0
+                                                               lb2_0)
                                                         (let ((app_0
                                                                (min
                                                                 min1_0
@@ -3850,39 +3738,23 @@
                                                              (max
                                                               lb0_0
                                                               lb1_0
-                                                              lb2_0)))))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         3
-                                                         args)))))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      3
-                                                      args)))))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   3
-                                                   args))))
+                                                              lb2_0))))))))))
                                                (if (rx:lookahead? rx_1)
                                                  (call-with-values
                                                   (lambda ()
                                                     (validate_0
                                                      (rx:lookahead-rx rx_1)))
-                                                  (case-lambda
-                                                   ((min1_0 max1_0 lb1_0)
-                                                    (values 0 0 lb1_0))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     3
-                                                     args))))
+                                                  (lambda (min1_0 max1_0 lb1_0)
+                                                    (values 0 0 lb1_0)))
                                                  (if (rx:lookbehind? rx_1)
                                                    (call-with-values
                                                     (lambda ()
                                                       (validate_0
                                                        (rx:lookbehind-rx
                                                         rx_1)))
-                                                    (case-lambda
-                                                     ((min1_0 max1_0 lb1_0)
+                                                    (lambda (min1_0
+                                                             max1_0
+                                                             lb1_0)
                                                       (begin
                                                         (if (= +inf.0 max1_0)
                                                           (regexp-error
@@ -3897,11 +3769,7 @@
                                                         (values
                                                          0
                                                          0
-                                                         (max max1_0 lb1_0))))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       3
-                                                       args))))
+                                                         (max max1_0 lb1_0)))))
                                                    (if (rx:cut? rx_1)
                                                      (validate_0
                                                       (rx:cut-rx rx_1))
@@ -3947,8 +3815,7 @@
                                                           "internal error: ~s"
                                                           rx_1)))))))))))))))))))))))
                 (validate_0 rx_0)))
-             (case-lambda
-              ((min-len_0 max-len_0 max-lookbehind_0)
+             (lambda (min-len_0 max-len_0 max-lookbehind_0)
                (begin
                  (let ((ht_0 must-sizes_0))
                    (begin
@@ -3969,8 +3836,7 @@
                                (values)))))))
                       (for-loop_0 (hash-iterate-first ht_0)))))
                  (void)
-                 max-lookbehind_0))
-              (args (raise-binding-result-arity-error 3 args))))))))))
+                 max-lookbehind_0)))))))))
 (define merge-depends-sizes
   (lambda (ht1_0 ht2_0)
     (if (zero? (hash-count ht1_0))
@@ -4301,8 +4167,7 @@
   (lambda (bstr_0 i_0)
     (call-with-values
      (lambda () (unsafe-normalise-inputs unsafe-bytes-length bstr_0 i_0 #f 1))
-     (case-lambda
-      ((v*_0 start*_0 stop*_0 step*_0)
+     (lambda (v*_0 start*_0 stop*_0 step*_0)
        (letrec*
         ((for-loop_0
           (|#%name|
@@ -4319,8 +4184,7 @@
                        (for-loop_0 result_1 (unsafe-fx+ idx_0 1))
                        result_1)))
                  result_0))))))
-        (for-loop_0 #t start*_0)))
-      (args (raise-binding-result-arity-error 4 args))))))
+        (for-loop_0 #t start*_0))))))
 (define anchored?
   (lambda (rx_0)
     (if (eq? rx_0 'start)
@@ -5224,8 +5088,7 @@
                   0
                   len_0
                   1))
-               (case-lambda
-                ((v*_0 start*_0 stop*_0 step*_0)
+               (lambda (v*_0 start*_0 stop*_0 step*_0)
                  (call-with-values
                   (lambda ()
                     (unsafe-normalise-inputs
@@ -5234,8 +5097,7 @@
                      pos_0
                      (+ pos_0 len_0)
                      1))
-                  (case-lambda
-                   ((v*_1 start*_1 stop*_1 step*_1)
+                  (lambda (v*_1 start*_1 stop*_1 step*_1)
                     (let ((v*_2 v*_0)
                           (start*_2 start*_0)
                           (stop*_2 stop*_0)
@@ -5270,15 +5132,12 @@
                                            (unsafe-fx+ idx_1 1))
                                           result_1)))))
                                 result_0))))))
-                       (for-loop_0 #t start*_2 start*_1))))
-                   (args (raise-binding-result-arity-error 4 args)))))
-                (args (raise-binding-result-arity-error 4 args))))
+                       (for-loop_0 #t start*_2 start*_1)))))))
               #f)
             (call-with-values
              (lambda ()
                (unsafe-normalise-inputs unsafe-bytes-length bstr_0 0 len_0 1))
-             (case-lambda
-              ((v*_0 start*_0 stop*_0 step*_0)
+             (lambda (v*_0 start*_0 stop*_0 step*_0)
                (let ((start_1 pos_0))
                  (let ((v*_1 v*_0)
                        (start*_1 start*_0)
@@ -5321,8 +5180,7 @@
                                       (+ pos_1 1))
                                      result_1)))
                                result_0))))))
-                      (for-loop_0 #t start*_1 start_1))))))
-              (args (raise-binding-result-arity-error 4 args)))))
+                      (for-loop_0 #t start*_1 start_1))))))))
         (|#%app|
          next-m_0
          s_0
@@ -5346,8 +5204,7 @@
                   0
                   len_0
                   1))
-               (case-lambda
-                ((v*_0 start*_0 stop*_0 step*_0)
+               (lambda (v*_0 start*_0 stop*_0 step*_0)
                  (call-with-values
                   (lambda ()
                     (unsafe-normalise-inputs
@@ -5356,8 +5213,7 @@
                      pos_0
                      (+ pos_0 len_0)
                      1))
-                  (case-lambda
-                   ((v*_1 start*_1 stop*_1 step*_1)
+                  (lambda (v*_1 start*_1 stop*_1 step*_1)
                     (let ((v*_2 v*_0)
                           (start*_2 start*_0)
                           (stop*_2 stop*_0)
@@ -5392,15 +5248,12 @@
                                            (unsafe-fx+ idx_1 1))
                                           result_1)))))
                                 result_0))))))
-                       (for-loop_0 #t start*_2 start*_1))))
-                   (args (raise-binding-result-arity-error 4 args)))))
-                (args (raise-binding-result-arity-error 4 args))))
+                       (for-loop_0 #t start*_2 start*_1)))))))
               #f)
             (call-with-values
              (lambda ()
                (unsafe-normalise-inputs unsafe-bytes-length bstr_0 0 len_0 1))
-             (case-lambda
-              ((v*_0 start*_0 stop*_0 step*_0)
+             (lambda (v*_0 start*_0 stop*_0 step*_0)
                (let ((start_1 pos_0))
                  (let ((v*_1 v*_0)
                        (start*_1 start*_0)
@@ -5443,8 +5296,7 @@
                                       (+ pos_1 1))
                                      result_1)))
                                result_0))))))
-                      (for-loop_0 #t start*_1 start_1))))))
-              (args (raise-binding-result-arity-error 4 args)))))
+                      (for-loop_0 #t start*_1 start_1))))))))
         (+ pos_0 len_0)
         #f))))
 (define bytes-matcher*
@@ -5473,8 +5325,7 @@
                                    0
                                    len_0
                                    1))
-                                (case-lambda
-                                 ((v*_0 start*_0 stop*_0 step*_0)
+                                (lambda (v*_0 start*_0 stop*_0 step*_0)
                                   (call-with-values
                                    (lambda ()
                                      (unsafe-normalise-inputs
@@ -5483,8 +5334,7 @@
                                       pos_1
                                       (+ pos_1 len_0)
                                       1))
-                                   (case-lambda
-                                    ((v*_1 start*_1 stop*_1 step*_1)
+                                   (lambda (v*_1 start*_1 stop*_1 step*_1)
                                      (let ((v*_2 v*_0)
                                            (start*_2 start*_0)
                                            (stop*_2 stop*_0)
@@ -5541,15 +5391,10 @@
                                                              1))
                                                            result_1)))))
                                                  result_0))))))
-                                        (for-loop_0 #t start*_2 start*_1))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      4
-                                      args)))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   4
-                                   args)))))))
+                                        (for-loop_0
+                                         #t
+                                         start*_2
+                                         start*_1))))))))))
                         (values pos_1 n_0 len_0)
                         (loop_0 pos3_0 (add1 n_0)))))))))
              (loop_0 pos_0 0)))
@@ -5581,8 +5426,7 @@
                                      0
                                      len_0
                                      1))
-                                  (case-lambda
-                                   ((v*_0 start*_0 stop*_0 step*_0)
+                                  (lambda (v*_0 start*_0 stop*_0 step*_0)
                                     (let ((start_1 pos_1))
                                       (let ((v*_1 v*_0)
                                             (start*_1 start*_0)
@@ -5644,11 +5488,7 @@
                                            (for-loop_0
                                             #t
                                             start*_1
-                                            start_1))))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     4
-                                     args)))))))))
+                                            start_1))))))))))))
                       (values pos_1 n_0 len_0)
                       (let ((app_0 (+ pos_1 len_0)))
                         (loop_0 app_0 (add1 n_0)))))))))
@@ -6047,8 +5887,7 @@
     (lambda (s_0 pos_0 start_0 limit_0 end_0 state_0 stack_0)
       (call-with-values
        (lambda () (|#%app| r-m*_0 s_0 pos_0 start_0 limit_0 end_0 state_0))
-       (case-lambda
-        ((pos2_0 n_0 back-amt_0)
+       (lambda (pos2_0 n_0 back-amt_0)
          (letrec*
           ((bloop_0
             (|#%name|
@@ -6111,8 +5950,7 @@
                              (group-revert_0)
                              (let ((app_0 (- pos_1 back-amt_0)))
                                (bloop_0 app_0 (sub1 n_1))))))))))))))
-          (bloop_0 pos2_0 n_0)))
-        (args (raise-binding-result-arity-error 3 args)))))))
+          (bloop_0 pos2_0 n_0)))))))
 (define lazy-repeat-matcher
   (lambda (r-m_0 min_0 max_0 next-m_0)
     (lambda (s_0 pos_0 start_0 limit_0 end_0 state_0 stack_0)
@@ -6264,8 +6102,7 @@
                              app_0
                              (cdr p_0)
                              1)))
-                        (case-lambda
-                         ((v*_0 start*_0 stop*_0 step*_0)
+                        (lambda (v*_0 start*_0 stop*_0 step*_0)
                           (call-with-values
                            (lambda ()
                              (unsafe-normalise-inputs
@@ -6274,8 +6111,7 @@
                               pos_0
                               (+ pos_0 len_0)
                               1))
-                           (case-lambda
-                            ((v*_1 start*_1 stop*_1 step*_1)
+                           (lambda (v*_1 start*_1 stop*_1 step*_1)
                              (let ((v*_2 v*_0)
                                    (start*_2 start*_0)
                                    (stop*_2 stop*_0)
@@ -6318,9 +6154,7 @@
                                                     (unsafe-fx+ idx_1 1))
                                                    result_1)))))
                                          result_0))))))
-                                (for-loop_0 #t start*_2 start*_1))))
-                            (args (raise-binding-result-arity-error 4 args)))))
-                         (args (raise-binding-result-arity-error 4 args))))
+                                (for-loop_0 #t start*_2 start*_1)))))))
                        #f)
                      (let ((start_1 (car p_0)))
                        (let ((end_1 (cdr p_0)))
@@ -6397,8 +6231,7 @@
                              app_0
                              (cdr p_0)
                              1)))
-                        (case-lambda
-                         ((v*_0 start*_0 stop*_0 step*_0)
+                        (lambda (v*_0 start*_0 stop*_0 step*_0)
                           (call-with-values
                            (lambda ()
                              (unsafe-normalise-inputs
@@ -6407,8 +6240,7 @@
                               pos_0
                               (+ pos_0 len_0)
                               1))
-                           (case-lambda
-                            ((v*_1 start*_1 stop*_1 step*_1)
+                           (lambda (v*_1 start*_1 stop*_1 step*_1)
                              (let ((v*_2 v*_0)
                                    (start*_2 start*_0)
                                    (stop*_2 stop*_0)
@@ -6457,9 +6289,7 @@
                                                     (unsafe-fx+ idx_1 1))
                                                    result_1)))))
                                          result_0))))))
-                                (for-loop_0 #t start*_2 start*_1))))
-                            (args (raise-binding-result-arity-error 4 args)))))
-                         (args (raise-binding-result-arity-error 4 args))))
+                                (for-loop_0 #t start*_2 start*_1)))))))
                        #f)
                      (let ((start_1 (car p_0)))
                        (let ((end_1 (cdr p_0)))
@@ -7296,8 +7126,7 @@
                 (string->immutable-string orig-p_0))))
          (call-with-values
           (lambda () (parse.1 px?_0 p_0))
-          (case-lambda
-           ((raw-rx_0 num-groups_0 references?_0)
+          (lambda (raw-rx_0 num-groups_0 references?_0)
             (let ((rx_0 (if as-bytes?_0 raw-rx_0 (convert raw-rx_0))))
               (let ((max-lookbehind_0 (validate rx_0 num-groups_0)))
                 (let ((matcher_0 (1/compile rx_0)))
@@ -7313,8 +7142,7 @@
                        max-lookbehind_0
                        app_0
                        app_1
-                       (get-start-range rx_0))))))))
-           (args (raise-binding-result-arity-error 3 args))))))
+                       (get-start-range rx_0)))))))))))
      regexp-error-tag
      (lambda (str_0)
        (if handler_0
@@ -7518,8 +7346,7 @@
                (call-with-values
                 (lambda ()
                   (begin (values state5_0 (unsafe-vector-length state5_0))))
-                (case-lambda
-                 ((vec_0 len_0)
+                (lambda (vec_0 len_0)
                   (letrec*
                    ((for-loop_0
                      (|#%name|
@@ -7542,8 +7369,7 @@
                                        (values fold-var_1))))
                                 (for-loop_0 fold-var_1 (unsafe-fx+ 1 pos_0))))
                             fold-var_0))))))
-                   (for-loop_0 null 0)))
-                 (args (raise-binding-result-arity-error 2 args)))))))))))))
+                   (for-loop_0 null 0)))))))))))))
 (define byte-positions->bytess.1
   (|#%name|
    byte-positions->bytess
@@ -7559,8 +7385,7 @@
              (call-with-values
               (lambda ()
                 (begin (values state12_0 (unsafe-vector-length state12_0))))
-              (case-lambda
-               ((vec_0 len_0)
+              (lambda (vec_0 len_0)
                 (letrec*
                  ((for-loop_0
                    (|#%name|
@@ -7584,8 +7409,7 @@
                                      (values fold-var_1))))
                               (for-loop_0 fold-var_1 (unsafe-fx+ 1 pos_0))))
                           fold-var_0))))))
-                 (for-loop_0 null 0)))
-               (args (raise-binding-result-arity-error 2 args)))))
+                 (for-loop_0 null 0)))))
             null)))))))
 (define byte-positions->string-positions.1
   (|#%name|
@@ -7629,8 +7453,7 @@
                (call-with-values
                 (lambda ()
                   (begin (values state23_0 (unsafe-vector-length state23_0))))
-                (case-lambda
-                 ((vec_0 len_0)
+                (lambda (vec_0 len_0)
                   (letrec*
                    ((for-loop_0
                      (|#%name|
@@ -7654,8 +7477,7 @@
                                        (values fold-var_1))))
                                 (for-loop_0 fold-var_1 (unsafe-fx+ 1 pos_0))))
                             fold-var_0))))))
-                   (for-loop_0 null 0)))
-                 (args (raise-binding-result-arity-error 2 args)))))
+                   (for-loop_0 null 0)))))
               null))))))))
 (define byte-positions->strings.1
   (|#%name|
@@ -7676,8 +7498,7 @@
              (call-with-values
               (lambda ()
                 (begin (values state30_0 (unsafe-vector-length state30_0))))
-              (case-lambda
-               ((vec_0 len_0)
+              (lambda (vec_0 len_0)
                 (letrec*
                  ((for-loop_0
                    (|#%name|
@@ -7702,8 +7523,7 @@
                                      (values fold-var_1))))
                               (for-loop_0 fold-var_1 (unsafe-fx+ 1 pos_0))))
                           fold-var_0))))))
-                 (for-loop_0 null 0)))
-               (args (raise-binding-result-arity-error 2 args)))))
+                 (for-loop_0 null 0)))))
             null)))))))
 (define byte-index->string-index
   (lambda (str_0 start-pos_0 pos_0)
@@ -7828,8 +7648,7 @@
                   pos_0
                   end-pos_0
                   1))
-               (case-lambda
-                ((v*_0 start*_0 stop*_0 step*_0)
+               (lambda (v*_0 start*_0 stop*_0 step*_0)
                  (letrec*
                   ((for-loop_0
                     (|#%name|
@@ -7847,8 +7666,7 @@
                                  (for-loop_0 result_1 (unsafe-fx+ idx_0 1))
                                  result_1)))
                            result_0))))))
-                  (for-loop_0 #f start*_0)))
-                (args (raise-binding-result-arity-error 4 args)))))
+                  (for-loop_0 #f start*_0)))))
             (let ((mc1_0 (unsafe-bytes-ref must-string_0 0)))
               (let ((end_0
                      (- end-pos_0 (sub1 (unsafe-bytes-length must-string_0)))))
@@ -7873,8 +7691,10 @@
                                                 (add1 pos_1)
                                                 #f
                                                 1))
-                                             (case-lambda
-                                              ((v*_0 start*_0 stop*_0 step*_0)
+                                             (lambda (v*_0
+                                                      start*_0
+                                                      stop*_0
+                                                      step*_0)
                                                (call-with-values
                                                 (lambda ()
                                                   (unsafe-normalise-inputs
@@ -7883,11 +7703,10 @@
                                                    1
                                                    #f
                                                    1))
-                                                (case-lambda
-                                                 ((v*_1
-                                                   start*_1
-                                                   stop*_1
-                                                   step*_1)
+                                                (lambda (v*_1
+                                                         start*_1
+                                                         stop*_1
+                                                         step*_1)
                                                   (let ((v*_2 v*_0)
                                                         (start*_2 start*_0)
                                                         (stop*_2 stop*_0)
@@ -7952,15 +7771,7 @@
                                                      (for-loop_1
                                                       #t
                                                       start*_2
-                                                      start*_1))))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   4
-                                                   args)))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                4
-                                                args))))
+                                                      start*_1)))))))
                                             #f)))
                                      (values result_1))))
                               (if (if (not (let ((x_0 (list pos_1))) result_1))
@@ -8035,9 +7846,7 @@
           start-pos_0
           (if end-pos_0 end-pos_0 (unsafe-bytes-length in_0))
           state_0))
-       (case-lambda
-        ((ms-pos_0 me-pos_0) (if ms-pos_0 #t #f))
-        (args (raise-binding-result-arity-error 2 args)))))))
+       (lambda (ms-pos_0 me-pos_0) (if ms-pos_0 #t #f))))))
 (define fast-drive-regexp-match?/string
   (lambda (rx_0 in-str_0 start-offset_0 end-offset_0)
     (let ((state_0
@@ -8053,9 +7862,7 @@
         (call-with-values
          (lambda ()
            (search-match rx_0 in_0 0 0 (unsafe-bytes-length in_0) state_0))
-         (case-lambda
-          ((ms-pos_0 me-pos_0) (if ms-pos_0 #t #f))
-          (args (raise-binding-result-arity-error 2 args))))))))
+         (lambda (ms-pos_0 me-pos_0) (if ms-pos_0 #t #f)))))))
 (define fast-drive-regexp-match-positions/bytes
   (lambda (rx_0 in_0 start-pos_0 end-pos_0)
     (let ((state_0
@@ -8070,15 +7877,13 @@
           start-pos_0
           (if end-pos_0 end-pos_0 (unsafe-bytes-length in_0))
           state_0))
-       (case-lambda
-        ((ms-pos_0 me-pos_0)
+       (lambda (ms-pos_0 me-pos_0)
          (if ms-pos_0
            (if state_0
              (let ((app_0 (cons ms-pos_0 me-pos_0)))
                (cons app_0 (vector->list state_0)))
              (list (cons ms-pos_0 me-pos_0)))
-           #f))
-        (args (raise-binding-result-arity-error 2 args)))))))
+           #f))))))
 (define fast-drive-regexp-match-positions/string
   (lambda (rx_0 in-str_0 start-offset_0 end-offset_0)
     (let ((in_0
@@ -8093,8 +7898,7 @@
         (call-with-values
          (lambda ()
            (search-match rx_0 in_0 0 0 (unsafe-bytes-length in_0) state_0))
-         (case-lambda
-          ((ms-pos_0 me-pos_0)
+         (lambda (ms-pos_0 me-pos_0)
            (let ((string-offset_0
                   (|#%name|
                    string-offset
@@ -8115,8 +7919,7 @@
                       (lambda ()
                         (begin
                           (values state_0 (unsafe-vector-length state_0))))
-                      (case-lambda
-                       ((vec_0 len_0)
+                      (lambda (vec_0 len_0)
                         (letrec*
                          ((for-loop_0
                            (|#%name|
@@ -8143,11 +7946,9 @@
                                        fold-var_1
                                        (unsafe-fx+ 1 pos_0))))
                                   fold-var_0))))))
-                         (for-loop_0 null 0)))
-                       (args (raise-binding-result-arity-error 2 args)))))
+                         (for-loop_0 null 0)))))
                     null)))
-               #f)))
-          (args (raise-binding-result-arity-error 2 args))))))))
+               #f))))))))
 (define fast-drive-regexp-match/bytes
   (lambda (rx_0 in_0 start-pos_0 end-pos_0)
     (let ((state_0
@@ -8162,8 +7963,7 @@
           start-pos_0
           (if end-pos_0 end-pos_0 (unsafe-bytes-length in_0))
           state_0))
-       (case-lambda
-        ((ms-pos_0 me-pos_0)
+       (lambda (ms-pos_0 me-pos_0)
          (if ms-pos_0
            (let ((app_0 (subbytes in_0 ms-pos_0 me-pos_0)))
              (cons
@@ -8173,8 +7973,7 @@
                  (call-with-values
                   (lambda ()
                     (begin (values state_0 (unsafe-vector-length state_0))))
-                  (case-lambda
-                   ((vec_0 len_0)
+                  (lambda (vec_0 len_0)
                     (letrec*
                      ((for-loop_0
                        (|#%name|
@@ -8199,11 +7998,9 @@
                                    fold-var_1
                                    (unsafe-fx+ 1 pos_0))))
                               fold-var_0))))))
-                     (for-loop_0 null 0)))
-                   (args (raise-binding-result-arity-error 2 args)))))
+                     (for-loop_0 null 0)))))
                 null)))
-           #f))
-        (args (raise-binding-result-arity-error 2 args)))))))
+           #f))))))
 (define fast-drive-regexp-match/string
   (lambda (rx_0 in-str_0 start-offset_0 end-offset_0)
     (let ((in_0
@@ -8218,8 +8015,7 @@
         (call-with-values
          (lambda ()
            (search-match rx_0 in_0 0 0 (unsafe-bytes-length in_0) state_0))
-         (case-lambda
-          ((ms-pos_0 me-pos_0)
+         (lambda (ms-pos_0 me-pos_0)
            (if ms-pos_0
              (let ((app_0 (bytes->string/utf-8 in_0 '#\x3f ms-pos_0 me-pos_0)))
                (cons
@@ -8229,8 +8025,7 @@
                    (call-with-values
                     (lambda ()
                       (begin (values state_0 (unsafe-vector-length state_0))))
-                    (case-lambda
-                     ((vec_0 len_0)
+                    (lambda (vec_0 len_0)
                       (letrec*
                        ((for-loop_0
                          (|#%name|
@@ -8256,11 +8051,9 @@
                                      fold-var_1
                                      (unsafe-fx+ 1 pos_0))))
                                 fold-var_0))))))
-                       (for-loop_0 null 0)))
-                     (args (raise-binding-result-arity-error 2 args)))))
+                       (for-loop_0 null 0)))))
                   null)))
-             #f))
-          (args (raise-binding-result-arity-error 2 args))))))))
+             #f)))))))
 (define drive-regexp-match.1
   (|#%name|
    drive-regexp-match
@@ -8402,8 +8195,7 @@
                                  start-offset_0
                                  end-offset_0
                                  state_0))
-                              (case-lambda
-                               ((ms-pos_0 me-pos_0)
+                              (lambda (ms-pos_0 me-pos_0)
                                 (begin
                                   (if out24_0
                                     (write-bytes
@@ -8446,9 +8238,7 @@
                                                end-bytes-count9_0
                                                in_0
                                                me-pos_0))
-                                            (void))))))))
-                               (args
-                                (raise-binding-result-arity-error 2 args))))
+                                            (void)))))))))
                              (if (if (string? in_0)
                                    (if (not out24_0)
                                      (if (equal? #vu8() prefix25_0)
@@ -8480,8 +8270,7 @@
                                          0
                                          end-pos_0
                                          state_0))
-                                      (case-lambda
-                                       ((ms-pos_0 me-pos_0)
+                                      (lambda (ms-pos_0 me-pos_0)
                                         (begin
                                           (if out24_0
                                             (begin
@@ -8556,11 +8345,7 @@
                                                        end-bytes-count9_0
                                                        bstr-in_0
                                                        me-pos_0))
-                                                    (void))))))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         2
-                                         args)))))))
+                                                    (void))))))))))))
                                (let ((prefix-len_0
                                       (unsafe-bytes-length prefix25_0)))
                                  (let ((search-pos_0
@@ -8671,8 +8456,7 @@
                                                    end-pos_0
                                                    state_0)
                                                   (values #f #f)))
-                                              (case-lambda
-                                               ((ms-pos_0 me-pos_0)
+                                              (lambda (ms-pos_0 me-pos_0)
                                                 (let ((write/consume-skipped_0
                                                        (|#%name|
                                                         write/consume-skipped
@@ -8840,11 +8624,7 @@
                                                                       me-pos_0
                                                                       delta_0)))))
                                                               (void))))))
-                                                    (write/consume-skipped_0))))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args)))))))))))))))))))))))))))
+                                                    (write/consume-skipped_0))))))))))))))))))))))))))))
 (define check-range
   (lambda (who_0 what_0 in_0 pos_0 start-pos_0)
     (let ((len_0

--- a/racket/src/cs/schemified/schemify.scm
+++ b/racket/src/cs/schemified/schemify.scm
@@ -1864,8 +1864,7 @@
         (void)
         (call-with-values
          (lambda () (procedure-keywords f_0))
-         (case-lambda
-          ((required-keywords_0 optional-keywords_0)
+         (lambda (required-keywords_0 optional-keywords_0)
            (let ((app_0
                   (if (pair? required-keywords_0)
                     (string-append
@@ -1967,8 +1966,7 @@
                                            app_5
                                            (loop_0 (cdr ls_1))))))))))
                                (loop_0 ls_0)))))
-                           null))))))))))
-          (args (raise-binding-result-arity-error 2 args))))))))
+                           null)))))))))))))))
 (define gen-map
   (lambda (f_0 ls_0)
     (begin
@@ -5052,15 +5050,13 @@
       (if (procedure? knowns/proc_0)
         (call-with-values
          (lambda () (|#%app| knowns/proc_0 (import-group-key grp_0)))
-         (case-lambda
-          ((knowns_0 converter_0 import-keys_0)
+         (lambda (knowns_0 converter_0 import-keys_0)
            (let ((knowns-or-empty_0 (if knowns_0 knowns_0 (hasheq))))
              (begin
                (set-import-group-knowns/proc! grp_0 knowns-or-empty_0)
                (set-import-group-converter! grp_0 converter_0)
                (set-import-group-import-keys! grp_0 import-keys_0)
-               knowns-or-empty_0)))
-          (args (raise-binding-result-arity-error 3 args))))
+               knowns-or-empty_0))))
         knowns/proc_0))))
 (define import-group-lookup-ready?
   (lambda (grp_0)
@@ -5759,58 +5755,37 @@
                                                                                  (values
                                                                                   idss_2
                                                                                   rhss_1))))))
-                                                                       (case-lambda
-                                                                        ((idss19_0
-                                                                          rhss20_0)
+                                                                       (lambda (idss19_0
+                                                                                rhss20_0)
                                                                          (values
                                                                           (cons
                                                                            idss19_0
                                                                            idss_0)
                                                                           (cons
                                                                            rhss20_0
-                                                                           rhss_0)))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args)))))
-                                                                    (case-lambda
-                                                                     ((idss_1
-                                                                       rhss_1)
+                                                                           rhss_0)))))
+                                                                    (lambda (idss_1
+                                                                             rhss_1)
                                                                       (values
                                                                        idss_1
-                                                                       rhss_1))
-                                                                     (args
-                                                                      (raise-binding-result-arity-error
-                                                                       2
-                                                                       args)))))
-                                                                 (case-lambda
-                                                                  ((idss_1
-                                                                    rhss_1)
+                                                                       rhss_1))))
+                                                                 (lambda (idss_1
+                                                                          rhss_1)
                                                                    (for-loop_0
                                                                     idss_1
                                                                     rhss_1
-                                                                    rest_0))
-                                                                  (args
-                                                                   (raise-binding-result-arity-error
-                                                                    2
-                                                                    args)))))))
+                                                                    rest_0))))))
                                                           (values
                                                            idss_0
                                                            rhss_0)))))))
                                                  (for-loop_0 null null a_0)))
-                                              (case-lambda
-                                               ((idss_0 rhss_0)
+                                              (lambda (idss_0 rhss_0)
                                                 (let ((app_0
                                                        (reverse$1 idss_0)))
                                                   (values
                                                    app_0
-                                                   (reverse$1 rhss_0))))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args))))))
-                                         (case-lambda
-                                          ((idss_0 rhss_0)
+                                                   (reverse$1 rhss_0)))))))
+                                         (lambda (idss_0 rhss_0)
                                            (let ((body_0
                                                   (let ((d_1 (cdr p_0)))
                                                     (let ((a_0
@@ -5818,13 +5793,11 @@
                                                       a_0))))
                                              (let ((idss_1 idss_0)
                                                    (rhss_1 rhss_0))
-                                               (values idss_1 rhss_1 body_0))))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args)))))))
-                                  (case-lambda
-                                   ((idss_0 rhss_0 body_0)
+                                               (values
+                                                idss_1
+                                                rhss_1
+                                                body_0))))))))
+                                  (lambda (idss_0 rhss_0 body_0)
                                     (let ((c_0
                                            (hash-ref
                                             simples16_0
@@ -5971,11 +5944,7 @@
                                                            c_0
                                                            2)))))
                                                     r_1))
-                                                r_0)))))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     3
-                                     args))))
+                                                r_0))))))))
                                  (if (if (eq? 'let hd_0)
                                        (let ((a_0 (cdr (unwrap e_0))))
                                          (let ((p_0 (unwrap a_0)))
@@ -6141,8 +6110,7 @@
                                                        a_0))))
                                               (let ((rhss_1 rhss_0))
                                                 (values rhss_1 body_0)))))))
-                                    (case-lambda
-                                     ((rhss_0 body_0)
+                                    (lambda (rhss_0 body_0)
                                       (let ((c_0
                                              (hash-ref
                                               simples16_0
@@ -6274,11 +6242,7 @@
                                                              c_0
                                                              2)))))
                                                       r_1))
-                                                  r_0)))))))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args))))
+                                                  r_0))))))))
                                    (if (if (eq? 'letrec-values hd_0)
                                          (let ((a_0 (cdr (unwrap e_0))))
                                            (let ((p_0 (unwrap a_0)))
@@ -6449,41 +6413,26 @@
                                                                                      (values
                                                                                       idss_2
                                                                                       rhss_1))))))
-                                                                           (case-lambda
-                                                                            ((idss22_0
-                                                                              rhss23_0)
+                                                                           (lambda (idss22_0
+                                                                                    rhss23_0)
                                                                              (values
                                                                               (cons
                                                                                idss22_0
                                                                                idss_0)
                                                                               (cons
                                                                                rhss23_0
-                                                                               rhss_0)))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args)))))
-                                                                        (case-lambda
-                                                                         ((idss_1
-                                                                           rhss_1)
+                                                                               rhss_0)))))
+                                                                        (lambda (idss_1
+                                                                                 rhss_1)
                                                                           (values
                                                                            idss_1
-                                                                           rhss_1))
-                                                                         (args
-                                                                          (raise-binding-result-arity-error
-                                                                           2
-                                                                           args)))))
-                                                                     (case-lambda
-                                                                      ((idss_1
-                                                                        rhss_1)
+                                                                           rhss_1))))
+                                                                     (lambda (idss_1
+                                                                              rhss_1)
                                                                        (for-loop_0
                                                                         idss_1
                                                                         rhss_1
-                                                                        rest_0))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        2
-                                                                        args)))))))
+                                                                        rest_0))))))
                                                               (values
                                                                idss_0
                                                                rhss_0)))))))
@@ -6491,19 +6440,13 @@
                                                       null
                                                       null
                                                       a_0)))
-                                                  (case-lambda
-                                                   ((idss_0 rhss_0)
+                                                  (lambda (idss_0 rhss_0)
                                                     (let ((app_0
                                                            (reverse$1 idss_0)))
                                                       (values
                                                        app_0
-                                                       (reverse$1 rhss_0))))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     2
-                                                     args))))))
-                                             (case-lambda
-                                              ((idss_0 rhss_0)
+                                                       (reverse$1 rhss_0)))))))
+                                             (lambda (idss_0 rhss_0)
                                                (let ((body_0
                                                       (let ((d_1 (cdr p_0)))
                                                         (let ((a_0
@@ -6515,13 +6458,8 @@
                                                    (values
                                                     idss_1
                                                     rhss_1
-                                                    body_0))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args)))))))
-                                      (case-lambda
-                                       ((idss_0 rhss_0 body_0)
+                                                    body_0))))))))
+                                      (lambda (idss_0 rhss_0 body_0)
                                         (let ((c_0
                                                (hash-ref
                                                 simples16_0
@@ -6677,11 +6615,7 @@
                                                                c_0
                                                                2)))))
                                                         r_1))
-                                                    r_0)))))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         3
-                                         args))))
+                                                    r_0))))))))
                                      (if (if (eq? 'letrec* hd_0)
                                            (let ((a_0 (cdr (unwrap e_0))))
                                              (let ((p_0 (unwrap a_0)))
@@ -6846,41 +6780,26 @@
                                                                                        (values
                                                                                         ids_2
                                                                                         rhss_1))))))
-                                                                             (case-lambda
-                                                                              ((ids24_0
-                                                                                rhss25_0)
+                                                                             (lambda (ids24_0
+                                                                                      rhss25_0)
                                                                                (values
                                                                                 (cons
                                                                                  ids24_0
                                                                                  ids_0)
                                                                                 (cons
                                                                                  rhss25_0
-                                                                                 rhss_0)))
-                                                                              (args
-                                                                               (raise-binding-result-arity-error
-                                                                                2
-                                                                                args)))))
-                                                                          (case-lambda
-                                                                           ((ids_1
-                                                                             rhss_1)
+                                                                                 rhss_0)))))
+                                                                          (lambda (ids_1
+                                                                                   rhss_1)
                                                                             (values
                                                                              ids_1
-                                                                             rhss_1))
-                                                                           (args
-                                                                            (raise-binding-result-arity-error
-                                                                             2
-                                                                             args)))))
-                                                                       (case-lambda
-                                                                        ((ids_1
-                                                                          rhss_1)
+                                                                             rhss_1))))
+                                                                       (lambda (ids_1
+                                                                                rhss_1)
                                                                          (for-loop_0
                                                                           ids_1
                                                                           rhss_1
-                                                                          rest_0))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args)))))))
+                                                                          rest_0))))))
                                                                 (values
                                                                  ids_0
                                                                  rhss_0)))))))
@@ -6888,20 +6807,15 @@
                                                         null
                                                         null
                                                         a_0)))
-                                                    (case-lambda
-                                                     ((ids_0 rhss_0)
+                                                    (lambda (ids_0 rhss_0)
                                                       (let ((app_0
                                                              (reverse$1
                                                               ids_0)))
                                                         (values
                                                          app_0
-                                                         (reverse$1 rhss_0))))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args))))))
-                                               (case-lambda
-                                                ((ids_0 rhss_0)
+                                                         (reverse$1
+                                                          rhss_0)))))))
+                                               (lambda (ids_0 rhss_0)
                                                  (let ((body_0
                                                         (let ((d_1 (cdr p_0)))
                                                           (let ((a_0
@@ -6914,13 +6828,8 @@
                                                      (values
                                                       ids_1
                                                       rhss_1
-                                                      body_0))))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args)))))))
-                                        (case-lambda
-                                         ((ids_0 rhss_0 body_0)
+                                                      body_0))))))))
+                                        (lambda (ids_0 rhss_0 body_0)
                                           (let ((c_0
                                                  (hash-ref
                                                   simples16_0
@@ -7058,11 +6967,7 @@
                                                                  c_0
                                                                  2)))))
                                                           r_1))
-                                                      r_0)))))))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           3
-                                           args))))
+                                                      r_0))))))))
                                        (if (if (if (eq? 'begin hd_0)
                                                  (let ((a_0
                                                         (cdr (unwrap e_0))))
@@ -7109,8 +7014,7 @@
                                                           (values
                                                            e0_1
                                                            es_0)))))))
-                                              (case-lambda
-                                               ((e0_0 es_0)
+                                              (lambda (e0_0 es_0)
                                                 (let ((c_0
                                                        (hash-ref
                                                         simples16_0
@@ -7253,11 +7157,7 @@
                                                                        c_0
                                                                        2)))))
                                                                 r_1))
-                                                            r_0)))))))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args))))
+                                                            r_0))))))))
                                              (if (if (if (eq? 'set! hd_0)
                                                        (let ((a_0
                                                               (cdr
@@ -7375,20 +7275,15 @@
                                                                        (values
                                                                         thn_1
                                                                         els_0)))))))
-                                                           (case-lambda
-                                                            ((thn_0 els_0)
+                                                           (lambda (thn_0
+                                                                    els_0)
                                                              (let ((tst_1
                                                                     tst_0))
                                                                (values
                                                                 tst_1
                                                                 thn_0
-                                                                els_0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args))))))))
-                                                  (case-lambda
-                                                   ((tst_0 thn_0 els_0)
+                                                                els_0))))))))
+                                                  (lambda (tst_0 thn_0 els_0)
                                                     (if (simple?_0 tst_0 1)
                                                       (if (simple?_0
                                                            thn_0
@@ -7397,11 +7292,7 @@
                                                          els_0
                                                          result-arity_0)
                                                         #f)
-                                                      #f))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     3
-                                                     args))))
+                                                      #f)))
                                                  (if (if (eq? 'values hd_0)
                                                        (let ((a_0
                                                               (cdr
@@ -7603,8 +7494,7 @@
                                                                   (values
                                                                    proc_1
                                                                    es_0)))))))
-                                                      (case-lambda
-                                                       ((proc_0 es_0)
+                                                      (lambda (proc_0 es_0)
                                                         (let ((c_0
                                                                (hash-ref
                                                                 simples16_0
@@ -7777,11 +7667,7 @@
                                                                                c_0
                                                                                2)))))
                                                                         r_1))
-                                                                    r_0)))))))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))
+                                                                    r_0))))))))
                                                      (if (let ((p_0
                                                                 (unwrap e_0)))
                                                            (if (pair? p_0)
@@ -7806,8 +7692,7 @@
                                                                   (values
                                                                    proc_1
                                                                    args_0))))))
-                                                        (case-lambda
-                                                         ((proc_0 args_0)
+                                                        (lambda (proc_0 args_0)
                                                           (let ((c_0
                                                                  (hash-ref
                                                                   simples16_0
@@ -7989,11 +7874,7 @@
                                                                                  c_0
                                                                                  2)))))
                                                                           r_1))
-                                                                      r_0)))))))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args))))
+                                                                      r_0))))))))
                                                        (let ((e_1
                                                               (unwrap e_0)))
                                                          (if (returns_0 1)
@@ -8101,9 +7982,7 @@
     (call-with-values
      (lambda ()
        (find-known+import key_0 prim-knowns_0 knowns_0 imports_0 mutated_0))
-     (case-lambda
-      ((k_0 im_0) k_0)
-      (args (raise-binding-result-arity-error 2 args))))))
+     (lambda (k_0 im_0) k_0))))
 (define unwrap-let
   (lambda (v_0)
     (let ((hd_0
@@ -8269,18 +8148,14 @@
                                               a_2))))
                                      (let ((id_1 id_0))
                                        (values id_1 rhs_0))))))))
-                         (case-lambda
-                          ((id_0 rhs_0)
+                         (lambda (id_0 rhs_0)
                            (let ((body_0
                                   (let ((d_1 (cdr p_0)))
                                     (let ((a_0 (car (unwrap d_1)))) a_0))))
                              (let ((id_1 id_0) (rhs_1 rhs_0))
-                               (values id_1 rhs_1 body_0))))
-                          (args (raise-binding-result-arity-error 2 args)))))))
-                  (case-lambda
-                   ((id_0 rhs_0 body_0)
-                    (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0))
-                   (args (raise-binding-result-arity-error 3 args))))
+                               (values id_1 rhs_1 body_0))))))))
+                  (lambda (id_0 rhs_0 body_0)
+                    (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0)))
                  (if (if (eq? 'letrec-values hd_0)
                        (let ((a_0 (cdr (unwrap v_0))))
                          (let ((p_0 (unwrap a_0)))
@@ -8356,19 +8231,14 @@
                                                 a_2))))
                                        (let ((id_1 id_0))
                                          (values id_1 rhs_0))))))))
-                           (case-lambda
-                            ((id_0 rhs_0)
+                           (lambda (id_0 rhs_0)
                              (let ((body_0
                                     (let ((d_1 (cdr p_0)))
                                       (let ((a_0 (car (unwrap d_1)))) a_0))))
                                (let ((id_1 id_0) (rhs_1 rhs_0))
-                                 (values id_1 rhs_1 body_0))))
-                            (args
-                             (raise-binding-result-arity-error 2 args)))))))
-                    (case-lambda
-                     ((id_0 rhs_0 body_0)
-                      (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0))
-                     (args (raise-binding-result-arity-error 3 args))))
+                                 (values id_1 rhs_1 body_0))))))))
+                    (lambda (id_0 rhs_0 body_0)
+                      (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0)))
                    (if (if (eq? 'let hd_0)
                          (let ((a_0 (cdr (unwrap v_0))))
                            (let ((p_0 (unwrap a_0)))
@@ -8425,19 +8295,14 @@
                                                   a_2))))
                                          (let ((id_1 id_0))
                                            (values id_1 rhs_0))))))))
-                             (case-lambda
-                              ((id_0 rhs_0)
+                             (lambda (id_0 rhs_0)
                                (let ((body_0
                                       (let ((d_1 (cdr p_0)))
                                         (let ((a_0 (car (unwrap d_1)))) a_0))))
                                  (let ((id_1 id_0) (rhs_1 rhs_0))
-                                   (values id_1 rhs_1 body_0))))
-                              (args
-                               (raise-binding-result-arity-error 2 args)))))))
-                      (case-lambda
-                       ((id_0 rhs_0 body_0)
-                        (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0))
-                       (args (raise-binding-result-arity-error 3 args))))
+                                   (values id_1 rhs_1 body_0))))))))
+                      (lambda (id_0 rhs_0 body_0)
+                        (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0)))
                      (if (if (eq? 'letrec* hd_0)
                            (let ((a_0 (cdr (unwrap v_0))))
                              (let ((p_0 (unwrap a_0)))
@@ -8499,22 +8364,15 @@
                                                     a_2))))
                                            (let ((id_1 id_0))
                                              (values id_1 rhs_0))))))))
-                               (case-lambda
-                                ((id_0 rhs_0)
+                               (lambda (id_0 rhs_0)
                                  (let ((body_0
                                         (let ((d_1 (cdr p_0)))
                                           (let ((a_0 (car (unwrap d_1))))
                                             a_0))))
                                    (let ((id_1 id_0) (rhs_1 rhs_0))
-                                     (values id_1 rhs_1 body_0))))
-                                (args
-                                 (raise-binding-result-arity-error
-                                  2
-                                  args)))))))
-                        (case-lambda
-                         ((id_0 rhs_0 body_0)
-                          (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0))
-                         (args (raise-binding-result-arity-error 3 args))))
+                                     (values id_1 rhs_1 body_0))))))))
+                        (lambda (id_0 rhs_0 body_0)
+                          (let-lambda?.1 simple?1_0 id_0 rhs_0 body_0)))
                        (if (if (eq? 'let-values hd_0)
                              (let ((a_0 (cdr (unwrap v_0))))
                                (let ((p_0 (unwrap a_0)))
@@ -8675,17 +8533,14 @@
                                          (let ((a_2 (car (unwrap d_1))))
                                            a_2))))
                                   (let ((id_1 id_0)) (values id_1 rhs_0))))))))
-                      (case-lambda
-                       ((id_0 rhs_0)
+                      (lambda (id_0 rhs_0)
                         (let ((body_0
                                (let ((d_1 (cdr p_0)))
                                  (let ((a_0 (car (unwrap d_1)))) a_0))))
                           (let ((id_1 id_0) (rhs_1 rhs_0))
-                            (values id_1 rhs_1 body_0))))
-                       (args (raise-binding-result-arity-error 2 args)))))))
-               (case-lambda
-                ((id_0 rhs_0 body_0) (extract-let-lambda #f id_0 rhs_0 body_0))
-                (args (raise-binding-result-arity-error 3 args))))
+                            (values id_1 rhs_1 body_0))))))))
+               (lambda (id_0 rhs_0 body_0)
+                 (extract-let-lambda #f id_0 rhs_0 body_0)))
               (if (if (eq? 'letrec-values hd_0)
                     (let ((a_0 (cdr (unwrap new-v_0))))
                       (let ((p_0 (unwrap a_0)))
@@ -8757,18 +8612,14 @@
                                              a_2))))
                                     (let ((id_1 id_0))
                                       (values id_1 rhs_0))))))))
-                        (case-lambda
-                         ((id_0 rhs_0)
+                        (lambda (id_0 rhs_0)
                           (let ((body_0
                                  (let ((d_1 (cdr p_0)))
                                    (let ((a_0 (car (unwrap d_1)))) a_0))))
                             (let ((id_1 id_0) (rhs_1 rhs_0))
-                              (values id_1 rhs_1 body_0))))
-                         (args (raise-binding-result-arity-error 2 args)))))))
-                 (case-lambda
-                  ((id_0 rhs_0 body_0)
-                   (extract-let-lambda #t id_0 rhs_0 body_0))
-                  (args (raise-binding-result-arity-error 3 args))))
+                              (values id_1 rhs_1 body_0))))))))
+                 (lambda (id_0 rhs_0 body_0)
+                   (extract-let-lambda #t id_0 rhs_0 body_0)))
                 (if (if (eq? 'let hd_0)
                       (let ((a_0 (cdr (unwrap new-v_0))))
                         (let ((p_0 (unwrap a_0)))
@@ -8824,19 +8675,14 @@
                                                a_2))))
                                       (let ((id_1 id_0))
                                         (values id_1 rhs_0))))))))
-                          (case-lambda
-                           ((id_0 rhs_0)
+                          (lambda (id_0 rhs_0)
                             (let ((body_0
                                    (let ((d_1 (cdr p_0)))
                                      (let ((a_0 (car (unwrap d_1)))) a_0))))
                               (let ((id_1 id_0) (rhs_1 rhs_0))
-                                (values id_1 rhs_1 body_0))))
-                           (args
-                            (raise-binding-result-arity-error 2 args)))))))
-                   (case-lambda
-                    ((id_0 rhs_0 body_0)
-                     (extract-let-lambda #f id_0 rhs_0 body_0))
-                    (args (raise-binding-result-arity-error 3 args))))
+                                (values id_1 rhs_1 body_0))))))))
+                   (lambda (id_0 rhs_0 body_0)
+                     (extract-let-lambda #f id_0 rhs_0 body_0)))
                   (if (if (eq? 'letrec* hd_0)
                         (let ((a_0 (cdr (unwrap new-v_0))))
                           (let ((p_0 (unwrap a_0)))
@@ -8893,19 +8739,14 @@
                                                  a_2))))
                                         (let ((id_1 id_0))
                                           (values id_1 rhs_0))))))))
-                            (case-lambda
-                             ((id_0 rhs_0)
+                            (lambda (id_0 rhs_0)
                               (let ((body_0
                                      (let ((d_1 (cdr p_0)))
                                        (let ((a_0 (car (unwrap d_1)))) a_0))))
                                 (let ((id_1 id_0) (rhs_1 rhs_0))
-                                  (values id_1 rhs_1 body_0))))
-                             (args
-                              (raise-binding-result-arity-error 2 args)))))))
-                     (case-lambda
-                      ((id_0 rhs_0 body_0)
-                       (extract-let-lambda #t id_0 rhs_0 body_0))
-                      (args (raise-binding-result-arity-error 3 args))))
+                                  (values id_1 rhs_1 body_0))))))))
+                     (lambda (id_0 rhs_0 body_0)
+                       (extract-let-lambda #t id_0 rhs_0 body_0)))
                     (if (if (eq? 'let-values hd_0)
                           (let ((a_0 (cdr (unwrap new-v_0))))
                             (let ((p_0 (unwrap a_0)))
@@ -9024,9 +8865,7 @@
   (lambda (v_0)
     (call-with-values
      (lambda () (extract-lambda v_0))
-     (case-lambda
-      ((lam_0 inlinable?_0) (values lam_0 #f))
-      (args (raise-binding-result-arity-error 2 args))))))
+     (lambda (lam_0 inlinable?_0) (values lam_0 #f)))))
 (define lambda-arity-mask
   (lambda (v_0)
     (let ((hd_0
@@ -9447,19 +9286,13 @@
                                                   d_5)))))
                                        (let ((fields_1 fields_0))
                                          (values fields_1 rest_0)))))))
-                             (case-lambda
-                              ((fields_0 rest_0)
+                             (lambda (fields_0 rest_0)
                                (let ((parent_1 parent_0))
-                                 (values parent_1 fields_0 rest_0)))
-                              (args
-                               (raise-binding-result-arity-error 2 args))))))))
-                    (case-lambda
-                     ((parent_0 fields_0 rest_0)
+                                 (values parent_1 fields_0 rest_0))))))))
+                    (lambda (parent_0 fields_0 rest_0)
                       (let ((name_1 name_0))
-                        (values name_1 parent_0 fields_0 rest_0)))
-                     (args (raise-binding-result-arity-error 3 args))))))))
-           (case-lambda
-            ((name_0 parent_0 fields_0 rest_0)
+                        (values name_1 parent_0 fields_0 rest_0))))))))
+           (lambda (name_0 parent_0 fields_0 rest_0)
              (let ((u-name_0 (unwrap name_0)))
                (let ((u-parent_0
                       (let ((u-parent_0 (unwrap parent_0)))
@@ -9481,12 +9314,7 @@
                                    knowns_0
                                    imports_0
                                    mutated_0))
-                                (case-lambda
-                                 ((k_0 im_0) k_0)
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   2
-                                   args))))))))
+                                (lambda (k_0 im_0) k_0))))))
                        (if (exact-nonnegative-integer? fields_0)
                          (if (<= (length rest_0) 6)
                            (let ((prefab-imms_0
@@ -9867,12 +9695,7 @@
                                            knowns_0
                                            imports_0
                                            mutated_0))
-                                        (case-lambda
-                                         ((k_0 im_0) k_0)
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args)))))
+                                        (lambda (k_0 im_0) k_0)))
                                       #f)))
                                (let ((prefab-imms_1 prefab-imms_0))
                                  (let ((includes-property?_0
@@ -10063,41 +9886,26 @@
                                                                                                 (values
                                                                                                  props_2
                                                                                                  vals_1)))))))
-                                                                                    (case-lambda
-                                                                                     ((props3_0
-                                                                                       vals4_0)
+                                                                                    (lambda (props3_0
+                                                                                             vals4_0)
                                                                                       (values
                                                                                        (cons
                                                                                         props3_0
                                                                                         props_0)
                                                                                        (cons
                                                                                         vals4_0
-                                                                                        vals_0)))
-                                                                                     (args
-                                                                                      (raise-binding-result-arity-error
-                                                                                       2
-                                                                                       args)))))
-                                                                                 (case-lambda
-                                                                                  ((props_1
-                                                                                    vals_1)
+                                                                                        vals_0)))))
+                                                                                 (lambda (props_1
+                                                                                          vals_1)
                                                                                    (values
                                                                                     props_1
-                                                                                    vals_1))
-                                                                                  (args
-                                                                                   (raise-binding-result-arity-error
-                                                                                    2
-                                                                                    args)))))
-                                                                              (case-lambda
-                                                                               ((props_1
-                                                                                 vals_1)
+                                                                                    vals_1))))
+                                                                              (lambda (props_1
+                                                                                       vals_1)
                                                                                 (for-loop_0
                                                                                  props_1
                                                                                  vals_1
-                                                                                 rest_1))
-                                                                               (args
-                                                                                (raise-binding-result-arity-error
-                                                                                 2
-                                                                                 args)))))))
+                                                                                 rest_1))))))
                                                                        (values
                                                                         props_0
                                                                         vals_0)))))))
@@ -10105,21 +9913,16 @@
                                                                null
                                                                null
                                                                d_0)))
-                                                           (case-lambda
-                                                            ((props_0 vals_0)
+                                                           (lambda (props_0
+                                                                    vals_0)
                                                              (let ((app_0
                                                                     (reverse$1
                                                                      props_0)))
                                                                (values
                                                                 app_0
                                                                 (reverse$1
-                                                                 vals_0))))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args))))))
-                                                      (case-lambda
-                                                       ((props_0 vals_0)
+                                                                 vals_0)))))))
+                                                      (lambda (props_0 vals_0)
                                                         (begin
                                                           (letrec*
                                                            ((for-loop_0
@@ -10158,11 +9961,7 @@
                                                                     result_0))))))
                                                            (for-loop_0
                                                             #f
-                                                            props_0))))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))
+                                                            props_0)))))
                                                      #f)))
                                                #f))))))
                                    (letrec*
@@ -10191,12 +9990,9 @@
                                                                  knowns_0
                                                                  imports_0
                                                                  mutated_0))
-                                                              (case-lambda
-                                                               ((k_0 im_0) k_0)
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args)))))))
+                                                              (lambda (k_0
+                                                                       im_0)
+                                                                k_0)))))
                                                        (if (not k_0)
                                                          #f
                                                          (if (known-literal?
@@ -10435,16 +10231,11 @@
                                                                         (values
                                                                          proc-spec_1
                                                                          immutables_0))))))))
-                                                          (case-lambda
-                                                           ((proc-spec_0
-                                                             immutables_0)
+                                                          (lambda (proc-spec_0
+                                                                   immutables_0)
                                                             (handle-proc-spec_0
                                                              proc-spec_0
-                                                             immutables_0))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args))))
+                                                             immutables_0)))
                                                          #f)))))
                                                #f)))
                                         (if (if (eq? prefab-imms_1 'non-prefab)
@@ -10506,8 +10297,7 @@
                            #f)
                          #f)
                        #f)
-                     #f)))))
-            (args (raise-binding-result-arity-error 4 args))))
+                     #f))))))
           #f)))))
 (define pure-properties-list
   (lambda (e_0 prim-knowns_0 knowns_0 imports_0 mutated_0 simples_0)
@@ -10622,37 +10412,20 @@
                                                    (values
                                                     props_2
                                                     vals_1)))))))
-                                       (case-lambda
-                                        ((props6_0 vals7_0)
+                                       (lambda (props6_0 vals7_0)
                                          (values
                                           (cons props6_0 props_0)
-                                          (cons vals7_0 vals_0)))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args)))))
-                                    (case-lambda
-                                     ((props_1 vals_1) (values props_1 vals_1))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args)))))
-                                 (case-lambda
-                                  ((props_1 vals_1)
-                                   (for-loop_0 props_1 vals_1 rest_0))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    2
-                                    args)))))))
+                                          (cons vals7_0 vals_0)))))
+                                    (lambda (props_1 vals_1)
+                                      (values props_1 vals_1))))
+                                 (lambda (props_1 vals_1)
+                                   (for-loop_0 props_1 vals_1 rest_0))))))
                           (values props_0 vals_0)))))))
                  (for-loop_0 null null d_0)))
-              (case-lambda
-               ((props_0 vals_0)
+              (lambda (props_0 vals_0)
                 (let ((app_0 (reverse$1 props_0)))
-                  (values app_0 (reverse$1 vals_0))))
-               (args (raise-binding-result-arity-error 2 args))))))
-         (case-lambda
-          ((props_0 vals_0)
+                  (values app_0 (reverse$1 vals_0)))))))
+         (lambda (props_0 vals_0)
            (if (begin
                  (letrec*
                   ((for-loop_0
@@ -10680,12 +10453,8 @@
                                                                knowns_0
                                                                imports_0
                                                                mutated_0))
-                                                            (case-lambda
-                                                             ((k_0 im_0) k_0)
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args))))))
+                                                            (lambda (k_0 im_0)
+                                                              k_0))))
                                                        (simple?.1
                                                         #f
                                                         #t
@@ -10716,8 +10485,7 @@
                            result_0))))))
                   (for-loop_0 #t props_0 vals_0)))
              vals_0
-             #f))
-          (args (raise-binding-result-arity-error 2 args))))
+             #f)))
         (if (begin-unsafe
              (let ((app_0 (unwrap 'null))) (eq? app_0 (unwrap e_0))))
           null
@@ -10869,8 +10637,7 @@
                                  (let ((d_1 (cdr p_1)))
                                    (let ((a_2 (car (unwrap d_1)))) a_2))))
                             (let ((tmp1_1 tmp1_0)) (values tmp1_1 id_0))))))))
-                (case-lambda
-                 ((tmp1_0 id_0)
+                (lambda (tmp1_0 id_0)
                   (call-with-values
                    (lambda ()
                      (let ((d_1 (cdr p_0)))
@@ -10887,21 +10654,16 @@
                                         (let ((a_1 (car (unwrap d_3)))) a_1))))
                                  (let ((tmp2_1 tmp2_0))
                                    (values tmp2_1 tmp3_0)))))))))
-                   (case-lambda
-                    ((tmp2_0 tmp3_0)
+                   (lambda (tmp2_0 tmp3_0)
                      (let ((tmp1_1 tmp1_0) (id_1 id_0))
-                       (values tmp1_1 id_1 tmp2_0 tmp3_0)))
-                    (args (raise-binding-result-arity-error 2 args)))))
-                 (args (raise-binding-result-arity-error 2 args)))))))
-         (case-lambda
-          ((tmp1_0 id_0 tmp2_0 tmp3_0)
+                       (values tmp1_1 id_1 tmp2_0 tmp3_0)))))))))
+         (lambda (tmp1_0 id_0 tmp2_0 tmp3_0)
            (let ((u-tmp1_0 (unwrap tmp1_0)))
              (if (eq? u-tmp1_0 (unwrap tmp2_0))
                (if (eq? u-tmp1_0 (unwrap tmp3_0))
                  (let ((u_0 (unwrap id_0))) (if (symbol? u_0) u_0 #f))
                  #f)
-               #f)))
-          (args (raise-binding-result-arity-error 4 args))))
+               #f))))
         #f))))
 (define literal?
   (lambda (v_0)
@@ -11030,8 +10792,7 @@
                                (lambda ()
                                  (begin
                                    (values q_1 (unsafe-vector-length q_1))))
-                               (case-lambda
-                                ((vec_0 len_0)
+                               (lambda (vec_0 len_0)
                                  (letrec*
                                   ((for-loop_0
                                     (|#%name|
@@ -11048,9 +10809,7 @@
                                                (for-loop_0
                                                 (unsafe-fx+ 1 pos_0))))
                                            (values)))))))
-                                  (for-loop_0 0)))
-                                (args
-                                 (raise-binding-result-arity-error 2 args))))
+                                  (for-loop_0 0))))
                               (void))))
                         (if (hash? q_1)
                           (begin
@@ -11076,8 +10835,7 @@
                                                  (hash-iterate-key+value
                                                   q_1
                                                   i_0))
-                                               (case-lambda
-                                                ((k_0 v_0)
+                                               (lambda (k_0 v_0)
                                                  (begin
                                                    (begin
                                                      (check-register_0
@@ -11089,11 +10847,7 @@
                                                    (for-loop_0
                                                     (hash-iterate-next
                                                      q_1
-                                                     i_0))))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args))))
+                                                     i_0)))))
                                               (values)))))))
                                      (for-loop_0 (hash-iterate-first q_1))))
                                   (void)))))
@@ -11123,13 +10877,8 @@
                                        seen_1)))
                                   (call-with-values
                                    (lambda () (struct-info q_1))
-                                   (case-lambda
-                                    ((st_0 skipped?_0)
-                                     (check-register_0 st_0 seen_0))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args)))))
+                                   (lambda (st_0 skipped?_0)
+                                     (check-register_0 st_0 seen_0))))
                                 (register!_0 q_1))))))))))))))))
      (check-register_0 q_0 hash2610))))
 (define try-fold-primitive
@@ -11265,9 +11014,7 @@
                      knowns_0
                      imports_0
                      mutated_0))
-                  (case-lambda
-                   ((k_0 im_0) k_0)
-                   (args (raise-binding-result-arity-error 2 args)))))
+                  (lambda (k_0 im_0) k_0)))
                 (if (if (pair? u_0)
                       (if (eq? 'assert-ctype-representation (unwrap (car u_0)))
                         (pair? (unwrap (cdr u_0)))
@@ -11444,13 +11191,10 @@
                                    (let ((d_2 (cdr p_1)))
                                      (let ((a_0 (car (unwrap d_2)))) a_0))))
                               (let ((e1_1 e1_0)) (values e1_1 e2_0)))))))
-                    (case-lambda
-                     ((e1_0 e2_0) (let ((t_1 t_0)) (values t_1 e1_0 e2_0)))
-                     (args (raise-binding-result-arity-error 2 args))))))))
-           (case-lambda
-            ((t_0 e1_0 e2_0)
-             (if (literal? t_0) (if (unwrap t_0) e1_0 e2_0) v_0))
-            (args (raise-binding-result-arity-error 3 args))))
+                    (lambda (e1_0 e2_0)
+                      (let ((t_1 t_0)) (values t_1 e1_0 e2_0))))))))
+           (lambda (t_0 e1_0 e2_0)
+             (if (literal? t_0) (if (unwrap t_0) e1_0 e2_0) v_0)))
           (if (if (eq? 'begin hd_0)
                 (let ((a_0 (cdr (unwrap v_1))))
                   (let ((p_0 (unwrap a_0)))
@@ -11485,8 +11229,7 @@
                      (let ((e_0 (let ((a_0 (car p_0))) a_0)))
                        (let ((es_0 (let ((d_2 (cdr p_0))) d_2)))
                          (let ((e_1 e_0)) (values e_1 es_0))))))))
-             (case-lambda
-              ((e_0 es_0)
+             (lambda (e_0 es_0)
                (optimize
                 (reannotate v_0 (list* 'begin e_0 es_0))
                 prim-knowns_0
@@ -11495,8 +11238,7 @@
                 imports_0
                 mutated_0
                 target_0
-                compiler-query_0))
-              (args (raise-binding-result-arity-error 2 args))))
+                compiler-query_0)))
             (if (if (eq? 'not hd_0)
                   (let ((a_0 (cdr (unwrap v_1))))
                     (let ((p_0 (unwrap a_0)))
@@ -11527,10 +11269,8 @@
                   (if (lambda?.1 #f e_0)
                     (call-with-values
                      (lambda () (extract-lambda e_0))
-                     (case-lambda
-                      ((lam_0 inlinable?_0)
-                       (if inlinable?_0 #t (list* 'begin e_0 '(#t))))
-                      (args (raise-binding-result-arity-error 2 args))))
+                     (lambda (lam_0 inlinable?_0)
+                       (if inlinable?_0 #t (list* 'begin e_0 '(#t)))))
                     (let ((u_0 (unwrap e_0)))
                       (if (symbol? u_0)
                         (let ((k_0
@@ -11543,12 +11283,7 @@
                                     knowns_0
                                     imports_0
                                     mutated_0))
-                                 (case-lambda
-                                  ((k_0 im_0) k_0)
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    2
-                                    args)))))))
+                                 (lambda (k_0 im_0) k_0)))))
                           (if (known-procedure? k_0) #t v_0))
                         v_0))))
                 (if (if (eq? 'procedure-arity-includes? hd_0)
@@ -11572,13 +11307,9 @@
                                   (let ((n_0 (let ((a_0 (car p_1))) a_0)))
                                     (let ((opt_0 (let ((d_2 (cdr p_1))) d_2)))
                                       (let ((n_1 n_0)) (values n_1 opt_0)))))))
-                            (case-lambda
-                             ((n_0 opt_0)
-                              (let ((e_1 e_0)) (values e_1 n_0 opt_0)))
-                             (args
-                              (raise-binding-result-arity-error 2 args))))))))
-                   (case-lambda
-                    ((e_0 n_0 opt_0)
+                            (lambda (n_0 opt_0)
+                              (let ((e_1 e_0)) (values e_1 n_0 opt_0))))))))
+                   (lambda (e_0 n_0 opt_0)
                      (let ((u-n_0 (unwrap n_0)))
                        (if (if (exact-nonnegative-integer? n_0)
                              (let ((or-part_0 (null? opt_0)))
@@ -11591,16 +11322,14 @@
                          (if (lambda?.1 #f e_0)
                            (call-with-values
                             (lambda () (extract-lambda e_0))
-                            (case-lambda
-                             ((lam_0 inlinable?_0)
+                            (lambda (lam_0 inlinable?_0)
                               (let ((inc?_0
                                      (bitwise-bit-set?
                                       (lambda-arity-mask lam_0)
                                       n_0)))
                                 (if inlinable?_0
                                   inc?_0
-                                  (list 'begin e_0 inc?_0))))
-                             (args (raise-binding-result-arity-error 2 args))))
+                                  (list 'begin e_0 inc?_0)))))
                            (let ((u_0 (unwrap e_0)))
                              (if (symbol? u_0)
                                (let ((k_0
@@ -11613,20 +11342,14 @@
                                            knowns_0
                                            imports_0
                                            mutated_0))
-                                        (case-lambda
-                                         ((k_0 im_0) k_0)
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args)))))))
+                                        (lambda (k_0 im_0) k_0)))))
                                  (if (known-procedure? k_0)
                                    (bitwise-bit-set?
                                     (known-procedure-arity-mask k_0)
                                     u-n_0)
                                    v_0))
                                v_0)))
-                         v_0)))
-                    (args (raise-binding-result-arity-error 3 args))))
+                         v_0))))
                   (if (if (eq? 'procedure-specialize hd_0)
                         (let ((a_0 (cdr (unwrap v_1))))
                           (let ((p_0 (unwrap a_0)))
@@ -11731,39 +11454,28 @@
                                                                                 (values
                                                                                  result-type_1
                                                                                  arg-types_0)))))))
-                                                                    (case-lambda
-                                                                     ((result-type_0
-                                                                       arg-types_0)
+                                                                    (lambda (result-type_0
+                                                                             arg-types_0)
                                                                       (let ((async-apply_1
                                                                              async-apply_0))
                                                                         (values
                                                                          async-apply_1
                                                                          result-type_0
-                                                                         arg-types_0)))
-                                                                     (args
-                                                                      (raise-binding-result-arity-error
-                                                                       2
-                                                                       args))))))))
-                                                           (case-lambda
-                                                            ((async-apply_0
-                                                              result-type_0
-                                                              arg-types_0)
+                                                                         arg-types_0))))))))
+                                                           (lambda (async-apply_0
+                                                                    result-type_0
+                                                                    arg-types_0)
                                                              (let ((blocking?_1
                                                                     blocking?_0))
                                                                (values
                                                                 blocking?_1
                                                                 async-apply_0
                                                                 result-type_0
-                                                                arg-types_0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args))))))))
-                                                  (case-lambda
-                                                   ((blocking?_0
-                                                     async-apply_0
-                                                     result-type_0
-                                                     arg-types_0)
+                                                                arg-types_0))))))))
+                                                  (lambda (blocking?_0
+                                                           async-apply_0
+                                                           result-type_0
+                                                           arg-types_0)
                                                     (let ((varargs-after_1
                                                            varargs-after_0))
                                                       (values
@@ -11771,17 +11483,12 @@
                                                        blocking?_0
                                                        async-apply_0
                                                        result-type_0
-                                                       arg-types_0)))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     4
-                                                     args))))))))
-                                         (case-lambda
-                                          ((varargs-after_0
-                                            blocking?_0
-                                            async-apply_0
-                                            result-type_0
-                                            arg-types_0)
+                                                       arg-types_0))))))))
+                                         (lambda (varargs-after_0
+                                                  blocking?_0
+                                                  async-apply_0
+                                                  result-type_0
+                                                  arg-types_0)
                                            (let ((abi_1 abi_0))
                                              (values
                                               abi_1
@@ -11789,18 +11496,13 @@
                                               blocking?_0
                                               async-apply_0
                                               result-type_0
-                                              arg-types_0)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            5
-                                            args))))))))
-                                (case-lambda
-                                 ((abi_0
-                                   varargs-after_0
-                                   blocking?_0
-                                   async-apply_0
-                                   result-type_0
-                                   arg-types_0)
+                                              arg-types_0))))))))
+                                (lambda (abi_0
+                                         varargs-after_0
+                                         blocking?_0
+                                         async-apply_0
+                                         result-type_0
+                                         arg-types_0)
                                   (let ((must-at_1 must-at_0))
                                     (values
                                      must-at_1
@@ -11809,19 +11511,14 @@
                                      blocking?_0
                                      async-apply_0
                                      result-type_0
-                                     arg-types_0)))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   6
-                                   args))))))))
-                       (case-lambda
-                        ((must-at_0
-                          abi_0
-                          varargs-after_0
-                          blocking?_0
-                          async-apply_0
-                          result-type_0
-                          arg-types_0)
+                                     arg-types_0))))))))
+                       (lambda (must-at_0
+                                abi_0
+                                varargs-after_0
+                                blocking?_0
+                                async-apply_0
+                                result-type_0
+                                arg-types_0)
                          (let ((or-part_0
                                 (if (eq? target_0 'compile)
                                   (let ((or-part_0
@@ -11876,8 +11573,7 @@
                                              must-at_0)))
                                         #f)))
                                   #f)))
-                           (if or-part_0 or-part_0 v_0)))
-                        (args (raise-binding-result-arity-error 7 args))))
+                           (if or-part_0 or-part_0 v_0))))
                       (if (if (eq? 'system-type hd_0) #t #f)
                         (let ((hd_1
                                (let ((p_0 (unwrap v_0)))
@@ -12127,8 +11823,7 @@
                                    (let ((rands_0 (let ((d_0 (cdr p_0))) d_0)))
                                      (let ((rator_1 rator_0))
                                        (values rator_1 rands_0))))))
-                             (case-lambda
-                              ((rator_0 rands_0)
+                             (lambda (rator_0 rands_0)
                                (let ((u-rator_0 (unwrap rator_0)))
                                  (let ((k_0
                                         (if (symbol? u-rator_0)
@@ -12197,9 +11892,7 @@
                                                 #f)
                                               #f)
                                             #f)))
-                                     (if c1_0 (car c1_0) v_0)))))
-                              (args
-                               (raise-binding-result-arity-error 2 args))))
+                                     (if c1_0 (car c1_0) v_0))))))
                             (let ((u_0 (unwrap v_0)))
                               (if (symbol? u_0)
                                 (let ((k_0
@@ -12253,10 +11946,8 @@
                                           (unwrap-list d_1))))
                                    (let ((formal_1 formal_0))
                                      (values formal_1 body_0)))))))
-                         (case-lambda
-                          ((formal_0 body_0)
-                           (list* 'lambda formal_0 (optimize*-body_0 body_0)))
-                          (args (raise-binding-result-arity-error 2 args))))
+                         (lambda (formal_0 body_0)
+                           (list* 'lambda formal_0 (optimize*-body_0 body_0))))
                         (if (if (eq? 'case-lambda hd_0)
                               (let ((a_0 (cdr (unwrap v_1))))
                                 (if (wrap-list? a_0)
@@ -12361,51 +12052,31 @@
                                                                    (values
                                                                     formalss_2
                                                                     bodys_1))))))
-                                                         (case-lambda
-                                                          ((formalss4_0
-                                                            bodys5_0)
+                                                         (lambda (formalss4_0
+                                                                  bodys5_0)
                                                            (values
                                                             (cons
                                                              formalss4_0
                                                              formalss_0)
                                                             (cons
                                                              bodys5_0
-                                                             bodys_0)))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))
-                                                      (case-lambda
-                                                       ((formalss_1 bodys_1)
+                                                             bodys_0)))))
+                                                      (lambda (formalss_1
+                                                               bodys_1)
                                                         (values
                                                          formalss_1
-                                                         bodys_1))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args)))))
-                                                   (case-lambda
-                                                    ((formalss_1 bodys_1)
+                                                         bodys_1))))
+                                                   (lambda (formalss_1 bodys_1)
                                                      (for-loop_0
                                                       formalss_1
                                                       bodys_1
-                                                      rest_0))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      2
-                                                      args)))))))
+                                                      rest_0))))))
                                             (values formalss_0 bodys_0)))))))
                                    (for-loop_0 null null d_0)))
-                                (case-lambda
-                                 ((formalss_0 bodys_0)
+                                (lambda (formalss_0 bodys_0)
                                   (let ((app_0 (reverse$1 formalss_0)))
-                                    (values app_0 (reverse$1 bodys_0))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   2
-                                   args))))))
-                           (case-lambda
-                            ((formalss_0 bodys_0)
+                                    (values app_0 (reverse$1 bodys_0)))))))
+                           (lambda (formalss_0 bodys_0)
                              (list*
                               'case-lambda
                               (reverse$1
@@ -12441,8 +12112,7 @@
                                                       rest_0
                                                       rest_1))))))
                                            fold-var_0))))))
-                                  (for-loop_0 null formalss_0 bodys_0))))))
-                            (args (raise-binding-result-arity-error 2 args))))
+                                  (for-loop_0 null formalss_0 bodys_0)))))))
                           (if (if (eq? 'let-values hd_0) #t #f)
                             (optimize*-let_0 v_1)
                             (if (if (eq? 'letrec-values hd_0) #t #f)
@@ -12492,25 +12162,17 @@
                                                       (values
                                                        thn_1
                                                        els_0)))))))
-                                          (case-lambda
-                                           ((thn_0 els_0)
+                                          (lambda (thn_0 els_0)
                                             (let ((tst_1 tst_0))
-                                              (values tst_1 thn_0 els_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args))))))))
-                                 (case-lambda
-                                  ((tst_0 thn_0 els_0)
+                                              (values tst_1 thn_0 els_0))))))))
+                                 (lambda (tst_0 thn_0 els_0)
                                    (let ((app_0 (optimize*_0 tst_0)))
                                      (let ((app_1 (optimize*_0 thn_0)))
                                        (list
                                         'if
                                         app_0
                                         app_1
-                                        (optimize*_0 els_0)))))
-                                  (args
-                                   (raise-binding-result-arity-error 3 args))))
+                                        (optimize*_0 els_0))))))
                                 (if (if (eq? 'with-continuation-mark hd_0)
                                       (let ((a_0 (cdr (unwrap v_1))))
                                         (let ((p_0 (unwrap a_0)))
@@ -12558,27 +12220,20 @@
                                                         (values
                                                          val_1
                                                          body_0)))))))
-                                            (case-lambda
-                                             ((val_0 body_0)
+                                            (lambda (val_0 body_0)
                                               (let ((key_1 key_0))
-                                                (values key_1 val_0 body_0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               2
-                                               args))))))))
-                                   (case-lambda
-                                    ((key_0 val_0 body_0)
+                                                (values
+                                                 key_1
+                                                 val_0
+                                                 body_0))))))))
+                                   (lambda (key_0 val_0 body_0)
                                      (let ((app_0 (optimize*_0 key_0)))
                                        (let ((app_1 (optimize*_0 val_0)))
                                          (list
                                           'with-continuation-mark
                                           app_0
                                           app_1
-                                          (optimize*_0 body_0)))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      3
-                                      args))))
+                                          (optimize*_0 body_0))))))
                                   (if (if (eq? 'begin hd_0)
                                         (let ((a_0 (cdr (unwrap v_1))))
                                           (wrap-list? a_0))
@@ -12617,17 +12272,12 @@
                                                           (unwrap-list d_1))))
                                                    (let ((e_1 e_0))
                                                      (values e_1 body_0)))))))
-                                         (case-lambda
-                                          ((e_0 body_0)
+                                         (lambda (e_0 body_0)
                                            (let ((app_0 (optimize*_0 e_0)))
                                              (list*
                                               'begin0
                                               app_0
-                                              (optimize*-body_0 body_0))))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
+                                              (optimize*-body_0 body_0)))))
                                         (if (if (eq? 'set! hd_0)
                                               (let ((a_0 (cdr (unwrap v_1))))
                                                 (let ((p_0 (unwrap a_0)))
@@ -12667,16 +12317,11 @@
                                                        (values
                                                         id_1
                                                         rhs_0)))))))
-                                           (case-lambda
-                                            ((id_0 rhs_0)
+                                           (lambda (id_0 rhs_0)
                                              (list
                                               'set!
                                               id_0
-                                              (optimize*_0 rhs_0)))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
+                                              (optimize*_0 rhs_0))))
                                           (if (if (eq?
                                                    'variable-reference-from-unsafe?
                                                    hd_0)
@@ -12813,19 +12458,14 @@
                                                                (values
                                                                 rator_1
                                                                 exps_0))))))
-                                                     (case-lambda
-                                                      ((rator_0 exps_0)
+                                                     (lambda (rator_0 exps_0)
                                                        (let ((app_0
                                                               (optimize*_0
                                                                rator_0)))
                                                          (list*
                                                           app_0
                                                           (optimize*-body_0
-                                                           exps_0))))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args))))
+                                                           exps_0)))))
                                                     v_1)))))))))))))))))))
               (optimize
                new-v_0
@@ -13010,64 +12650,39 @@
                                                                      (values
                                                                       idss_2
                                                                       rhss_1))))))
-                                                           (case-lambda
-                                                            ((idss6_0 rhss7_0)
+                                                           (lambda (idss6_0
+                                                                    rhss7_0)
                                                              (values
                                                               (cons
                                                                idss6_0
                                                                idss_0)
                                                               (cons
                                                                rhss7_0
-                                                               rhss_0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
-                                                        (case-lambda
-                                                         ((idss_1 rhss_1)
+                                                               rhss_0)))))
+                                                        (lambda (idss_1 rhss_1)
                                                           (values
                                                            idss_1
-                                                           rhss_1))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))
-                                                     (case-lambda
-                                                      ((idss_1 rhss_1)
+                                                           rhss_1))))
+                                                     (lambda (idss_1 rhss_1)
                                                        (for-loop_0
                                                         idss_1
                                                         rhss_1
-                                                        rest_0))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args)))))))
+                                                        rest_0))))))
                                               (values idss_0 rhss_0)))))))
                                      (for-loop_0 null null a_0)))
-                                  (case-lambda
-                                   ((idss_0 rhss_0)
+                                  (lambda (idss_0 rhss_0)
                                     (let ((app_0 (reverse$1 idss_0)))
-                                      (values app_0 (reverse$1 rhss_0))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args))))))
-                             (case-lambda
-                              ((idss_0 rhss_0)
+                                      (values app_0 (reverse$1 rhss_0)))))))
+                             (lambda (idss_0 rhss_0)
                                (let ((body_0
                                       (let ((d_1 (cdr p_1)))
                                         (unwrap-list d_1))))
                                  (let ((idss_1 idss_0) (rhss_1 rhss_0))
-                                   (values idss_1 rhss_1 body_0))))
-                              (args
-                               (raise-binding-result-arity-error 2 args)))))))
-                      (case-lambda
-                       ((idss_0 rhss_0 body_0)
+                                   (values idss_1 rhss_1 body_0))))))))
+                      (lambda (idss_0 rhss_0 body_0)
                         (let ((let-id_1 let-id_0))
-                          (values let-id_1 idss_0 rhss_0 body_0)))
-                       (args (raise-binding-result-arity-error 3 args)))))))
-               (case-lambda
-                ((let-id_0 idss_0 rhss_0 body_0)
+                          (values let-id_1 idss_0 rhss_0 body_0)))))))
+               (lambda (let-id_0 idss_0 rhss_0 body_0)
                  (let ((app_0
                         (reverse$1
                          (begin
@@ -13097,8 +12712,7 @@
                                                 rest_1))))))
                                      fold-var_0))))))
                             (for-loop_0 null idss_0 rhss_0))))))
-                   (list* let-id_0 app_0 (optimize*-body_0 body_0))))
-                (args (raise-binding-result-arity-error 4 args))))
+                   (list* let-id_0 app_0 (optimize*-body_0 body_0)))))
               (error 'match "failed ~e" v_1)))))))
      (optimize*_0 v_0))))
 (define parameter-result?
@@ -13173,13 +12787,11 @@
   (lambda (p_0)
     (call-with-values
      (lambda () (split-path p_0))
-     (case-lambda
-      ((base1_0 name1_0 dir?_0)
+     (lambda (base1_0 name1_0 dir?_0)
        (if (path-for-some-system? base1_0)
          (call-with-values
           (lambda () (split-path base1_0))
-          (case-lambda
-           ((base2_0 name2_0 dir?_1)
+          (lambda (base2_0 name2_0 dir?_1)
             (if (not base2_0)
               (path-for-some-system->string p_0)
               (if (symbol? name2_0)
@@ -13189,12 +12801,10 @@
                    ".../"
                    app_0
                    "/"
-                   (path-elem->string name1_0))))))
-           (args (raise-binding-result-arity-error 3 args))))
+                   (path-elem->string name1_0)))))))
          (if (eq? base1_0 'relative)
            (path-elem->string name1_0)
-           (path-for-some-system->string p_0))))
-      (args (raise-binding-result-arity-error 3 args))))))
+           (path-for-some-system->string p_0)))))))
 (define path-elem->string
   (lambda (p_0)
     (if (eq? p_0 'same)
@@ -13212,8 +12822,7 @@
         (let ((u-e_0 (wrap-truncate-paths orig_0)))
           (call-with-values
            (lambda () (wrap-source e_0))
-           (case-lambda
-            ((src_0 line_0 col_0 pos_0 span_0)
+           (lambda (src_0 line_0 col_0 pos_0 span_0)
              (if (if (not (path-for-some-system? src_0)) (eq? orig_0 u-e_0) #f)
                e_0
                (if (path-for-some-system? src_0)
@@ -13225,8 +12834,7 @@
                          pos_0
                          span_0)))
                    (begin-unsafe (datum->syntax #f u-e_0 new-srcloc_0 e_0)))
-                 (reannotate e_0 u-e_0))))
-            (args (raise-binding-result-arity-error 5 args))))))
+                 (reannotate e_0 u-e_0)))))))
       (if (pair? e_0)
         (let ((a_0 (wrap-truncate-paths (car e_0))))
           (let ((d_0 (wrap-truncate-paths (cdr e_0))))
@@ -13252,10 +12860,8 @@
                (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                  (let ((bodys_0 (let ((d_1 (cdr p_0))) d_1)))
                    (let ((args_1 args_0)) (values args_1 bodys_0)))))))
-         (case-lambda
-          ((args_0 bodys_0)
-           (smaller-than? bodys_0 (+ 3 (* 3 (args-size args_0)))))
-          (args (raise-binding-result-arity-error 2 args))))
+         (lambda (args_0 bodys_0)
+           (smaller-than? bodys_0 (+ 3 (* 3 (args-size args_0))))))
         (if (if (eq? 'case-lambda hd_0)
               (let ((a_0 (cdr (unwrap v_0))))
                 (if (wrap-list? a_0)
@@ -13329,38 +12935,20 @@
                                                    (values
                                                     argss_2
                                                     bodyss_1))))))
-                                         (case-lambda
-                                          ((argss1_0 bodyss2_0)
+                                         (lambda (argss1_0 bodyss2_0)
                                            (values
                                             (cons argss1_0 argss_0)
-                                            (cons bodyss2_0 bodyss_0)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args)))))
-                                      (case-lambda
-                                       ((argss_1 bodyss_1)
-                                        (values argss_1 bodyss_1))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         2
-                                         args)))))
-                                   (case-lambda
-                                    ((argss_1 bodyss_1)
-                                     (for-loop_0 argss_1 bodyss_1 rest_0))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args)))))))
+                                            (cons bodyss2_0 bodyss_0)))))
+                                      (lambda (argss_1 bodyss_1)
+                                        (values argss_1 bodyss_1))))
+                                   (lambda (argss_1 bodyss_1)
+                                     (for-loop_0 argss_1 bodyss_1 rest_0))))))
                             (values argss_0 bodyss_0)))))))
                    (for-loop_0 null null d_0)))
-                (case-lambda
-                 ((argss_0 bodyss_0)
+                (lambda (argss_0 bodyss_0)
                   (let ((app_0 (reverse$1 argss_0)))
-                    (values app_0 (reverse$1 bodyss_0))))
-                 (args (raise-binding-result-arity-error 2 args))))))
-           (case-lambda
-            ((argss_0 bodyss_0)
+                    (values app_0 (reverse$1 bodyss_0)))))))
+           (lambda (argss_0 bodyss_0)
              (begin
                (letrec*
                 ((for-loop_0
@@ -13393,8 +12981,7 @@
                                      (for-loop_0 result_1 rest_0 rest_1)
                                      result_1))))))
                          result_0))))))
-                (for-loop_0 #t argss_0 bodyss_0))))
-            (args (raise-binding-result-arity-error 2 args))))
+                (for-loop_0 #t argss_0 bodyss_0)))))
           #f)))))
 (define args-size
   (lambda (args_0)
@@ -13450,18 +13037,14 @@
                      (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                        (let ((bodys_0 (let ((d_1 (cdr p_0))) d_1)))
                          (let ((args_1 args_0)) (values args_1 bodys_0)))))))
-               (case-lambda
-                ((args_0 bodys_0)
+               (lambda (args_0 bodys_0)
                  (call-with-values
                   (lambda () (clone-args args_0 env_0 mutated_0))
-                  (case-lambda
-                   ((new-args_0 new-env_0)
+                  (lambda (new-args_0 new-env_0)
                     (list*
                      'lambda
                      new-args_0
-                     (clone-body bodys_0 new-env_0 mutated_0)))
-                   (args (raise-binding-result-arity-error 2 args)))))
-                (args (raise-binding-result-arity-error 2 args))))
+                     (clone-body bodys_0 new-env_0 mutated_0))))))
               (if (if (eq? 'case-lambda hd_0)
                     (let ((a_0 (cdr (unwrap v_0))))
                       (if (wrap-list? a_0)
@@ -13543,41 +13126,23 @@
                                                          (values
                                                           argss_2
                                                           bodyss_1))))))
-                                               (case-lambda
-                                                ((argss3_0 bodyss4_0)
+                                               (lambda (argss3_0 bodyss4_0)
                                                  (values
                                                   (cons argss3_0 argss_0)
-                                                  (cons bodyss4_0 bodyss_0)))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args)))))
-                                            (case-lambda
-                                             ((argss_1 bodyss_1)
-                                              (values argss_1 bodyss_1))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               2
-                                               args)))))
-                                         (case-lambda
-                                          ((argss_1 bodyss_1)
+                                                  (cons bodyss4_0 bodyss_0)))))
+                                            (lambda (argss_1 bodyss_1)
+                                              (values argss_1 bodyss_1))))
+                                         (lambda (argss_1 bodyss_1)
                                            (for-loop_0
                                             argss_1
                                             bodyss_1
-                                            rest_0))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args)))))))
+                                            rest_0))))))
                                   (values argss_0 bodyss_0)))))))
                          (for-loop_0 null null d_0)))
-                      (case-lambda
-                       ((argss_0 bodyss_0)
+                      (lambda (argss_0 bodyss_0)
                         (let ((app_0 (reverse$1 argss_0)))
-                          (values app_0 (reverse$1 bodyss_0))))
-                       (args (raise-binding-result-arity-error 2 args))))))
-                 (case-lambda
-                  ((argss_0 bodyss_0)
+                          (values app_0 (reverse$1 bodyss_0)))))))
+                 (lambda (argss_0 bodyss_0)
                    (list*
                     'case-lambda
                     (reverse$1
@@ -13602,19 +13167,14 @@
                                                             args_0
                                                             env_0
                                                             mutated_0))
-                                                         (case-lambda
-                                                          ((new-args_0
-                                                            new-env_0)
+                                                         (lambda (new-args_0
+                                                                  new-env_0)
                                                            (list*
                                                             new-args_0
                                                             (clone-body
                                                              bodys_0
                                                              new-env_0
-                                                             mutated_0)))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args))))
+                                                             mutated_0))))
                                                         fold-var_0)))
                                                   (values fold-var_1))))
                                            (for-loop_0
@@ -13622,8 +13182,7 @@
                                             rest_0
                                             rest_1))))))
                                  fold-var_0))))))
-                        (for-loop_0 null argss_0 bodyss_0))))))
-                  (args (raise-binding-result-arity-error 2 args))))
+                        (for-loop_0 null argss_0 bodyss_0)))))))
                 (let ((c1_0 (hash-ref imports_0 (unwrap v_0) #f)))
                   (if c1_0
                     (let ((i-k_0 (import-lookup c1_0)))
@@ -13904,53 +13463,31 @@
                                                              (values
                                                               idss_2
                                                               rhss_1))))))
-                                                   (case-lambda
-                                                    ((idss5_0 rhss6_0)
+                                                   (lambda (idss5_0 rhss6_0)
                                                      (values
                                                       (cons idss5_0 idss_0)
-                                                      (cons rhss6_0 rhss_0)))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      2
-                                                      args)))))
-                                                (case-lambda
-                                                 ((idss_1 rhss_1)
-                                                  (values idss_1 rhss_1))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   2
-                                                   args)))))
-                                             (case-lambda
-                                              ((idss_1 rhss_1)
+                                                      (cons rhss6_0 rhss_0)))))
+                                                (lambda (idss_1 rhss_1)
+                                                  (values idss_1 rhss_1))))
+                                             (lambda (idss_1 rhss_1)
                                                (for-loop_0
                                                 idss_1
                                                 rhss_1
-                                                rest_0))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args)))))))
+                                                rest_0))))))
                                       (values idss_0 rhss_0)))))))
                              (for-loop_0 null null a_0)))
-                          (case-lambda
-                           ((idss_0 rhss_0)
+                          (lambda (idss_0 rhss_0)
                             (let ((app_0 (reverse$1 idss_0)))
-                              (values app_0 (reverse$1 rhss_0))))
-                           (args (raise-binding-result-arity-error 2 args))))))
-                     (case-lambda
-                      ((idss_0 rhss_0)
+                              (values app_0 (reverse$1 rhss_0)))))))
+                     (lambda (idss_0 rhss_0)
                        (let ((bodys_0
                               (let ((d_1 (cdr p_1))) (unwrap-list d_1))))
                          (let ((idss_1 idss_0) (rhss_1 rhss_0))
-                           (values idss_1 rhss_1 bodys_0))))
-                      (args (raise-binding-result-arity-error 2 args)))))))
-              (case-lambda
-               ((idss_0 rhss_0 bodys_0)
+                           (values idss_1 rhss_1 bodys_0))))))))
+              (lambda (idss_0 rhss_0 bodys_0)
                 (let ((let-id_1 let-id_0))
-                  (values let-id_1 idss_0 rhss_0 bodys_0)))
-               (args (raise-binding-result-arity-error 3 args)))))))
-       (case-lambda
-        ((let-id_0 idss_0 rhss_0 bodys_0)
+                  (values let-id_1 idss_0 rhss_0 bodys_0)))))))
+       (lambda (let-id_0 idss_0 rhss_0 bodys_0)
          (call-with-values
           (lambda ()
             (begin
@@ -13970,29 +13507,17 @@
                                   (call-with-values
                                    (lambda ()
                                      (clone-args ids_0 env_1 mutated_0))
-                                   (case-lambda
-                                    ((new-ids_0 new-env_0)
+                                   (lambda (new-ids_0 new-env_0)
                                      (values
                                       (cons new-ids_0 rev-new-idss_0)
-                                      new-env_0))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args)))))
-                                (case-lambda
-                                 ((rev-new-idss_1 env_2)
-                                  (values rev-new-idss_1 env_2))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args)))))
-                             (case-lambda
-                              ((rev-new-idss_1 env_2)
-                               (for-loop_0 rev-new-idss_1 env_2 rest_0))
-                              (args
-                               (raise-binding-result-arity-error 2 args))))))
+                                      new-env_0))))
+                                (lambda (rev-new-idss_1 env_2)
+                                  (values rev-new-idss_1 env_2))))
+                             (lambda (rev-new-idss_1 env_2)
+                               (for-loop_0 rev-new-idss_1 env_2 rest_0)))))
                         (values rev-new-idss_0 env_1)))))))
                (for-loop_0 null env_0 idss_0))))
-          (case-lambda
-           ((rev-new-idss_0 new-env_0)
+          (lambda (rev-new-idss_0 new-env_0)
             (let ((app_0
                    (reverse$1
                     (let ((lst_0 (reverse$1 rev-new-idss_0)))
@@ -14025,9 +13550,10 @@
                                              rest_1))))))
                                   fold-var_0))))))
                          (for-loop_0 null lst_0 rhss_0)))))))
-              (list* let-id_0 app_0 (clone-body bodys_0 new-env_0 mutated_0))))
-           (args (raise-binding-result-arity-error 2 args)))))
-        (args (raise-binding-result-arity-error 4 args))))
+              (list*
+               let-id_0
+               app_0
+               (clone-body bodys_0 new-env_0 mutated_0)))))))
       (error 'match "failed ~e" v_0))))
 (define clone-expr
   (lambda (v_0 env_0 mutated_0)
@@ -14046,18 +13572,14 @@
                 (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                   (let ((bodys_0 (let ((d_1 (cdr p_0))) d_1)))
                     (let ((args_1 args_0)) (values args_1 bodys_0)))))))
-          (case-lambda
-           ((args_0 bodys_0)
+          (lambda (args_0 bodys_0)
             (call-with-values
              (lambda () (clone-args args_0 env_0 mutated_0))
-             (case-lambda
-              ((new-args_0 new-env_0)
+             (lambda (new-args_0 new-env_0)
                (list*
                 'lambda
                 new-args_0
-                (clone-body bodys_0 new-env_0 mutated_0)))
-              (args (raise-binding-result-arity-error 2 args)))))
-           (args (raise-binding-result-arity-error 2 args))))
+                (clone-body bodys_0 new-env_0 mutated_0))))))
          (if (if (eq? 'case-lambda hd_0)
                (let ((a_0 (cdr (unwrap v_0))))
                  (if (wrap-list? a_0)
@@ -14131,38 +13653,20 @@
                                                     (values
                                                      argss_2
                                                      bodyss_1))))))
-                                          (case-lambda
-                                           ((argss7_0 bodyss8_0)
+                                          (lambda (argss7_0 bodyss8_0)
                                             (values
                                              (cons argss7_0 argss_0)
-                                             (cons bodyss8_0 bodyss_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args)))))
-                                       (case-lambda
-                                        ((argss_1 bodyss_1)
-                                         (values argss_1 bodyss_1))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args)))))
-                                    (case-lambda
-                                     ((argss_1 bodyss_1)
-                                      (for-loop_0 argss_1 bodyss_1 rest_0))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args)))))))
+                                             (cons bodyss8_0 bodyss_0)))))
+                                       (lambda (argss_1 bodyss_1)
+                                         (values argss_1 bodyss_1))))
+                                    (lambda (argss_1 bodyss_1)
+                                      (for-loop_0 argss_1 bodyss_1 rest_0))))))
                              (values argss_0 bodyss_0)))))))
                     (for-loop_0 null null d_0)))
-                 (case-lambda
-                  ((argss_0 bodyss_0)
+                 (lambda (argss_0 bodyss_0)
                    (let ((app_0 (reverse$1 argss_0)))
-                     (values app_0 (reverse$1 bodyss_0))))
-                  (args (raise-binding-result-arity-error 2 args))))))
-            (case-lambda
-             ((argss_0 bodyss_0)
+                     (values app_0 (reverse$1 bodyss_0)))))))
+            (lambda (argss_0 bodyss_0)
               (list*
                'case-lambda
                (reverse$1
@@ -14187,18 +13691,14 @@
                                                        args_0
                                                        env_0
                                                        mutated_0))
-                                                    (case-lambda
-                                                     ((new-args_0 new-env_0)
+                                                    (lambda (new-args_0
+                                                             new-env_0)
                                                       (list*
                                                        new-args_0
                                                        (clone-body
                                                         bodys_0
                                                         new-env_0
-                                                        mutated_0)))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args))))
+                                                        mutated_0))))
                                                    fold-var_0)))
                                              (values fold-var_1))))
                                       (for-loop_0
@@ -14206,8 +13706,7 @@
                                        rest_0
                                        rest_1))))))
                             fold-var_0))))))
-                   (for-loop_0 null argss_0 bodyss_0))))))
-             (args (raise-binding-result-arity-error 2 args))))
+                   (for-loop_0 null argss_0 bodyss_0)))))))
            (if (if (eq? 'quote hd_0)
                  (let ((a_0 (cdr (unwrap v_0))))
                    (let ((p_0 (unwrap a_0)))
@@ -14257,22 +13756,17 @@
                                                 a_0))))
                                        (let ((thn_1 thn_0))
                                          (values thn_1 els_0)))))))
-                             (case-lambda
-                              ((thn_0 els_0)
+                             (lambda (thn_0 els_0)
                                (let ((tst_1 tst_0))
-                                 (values tst_1 thn_0 els_0)))
-                              (args
-                               (raise-binding-result-arity-error 2 args))))))))
-                    (case-lambda
-                     ((tst_0 thn_0 els_0)
+                                 (values tst_1 thn_0 els_0))))))))
+                    (lambda (tst_0 thn_0 els_0)
                       (let ((app_0 (clone-expr tst_0 env_0 mutated_0)))
                         (let ((app_1 (clone-expr thn_0 env_0 mutated_0)))
                           (list
                            'if
                            app_0
                            app_1
-                           (clone-expr els_0 env_0 mutated_0)))))
-                     (args (raise-binding-result-arity-error 3 args))))
+                           (clone-expr els_0 env_0 mutated_0))))))
                    (if (if (eq? 'with-continuation-mark hd_0)
                          (let ((a_0 (cdr (unwrap v_0))))
                            (let ((p_0 (unwrap a_0)))
@@ -14307,24 +13801,17 @@
                                                   a_0))))
                                          (let ((val_1 val_0))
                                            (values val_1 body_0)))))))
-                               (case-lambda
-                                ((val_0 body_0)
+                               (lambda (val_0 body_0)
                                  (let ((key_1 key_0))
-                                   (values key_1 val_0 body_0)))
-                                (args
-                                 (raise-binding-result-arity-error
-                                  2
-                                  args))))))))
-                      (case-lambda
-                       ((key_0 val_0 body_0)
+                                   (values key_1 val_0 body_0))))))))
+                      (lambda (key_0 val_0 body_0)
                         (let ((app_0 (clone-expr key_0 env_0 mutated_0)))
                           (let ((app_1 (clone-expr val_0 env_0 mutated_0)))
                             (list
                              'with-continuation-mark
                              app_0
                              app_1
-                             (clone-expr body_0 env_0 mutated_0)))))
-                       (args (raise-binding-result-arity-error 3 args))))
+                             (clone-expr body_0 env_0 mutated_0))))))
                      (if (if (eq? 'begin hd_0)
                            (let ((a_0 (cdr (unwrap v_0)))) (wrap-list? a_0))
                            #f)
@@ -14374,16 +13861,13 @@
                                                  a_0))))
                                         (let ((id_1 id_0))
                                           (values id_1 rhs_0)))))))
-                              (case-lambda
-                               ((id_0 rhs_0)
+                              (lambda (id_0 rhs_0)
                                 (let ((app_0
                                        (clone-expr id_0 env_0 mutated_0)))
                                   (list
                                    'set!
                                    app_0
-                                   (clone-expr rhs_0 env_0 mutated_0))))
-                               (args
-                                (raise-binding-result-arity-error 2 args))))
+                                   (clone-expr rhs_0 env_0 mutated_0)))))
                              (if (if (eq? '|#%variable-reference| hd_0)
                                    (let ((a_0 (cdr (unwrap v_0))))
                                      (begin-unsafe
@@ -14568,16 +14052,14 @@
                  (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                    (let ((bodys_0 (let ((d_1 (cdr p_0))) d_1)))
                      (let ((args_1 args_0)) (values args_1 bodys_0)))))))
-           (case-lambda
-            ((args_0 bodys_0)
+           (lambda (args_0 bodys_0)
              (body-needed-imports
               bodys_0
               prim-knowns_0
               imports_0
               exports_0
               (add-args env_0 args_0)
-              needed_0))
-            (args (raise-binding-result-arity-error 2 args))))
+              needed_0)))
           (if (if (eq? 'case-lambda hd_0)
                 (let ((a_0 (cdr (unwrap v_0))))
                   (if (wrap-list? a_0)
@@ -14653,38 +14135,23 @@
                                                      (values
                                                       argss_2
                                                       bodyss_1))))))
-                                           (case-lambda
-                                            ((argss9_0 bodyss10_0)
+                                           (lambda (argss9_0 bodyss10_0)
                                              (values
                                               (cons argss9_0 argss_0)
-                                              (cons bodyss10_0 bodyss_0)))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args)))))
-                                        (case-lambda
-                                         ((argss_1 bodyss_1)
-                                          (values argss_1 bodyss_1))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args)))))
-                                     (case-lambda
-                                      ((argss_1 bodyss_1)
-                                       (for-loop_0 argss_1 bodyss_1 rest_0))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args)))))))
+                                              (cons bodyss10_0 bodyss_0)))))
+                                        (lambda (argss_1 bodyss_1)
+                                          (values argss_1 bodyss_1))))
+                                     (lambda (argss_1 bodyss_1)
+                                       (for-loop_0
+                                        argss_1
+                                        bodyss_1
+                                        rest_0))))))
                               (values argss_0 bodyss_0)))))))
                      (for-loop_0 null null d_0)))
-                  (case-lambda
-                   ((argss_0 bodyss_0)
+                  (lambda (argss_0 bodyss_0)
                     (let ((app_0 (reverse$1 argss_0)))
-                      (values app_0 (reverse$1 bodyss_0))))
-                   (args (raise-binding-result-arity-error 2 args))))))
-             (case-lambda
-              ((argss_0 bodyss_0)
+                      (values app_0 (reverse$1 bodyss_0)))))))
+             (lambda (argss_0 bodyss_0)
                (begin
                  (letrec*
                   ((for-loop_0
@@ -14709,8 +14176,7 @@
                                             (values needed_2))))
                                      (for-loop_0 needed_2 rest_0 rest_1))))))
                            needed_1))))))
-                  (for-loop_0 needed_0 argss_0 bodyss_0))))
-              (args (raise-binding-result-arity-error 2 args))))
+                  (for-loop_0 needed_0 argss_0 bodyss_0)))))
             (if (if (eq? 'quote hd_0)
                   (let ((a_0 (cdr (unwrap v_0))))
                     (let ((p_0 (unwrap a_0)))
@@ -14772,16 +14238,10 @@
                                                  a_0))))
                                         (let ((thn_1 thn_0))
                                           (values thn_1 els_0)))))))
-                              (case-lambda
-                               ((thn_0 els_0)
+                              (lambda (thn_0 els_0)
                                 (let ((tst_1 tst_0))
-                                  (values tst_1 thn_0 els_0)))
-                               (args
-                                (raise-binding-result-arity-error
-                                 2
-                                 args))))))))
-                     (case-lambda
-                      ((tst_0 thn_0 els_0)
+                                  (values tst_1 thn_0 els_0))))))))
+                     (lambda (tst_0 thn_0 els_0)
                        (needed-imports
                         tst_0
                         prim-knowns_0
@@ -14800,8 +14260,7 @@
                           imports_0
                           exports_0
                           env_0
-                          needed_0))))
-                      (args (raise-binding-result-arity-error 3 args))))
+                          needed_0)))))
                     (if (if (eq? 'with-continuation-mark hd_0)
                           (let ((a_0 (cdr (unwrap v_0))))
                             (let ((p_0 (unwrap a_0)))
@@ -14838,16 +14297,10 @@
                                                    a_0))))
                                           (let ((val_1 val_0))
                                             (values val_1 body_0)))))))
-                                (case-lambda
-                                 ((val_0 body_0)
+                                (lambda (val_0 body_0)
                                   (let ((key_1 key_0))
-                                    (values key_1 val_0 body_0)))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   2
-                                   args))))))))
-                       (case-lambda
-                        ((key_0 val_0 body_0)
+                                    (values key_1 val_0 body_0))))))))
+                       (lambda (key_0 val_0 body_0)
                          (needed-imports
                           key_0
                           prim-knowns_0
@@ -14866,8 +14319,7 @@
                             imports_0
                             exports_0
                             env_0
-                            needed_0))))
-                        (args (raise-binding-result-arity-error 3 args))))
+                            needed_0)))))
                       (if (if (eq? 'begin hd_0)
                             (let ((a_0 (cdr (unwrap v_0)))) (wrap-list? a_0))
                             #f)
@@ -14933,8 +14385,7 @@
                                                   a_0))))
                                          (let ((id_1 id_0))
                                            (values id_1 rhs_0)))))))
-                               (case-lambda
-                                ((id_0 rhs_0)
+                               (lambda (id_0 rhs_0)
                                  (let ((u_0 (unwrap id_0)))
                                    (if (hash-ref exports_0 id_0 #f)
                                      #f
@@ -14950,9 +14401,7 @@
                                        imports_0
                                        exports_0
                                        env_0
-                                       needed_0)))))
-                                (args
-                                 (raise-binding-result-arity-error 2 args))))
+                                       needed_0))))))
                               (if (if (eq? '|#%variable-reference| hd_0) #t #f)
                                 #f
                                 (if (let ((p_0 (unwrap v_0)))
@@ -15164,53 +14613,33 @@
                                                              (values
                                                               idss_2
                                                               rhss_1))))))
-                                                   (case-lambda
-                                                    ((idss11_0 rhss12_0)
+                                                   (lambda (idss11_0 rhss12_0)
                                                      (values
                                                       (cons idss11_0 idss_0)
-                                                      (cons rhss12_0 rhss_0)))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      2
-                                                      args)))))
-                                                (case-lambda
-                                                 ((idss_1 rhss_1)
-                                                  (values idss_1 rhss_1))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   2
-                                                   args)))))
-                                             (case-lambda
-                                              ((idss_1 rhss_1)
+                                                      (cons
+                                                       rhss12_0
+                                                       rhss_0)))))
+                                                (lambda (idss_1 rhss_1)
+                                                  (values idss_1 rhss_1))))
+                                             (lambda (idss_1 rhss_1)
                                                (for-loop_0
                                                 idss_1
                                                 rhss_1
-                                                rest_0))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args)))))))
+                                                rest_0))))))
                                       (values idss_0 rhss_0)))))))
                              (for-loop_0 null null a_0)))
-                          (case-lambda
-                           ((idss_0 rhss_0)
+                          (lambda (idss_0 rhss_0)
                             (let ((app_0 (reverse$1 idss_0)))
-                              (values app_0 (reverse$1 rhss_0))))
-                           (args (raise-binding-result-arity-error 2 args))))))
-                     (case-lambda
-                      ((idss_0 rhss_0)
+                              (values app_0 (reverse$1 rhss_0)))))))
+                     (lambda (idss_0 rhss_0)
                        (let ((bodys_0
                               (let ((d_1 (cdr p_1))) (unwrap-list d_1))))
                          (let ((idss_1 idss_0) (rhss_1 rhss_0))
-                           (values idss_1 rhss_1 bodys_0))))
-                      (args (raise-binding-result-arity-error 2 args)))))))
-              (case-lambda
-               ((idss_0 rhss_0 bodys_0)
+                           (values idss_1 rhss_1 bodys_0))))))))
+              (lambda (idss_0 rhss_0 bodys_0)
                 (let ((let-id_1 let-id_0))
-                  (values let-id_1 idss_0 rhss_0 bodys_0)))
-               (args (raise-binding-result-arity-error 3 args)))))))
-       (case-lambda
-        ((let-id_0 idss_0 rhss_0 bodys_0)
+                  (values let-id_1 idss_0 rhss_0 bodys_0)))))))
+       (lambda (let-id_0 idss_0 rhss_0 bodys_0)
          (let ((new-env_0
                 (begin
                   (letrec*
@@ -15280,8 +14709,7 @@
                                      (values needed_2))))
                               (for-loop_0 needed_2 rest_0))))
                         needed_1))))))
-               (for-loop_0 needed_0 rhss_0))))))
-        (args (raise-binding-result-arity-error 4 args))))
+               (for-loop_0 needed_0 rhss_0)))))))
       (error 'match "failed ~e" v_0))))
 (define add-args
   (lambda (env_0 args_0)
@@ -15677,8 +15105,7 @@
                                                      (values
                                                       thn_1
                                                       els_0))))))))
-                                       (case-lambda
-                                        ((thn_0 els_0)
+                                       (lambda (thn_0 els_0)
                                          (if (single-valued?
                                               thn_0
                                               knowns_0
@@ -15693,11 +15120,7 @@
                                             imports_0
                                             mutated_0
                                             (unsafe-fxrshift fuel_0 1))
-                                           #f))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args))))
+                                           #f)))
                                       (if (if (eq? '|#%app/value| hd_0) #t #f)
                                         #t
                                         (if (if (eq? '|#%app/no-return| hd_0)
@@ -15720,8 +15143,7 @@
                                                        (values
                                                         proc_1
                                                         args_0))))))
-                                             (case-lambda
-                                              ((proc_0 args_0)
+                                             (lambda (proc_0 args_0)
                                                (let ((proc_1 (unwrap proc_0)))
                                                  (if (symbol? proc_1)
                                                    (if (let ((v_0
@@ -15744,11 +15166,7 @@
                                                        proc_1
                                                        #f))
                                                      #f)
-                                                   #f)))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
+                                                   #f))))
                                             #t))))))))))))))))))))))
 (define infer-known.1
   (|#%name|
@@ -15781,8 +15199,7 @@
                  (if (lambda?.1 #f rhs_0)
                    (call-with-values
                     (lambda () (extract-lambda rhs_0))
-                    (case-lambda
-                     ((lam_0 inlinable?_0)
+                    (lambda (lam_0 inlinable?_0)
                       (let ((arity-mask_0 (lambda-arity-mask lam_0)))
                         (if (if inlinable?_0
                               (if (not post-schemify?3_0)
@@ -15817,8 +15234,7 @@
                                imports15_0
                                mutated16_0)
                             (known-procedure/single-valued arity-mask_0)
-                            (known-procedure arity-mask_0)))))
-                     (args (raise-binding-result-arity-error 2 args))))
+                            (known-procedure arity-mask_0))))))
                    (if (if (literal? rhs_0)
                          (not (hash-ref mutated16_0 (unwrap id12_0) #f))
                          #f)
@@ -15943,8 +15359,7 @@
                                                   (values
                                                    type1_1
                                                    type2_0)))))))
-                                      (case-lambda
-                                       ((type1_0 type2_0)
+                                      (lambda (type1_0 type2_0)
                                         (let ((k_0 (loop_0 type1_0)))
                                           (if (known-ctype? k_0)
                                             k_0
@@ -15979,11 +15394,7 @@
                                                             c5_0
                                                             #f)
                                                           #f))))))
-                                              #f))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         2
-                                         args))))
+                                              #f)))))
                                      (if (if defn5_0
                                            (simple?.1
                                             #f
@@ -16024,9 +15435,8 @@
                 (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                   (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                     (let ((args_1 args_0)) (values args_1 body_0)))))))
-          (case-lambda
-           ((args_0 body_0) (list 'lambda args_0 (list* 'begin-unsafe body_0)))
-           (args (raise-binding-result-arity-error 2 args))))
+          (lambda (args_0 body_0)
+            (list 'lambda args_0 (list* 'begin-unsafe body_0))))
          (if (if (eq? 'case-lambda hd_0)
                (let ((a_0 (cdr (unwrap lam_0))))
                  (if (wrap-list? a_0)
@@ -16100,38 +15510,20 @@
                                                     (values
                                                      argss_2
                                                      bodys_1))))))
-                                          (case-lambda
-                                           ((argss30_0 bodys31_0)
+                                          (lambda (argss30_0 bodys31_0)
                                             (values
                                              (cons argss30_0 argss_0)
-                                             (cons bodys31_0 bodys_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args)))))
-                                       (case-lambda
-                                        ((argss_1 bodys_1)
-                                         (values argss_1 bodys_1))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args)))))
-                                    (case-lambda
-                                     ((argss_1 bodys_1)
-                                      (for-loop_0 argss_1 bodys_1 rest_0))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args)))))))
+                                             (cons bodys31_0 bodys_0)))))
+                                       (lambda (argss_1 bodys_1)
+                                         (values argss_1 bodys_1))))
+                                    (lambda (argss_1 bodys_1)
+                                      (for-loop_0 argss_1 bodys_1 rest_0))))))
                              (values argss_0 bodys_0)))))))
                     (for-loop_0 null null d_0)))
-                 (case-lambda
-                  ((argss_0 bodys_0)
+                 (lambda (argss_0 bodys_0)
                    (let ((app_0 (reverse$1 argss_0)))
-                     (values app_0 (reverse$1 bodys_0))))
-                  (args (raise-binding-result-arity-error 2 args))))))
-            (case-lambda
-             ((argss_0 bodys_0)
+                     (values app_0 (reverse$1 bodys_0)))))))
+            (lambda (argss_0 bodys_0)
               (list*
                'case-lambda
                (reverse$1
@@ -16159,8 +15551,7 @@
                                          rest_0
                                          rest_1)))))))
                             fold-var_0))))))
-                   (for-loop_0 null argss_0 bodys_0))))))
-             (args (raise-binding-result-arity-error 2 args))))
+                   (for-loop_0 null argss_0 bodys_0)))))))
            lam_0))))))
 (define find-definitions.1
   (|#%name|
@@ -16209,8 +15600,7 @@
                                (let ((d_1 (cdr p_0)))
                                  (let ((a_0 (car (unwrap d_1)))) a_0))))
                           (let ((ids_1 ids_0)) (values ids_1 rhs_0)))))))
-                (case-lambda
-                 ((ids_0 rhs_0)
+                (lambda (ids_0 rhs_0)
                   (let ((new-rhs_0 (unwrap-let rhs_0)))
                     (let ((maybe-immediate-values_0
                            (|#%name|
@@ -16551,31 +15941,20 @@
                                                               (values
                                                                s?_1
                                                                acc/muts_0)))))))
-                                                  (case-lambda
-                                                   ((s?_0 acc/muts_0)
+                                                  (lambda (s?_0 acc/muts_0)
                                                     (let ((make-s_1 make-s_0))
                                                       (values
                                                        make-s_1
                                                        s?_0
-                                                       acc/muts_0)))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     2
-                                                     args))))))))
-                                         (case-lambda
-                                          ((make-s_0 s?_0 acc/muts_0)
+                                                       acc/muts_0))))))))
+                                         (lambda (make-s_0 s?_0 acc/muts_0)
                                            (let ((struct:s_1 struct:s_0))
                                              (values
                                               struct:s_1
                                               make-s_0
                                               s?_0
-                                              acc/muts_0)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            3
-                                            args))))))))
-                                (case-lambda
-                                 ((struct:s_0 make-s_0 s?_0 acc/muts_0)
+                                              acc/muts_0))))))))
+                                (lambda (struct:s_0 make-s_0 s?_0 acc/muts_0)
                                   (call-with-values
                                    (lambda ()
                                      (let ((d_0 (cdr p_0)))
@@ -16652,39 +16031,28 @@
                                                                                               (values
                                                                                                -ref_1
                                                                                                -set!_0)))))))
-                                                                                  (case-lambda
-                                                                                   ((-ref_0
-                                                                                     -set!_0)
+                                                                                  (lambda (-ref_0
+                                                                                           -set!_0)
                                                                                     (let ((?_1
                                                                                            ?_0))
                                                                                       (values
                                                                                        ?_1
                                                                                        -ref_0
-                                                                                       -set!_0)))
-                                                                                   (args
-                                                                                    (raise-binding-result-arity-error
-                                                                                     2
-                                                                                     args))))))))
-                                                                         (case-lambda
-                                                                          ((?_0
-                                                                            -ref_0
-                                                                            -set!_0)
+                                                                                       -set!_0))))))))
+                                                                         (lambda (?_0
+                                                                                  -ref_0
+                                                                                  -set!_0)
                                                                            (let ((make_1
                                                                                   make_0))
                                                                              (values
                                                                               make_1
                                                                               ?_0
                                                                               -ref_0
-                                                                              -set!_0)))
-                                                                          (args
-                                                                           (raise-binding-result-arity-error
-                                                                            3
-                                                                            args))))))))
-                                                                (case-lambda
-                                                                 ((make_0
-                                                                   ?_0
-                                                                   -ref_0
-                                                                   -set!_0)
+                                                                              -set!_0))))))))
+                                                                (lambda (make_0
+                                                                         ?_0
+                                                                         -ref_0
+                                                                         -set!_0)
                                                                   (let ((struct:_1
                                                                          struct:_0))
                                                                     (values
@@ -16692,17 +16060,12 @@
                                                                      make_0
                                                                      ?_0
                                                                      -ref_0
-                                                                     -set!_0)))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   4
-                                                                   args))))))))
-                                                       (case-lambda
-                                                        ((struct:_0
-                                                          make_0
-                                                          ?_0
-                                                          -ref_0
-                                                          -set!_0)
+                                                                     -set!_0))))))))
+                                                       (lambda (struct:_0
+                                                                make_0
+                                                                ?_0
+                                                                -ref_0
+                                                                -set!_0)
                                                          (let ((rhs_1
                                                                 (let ((d_2
                                                                        (cdr
@@ -16727,18 +16090,13 @@
                                                               ?_1
                                                               -ref_1
                                                               -set!_1
-                                                              rhs_1))))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          5
-                                                          args))))))))
-                                              (case-lambda
-                                               ((struct:_0
-                                                 make_0
-                                                 ?_0
-                                                 -ref_0
-                                                 -set!_0
-                                                 rhs_1)
+                                                              rhs_1)))))))))
+                                              (lambda (struct:_0
+                                                       make_0
+                                                       ?_0
+                                                       -ref_0
+                                                       -set!_0
+                                                       rhs_1)
                                                 (call-with-values
                                                  (lambda ()
                                                    (let ((d_2 (cdr p_1)))
@@ -16792,39 +16150,28 @@
                                                                                    (values
                                                                                     ?2_1
                                                                                     make-acc/muts_0)))))))
-                                                                       (case-lambda
-                                                                        ((?2_0
-                                                                          make-acc/muts_0)
+                                                                       (lambda (?2_0
+                                                                                make-acc/muts_0)
                                                                          (let ((make2_1
                                                                                 make2_0))
                                                                            (values
                                                                             make2_1
                                                                             ?2_0
-                                                                            make-acc/muts_0)))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args))))))))
-                                                              (case-lambda
-                                                               ((make2_0
-                                                                 ?2_0
-                                                                 make-acc/muts_0)
+                                                                            make-acc/muts_0))))))))
+                                                              (lambda (make2_0
+                                                                       ?2_0
+                                                                       make-acc/muts_0)
                                                                 (let ((struct:2_1
                                                                        struct:2_0))
                                                                   (values
                                                                    struct:2_1
                                                                    make2_0
                                                                    ?2_0
-                                                                   make-acc/muts_0)))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 3
-                                                                 args))))))))))
-                                                 (case-lambda
-                                                  ((struct:2_0
-                                                    make2_0
-                                                    ?2_0
-                                                    make-acc/muts_0)
+                                                                   make-acc/muts_0))))))))))
+                                                 (lambda (struct:2_0
+                                                          make2_0
+                                                          ?2_0
+                                                          make-acc/muts_0)
                                                    (let ((struct:_1 struct:_0)
                                                          (make_1 make_0)
                                                          (?_1 ?_0)
@@ -16841,26 +16188,17 @@
                                                       struct:2_0
                                                       make2_0
                                                       ?2_0
-                                                      make-acc/muts_0)))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    4
-                                                    args)))))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 6
-                                                 args)))))))))
-                                   (case-lambda
-                                    ((struct:_0
-                                      make_0
-                                      ?_0
-                                      -ref_0
-                                      -set!_0
-                                      rhs_1
-                                      struct:2_0
-                                      make2_0
-                                      ?2_0
-                                      make-acc/muts_0)
+                                                      make-acc/muts_0)))))))))))
+                                   (lambda (struct:_0
+                                            make_0
+                                            ?_0
+                                            -ref_0
+                                            -set!_0
+                                            rhs_1
+                                            struct:2_0
+                                            make2_0
+                                            ?2_0
+                                            make-acc/muts_0)
                                      (let ((struct:s_1 struct:s_0)
                                            (make-s_1 make-s_0)
                                            (s?_1 s?_0)
@@ -16879,30 +16217,21 @@
                                         struct:2_0
                                         make2_0
                                         ?2_0
-                                        make-acc/muts_0)))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      10
-                                      args)))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   4
-                                   args))))))
-                           (case-lambda
-                            ((struct:s_0
-                              make-s_0
-                              s?_0
-                              acc/muts_0
-                              struct:_0
-                              make_0
-                              ?_0
-                              -ref_0
-                              -set!_0
-                              rhs_1
-                              struct:2_0
-                              make2_0
-                              ?2_0
-                              make-acc/muts_0)
+                                        make-acc/muts_0))))))))
+                           (lambda (struct:s_0
+                                    make-s_0
+                                    s?_0
+                                    acc/muts_0
+                                    struct:_0
+                                    make_0
+                                    ?_0
+                                    -ref_0
+                                    -set!_0
+                                    rhs_1
+                                    struct:2_0
+                                    make2_0
+                                    ?2_0
+                                    make-acc/muts_0)
                              (let ((info_0
                                     (if (begin-unsafe
                                          (let ((app_0 (unwrap struct:_0)))
@@ -17175,18 +16504,13 @@
                                                                                      (values
                                                                                       ctc_1
                                                                                       realm_0))))))
-                                                                           (case-lambda
-                                                                            ((ctc_0
-                                                                              realm_0)
+                                                                           (lambda (ctc_0
+                                                                                    realm_0)
                                                                              (if (ok-contract-expr?_0
                                                                                   ctc_0)
                                                                                (symbol?
                                                                                 realm_0)
-                                                                               #f))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args))))
+                                                                               #f)))
                                                                           #f))))))))
                                                           (begin
                                                             (letrec*
@@ -17359,39 +16683,28 @@
                                                                                                                                     (values
                                                                                                                                      name_1
                                                                                                                                      more_0)))))))
-                                                                                                                        (case-lambda
-                                                                                                                         ((name_0
-                                                                                                                           more_0)
+                                                                                                                        (lambda (name_0
+                                                                                                                                 more_0)
                                                                                                                           (let ((pos_1
                                                                                                                                  pos_0))
                                                                                                                             (values
                                                                                                                              pos_1
                                                                                                                              name_0
-                                                                                                                             more_0)))
-                                                                                                                         (args
-                                                                                                                          (raise-binding-result-arity-error
-                                                                                                                           2
-                                                                                                                           args))))))))
-                                                                                                               (case-lambda
-                                                                                                                ((pos_0
-                                                                                                                  name_0
-                                                                                                                  more_0)
+                                                                                                                             more_0))))))))
+                                                                                                               (lambda (pos_0
+                                                                                                                        name_0
+                                                                                                                        more_0)
                                                                                                                  (let ((ref-or-set_1
                                                                                                                         ref-or-set_0))
                                                                                                                    (values
                                                                                                                     ref-or-set_1
                                                                                                                     pos_0
                                                                                                                     name_0
-                                                                                                                    more_0)))
-                                                                                                                (args
-                                                                                                                 (raise-binding-result-arity-error
-                                                                                                                  3
-                                                                                                                  args))))))))
-                                                                                                      (case-lambda
-                                                                                                       ((ref-or-set_0
-                                                                                                         pos_0
-                                                                                                         name_0
-                                                                                                         more_0)
+                                                                                                                    more_0))))))))
+                                                                                                      (lambda (ref-or-set_0
+                                                                                                               pos_0
+                                                                                                               name_0
+                                                                                                               more_0)
                                                                                                         (let ((make_2
                                                                                                                make_1))
                                                                                                           (values
@@ -17399,17 +16712,12 @@
                                                                                                            ref-or-set_0
                                                                                                            pos_0
                                                                                                            name_0
-                                                                                                           more_0)))
-                                                                                                       (args
-                                                                                                        (raise-binding-result-arity-error
-                                                                                                         4
-                                                                                                         args)))))))
-                                                                                               (case-lambda
-                                                                                                ((make_1
-                                                                                                  ref-or-set_0
-                                                                                                  pos_0
-                                                                                                  name_0
-                                                                                                  more_0)
+                                                                                                           more_0)))))))
+                                                                                               (lambda (make_1
+                                                                                                        ref-or-set_0
+                                                                                                        pos_0
+                                                                                                        name_0
+                                                                                                        more_0)
                                                                                                  (let ((or-part_0
                                                                                                         (if (ok-error-config?_0
                                                                                                              more_0)
@@ -17504,11 +16812,7 @@
                                                                                                           #f)))
                                                                                                    (if or-part_0
                                                                                                      or-part_0
-                                                                                                     knowns_2)))
-                                                                                                (args
-                                                                                                 (raise-binding-result-arity-error
-                                                                                                  5
-                                                                                                  args))))
+                                                                                                     knowns_2))))
                                                                                               knowns_2)))
                                                                                        (values
                                                                                         knowns_3))))
@@ -17540,8 +16844,7 @@
                                                       (struct-type-info-sealed?
                                                        info_0))))))
                                               info_0)))))))
-                                 (nothing_0))))
-                            (args (raise-binding-result-arity-error 14 args))))
+                                 (nothing_0)))))
                           (if (let ((p_0 (unwrap v_0)))
                                 (if (pair? p_0)
                                   (if (let ((a_0 (car p_0)))
@@ -17644,47 +16947,40 @@
                                                                          (values
                                                                           s-ref_1
                                                                           s-set!_0)))))))
-                                                             (case-lambda
-                                                              ((s-ref_0
-                                                                s-set!_0)
+                                                             (lambda (s-ref_0
+                                                                      s-set!_0)
                                                                (let ((s?_1
                                                                       s?_0))
                                                                  (values
                                                                   s?_1
                                                                   s-ref_0
-                                                                  s-set!_0)))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                2
-                                                                args))))))))
-                                                    (case-lambda
-                                                     ((s?_0 s-ref_0 s-set!_0)
+                                                                  s-set!_0))))))))
+                                                    (lambda (s?_0
+                                                             s-ref_0
+                                                             s-set!_0)
                                                       (let ((make-s_1
                                                              make-s_0))
                                                         (values
                                                          make-s_1
                                                          s?_0
                                                          s-ref_0
-                                                         s-set!_0)))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       3
-                                                       args))))))))
-                                           (case-lambda
-                                            ((make-s_0 s?_0 s-ref_0 s-set!_0)
+                                                         s-set!_0))))))))
+                                           (lambda (make-s_0
+                                                    s?_0
+                                                    s-ref_0
+                                                    s-set!_0)
                                              (let ((struct:s_1 struct:s_0))
                                                (values
                                                 struct:s_1
                                                 make-s_0
                                                 s?_0
                                                 s-ref_0
-                                                s-set!_0)))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              4
-                                              args))))))))
-                                  (case-lambda
-                                   ((struct:s_0 make-s_0 s?_0 s-ref_0 s-set!_0)
+                                                s-set!_0))))))))
+                                  (lambda (struct:s_0
+                                           make-s_0
+                                           s?_0
+                                           s-ref_0
+                                           s-set!_0)
                                     (let ((rhs_1
                                            (let ((d_0 (cdr p_0)))
                                              (let ((a_0 (car (unwrap d_0))))
@@ -17700,18 +16996,13 @@
                                          s?_1
                                          s-ref_1
                                          s-set!_1
-                                         rhs_1))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     5
-                                     args))))))
-                             (case-lambda
-                              ((struct:s_0
-                                make-s_0
-                                s?_0
-                                s-ref_0
-                                s-set!_0
-                                rhs_1)
+                                         rhs_1)))))))
+                             (lambda (struct:s_0
+                                      make-s_0
+                                      s?_0
+                                      s-ref_0
+                                      s-set!_0
+                                      rhs_1)
                                (let ((info_0
                                       (make-struct-type-info
                                        rhs_1
@@ -17771,9 +17062,7 @@
                                                   (struct-type-info-sealed?
                                                    info_0))))))))
                                       info_0))
-                                   (maybe-immediate-values_0))))
-                              (args
-                               (raise-binding-result-arity-error 6 args))))
+                                   (maybe-immediate-values_0)))))
                             (if (let ((p_0 (unwrap v_0)))
                                   (if (pair? p_0)
                                     (if (let ((a_0 (car p_0)))
@@ -17859,19 +17148,13 @@
                                                          (values
                                                           s?_1
                                                           s-ref_0)))))))
-                                             (case-lambda
-                                              ((s?_0 s-ref_0)
+                                             (lambda (s?_0 s-ref_0)
                                                (let ((prop:s_1 prop:s_0))
                                                  (values
                                                   prop:s_1
                                                   s?_0
-                                                  s-ref_0)))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))))))
-                                    (case-lambda
-                                     ((prop:s_0 s?_0 s-ref_0)
+                                                  s-ref_0))))))))
+                                    (lambda (prop:s_0 s?_0 s-ref_0)
                                       (let ((rest_0
                                              (let ((d_0 (cdr p_0)))
                                                (let ((a_0 (car (unwrap d_0))))
@@ -17887,13 +17170,8 @@
                                            prop:s_1
                                            s?_1
                                            s-ref_1
-                                           rest_0))))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       3
-                                       args))))))
-                               (case-lambda
-                                ((prop:s_0 s?_0 s-ref_0 rest_0)
+                                           rest_0)))))))
+                               (lambda (prop:s_0 s?_0 s-ref_0 rest_0)
                                  (let ((type_0
                                         (string->uninterned-symbol
                                          (symbol->string (unwrap prop:s_0)))))
@@ -17924,11 +17202,8 @@
                                              app_0
                                              (known-struct-type-property/immediate-guard)))
                                           knowns_1)))
-                                    #f)))
-                                (args
-                                 (raise-binding-result-arity-error 4 args))))
-                              (maybe-immediate-values_0))))))))
-                 (args (raise-binding-result-arity-error 2 args))))
+                                    #f))))
+                              (maybe-immediate-values_0)))))))))
                (nothing_0)))))))))
 (define find-one-definition.1
   (|#%name|
@@ -18223,22 +17498,17 @@
                                                    (unwrap-list d_3))))
                                             (let ((s?_1 s?_0))
                                               (values s?_1 acc/muts_0)))))))
-                                  (case-lambda
-                                   ((s?_0 acc/muts_0)
+                                  (lambda (s?_0 acc/muts_0)
                                     (let ((make-s_1 make-s_0))
-                                      (values make-s_1 s?_0 acc/muts_0)))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args))))))))
-                         (case-lambda
-                          ((make-s_0 s?_0 acc/muts_0)
+                                      (values make-s_1 s?_0 acc/muts_0))))))))
+                         (lambda (make-s_0 s?_0 acc/muts_0)
                            (let ((struct:s_1 struct:s_0))
-                             (values struct:s_1 make-s_0 s?_0 acc/muts_0)))
-                          (args
-                           (raise-binding-result-arity-error 3 args))))))))
-                (case-lambda
-                 ((struct:s_0 make-s_0 s?_0 acc/muts_0)
+                             (values
+                              struct:s_1
+                              make-s_0
+                              s?_0
+                              acc/muts_0))))))))
+                (lambda (struct:s_0 make-s_0 s?_0 acc/muts_0)
                   (call-with-values
                    (lambda ()
                      (let ((d_1 (cdr p_0)))
@@ -18304,49 +17574,40 @@
                                                                               (values
                                                                                -ref_1
                                                                                -set!_0)))))))
-                                                                  (case-lambda
-                                                                   ((-ref_0
-                                                                     -set!_0)
+                                                                  (lambda (-ref_0
+                                                                           -set!_0)
                                                                     (let ((?1_1
                                                                            ?1_0))
                                                                       (values
                                                                        ?1_1
                                                                        -ref_0
-                                                                       -set!_0)))
-                                                                   (args
-                                                                    (raise-binding-result-arity-error
-                                                                     2
-                                                                     args))))))))
-                                                         (case-lambda
-                                                          ((?1_0
-                                                            -ref_0
-                                                            -set!_0)
+                                                                       -set!_0))))))))
+                                                         (lambda (?1_0
+                                                                  -ref_0
+                                                                  -set!_0)
                                                            (let ((make_1
                                                                   make_0))
                                                              (values
                                                               make_1
                                                               ?1_0
                                                               -ref_0
-                                                              -set!_0)))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            3
-                                                            args))))))))
-                                                (case-lambda
-                                                 ((make_0 ?1_0 -ref_0 -set!_0)
+                                                              -set!_0))))))))
+                                                (lambda (make_0
+                                                         ?1_0
+                                                         -ref_0
+                                                         -set!_0)
                                                   (let ((struct:_1 struct:_0))
                                                     (values
                                                      struct:_1
                                                      make_0
                                                      ?1_0
                                                      -ref_0
-                                                     -set!_0)))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   4
-                                                   args))))))))
-                                       (case-lambda
-                                        ((struct:_0 make_0 ?1_0 -ref_0 -set!_0)
+                                                     -set!_0))))))))
+                                       (lambda (struct:_0
+                                                make_0
+                                                ?1_0
+                                                -ref_0
+                                                -set!_0)
                                          (let ((mk_0
                                                 (let ((d_3 (cdr p_2)))
                                                   (let ((a_3
@@ -18363,13 +17624,13 @@
                                               ?1_1
                                               -ref_1
                                               -set!_1
-                                              mk_0))))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          5
-                                          args))))))))
-                              (case-lambda
-                               ((struct:_0 make_0 ?1_0 -ref_0 -set!_0 mk_0)
+                                              mk_0)))))))))
+                              (lambda (struct:_0
+                                       make_0
+                                       ?1_0
+                                       -ref_0
+                                       -set!_0
+                                       mk_0)
                                 (call-with-values
                                  (lambda ()
                                    (let ((d_3 (cdr p_1)))
@@ -18408,32 +17669,27 @@
                                                                    (values
                                                                     ?2_1
                                                                     make-acc/muts_0)))))))
-                                                       (case-lambda
-                                                        ((?2_0 make-acc/muts_0)
+                                                       (lambda (?2_0
+                                                                make-acc/muts_0)
                                                          (let ((make2_1
                                                                 make2_0))
                                                            (values
                                                             make2_1
                                                             ?2_0
-                                                            make-acc/muts_0)))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args))))))))
-                                              (case-lambda
-                                               ((make2_0 ?2_0 make-acc/muts_0)
+                                                            make-acc/muts_0))))))))
+                                              (lambda (make2_0
+                                                       ?2_0
+                                                       make-acc/muts_0)
                                                 (let ((struct:2_1 struct:2_0))
                                                   (values
                                                    struct:2_1
                                                    make2_0
                                                    ?2_0
-                                                   make-acc/muts_0)))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 3
-                                                 args))))))))))
-                                 (case-lambda
-                                  ((struct:2_0 make2_0 ?2_0 make-acc/muts_0)
+                                                   make-acc/muts_0))))))))))
+                                 (lambda (struct:2_0
+                                          make2_0
+                                          ?2_0
+                                          make-acc/muts_0)
                                    (let ((struct:_1 struct:_0)
                                          (make_1 make_0)
                                          (?1_1 ?1_0)
@@ -18450,26 +17706,17 @@
                                       struct:2_0
                                       make2_0
                                       ?2_0
-                                      make-acc/muts_0)))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    4
-                                    args)))))
-                               (args
-                                (raise-binding-result-arity-error
-                                 6
-                                 args)))))))))
-                   (case-lambda
-                    ((struct:_0
-                      make_0
-                      ?1_0
-                      -ref_0
-                      -set!_0
-                      mk_0
-                      struct:2_0
-                      make2_0
-                      ?2_0
-                      make-acc/muts_0)
+                                      make-acc/muts_0)))))))))))
+                   (lambda (struct:_0
+                            make_0
+                            ?1_0
+                            -ref_0
+                            -set!_0
+                            mk_0
+                            struct:2_0
+                            make2_0
+                            ?2_0
+                            make-acc/muts_0)
                      (let ((struct:s_1 struct:s_0)
                            (make-s_1 make-s_0)
                            (s?_1 s?_0)
@@ -18488,24 +17735,21 @@
                         struct:2_0
                         make2_0
                         ?2_0
-                        make-acc/muts_0)))
-                    (args (raise-binding-result-arity-error 10 args)))))
-                 (args (raise-binding-result-arity-error 4 args)))))))
-         (case-lambda
-          ((struct:s_0
-            make-s_0
-            s?_0
-            acc/muts_0
-            struct:_0
-            make_0
-            ?1_0
-            -ref_0
-            -set!_0
-            mk_0
-            struct:2_0
-            make2_0
-            ?2_0
-            make-acc/muts_0)
+                        make-acc/muts_0)))))))))
+         (lambda (struct:s_0
+                  make-s_0
+                  s?_0
+                  acc/muts_0
+                  struct:_0
+                  make_0
+                  ?1_0
+                  -ref_0
+                  -set!_0
+                  mk_0
+                  struct:2_0
+                  make2_0
+                  ?2_0
+                  make-acc/muts_0)
            (let ((sti_0
                   (if (begin-unsafe
                        (let ((app_0 (unwrap struct:_0)))
@@ -18735,23 +17979,17 @@
                                                                                           (values
                                                                                            pos_1
                                                                                            field-name_0)))))))
-                                                                              (case-lambda
-                                                                               ((pos_0
-                                                                                 field-name_0)
+                                                                              (lambda (pos_0
+                                                                                       field-name_0)
                                                                                 (let ((ref-id_1
                                                                                        ref-id_0))
                                                                                   (values
                                                                                    ref-id_1
                                                                                    pos_0
-                                                                                   field-name_0)))
-                                                                               (args
-                                                                                (raise-binding-result-arity-error
-                                                                                 2
-                                                                                 args))))))))
-                                                                     (case-lambda
-                                                                      ((ref-id_0
-                                                                        pos_0
-                                                                        field-name_0)
+                                                                                   field-name_0))))))))
+                                                                     (lambda (ref-id_0
+                                                                              pos_0
+                                                                              field-name_0)
                                                                        (if (begin-unsafe
                                                                             (let ((app_0
                                                                                    (unwrap
@@ -18765,11 +18003,7 @@
                                                                            (exact-nonnegative-integer?
                                                                             pos_0)
                                                                            #f)
-                                                                         #f))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        3
-                                                                        args))))
+                                                                         #f)))
                                                                     (if (if (eq?
                                                                              'make-struct-field-accessor
                                                                              hd_1)
@@ -18926,39 +18160,28 @@
                                                                                                      (values
                                                                                                       field/proc-name_1
                                                                                                       contract_0)))))))
-                                                                                         (case-lambda
-                                                                                          ((field/proc-name_0
-                                                                                            contract_0)
+                                                                                         (lambda (field/proc-name_0
+                                                                                                  contract_0)
                                                                                            (let ((pos_1
                                                                                                   pos_0))
                                                                                              (values
                                                                                               pos_1
                                                                                               field/proc-name_0
-                                                                                              contract_0)))
-                                                                                          (args
-                                                                                           (raise-binding-result-arity-error
-                                                                                            2
-                                                                                            args))))))))
-                                                                                (case-lambda
-                                                                                 ((pos_0
-                                                                                   field/proc-name_0
-                                                                                   contract_0)
+                                                                                              contract_0))))))))
+                                                                                (lambda (pos_0
+                                                                                         field/proc-name_0
+                                                                                         contract_0)
                                                                                   (let ((ref-id_1
                                                                                          ref-id_0))
                                                                                     (values
                                                                                      ref-id_1
                                                                                      pos_0
                                                                                      field/proc-name_0
-                                                                                     contract_0)))
-                                                                                 (args
-                                                                                  (raise-binding-result-arity-error
-                                                                                   3
-                                                                                   args))))))))
-                                                                       (case-lambda
-                                                                        ((ref-id_0
-                                                                          pos_0
-                                                                          field/proc-name_0
-                                                                          contract_0)
+                                                                                     contract_0))))))))
+                                                                       (lambda (ref-id_0
+                                                                                pos_0
+                                                                                field/proc-name_0
+                                                                                contract_0)
                                                                          (if (begin-unsafe
                                                                               (let ((app_0
                                                                                      (unwrap
@@ -18975,11 +18198,7 @@
                                                                                 contract_0)
                                                                                #f)
                                                                              #f)
-                                                                           #f))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          4
-                                                                          args))))
+                                                                           #f)))
                                                                       (if (if (eq?
                                                                                'make-struct-field-accessor
                                                                                hd_1)
@@ -19208,39 +18427,28 @@
                                                                                                                 (values
                                                                                                                  contract_1
                                                                                                                  realm_0)))))))
-                                                                                                    (case-lambda
-                                                                                                     ((contract_0
-                                                                                                       realm_0)
+                                                                                                    (lambda (contract_0
+                                                                                                             realm_0)
                                                                                                       (let ((field/proc-name_1
                                                                                                              field/proc-name_0))
                                                                                                         (values
                                                                                                          field/proc-name_1
                                                                                                          contract_0
-                                                                                                         realm_0)))
-                                                                                                     (args
-                                                                                                      (raise-binding-result-arity-error
-                                                                                                       2
-                                                                                                       args))))))))
-                                                                                           (case-lambda
-                                                                                            ((field/proc-name_0
-                                                                                              contract_0
-                                                                                              realm_0)
+                                                                                                         realm_0))))))))
+                                                                                           (lambda (field/proc-name_0
+                                                                                                    contract_0
+                                                                                                    realm_0)
                                                                                              (let ((pos_1
                                                                                                     pos_0))
                                                                                                (values
                                                                                                 pos_1
                                                                                                 field/proc-name_0
                                                                                                 contract_0
-                                                                                                realm_0)))
-                                                                                            (args
-                                                                                             (raise-binding-result-arity-error
-                                                                                              3
-                                                                                              args))))))))
-                                                                                  (case-lambda
-                                                                                   ((pos_0
-                                                                                     field/proc-name_0
-                                                                                     contract_0
-                                                                                     realm_0)
+                                                                                                realm_0))))))))
+                                                                                  (lambda (pos_0
+                                                                                           field/proc-name_0
+                                                                                           contract_0
+                                                                                           realm_0)
                                                                                     (let ((ref-id_1
                                                                                            ref-id_0))
                                                                                       (values
@@ -19248,17 +18456,12 @@
                                                                                        pos_0
                                                                                        field/proc-name_0
                                                                                        contract_0
-                                                                                       realm_0)))
-                                                                                   (args
-                                                                                    (raise-binding-result-arity-error
-                                                                                     4
-                                                                                     args))))))))
-                                                                         (case-lambda
-                                                                          ((ref-id_0
-                                                                            pos_0
-                                                                            field/proc-name_0
-                                                                            contract_0
-                                                                            realm_0)
+                                                                                       realm_0))))))))
+                                                                         (lambda (ref-id_0
+                                                                                  pos_0
+                                                                                  field/proc-name_0
+                                                                                  contract_0
+                                                                                  realm_0)
                                                                            (if (begin-unsafe
                                                                                 (let ((app_0
                                                                                        (unwrap
@@ -19278,11 +18481,7 @@
                                                                                    #f)
                                                                                  #f)
                                                                                #f)
-                                                                             #f))
-                                                                          (args
-                                                                           (raise-binding-result-arity-error
-                                                                            5
-                                                                            args))))
+                                                                             #f)))
                                                                         (if (if (eq?
                                                                                  'make-struct-field-mutator
                                                                                  hd_1)
@@ -19417,23 +18616,17 @@
                                                                                                 (values
                                                                                                  pos_1
                                                                                                  field-name_0)))))))
-                                                                                    (case-lambda
-                                                                                     ((pos_0
-                                                                                       field-name_0)
+                                                                                    (lambda (pos_0
+                                                                                             field-name_0)
                                                                                       (let ((set-id_1
                                                                                              set-id_0))
                                                                                         (values
                                                                                          set-id_1
                                                                                          pos_0
-                                                                                         field-name_0)))
-                                                                                     (args
-                                                                                      (raise-binding-result-arity-error
-                                                                                       2
-                                                                                       args))))))))
-                                                                           (case-lambda
-                                                                            ((set-id_0
-                                                                              pos_0
-                                                                              field-name_0)
+                                                                                         field-name_0))))))))
+                                                                           (lambda (set-id_0
+                                                                                    pos_0
+                                                                                    field-name_0)
                                                                              (if (begin-unsafe
                                                                                   (let ((app_0
                                                                                          (unwrap
@@ -19447,11 +18640,7 @@
                                                                                  (exact-nonnegative-integer?
                                                                                   pos_0)
                                                                                  #f)
-                                                                               #f))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              3
-                                                                              args))))
+                                                                               #f)))
                                                                           (if (if (eq?
                                                                                    'make-struct-field-mutator
                                                                                    hd_1)
@@ -19608,39 +18797,28 @@
                                                                                                            (values
                                                                                                             field/proc-name_1
                                                                                                             contract_0)))))))
-                                                                                               (case-lambda
-                                                                                                ((field/proc-name_0
-                                                                                                  contract_0)
+                                                                                               (lambda (field/proc-name_0
+                                                                                                        contract_0)
                                                                                                  (let ((pos_1
                                                                                                         pos_0))
                                                                                                    (values
                                                                                                     pos_1
                                                                                                     field/proc-name_0
-                                                                                                    contract_0)))
-                                                                                                (args
-                                                                                                 (raise-binding-result-arity-error
-                                                                                                  2
-                                                                                                  args))))))))
-                                                                                      (case-lambda
-                                                                                       ((pos_0
-                                                                                         field/proc-name_0
-                                                                                         contract_0)
+                                                                                                    contract_0))))))))
+                                                                                      (lambda (pos_0
+                                                                                               field/proc-name_0
+                                                                                               contract_0)
                                                                                         (let ((set-id_1
                                                                                                set-id_0))
                                                                                           (values
                                                                                            set-id_1
                                                                                            pos_0
                                                                                            field/proc-name_0
-                                                                                           contract_0)))
-                                                                                       (args
-                                                                                        (raise-binding-result-arity-error
-                                                                                         3
-                                                                                         args))))))))
-                                                                             (case-lambda
-                                                                              ((set-id_0
-                                                                                pos_0
-                                                                                field/proc-name_0
-                                                                                contract_0)
+                                                                                           contract_0))))))))
+                                                                             (lambda (set-id_0
+                                                                                      pos_0
+                                                                                      field/proc-name_0
+                                                                                      contract_0)
                                                                                (if (begin-unsafe
                                                                                     (let ((app_0
                                                                                            (unwrap
@@ -19657,11 +18835,7 @@
                                                                                       contract_0)
                                                                                      #f)
                                                                                    #f)
-                                                                                 #f))
-                                                                              (args
-                                                                               (raise-binding-result-arity-error
-                                                                                4
-                                                                                args))))
+                                                                                 #f)))
                                                                             (if (if (eq?
                                                                                      'make-struct-field-mutator
                                                                                      hd_1)
@@ -19890,39 +19064,28 @@
                                                                                                                       (values
                                                                                                                        contract_1
                                                                                                                        realm_0)))))))
-                                                                                                          (case-lambda
-                                                                                                           ((contract_0
-                                                                                                             realm_0)
+                                                                                                          (lambda (contract_0
+                                                                                                                   realm_0)
                                                                                                             (let ((field/proc-name_1
                                                                                                                    field/proc-name_0))
                                                                                                               (values
                                                                                                                field/proc-name_1
                                                                                                                contract_0
-                                                                                                               realm_0)))
-                                                                                                           (args
-                                                                                                            (raise-binding-result-arity-error
-                                                                                                             2
-                                                                                                             args))))))))
-                                                                                                 (case-lambda
-                                                                                                  ((field/proc-name_0
-                                                                                                    contract_0
-                                                                                                    realm_0)
+                                                                                                               realm_0))))))))
+                                                                                                 (lambda (field/proc-name_0
+                                                                                                          contract_0
+                                                                                                          realm_0)
                                                                                                    (let ((pos_1
                                                                                                           pos_0))
                                                                                                      (values
                                                                                                       pos_1
                                                                                                       field/proc-name_0
                                                                                                       contract_0
-                                                                                                      realm_0)))
-                                                                                                  (args
-                                                                                                   (raise-binding-result-arity-error
-                                                                                                    3
-                                                                                                    args))))))))
-                                                                                        (case-lambda
-                                                                                         ((pos_0
-                                                                                           field/proc-name_0
-                                                                                           contract_0
-                                                                                           realm_0)
+                                                                                                      realm_0))))))))
+                                                                                        (lambda (pos_0
+                                                                                                 field/proc-name_0
+                                                                                                 contract_0
+                                                                                                 realm_0)
                                                                                           (let ((set-id_1
                                                                                                  set-id_0))
                                                                                             (values
@@ -19930,17 +19093,12 @@
                                                                                              pos_0
                                                                                              field/proc-name_0
                                                                                              contract_0
-                                                                                             realm_0)))
-                                                                                         (args
-                                                                                          (raise-binding-result-arity-error
-                                                                                           4
-                                                                                           args))))))))
-                                                                               (case-lambda
-                                                                                ((set-id_0
-                                                                                  pos_0
-                                                                                  field/proc-name_0
-                                                                                  contract_0
-                                                                                  realm_0)
+                                                                                             realm_0))))))))
+                                                                               (lambda (set-id_0
+                                                                                        pos_0
+                                                                                        field/proc-name_0
+                                                                                        contract_0
+                                                                                        realm_0)
                                                                                  (if (begin-unsafe
                                                                                       (let ((app_0
                                                                                              (unwrap
@@ -19960,11 +19118,7 @@
                                                                                          #f)
                                                                                        #f)
                                                                                      #f)
-                                                                                   #f))
-                                                                                (args
-                                                                                 (raise-binding-result-arity-error
-                                                                                  5
-                                                                                  args))))
+                                                                                   #f)))
                                                                               #f)))))))))
                                                            (values result_1))))
                                                     (if (if (not
@@ -20999,18 +20153,13 @@
                                                                                                           (values
                                                                                                            pos_1
                                                                                                            field-name_0))))))))
-                                                                                            (case-lambda
-                                                                                             ((pos_0
-                                                                                               field-name_0)
+                                                                                            (lambda (pos_0
+                                                                                                     field-name_0)
                                                                                               (build-accessor_0
                                                                                                pos_0
                                                                                                field-name_0
                                                                                                #f
-                                                                                               'racket))
-                                                                                             (args
-                                                                                              (raise-binding-result-arity-error
-                                                                                               2
-                                                                                               args))))
+                                                                                               'racket)))
                                                                                            (if (if (eq?
                                                                                                     'make-struct-field-accessor
                                                                                                     hd_1)
@@ -21158,32 +20307,22 @@
                                                                                                                      (values
                                                                                                                       field/proc-name_1
                                                                                                                       contract_0)))))))
-                                                                                                         (case-lambda
-                                                                                                          ((field/proc-name_0
-                                                                                                            contract_0)
+                                                                                                         (lambda (field/proc-name_0
+                                                                                                                  contract_0)
                                                                                                            (let ((pos_1
                                                                                                                   pos_0))
                                                                                                              (values
                                                                                                               pos_1
                                                                                                               field/proc-name_0
-                                                                                                              contract_0)))
-                                                                                                          (args
-                                                                                                           (raise-binding-result-arity-error
-                                                                                                            2
-                                                                                                            args)))))))))
-                                                                                              (case-lambda
-                                                                                               ((pos_0
-                                                                                                 field/proc-name_0
-                                                                                                 contract_0)
+                                                                                                              contract_0)))))))))
+                                                                                              (lambda (pos_0
+                                                                                                       field/proc-name_0
+                                                                                                       contract_0)
                                                                                                 (build-accessor_0
                                                                                                  pos_0
                                                                                                  field/proc-name_0
                                                                                                  contract_0
-                                                                                                 'racket))
-                                                                                               (args
-                                                                                                (raise-binding-result-arity-error
-                                                                                                 3
-                                                                                                 args))))
+                                                                                                 'racket)))
                                                                                              (if (if (eq?
                                                                                                       'make-struct-field-accessor
                                                                                                       hd_1)
@@ -21403,48 +20542,33 @@
                                                                                                                                 (values
                                                                                                                                  contract_1
                                                                                                                                  realm_0)))))))
-                                                                                                                    (case-lambda
-                                                                                                                     ((contract_0
-                                                                                                                       realm_0)
+                                                                                                                    (lambda (contract_0
+                                                                                                                             realm_0)
                                                                                                                       (let ((field/proc-name_1
                                                                                                                              field/proc-name_0))
                                                                                                                         (values
                                                                                                                          field/proc-name_1
                                                                                                                          contract_0
-                                                                                                                         realm_0)))
-                                                                                                                     (args
-                                                                                                                      (raise-binding-result-arity-error
-                                                                                                                       2
-                                                                                                                       args))))))))
-                                                                                                           (case-lambda
-                                                                                                            ((field/proc-name_0
-                                                                                                              contract_0
-                                                                                                              realm_0)
+                                                                                                                         realm_0))))))))
+                                                                                                           (lambda (field/proc-name_0
+                                                                                                                    contract_0
+                                                                                                                    realm_0)
                                                                                                              (let ((pos_1
                                                                                                                     pos_0))
                                                                                                                (values
                                                                                                                 pos_1
                                                                                                                 field/proc-name_0
                                                                                                                 contract_0
-                                                                                                                realm_0)))
-                                                                                                            (args
-                                                                                                             (raise-binding-result-arity-error
-                                                                                                              3
-                                                                                                              args)))))))))
-                                                                                                (case-lambda
-                                                                                                 ((pos_0
-                                                                                                   field/proc-name_0
-                                                                                                   contract_0
-                                                                                                   realm_0)
+                                                                                                                realm_0)))))))))
+                                                                                                (lambda (pos_0
+                                                                                                         field/proc-name_0
+                                                                                                         contract_0
+                                                                                                         realm_0)
                                                                                                   (build-accessor_0
                                                                                                    pos_0
                                                                                                    field/proc-name_0
                                                                                                    contract_0
-                                                                                                   realm_0))
-                                                                                                 (args
-                                                                                                  (raise-binding-result-arity-error
-                                                                                                   4
-                                                                                                   args))))
+                                                                                                   realm_0)))
                                                                                                (if (if (eq?
                                                                                                         'make-struct-field-mutator
                                                                                                         hd_1)
@@ -21570,18 +20694,13 @@
                                                                                                                 (values
                                                                                                                  pos_1
                                                                                                                  field-name_0))))))))
-                                                                                                  (case-lambda
-                                                                                                   ((pos_0
-                                                                                                     field-name_0)
+                                                                                                  (lambda (pos_0
+                                                                                                           field-name_0)
                                                                                                     (build-mutator_0
                                                                                                      pos_0
                                                                                                      field-name_0
                                                                                                      #f
-                                                                                                     'racket))
-                                                                                                   (args
-                                                                                                    (raise-binding-result-arity-error
-                                                                                                     2
-                                                                                                     args))))
+                                                                                                     'racket)))
                                                                                                  (if (if (eq?
                                                                                                           'make-struct-field-mutator
                                                                                                           hd_1)
@@ -21729,32 +20848,22 @@
                                                                                                                            (values
                                                                                                                             field-name_1
                                                                                                                             contract_0)))))))
-                                                                                                               (case-lambda
-                                                                                                                ((field-name_0
-                                                                                                                  contract_0)
+                                                                                                               (lambda (field-name_0
+                                                                                                                        contract_0)
                                                                                                                  (let ((pos_1
                                                                                                                         pos_0))
                                                                                                                    (values
                                                                                                                     pos_1
                                                                                                                     field-name_0
-                                                                                                                    contract_0)))
-                                                                                                                (args
-                                                                                                                 (raise-binding-result-arity-error
-                                                                                                                  2
-                                                                                                                  args)))))))))
-                                                                                                    (case-lambda
-                                                                                                     ((pos_0
-                                                                                                       field-name_0
-                                                                                                       contract_0)
+                                                                                                                    contract_0)))))))))
+                                                                                                    (lambda (pos_0
+                                                                                                             field-name_0
+                                                                                                             contract_0)
                                                                                                       (build-mutator_0
                                                                                                        pos_0
                                                                                                        field-name_0
                                                                                                        contract_0
-                                                                                                       'racket))
-                                                                                                     (args
-                                                                                                      (raise-binding-result-arity-error
-                                                                                                       3
-                                                                                                       args))))
+                                                                                                       'racket)))
                                                                                                    (if (if (eq?
                                                                                                             'make-struct-field-mutator
                                                                                                             hd_1)
@@ -21974,48 +21083,33 @@
                                                                                                                                       (values
                                                                                                                                        contract_1
                                                                                                                                        realm_0)))))))
-                                                                                                                          (case-lambda
-                                                                                                                           ((contract_0
-                                                                                                                             realm_0)
+                                                                                                                          (lambda (contract_0
+                                                                                                                                   realm_0)
                                                                                                                             (let ((field-name_1
                                                                                                                                    field-name_0))
                                                                                                                               (values
                                                                                                                                field-name_1
                                                                                                                                contract_0
-                                                                                                                               realm_0)))
-                                                                                                                           (args
-                                                                                                                            (raise-binding-result-arity-error
-                                                                                                                             2
-                                                                                                                             args))))))))
-                                                                                                                 (case-lambda
-                                                                                                                  ((field-name_0
-                                                                                                                    contract_0
-                                                                                                                    realm_0)
+                                                                                                                               realm_0))))))))
+                                                                                                                 (lambda (field-name_0
+                                                                                                                          contract_0
+                                                                                                                          realm_0)
                                                                                                                    (let ((pos_1
                                                                                                                           pos_0))
                                                                                                                      (values
                                                                                                                       pos_1
                                                                                                                       field-name_0
                                                                                                                       contract_0
-                                                                                                                      realm_0)))
-                                                                                                                  (args
-                                                                                                                   (raise-binding-result-arity-error
-                                                                                                                    3
-                                                                                                                    args)))))))))
-                                                                                                      (case-lambda
-                                                                                                       ((pos_0
-                                                                                                         field-name_0
-                                                                                                         contract_0
-                                                                                                         realm_0)
+                                                                                                                      realm_0)))))))))
+                                                                                                      (lambda (pos_0
+                                                                                                               field-name_0
+                                                                                                               contract_0
+                                                                                                               realm_0)
                                                                                                         (build-mutator_0
                                                                                                          pos_0
                                                                                                          field-name_0
                                                                                                          contract_0
-                                                                                                         realm_0))
-                                                                                                       (args
-                                                                                                        (raise-binding-result-arity-error
-                                                                                                         4
-                                                                                                         args))))
+                                                                                                         realm_0)))
                                                                                                      (error
                                                                                                       "oops"))))))))))))
                                                                                fold-var_0)))
@@ -22030,8 +21124,7 @@
                                                 null
                                                 acc/muts_0
                                                 make-acc/muts_0)))))))))))))))))))))
-               #f)))
-          (args (raise-binding-result-arity-error 14 args))))
+               #f))))
         #f))))
 (define struct-convert-local.1
   (|#%name|
@@ -22091,14 +21184,11 @@
                                   (let ((d_1 (cdr p_1)))
                                     (let ((a_2 (car (unwrap d_1)))) a_2))))
                              (let ((ids_1 ids_0)) (values ids_1 rhs_0))))))))
-                 (case-lambda
-                  ((ids_0 rhs_0)
+                 (lambda (ids_0 rhs_0)
                    (let ((bodys_0 (let ((d_1 (cdr p_0))) (unwrap-list d_1))))
                      (let ((ids_1 ids_0) (rhs_1 rhs_0))
-                       (values ids_1 rhs_1 bodys_0))))
-                  (args (raise-binding-result-arity-error 2 args)))))))
-          (case-lambda
-           ((ids_0 rhs_0 bodys_0)
+                       (values ids_1 rhs_1 bodys_0))))))))
+          (lambda (ids_0 rhs_0 bodys_0)
             (let ((defn_0 (list 'define-values ids_0 rhs_0)))
               (let ((new-seq_0
                      (struct-convert
@@ -22133,8 +21223,7 @@
                             simples12_0
                             unsafe-mode?2_0
                             target3_0))
-                         (case-lambda
-                          ((new-knowns_0 info_0)
+                         (lambda (new-knowns_0 info_0)
                            (if letrec?1_0
                              (let ((app_0
                                     (letrec*
@@ -22202,14 +21291,9 @@
                                                            (values
                                                             forms_1
                                                             rest_0))))))
-                                                 (case-lambda
-                                                  ((forms_0 rest_0)
+                                                 (lambda (forms_0 rest_0)
                                                    (loop_0
-                                                    (append forms_0 rest_0)))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args))))
+                                                    (append forms_0 rest_0))))
                                                 (if (let ((p_0
                                                            (unwrap new-seq_2)))
                                                       (if (pair? p_0)
@@ -22299,8 +21383,7 @@
                                                                       (values
                                                                        id_1
                                                                        rhs_1))))))))
-                                                        (case-lambda
-                                                         ((id_0 rhs_1)
+                                                        (lambda (id_0 rhs_1)
                                                           (let ((rest_0
                                                                  (let ((d_0
                                                                         (cdr
@@ -22312,22 +21395,13 @@
                                                               (values
                                                                id_1
                                                                rhs_2
-                                                               rest_0))))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args))))))
-                                                   (case-lambda
-                                                    ((id_0 rhs_1 rest_0)
+                                                               rest_0)))))))
+                                                   (lambda (id_0 rhs_1 rest_0)
                                                      (let ((app_0
                                                             (list id_0 rhs_1)))
                                                        (cons
                                                         app_0
-                                                        (loop_0 rest_0))))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      3
-                                                      args))))
+                                                        (loop_0 rest_0)))))
                                                   (error
                                                    'match
                                                    "failed ~e"
@@ -22398,13 +21472,8 @@
                                                     (values
                                                      forms_1
                                                      rest_0))))))
-                                          (case-lambda
-                                           ((forms_0 rest_0)
-                                            (loop_0 (append forms_0 rest_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args))))
+                                          (lambda (forms_0 rest_0)
+                                            (loop_0 (append forms_0 rest_0))))
                                          (if (let ((p_0 (unwrap new-seq_2)))
                                                (if (pair? p_0)
                                                  (if (let ((a_0 (car p_0)))
@@ -22484,8 +21553,7 @@
                                                                (values
                                                                 id_1
                                                                 rhs_1))))))))
-                                                 (case-lambda
-                                                  ((id_0 rhs_1)
+                                                 (lambda (id_0 rhs_1)
                                                    (let ((rest_0
                                                           (let ((d_0
                                                                  (cdr p_0)))
@@ -22495,32 +21563,21 @@
                                                        (values
                                                         id_1
                                                         rhs_2
-                                                        rest_0))))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args))))))
-                                            (case-lambda
-                                             ((id_0 rhs_1 rest_0)
+                                                        rest_0)))))))
+                                            (lambda (id_0 rhs_1 rest_0)
                                               (let ((app_0
                                                      (list (list id_0 rhs_1))))
                                                 (list
                                                  'let
                                                  app_0
-                                                 (loop_0 rest_0))))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               3
-                                               args))))
+                                                 (loop_0 rest_0)))))
                                            (error
                                             'match
                                             "failed ~e"
                                             new-seq_2)))))))))
-                              (loop_0 new-seq_1))))
-                          (args (raise-binding-result-arity-error 2 args)))))
+                              (loop_0 new-seq_1))))))
                       (error 'match "failed ~e" new-seq_0)))
-                  #f))))
-           (args (raise-binding-result-arity-error 3 args))))
+                  #f)))))
          #f)))))
 (define schemify-body$1
   (|#%name|
@@ -22621,8 +21678,7 @@
                                                        (values
                                                         ids_1
                                                         rhs_0)))))))
-                                           (case-lambda
-                                            ((ids_0 rhs_0)
+                                           (lambda (ids_0 rhs_0)
                                              (begin
                                                (letrec*
                                                 ((for-loop_1
@@ -22666,11 +21722,7 @@
                                                          src-syms_3))))))
                                                 (for-loop_1
                                                  src-syms_2
-                                                 ids_0))))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
+                                                 ids_0)))))
                                           src-syms_2))))
                                  (values src-syms_3))))
                           (for-loop_0 src-syms_3 rest_0))))
@@ -22884,44 +21936,27 @@
                                                           (values
                                                            ids_3
                                                            rhss_1))))))
-                                                (case-lambda
-                                                 ((ids3_0 rhss4_0)
+                                                (lambda (ids3_0 rhss4_0)
                                                   (values
                                                    (cons ids3_0 ids_1)
-                                                   (cons rhss4_0 rhss_0)))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   2
-                                                   args)))))
-                                             (case-lambda
-                                              ((ids_2 rhss_1)
-                                               (values ids_2 rhss_1))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args)))))
-                                          (case-lambda
-                                           ((ids_2 rhss_1)
-                                            (for-loop_0 ids_2 rhss_1 rest_0))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args)))))))
+                                                   (cons rhss4_0 rhss_0)))))
+                                             (lambda (ids_2 rhss_1)
+                                               (values ids_2 rhss_1))))
+                                          (lambda (ids_2 rhss_1)
+                                            (for-loop_0
+                                             ids_2
+                                             rhss_1
+                                             rest_0))))))
                                    (values ids_1 rhss_0)))))))
                           (for-loop_0 null null a_0)))
-                       (case-lambda
-                        ((ids_1 rhss_0)
+                       (lambda (ids_1 rhss_0)
                          (let ((app_0 (reverse$1 ids_1)))
-                           (values app_0 (reverse$1 rhss_0))))
-                        (args (raise-binding-result-arity-error 2 args))))))
-                  (case-lambda
-                   ((ids_1 rhss_0)
+                           (values app_0 (reverse$1 rhss_0)))))))
+                  (lambda (ids_1 rhss_0)
                     (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                       (let ((ids_2 ids_1) (rhss_1 rhss_0))
-                        (values ids_2 rhss_1 body_0))))
-                   (args (raise-binding-result-arity-error 2 args)))))))
-           (case-lambda
-            ((ids_1 rhss_0 body_0)
+                        (values ids_2 rhss_1 body_0))))))))
+           (lambda (ids_1 rhss_0 body_0)
              (let ((app_0
                     (reverse$1
                      (begin
@@ -22970,8 +22005,7 @@
                                            rest_1)))))))
                               fold-var_0))))))
                      (for-loop_0 null ids_1 rhss_0))))
-                 body_0))))
-            (args (raise-binding-result-arity-error 3 args))))
+                 body_0)))))
           (error 'match "failed ~e" e_0))
         e_0))))
 (define id-to-variable
@@ -23096,8 +22130,7 @@
                                                               (values
                                                                ids_1
                                                                rhs_0)))))))
-                                                  (case-lambda
-                                                   ((ids_0 rhs_0)
+                                                  (lambda (ids_0 rhs_0)
                                                     (begin
                                                       (letrec*
                                                        ((for-loop_1
@@ -23141,11 +22174,7 @@
                                                                 unexported-ids_1))))))
                                                        (for-loop_1
                                                         unexported-ids_0
-                                                        ids_0))))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     2
-                                                     args))))
+                                                        ids_0)))))
                                                  unexported-ids_0))))
                                         (values unexported-ids_1))))
                                  (for-loop_0 unexported-ids_1 rest_0))))
@@ -23218,8 +22247,7 @@
                                                 simples_0
                                                 unsafe-mode?_0
                                                 target_0))
-                                             (case-lambda
-                                              ((knowns_1 info_0)
+                                             (lambda (knowns_1 info_0)
                                                (begin
                                                  (let ((hd_0
                                                         (let ((p_0
@@ -23295,8 +22323,7 @@
                                                                   (values
                                                                    ids_1
                                                                    rhs_0)))))))
-                                                      (case-lambda
-                                                       ((ids_0 rhs_0)
+                                                      (lambda (ids_0 rhs_0)
                                                         (begin
                                                           (if info_0
                                                             (begin
@@ -23429,11 +22456,7 @@
                                                                       (values)))))))
                                                              (for-loop_1
                                                               ids_0)))
-                                                          (void)))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))
+                                                          (void))))
                                                      (find-mutated!
                                                       form_0
                                                       #f
@@ -23443,11 +22466,7 @@
                                                       mutated_0
                                                       simples_0
                                                       unsafe-mode?_0)))
-                                                 knowns_1))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))))
+                                                 knowns_1)))))
                                        (values prev-knowns_1))))
                                 (for-loop_0 prev-knowns_1 rest_0))))
                           prev-knowns_0))))))
@@ -23503,8 +22522,7 @@
                                                         a_0))))
                                                (let ((ids_1 ids_0))
                                                  (values ids_1 rhs_0)))))))
-                                     (case-lambda
-                                      ((ids_0 rhs_0)
+                                     (lambda (ids_0 rhs_0)
                                        (begin
                                          (begin
                                            (letrec*
@@ -23556,11 +22574,7 @@
                                                             rest_1))))
                                                      (values)))))))
                                             (for-loop_1 ids_0)))
-                                         (void)))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args))))
+                                         (void))))
                                     (void)))
                                 (for-loop_0 rest_0))))
                           (values)))))))
@@ -23698,14 +22712,12 @@
                                     (let ((d_1 (cdr p_0))) (unwrap-list d_1))))
                                (let ((formals_1 formals_0))
                                  (values formals_1 body_0)))))))
-                     (case-lambda
-                      ((formals_0 body_0)
+                     (lambda (formals_0 body_0)
                        (if ids_1
                          (delay!_0
                           ids_1
                           (lambda () (find-mutated!*_0 body_0 #f)))
-                         (find-mutated!*_0 body_0 #f)))
-                      (args (raise-binding-result-arity-error 2 args))))
+                         (find-mutated!*_0 body_0 #f))))
                     (if (if (eq? 'case-lambda hd_0)
                           (let ((a_0 (cdr (unwrap v_0))))
                             (if (wrap-list? a_0)
@@ -23803,48 +22815,30 @@
                                                                (values
                                                                 formalss_2
                                                                 bodys_1))))))
-                                                     (case-lambda
-                                                      ((formalss10_0 bodys11_0)
+                                                     (lambda (formalss10_0
+                                                              bodys11_0)
                                                        (values
                                                         (cons
                                                          formalss10_0
                                                          formalss_0)
                                                         (cons
                                                          bodys11_0
-                                                         bodys_0)))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args)))))
-                                                  (case-lambda
-                                                   ((formalss_1 bodys_1)
+                                                         bodys_0)))))
+                                                  (lambda (formalss_1 bodys_1)
                                                     (values
                                                      formalss_1
-                                                     bodys_1))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     2
-                                                     args)))))
-                                               (case-lambda
-                                                ((formalss_1 bodys_1)
+                                                     bodys_1))))
+                                               (lambda (formalss_1 bodys_1)
                                                  (for-loop_0
                                                   formalss_1
                                                   bodys_1
-                                                  rest_0))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args)))))))
+                                                  rest_0))))))
                                         (values formalss_0 bodys_0)))))))
                                (for-loop_0 null null d_0)))
-                            (case-lambda
-                             ((formalss_0 bodys_0)
+                            (lambda (formalss_0 bodys_0)
                               (let ((app_0 (reverse$1 formalss_0)))
-                                (values app_0 (reverse$1 bodys_0))))
-                             (args
-                              (raise-binding-result-arity-error 2 args))))))
-                       (case-lambda
-                        ((formalss_0 bodys_0)
+                                (values app_0 (reverse$1 bodys_0)))))))
+                       (lambda (formalss_0 bodys_0)
                          (if ids_1
                            (delay!_0
                             ids_1
@@ -23883,8 +22877,7 @@
                                                (for-loop_0 rest_0))))
                                          (values)))))))
                                 (for-loop_0 bodys_0)))
-                             (void))))
-                        (args (raise-binding-result-arity-error 2 args))))
+                             (void)))))
                       (if (if (eq? 'quote hd_0)
                             (let ((a_0 (cdr (unwrap v_0))))
                               (let ((p_0 (unwrap a_0)))
@@ -24038,62 +23031,40 @@
                                                                           (values
                                                                            idss_2
                                                                            rhss_1))))))
-                                                                (case-lambda
-                                                                 ((idss12_0
-                                                                   rhss13_0)
+                                                                (lambda (idss12_0
+                                                                         rhss13_0)
                                                                   (values
                                                                    (cons
                                                                     idss12_0
                                                                     idss_0)
                                                                    (cons
                                                                     rhss13_0
-                                                                    rhss_0)))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   2
-                                                                   args)))))
-                                                             (case-lambda
-                                                              ((idss_1 rhss_1)
+                                                                    rhss_0)))))
+                                                             (lambda (idss_1
+                                                                      rhss_1)
                                                                (values
                                                                 idss_1
-                                                                rhss_1))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                2
-                                                                args)))))
-                                                          (case-lambda
-                                                           ((idss_1 rhss_1)
+                                                                rhss_1))))
+                                                          (lambda (idss_1
+                                                                   rhss_1)
                                                             (for-loop_0
                                                              idss_1
                                                              rhss_1
-                                                             rest_0))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args)))))))
+                                                             rest_0))))))
                                                    (values idss_0 rhss_0)))))))
                                           (for-loop_0 null null a_0)))
-                                       (case-lambda
-                                        ((idss_0 rhss_0)
+                                       (lambda (idss_0 rhss_0)
                                          (let ((app_0 (reverse$1 idss_0)))
-                                           (values app_0 (reverse$1 rhss_0))))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args))))))
-                                  (case-lambda
-                                   ((idss_0 rhss_0)
+                                           (values
+                                            app_0
+                                            (reverse$1 rhss_0)))))))
+                                  (lambda (idss_0 rhss_0)
                                     (let ((bodys_0
                                            (let ((d_1 (cdr p_0)))
                                              (unwrap-list d_1))))
                                       (let ((idss_1 idss_0) (rhss_1 rhss_0))
-                                        (values idss_1 rhss_1 bodys_0))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args)))))))
-                           (case-lambda
-                            ((idss_0 rhss_0 bodys_0)
+                                        (values idss_1 rhss_1 bodys_0))))))))
+                           (lambda (idss_0 rhss_0 bodys_0)
                              (begin
                                (begin
                                  (letrec*
@@ -24121,8 +23092,7 @@
                                            (values)))))))
                                   (for-loop_0 idss_0 rhss_0)))
                                (void)
-                               (find-mutated!*_0 bodys_0 ids_1)))
-                            (args (raise-binding-result-arity-error 3 args))))
+                               (find-mutated!*_0 bodys_0 ids_1))))
                           (if (if (eq? 'letrec-values hd_0)
                                 (let ((a_0 (cdr (unwrap v_0))))
                                   (let ((p_0 (unwrap a_0)))
@@ -24269,67 +23239,42 @@
                                                                             (values
                                                                              idss_2
                                                                              rhss_1))))))
-                                                                  (case-lambda
-                                                                   ((idss14_0
-                                                                     rhss15_0)
+                                                                  (lambda (idss14_0
+                                                                           rhss15_0)
                                                                     (values
                                                                      (cons
                                                                       idss14_0
                                                                       idss_0)
                                                                      (cons
                                                                       rhss15_0
-                                                                      rhss_0)))
-                                                                   (args
-                                                                    (raise-binding-result-arity-error
-                                                                     2
-                                                                     args)))))
-                                                               (case-lambda
-                                                                ((idss_1
-                                                                  rhss_1)
+                                                                      rhss_0)))))
+                                                               (lambda (idss_1
+                                                                        rhss_1)
                                                                  (values
                                                                   idss_1
-                                                                  rhss_1))
-                                                                (args
-                                                                 (raise-binding-result-arity-error
-                                                                  2
-                                                                  args)))))
-                                                            (case-lambda
-                                                             ((idss_1 rhss_1)
+                                                                  rhss_1))))
+                                                            (lambda (idss_1
+                                                                     rhss_1)
                                                               (for-loop_0
                                                                idss_1
                                                                rhss_1
-                                                               rest_0))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args)))))))
+                                                               rest_0))))))
                                                      (values
                                                       idss_0
                                                       rhss_0)))))))
                                             (for-loop_0 null null a_0)))
-                                         (case-lambda
-                                          ((idss_0 rhss_0)
+                                         (lambda (idss_0 rhss_0)
                                            (let ((app_0 (reverse$1 idss_0)))
                                              (values
                                               app_0
-                                              (reverse$1 rhss_0))))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))))
-                                    (case-lambda
-                                     ((idss_0 rhss_0)
+                                              (reverse$1 rhss_0)))))))
+                                    (lambda (idss_0 rhss_0)
                                       (let ((bodys_0
                                              (let ((d_1 (cdr p_0)))
                                                (unwrap-list d_1))))
                                         (let ((idss_1 idss_0) (rhss_1 rhss_0))
-                                          (values idss_1 rhss_1 bodys_0))))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args)))))))
-                             (case-lambda
-                              ((idss_0 rhss_0 bodys_0)
+                                          (values idss_1 rhss_1 bodys_0))))))))
+                             (lambda (idss_0 rhss_0 bodys_0)
                                (if (letrec-splitable-values-binding?
                                     idss_0
                                     rhss_0)
@@ -24393,12 +23338,8 @@
                                                                          rest_1)))))
                                                                 (values)))))))
                                                        (for-loop_1 ids_2)))
-                                                    (case-lambda
-                                                     (() (for-loop_0 rest_0))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       0
-                                                       args))))))
+                                                    (lambda ()
+                                                      (for-loop_0 rest_0)))))
                                                (values)))))))
                                       (for-loop_0 idss_0)))
                                    (void)
@@ -24566,9 +23507,7 @@
                                                           rest_1))))))
                                                maybe-cc?_0))))))
                                       (for-loop_0 #f idss_0 rhss_0)))
-                                   (find-mutated!*_0 bodys_0 ids_1))))
-                              (args
-                               (raise-binding-result-arity-error 3 args))))
+                                   (find-mutated!*_0 bodys_0 ids_1)))))
                             (if (if (eq? 'if hd_0)
                                   (let ((a_0 (cdr (unwrap v_0))))
                                     (let ((p_0 (unwrap a_0)))
@@ -24611,22 +23550,14 @@
                                                            a_0))))
                                                   (let ((thn_1 thn_0))
                                                     (values thn_1 els_0)))))))
-                                        (case-lambda
-                                         ((thn_0 els_0)
+                                        (lambda (thn_0 els_0)
                                           (let ((tst_1 tst_0))
-                                            (values tst_1 thn_0 els_0)))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args))))))))
-                               (case-lambda
-                                ((tst_0 thn_0 els_0)
+                                            (values tst_1 thn_0 els_0))))))))
+                               (lambda (tst_0 thn_0 els_0)
                                  (begin
                                    (find-mutated!_0 tst_0 #f)
                                    (find-mutated!_0 thn_0 #f)
-                                   (find-mutated!_0 els_0 #f)))
-                                (args
-                                 (raise-binding-result-arity-error 3 args))))
+                                   (find-mutated!_0 els_0 #f))))
                               (if (if (eq? 'with-continuation-mark hd_0)
                                     (let ((a_0 (cdr (unwrap v_0))))
                                       (let ((p_0 (unwrap a_0)))
@@ -24672,22 +23603,17 @@
                                                       (values
                                                        val_1
                                                        body_0)))))))
-                                          (case-lambda
-                                           ((val_0 body_0)
+                                          (lambda (val_0 body_0)
                                             (let ((key_1 key_0))
-                                              (values key_1 val_0 body_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args))))))))
-                                 (case-lambda
-                                  ((key_0 val_0 body_0)
+                                              (values
+                                               key_1
+                                               val_0
+                                               body_0))))))))
+                                 (lambda (key_0 val_0 body_0)
                                    (begin
                                      (find-mutated!_0 key_0 #f)
                                      (find-mutated!_0 val_0 #f)
-                                     (find-mutated!_0 body_0 ids_1)))
-                                  (args
-                                   (raise-binding-result-arity-error 3 args))))
+                                     (find-mutated!_0 body_0 ids_1))))
                                 (if (if (eq? 'begin hd_0)
                                       (let ((a_0 (cdr (unwrap v_0))))
                                         (wrap-list? a_0))
@@ -24724,15 +23650,10 @@
                                                         (unwrap-list d_1))))
                                                  (let ((exp_1 exp_0))
                                                    (values exp_1 exps_0)))))))
-                                       (case-lambda
-                                        ((exp_0 exps_0)
+                                       (lambda (exp_0 exps_0)
                                          (begin
                                            (find-mutated!_0 exp_0 ids_1)
-                                           (find-mutated!*_0 exps_0 #f)))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args))))
+                                           (find-mutated!*_0 exps_0 #f))))
                                       (if (if (eq? 'set! hd_0)
                                             (let ((a_0 (cdr (unwrap v_0))))
                                               (let ((p_0 (unwrap a_0)))
@@ -24767,8 +23688,7 @@
                                                             a_0))))
                                                    (let ((id_1 id_0))
                                                      (values id_1 rhs_0)))))))
-                                         (case-lambda
-                                          ((id_0 rhs_0)
+                                         (lambda (id_0 rhs_0)
                                            (begin
                                              (let ((id_1 (unwrap id_0)))
                                                (let ((old-state_0
@@ -24787,11 +23707,7 @@
                                                          old-state_0))
                                                      (|#%app| old-state_0)
                                                      (void)))))
-                                             (find-mutated!_0 rhs_0 #f)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
+                                             (find-mutated!_0 rhs_0 #f))))
                                         (if (if (eq?
                                                  '|#%variable-reference|
                                                  hd_0)
@@ -24818,8 +23734,7 @@
                                                        (values
                                                         rator_1
                                                         exps_0))))))
-                                             (case-lambda
-                                              ((rator_0 exps_0)
+                                             (lambda (rator_0 exps_0)
                                                (if (if ids_1
                                                      (let ((rator_1
                                                             (unwrap rator_0)))
@@ -24834,14 +23749,9 @@
                                                                          knowns_0
                                                                          imports_0
                                                                          mutated_0))
-                                                                      (case-lambda
-                                                                       ((k_0
-                                                                         im_0)
-                                                                        k_0)
-                                                                       (args
-                                                                        (raise-binding-result-arity-error
-                                                                         2
-                                                                         args)))))))
+                                                                      (lambda (k_0
+                                                                               im_0)
+                                                                        k_0)))))
                                                                (if (let ((or-part_0
                                                                           (known-constructor?
                                                                            v_1)))
@@ -24938,11 +23848,7 @@
                                                    (find-mutated!_0 rator_0 #f)
                                                    (find-mutated!*_0
                                                     exps_0
-                                                    #f))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
+                                                    #f)))))
                                             (let ((v_1 (unwrap v_0)))
                                               (if (symbol? v_1)
                                                 (let ((state_0
@@ -25038,8 +23944,7 @@
                                                    a_0))))
                                           (let ((ids_1 ids_0))
                                             (values ids_1 rhs_0)))))))
-                                (case-lambda
-                                 ((ids_0 rhs_0)
+                                (lambda (ids_0 rhs_0)
                                   (if (lambda?.1 #t rhs_0)
                                     (begin
                                       (begin
@@ -25078,9 +23983,7 @@
                                          (for-loop_0 ids_0)))
                                       (void)
                                       (loop_0 (wrap-cdr mut-l_1)))
-                                    mut-l_1))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args))))
+                                    mut-l_1)))
                                mut-l_1)))))))))
                 (loop_0 mut-l_0))))
           (if (eq? mut-l_0 l_0) (wrap-cdr mut-l_0) l_0))
@@ -25162,12 +24065,12 @@
                                 (cons (list id_0 id_0) binds_0)))))))))))))))
          (loop_0 ids_0 rhss_0 #t null))))))
 (define left-to-right/let-values
-  (lambda (idss_0 rhss_0 bodys_0 mutated_0 target_0)
+  (lambda (idss_0 rhss_0 bodys_0 mutated_0 target_0 unsafe-mode?_0)
     (if (null? (cdr idss_0))
       (let ((e_0
              (if (null? (cdr bodys_0)) (car bodys_0) (list* 'begin bodys_0))))
         (let ((app_0 (car idss_0)))
-          (make-let-values app_0 (car rhss_0) e_0 target_0)))
+          (make-let-values app_0 (car rhss_0) e_0 target_0 unsafe-mode?_0)))
       (letrec*
        ((loop_0
          (|#%name|
@@ -25181,7 +24084,8 @@
                      app_0
                      app_1
                      (list* 'let binds_0 bodys_0)
-                     target_0)))
+                     target_0
+                     unsafe-mode?_0)))
                 (let ((ids_0 (car idss_1)))
                   (let ((app_0 (car rhss_1)))
                     (make-let-values
@@ -25225,7 +24129,8 @@
                                       fold-var_0))))))
                              (for-loop_0 null ids_0)))
                            binds_0))))
-                     target_0)))))))))
+                     target_0
+                     unsafe-mode?_0)))))))))
        (loop_0 idss_0 rhss_0 null)))))
 (define left-to-right/app
   (lambda (rator_0
@@ -25357,7 +24262,7 @@
                                (cons (car l_1) accum_0)))))))))))
                (loop_0 l_0 modes_0 null)))))))))
 (define make-let-values
-  (lambda (ids_0 rhs_0 body_0 target_0)
+  (lambda (ids_0 rhs_0 body_0 target_0 unsafe-mode?_0)
     (if (if (pair? ids_0) (null? (cdr ids_0)) #f)
       (list 'let (list (list (car ids_0) rhs_0)) body_0)
       (let ((v_0 (if (null? ids_0) rhs_0 #f)))
@@ -25396,7 +24301,7 @@
                    (let ((d_0 (cdr (unwrap v_0))))
                      (let ((a_0 (car (unwrap d_0)))) a_0))))
               (list 'begin rhs_1 body_0))
-            (if (eq? target_0 'cify)
+            (if (if unsafe-mode?_0 unsafe-mode?_0 (eq? target_0 'cify))
               (list
                'call-with-values
                (list 'lambda '() rhs_0)
@@ -25570,12 +24475,10 @@
                     (let ((binds_0 (let ((a_0 (car p_1))) (unwrap-list a_0))))
                       (let ((body_0 (let ((d_1 (cdr p_1))) d_1)))
                         (let ((binds_1 binds_0)) (values binds_1 body_0)))))))
-              (case-lambda
-               ((binds_0 body_0)
-                (let ((let-id_1 let-id_0)) (values let-id_1 binds_0 body_0)))
-               (args (raise-binding-result-arity-error 2 args)))))))
-       (case-lambda
-        ((let-id_0 binds_0 body_0)
+              (lambda (binds_0 body_0)
+                (let ((let-id_1 let-id_0))
+                  (values let-id_1 binds_0 body_0)))))))
+       (lambda (let-id_0 binds_0 body_0)
          (if (let ((or-part_0 (eq? let-id_0 'let)))
                (if or-part_0 or-part_0 (eq? let-id_0 'letrec*)))
            (letrec*
@@ -25798,41 +24701,26 @@
                                                                                            (values
                                                                                             ids_2
                                                                                             rhss_1))))))
-                                                                                 (case-lambda
-                                                                                  ((ids1_0
-                                                                                    rhss2_0)
+                                                                                 (lambda (ids1_0
+                                                                                          rhss2_0)
                                                                                    (values
                                                                                     (cons
                                                                                      ids1_0
                                                                                      ids_0)
                                                                                     (cons
                                                                                      rhss2_0
-                                                                                     rhss_0)))
-                                                                                  (args
-                                                                                   (raise-binding-result-arity-error
-                                                                                    2
-                                                                                    args)))))
-                                                                              (case-lambda
-                                                                               ((ids_1
-                                                                                 rhss_1)
+                                                                                     rhss_0)))))
+                                                                              (lambda (ids_1
+                                                                                       rhss_1)
                                                                                 (values
                                                                                  ids_1
-                                                                                 rhss_1))
-                                                                               (args
-                                                                                (raise-binding-result-arity-error
-                                                                                 2
-                                                                                 args)))))
-                                                                           (case-lambda
-                                                                            ((ids_1
-                                                                              rhss_1)
+                                                                                 rhss_1))))
+                                                                           (lambda (ids_1
+                                                                                    rhss_1)
                                                                              (for-loop_0
                                                                               ids_1
                                                                               rhss_1
-                                                                              rest_0))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args)))))))
+                                                                              rest_0))))))
                                                                     (values
                                                                      ids_0
                                                                      rhss_0)))))))
@@ -25840,21 +24728,15 @@
                                                             null
                                                             null
                                                             a_1)))
-                                                        (case-lambda
-                                                         ((ids_0 rhss_0)
+                                                        (lambda (ids_0 rhss_0)
                                                           (let ((app_0
                                                                  (reverse$1
                                                                   ids_0)))
                                                             (values
                                                              app_0
                                                              (reverse$1
-                                                              rhss_0))))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args))))))
-                                                   (case-lambda
-                                                    ((ids_0 rhss_0)
+                                                              rhss_0)))))))
+                                                   (lambda (ids_0 rhss_0)
                                                      (let ((body_1
                                                             (let ((d_2
                                                                    (cdr p_2)))
@@ -25868,39 +24750,24 @@
                                                          (values
                                                           ids_1
                                                           rhss_1
-                                                          body_1))))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      2
-                                                      args)))))))
-                                            (case-lambda
-                                             ((ids_0 rhss_0 body_1)
+                                                          body_1))))))))
+                                            (lambda (ids_0 rhss_0 body_1)
                                               (let ((nest-let-id_1
                                                      nest-let-id_0))
                                                 (values
                                                  nest-let-id_1
                                                  ids_0
                                                  rhss_0
-                                                 body_1)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               3
-                                               args)))))))))
-                                 (case-lambda
-                                  ((nest-let-id_0 ids_0 rhss_0 body_1)
+                                                 body_1)))))))))
+                                 (lambda (nest-let-id_0 ids_0 rhss_0 body_1)
                                    (let ((id_1 id_0))
                                      (values
                                       id_1
                                       nest-let-id_0
                                       ids_0
                                       rhss_0
-                                      body_1)))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    4
-                                    args)))))))
-                          (case-lambda
-                           ((id_0 nest-let-id_0 ids_0 rhss_0 body_1)
+                                      body_1)))))))
+                          (lambda (id_0 nest-let-id_0 ids_0 rhss_0 body_1)
                             (if (not
                                  (let ((or-part_0 (eq? let-id_0 'let)))
                                    (if or-part_0
@@ -26049,8 +24916,7 @@
                                    app_0
                                    (cons (car binds_1) accum-binds_0)
                                    wraps_0
-                                   convert?_0)))))
-                           (args (raise-binding-result-arity-error 5 args))))
+                                   convert?_0))))))
                          (if (let ((p_0 (unwrap v_0)))
                                (if (pair? p_0)
                                  (let ((a_0 (cdr p_0)))
@@ -26078,8 +24944,7 @@
                                e_0))
                            (error 'match "failed ~e" v_0))))))))))
             (loop_0 binds_0 '() '() #f))
-           e_0))
-        (args (raise-binding-result-arity-error 3 args))))
+           e_0)))
       e_0)))
 (define immediate-lambda?
   (lambda (e_0)
@@ -26116,8 +24981,7 @@
             new-s_0))
         (call-with-values
          (lambda () (wrap-source orig-s_0))
-         (case-lambda
-          ((src_0 line_0 col_0 pos_0 span_0)
+         (lambda (src_0 line_0 col_0 pos_0 span_0)
            (let ((add-property_0
                   (|#%name|
                    add-property
@@ -26166,8 +25030,7 @@
                     (reannotate orig-s_0 new-s_0)
                     'inferred-name
                     '|[|)
-                   new-s_0)))))
-          (args (raise-binding-result-arity-error 5 args))))))))
+                   new-s_0))))))))))
 (define source->string
   (lambda (src_0)
     (let ((str_0 (if (string? src_0) src_0 (path->string src_0))))
@@ -26255,14 +25118,11 @@
                                  (let ((a_0 (car (unwrap d_2)))) a_0)))))
                         (let ((type-e_1 type-e_0))
                           (values type-e_1 offset-e_0)))))))
-              (case-lambda
-               ((type-e_0 offset-e_0)
-                (let ((ptr-e_1 ptr-e_0)) (values ptr-e_1 type-e_0 offset-e_0)))
-               (args (raise-binding-result-arity-error 2 args)))))))
-       (case-lambda
-        ((ptr-e_0 type-e_0 offset-e_0)
-         (type->direct type-e_0 ptr-e_0 offset-e_0 #t make-ref #f))
-        (args (raise-binding-result-arity-error 3 args))))
+              (lambda (type-e_0 offset-e_0)
+                (let ((ptr-e_1 ptr-e_0))
+                  (values ptr-e_1 type-e_0 offset-e_0)))))))
+       (lambda (ptr-e_0 type-e_0 offset-e_0)
+         (type->direct type-e_0 ptr-e_0 offset-e_0 #t make-ref #f)))
       (if (let ((p_0 (unwrap args_0)))
             (if (pair? p_0)
               (let ((a_0 (cdr p_0)))
@@ -26292,15 +25152,11 @@
                                  (let ((a_0 (car (unwrap d_1)))) a_0))))
                           (let ((type-e_1 type-e_0))
                             (values type-e_1 offset-e_0)))))))
-                (case-lambda
-                 ((type-e_0 offset-e_0)
+                (lambda (type-e_0 offset-e_0)
                   (let ((ptr-e_1 ptr-e_0))
-                    (values ptr-e_1 type-e_0 offset-e_0)))
-                 (args (raise-binding-result-arity-error 2 args)))))))
-         (case-lambda
-          ((ptr-e_0 type-e_0 offset-e_0)
-           (type->direct type-e_0 ptr-e_0 offset-e_0 #f make-ref #f))
-          (args (raise-binding-result-arity-error 3 args))))
+                    (values ptr-e_1 type-e_0 offset-e_0)))))))
+         (lambda (ptr-e_0 type-e_0 offset-e_0)
+           (type->direct type-e_0 ptr-e_0 offset-e_0 #f make-ref #f)))
         (if (let ((p_0 (unwrap args_0)))
               (if (pair? p_0)
                 (let ((a_0 (cdr p_0)))
@@ -26320,10 +25176,8 @@
                         (let ((d_0 (cdr p_0)))
                           (let ((a_0 (car (unwrap d_0)))) a_0))))
                    (let ((ptr-e_1 ptr-e_0)) (values ptr-e_1 type-e_0))))))
-           (case-lambda
-            ((ptr-e_0 type-e_0)
-             (type->direct type-e_0 ptr-e_0 0 #f make-ref #f))
-            (args (raise-binding-result-arity-error 2 args))))
+           (lambda (ptr-e_0 type-e_0)
+             (type->direct type-e_0 ptr-e_0 0 #f make-ref #f)))
           #f)))))
 (define make-ref
   (lambda (ref_0 set_0 ptr-e_0 offset-e_0 val-e_0 abs?_0)
@@ -26397,20 +25251,14 @@
                                             a_0))))
                                    (let ((offset-e_1 offset-e_0))
                                      (values offset-e_1 val-e_0))))))))
-                       (case-lambda
-                        ((offset-e_0 val-e_0)
+                       (lambda (offset-e_0 val-e_0)
                          (let ((type-e_1 type-e_0))
-                           (values type-e_1 offset-e_0 val-e_0)))
-                        (args (raise-binding-result-arity-error 2 args))))))))
-              (case-lambda
-               ((type-e_0 offset-e_0 val-e_0)
+                           (values type-e_1 offset-e_0 val-e_0))))))))
+              (lambda (type-e_0 offset-e_0 val-e_0)
                 (let ((ptr-e_1 ptr-e_0))
-                  (values ptr-e_1 type-e_0 offset-e_0 val-e_0)))
-               (args (raise-binding-result-arity-error 3 args)))))))
-       (case-lambda
-        ((ptr-e_0 type-e_0 offset-e_0 val-e_0)
-         (type->direct type-e_0 ptr-e_0 offset-e_0 #t make-set val-e_0))
-        (args (raise-binding-result-arity-error 4 args))))
+                  (values ptr-e_1 type-e_0 offset-e_0 val-e_0)))))))
+       (lambda (ptr-e_0 type-e_0 offset-e_0 val-e_0)
+         (type->direct type-e_0 ptr-e_0 offset-e_0 #t make-set val-e_0)))
       (if (let ((p_0 (unwrap args_0)))
             (if (pair? p_0)
               (let ((a_0 (cdr p_0)))
@@ -26450,21 +25298,14 @@
                                             a_0))))
                                    (let ((offset-e_1 offset-e_0))
                                      (values offset-e_1 val-e_0)))))))
-                         (case-lambda
-                          ((offset-e_0 val-e_0)
+                         (lambda (offset-e_0 val-e_0)
                            (let ((type-e_1 type-e_0))
-                             (values type-e_1 offset-e_0 val-e_0)))
-                          (args
-                           (raise-binding-result-arity-error 2 args))))))))
-                (case-lambda
-                 ((type-e_0 offset-e_0 val-e_0)
+                             (values type-e_1 offset-e_0 val-e_0))))))))
+                (lambda (type-e_0 offset-e_0 val-e_0)
                   (let ((ptr-e_1 ptr-e_0))
-                    (values ptr-e_1 type-e_0 offset-e_0 val-e_0)))
-                 (args (raise-binding-result-arity-error 3 args)))))))
-         (case-lambda
-          ((ptr-e_0 type-e_0 offset-e_0 val-e_0)
-           (type->direct type-e_0 ptr-e_0 offset-e_0 #f make-set val-e_0))
-          (args (raise-binding-result-arity-error 4 args))))
+                    (values ptr-e_1 type-e_0 offset-e_0 val-e_0)))))))
+         (lambda (ptr-e_0 type-e_0 offset-e_0 val-e_0)
+           (type->direct type-e_0 ptr-e_0 offset-e_0 #f make-set val-e_0)))
         (if (let ((p_0 (unwrap args_0)))
               (if (pair? p_0)
                 (let ((a_0 (cdr p_0)))
@@ -26494,15 +25335,11 @@
                                    (let ((a_0 (car (unwrap d_1)))) a_0))))
                             (let ((type-e_1 type-e_0))
                               (values type-e_1 val-e_0)))))))
-                  (case-lambda
-                   ((type-e_0 val-e_0)
+                  (lambda (type-e_0 val-e_0)
                     (let ((ptr-e_1 ptr-e_0))
-                      (values ptr-e_1 type-e_0 val-e_0)))
-                   (args (raise-binding-result-arity-error 2 args)))))))
-           (case-lambda
-            ((ptr-e_0 type-e_0 val-e_0)
-             (type->direct type-e_0 ptr-e_0 0 #f make-set val-e_0))
-            (args (raise-binding-result-arity-error 3 args))))
+                      (values ptr-e_1 type-e_0 val-e_0)))))))
+           (lambda (ptr-e_0 type-e_0 val-e_0)
+             (type->direct type-e_0 ptr-e_0 0 #f make-set val-e_0)))
           #f)))))
 (define make-set
   (lambda (ref_0 set_0 ptr-e_0 offset-e_0 val-e_0 abs?_0)
@@ -26670,14 +25507,10 @@
                                    (let ((bodys_0 (let ((d_2 (cdr p_1))) d_2)))
                                      (let ((ex-ids_1 ex-ids_0))
                                        (values ex-ids_1 bodys_0)))))))
-                           (case-lambda
-                            ((ex-ids_0 bodys_0)
+                           (lambda (ex-ids_0 bodys_0)
                              (let ((im-idss_1 im-idss_0))
-                               (values im-idss_1 ex-ids_0 bodys_0)))
-                            (args
-                             (raise-binding-result-arity-error 2 args))))))))
-                  (case-lambda
-                   ((im-idss_0 ex-ids_0 bodys_0)
+                               (values im-idss_1 ex-ids_0 bodys_0))))))))
+                  (lambda (im-idss_0 ex-ids_0 bodys_0)
                     (let ((grps_0
                            (reverse$1
                             (begin
@@ -26866,8 +25699,7 @@
                                     no-prompt?_0
                                     #t
                                     compiler-query_0))
-                                 (case-lambda
-                                  ((new-body_0 defn-info_0 mutated_0)
+                                 (lambda (new-body_0 defn-info_0 mutated_0)
                                    (let ((all-grps_0
                                           (append
                                            grps_0
@@ -27299,12 +26131,7 @@
                                                               knowns_1))))))
                                                      (for-loop_0
                                                       knowns_0
-                                                      ex-ids_0))))))))))))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    3
-                                    args)))))))))))
-                   (args (raise-binding-result-arity-error 3 args))))
+                                                      ex-ids_0)))))))))))))))))))))
                  (error 'match "failed ~e" lk_0))))))))))
 (define schemify-body
   (lambda (l_0
@@ -27340,9 +26167,7 @@
          no-prompt?_0
          explicit-unnamed?_0
          (lambda (v_0) #f)))
-      (case-lambda
-       ((new-body_0 defn-info_0 mutated_0) new-body_0)
-       (args (raise-binding-result-arity-error 3 args)))))))
+      (lambda (new-body_0 defn-info_0 mutated_0) new-body_0)))))
 (define schemify-body*
   (lambda (l_0
            prim-knowns_0
@@ -27381,8 +26206,7 @@
                                    (hash-iterate-key+value
                                     extra-variables_0
                                     i_0))
-                                 (case-lambda
-                                  ((int-id_0 ex_0)
+                                 (lambda (int-id_0 ex_0)
                                    (let ((fold-var_1
                                           (let ((fold-var_1
                                                  (cons
@@ -27400,9 +26224,7 @@
                                       fold-var_1
                                       (hash-iterate-next
                                        extra-variables_0
-                                       i_0))))
-                                  (args
-                                   (raise-binding-result-arity-error 2 args))))
+                                       i_0)))))
                                 fold-var_0))))))
                        (for-loop_0
                         null
@@ -27449,13 +26271,9 @@
                                                        simples_0
                                                        unsafe-mode?_0
                                                        target_0))
-                                                    (case-lambda
-                                                     ((new-knowns_0 info_0)
-                                                      new-knowns_0)
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args))))))
+                                                    (lambda (new-knowns_0
+                                                             info_0)
+                                                      new-knowns_0))))
                                               (values knowns_2))))
                                        (for-loop_0 knowns_2 rest_0))))
                                  knowns_1))))))
@@ -27821,9 +26639,8 @@
                                                                                                   (values
                                                                                                    id_2
                                                                                                    rhs_0)))))))
-                                                                                      (case-lambda
-                                                                                       ((id_1
-                                                                                         rhs_0)
+                                                                                      (lambda (id_1
+                                                                                               rhs_0)
                                                                                         (infer-known.1
                                                                                          unsafe-undefined
                                                                                          #f
@@ -27838,11 +26655,7 @@
                                                                                          mutated_0
                                                                                          simples_0
                                                                                          unsafe-mode?_0
-                                                                                         target_0))
-                                                                                       (args
-                                                                                        (raise-binding-result-arity-error
-                                                                                         2
-                                                                                         args))))
+                                                                                         target_0)))
                                                                                      (error
                                                                                       'match
                                                                                       "failed ~e"
@@ -28225,8 +27038,7 @@
                                                                 (values
                                                                  id_1
                                                                  rhs_0)))))))
-                                                    (case-lambda
-                                                     ((id_0 rhs_0)
+                                                    (lambda (id_0 rhs_0)
                                                       (if (simple?.1
                                                            #f
                                                            #f
@@ -28251,11 +27063,7 @@
                                                            unsafe-undefined))
                                                         (finish-wrapped-definition_0
                                                          (list id_0)
-                                                         rhs_0)))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args))))
+                                                         rhs_0))))
                                                    (if (if (eq?
                                                             'define-values
                                                             hd_0)
@@ -28316,8 +27124,7 @@
                                                                   (values
                                                                    ids_1
                                                                    rhs_0)))))))
-                                                      (case-lambda
-                                                       ((ids_0 rhs_0)
+                                                      (lambda (ids_0 rhs_0)
                                                         (if (let ((temp54_0
                                                                    (length
                                                                     ids_0)))
@@ -28494,11 +27301,7 @@
                                                                unsafe-undefined)))
                                                           (finish-wrapped-definition_0
                                                            ids_0
-                                                           rhs_0)))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))
+                                                           rhs_0))))
                                                      (if (if (if (eq?
                                                                   'quote
                                                                   hd_0)
@@ -28801,17 +27604,14 @@
                                                   (unwrap-list d_1))))
                                            (let ((formals_1 formals_0))
                                              (values formals_1 body_0)))))))
-                                 (case-lambda
-                                  ((formals_0 body_0)
+                                 (lambda (formals_0 body_0)
                                    (infer-procedure-name
                                     v_2
                                     (list*
                                      'lambda
                                      formals_0
                                      (schemify-body_0 body_0 'tail))
-                                    explicit-unnamed?_0))
-                                  (args
-                                   (raise-binding-result-arity-error 2 args))))
+                                    explicit-unnamed?_0)))
                                 (if (if (eq? 'case-lambda hd_0)
                                       (let ((a_0 (cdr (unwrap v_2))))
                                         (if (wrap-list? a_0)
@@ -28928,57 +27728,36 @@
                                                                            (values
                                                                             formalss_2
                                                                             bodys_1))))))
-                                                                 (case-lambda
-                                                                  ((formalss83_0
-                                                                    bodys84_0)
+                                                                 (lambda (formalss83_0
+                                                                          bodys84_0)
                                                                    (values
                                                                     (cons
                                                                      formalss83_0
                                                                      formalss_0)
                                                                     (cons
                                                                      bodys84_0
-                                                                     bodys_0)))
-                                                                  (args
-                                                                   (raise-binding-result-arity-error
-                                                                    2
-                                                                    args)))))
-                                                              (case-lambda
-                                                               ((formalss_1
-                                                                 bodys_1)
+                                                                     bodys_0)))))
+                                                              (lambda (formalss_1
+                                                                       bodys_1)
                                                                 (values
                                                                  formalss_1
-                                                                 bodys_1))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args)))))
-                                                           (case-lambda
-                                                            ((formalss_1
-                                                              bodys_1)
+                                                                 bodys_1))))
+                                                           (lambda (formalss_1
+                                                                    bodys_1)
                                                              (for-loop_0
                                                               formalss_1
                                                               bodys_1
-                                                              rest_0))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))))
+                                                              rest_0))))))
                                                     (values
                                                      formalss_0
                                                      bodys_0)))))))
                                            (for-loop_0 null null d_0)))
-                                        (case-lambda
-                                         ((formalss_0 bodys_0)
+                                        (lambda (formalss_0 bodys_0)
                                           (let ((app_0 (reverse$1 formalss_0)))
                                             (values
                                              app_0
-                                             (reverse$1 bodys_0))))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args))))))
-                                   (case-lambda
-                                    ((formalss_0 bodys_0)
+                                             (reverse$1 bodys_0)))))))
+                                   (lambda (formalss_0 bodys_0)
                                      (infer-procedure-name
                                       v_2
                                       (list*
@@ -29025,11 +27804,7 @@
                                             null
                                             formalss_0
                                             bodys_0)))))
-                                      explicit-unnamed?_0))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args))))
+                                      explicit-unnamed?_0)))
                                   (if (if (if (eq? 'define-values hd_0)
                                             (let ((a_0 (cdr (unwrap v_2))))
                                               (let ((p_0 (unwrap a_0)))
@@ -29342,39 +28117,28 @@
                                                                           (values
                                                                            s?_1
                                                                            acc/muts_0)))))))
-                                                              (case-lambda
-                                                               ((s?_0
-                                                                 acc/muts_0)
+                                                              (lambda (s?_0
+                                                                       acc/muts_0)
                                                                 (let ((make-s_1
                                                                        make-s_0))
                                                                   (values
                                                                    make-s_1
                                                                    s?_0
-                                                                   acc/muts_0)))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args))))))))
-                                                     (case-lambda
-                                                      ((make-s_0
-                                                        s?_0
-                                                        acc/muts_0)
+                                                                   acc/muts_0))))))))
+                                                     (lambda (make-s_0
+                                                              s?_0
+                                                              acc/muts_0)
                                                        (let ((struct:s_1
                                                               struct:s_0))
                                                          (values
                                                           struct:s_1
                                                           make-s_0
                                                           s?_0
-                                                          acc/muts_0)))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        3
-                                                        args))))))))
-                                            (case-lambda
-                                             ((struct:s_0
-                                               make-s_0
-                                               s?_0
-                                               acc/muts_0)
+                                                          acc/muts_0))))))))
+                                            (lambda (struct:s_0
+                                                     make-s_0
+                                                     s?_0
+                                                     acc/muts_0)
                                               (call-with-values
                                                (lambda ()
                                                  (let ((d_1 (cdr p_0)))
@@ -29462,39 +28226,28 @@
                                                                                                           (values
                                                                                                            -ref_1
                                                                                                            -set!_0)))))))
-                                                                                              (case-lambda
-                                                                                               ((-ref_0
-                                                                                                 -set!_0)
+                                                                                              (lambda (-ref_0
+                                                                                                       -set!_0)
                                                                                                 (let ((?1_1
                                                                                                        ?1_0))
                                                                                                   (values
                                                                                                    ?1_1
                                                                                                    -ref_0
-                                                                                                   -set!_0)))
-                                                                                               (args
-                                                                                                (raise-binding-result-arity-error
-                                                                                                 2
-                                                                                                 args))))))))
-                                                                                     (case-lambda
-                                                                                      ((?1_0
-                                                                                        -ref_0
-                                                                                        -set!_0)
+                                                                                                   -set!_0))))))))
+                                                                                     (lambda (?1_0
+                                                                                              -ref_0
+                                                                                              -set!_0)
                                                                                        (let ((make_1
                                                                                               make_0))
                                                                                          (values
                                                                                           make_1
                                                                                           ?1_0
                                                                                           -ref_0
-                                                                                          -set!_0)))
-                                                                                      (args
-                                                                                       (raise-binding-result-arity-error
-                                                                                        3
-                                                                                        args))))))))
-                                                                            (case-lambda
-                                                                             ((make_0
-                                                                               ?1_0
-                                                                               -ref_0
-                                                                               -set!_0)
+                                                                                          -set!_0))))))))
+                                                                            (lambda (make_0
+                                                                                     ?1_0
+                                                                                     -ref_0
+                                                                                     -set!_0)
                                                                               (let ((struct:_1
                                                                                      struct:_0))
                                                                                 (values
@@ -29502,17 +28255,12 @@
                                                                                  make_0
                                                                                  ?1_0
                                                                                  -ref_0
-                                                                                 -set!_0)))
-                                                                             (args
-                                                                              (raise-binding-result-arity-error
-                                                                               4
-                                                                               args))))))))
-                                                                   (case-lambda
-                                                                    ((struct:_0
-                                                                      make_0
-                                                                      ?1_0
-                                                                      -ref_0
-                                                                      -set!_0)
+                                                                                 -set!_0))))))))
+                                                                   (lambda (struct:_0
+                                                                            make_0
+                                                                            ?1_0
+                                                                            -ref_0
+                                                                            -set!_0)
                                                                      (let ((mk_0
                                                                             (let ((d_3
                                                                                    (cdr
@@ -29538,18 +28286,13 @@
                                                                           ?1_1
                                                                           -ref_1
                                                                           -set!_1
-                                                                          mk_0))))
-                                                                    (args
-                                                                     (raise-binding-result-arity-error
-                                                                      5
-                                                                      args))))))))
-                                                          (case-lambda
-                                                           ((struct:_0
-                                                             make_0
-                                                             ?1_0
-                                                             -ref_0
-                                                             -set!_0
-                                                             mk_0)
+                                                                          mk_0)))))))))
+                                                          (lambda (struct:_0
+                                                                   make_0
+                                                                   ?1_0
+                                                                   -ref_0
+                                                                   -set!_0
+                                                                   mk_0)
                                                             (call-with-values
                                                              (lambda ()
                                                                (let ((d_3
@@ -29608,39 +28351,28 @@
                                                                                                (values
                                                                                                 ?2_1
                                                                                                 make-acc/muts_0)))))))
-                                                                                   (case-lambda
-                                                                                    ((?2_0
-                                                                                      make-acc/muts_0)
+                                                                                   (lambda (?2_0
+                                                                                            make-acc/muts_0)
                                                                                      (let ((make2_1
                                                                                             make2_0))
                                                                                        (values
                                                                                         make2_1
                                                                                         ?2_0
-                                                                                        make-acc/muts_0)))
-                                                                                    (args
-                                                                                     (raise-binding-result-arity-error
-                                                                                      2
-                                                                                      args))))))))
-                                                                          (case-lambda
-                                                                           ((make2_0
-                                                                             ?2_0
-                                                                             make-acc/muts_0)
+                                                                                        make-acc/muts_0))))))))
+                                                                          (lambda (make2_0
+                                                                                   ?2_0
+                                                                                   make-acc/muts_0)
                                                                             (let ((struct:2_1
                                                                                    struct:2_0))
                                                                               (values
                                                                                struct:2_1
                                                                                make2_0
                                                                                ?2_0
-                                                                               make-acc/muts_0)))
-                                                                           (args
-                                                                            (raise-binding-result-arity-error
-                                                                             3
-                                                                             args))))))))))
-                                                             (case-lambda
-                                                              ((struct:2_0
-                                                                make2_0
-                                                                ?2_0
-                                                                make-acc/muts_0)
+                                                                               make-acc/muts_0))))))))))
+                                                             (lambda (struct:2_0
+                                                                      make2_0
+                                                                      ?2_0
+                                                                      make-acc/muts_0)
                                                                (let ((struct:_1
                                                                       struct:_0)
                                                                      (make_1
@@ -29663,26 +28395,17 @@
                                                                   struct:2_0
                                                                   make2_0
                                                                   ?2_0
-                                                                  make-acc/muts_0)))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                4
-                                                                args)))))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             6
-                                                             args)))))))))
-                                               (case-lambda
-                                                ((struct:_0
-                                                  make_0
-                                                  ?1_0
-                                                  -ref_0
-                                                  -set!_0
-                                                  mk_0
-                                                  struct:2_0
-                                                  make2_0
-                                                  ?2_0
-                                                  make-acc/muts_0)
+                                                                  make-acc/muts_0)))))))))))
+                                               (lambda (struct:_0
+                                                        make_0
+                                                        ?1_0
+                                                        -ref_0
+                                                        -set!_0
+                                                        mk_0
+                                                        struct:2_0
+                                                        make2_0
+                                                        ?2_0
+                                                        make-acc/muts_0)
                                                  (let ((struct:s_1 struct:s_0)
                                                        (make-s_1 make-s_0)
                                                        (s?_1 s?_0)
@@ -29701,30 +28424,21 @@
                                                     struct:2_0
                                                     make2_0
                                                     ?2_0
-                                                    make-acc/muts_0)))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  10
-                                                  args)))))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               4
-                                               args)))))))
-                                     (case-lambda
-                                      ((struct:s_0
-                                        make-s_0
-                                        s?_0
-                                        acc/muts_0
-                                        struct:_0
-                                        make_0
-                                        ?1_0
-                                        -ref_0
-                                        -set!_0
-                                        mk_0
-                                        struct:2_0
-                                        make2_0
-                                        ?2_0
-                                        make-acc/muts_0)
+                                                    make-acc/muts_0)))))))))
+                                     (lambda (struct:s_0
+                                              make-s_0
+                                              s?_0
+                                              acc/muts_0
+                                              struct:_0
+                                              make_0
+                                              ?1_0
+                                              -ref_0
+                                              -set!_0
+                                              mk_0
+                                              struct:2_0
+                                              make2_0
+                                              ?2_0
+                                              make-acc/muts_0)
                                        (let ((new-seq_0
                                               (struct-convert
                                                v_2
@@ -29788,21 +28502,15 @@
                                                           (values
                                                            ids_1
                                                            rhs_0)))))))
-                                              (case-lambda
-                                               ((ids_0 rhs_0)
+                                              (lambda (ids_0 rhs_0)
                                                 (list
                                                  'define-values
                                                  ids_0
-                                                 (schemify_0 rhs_0 'fresh)))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args))))
-                                             (error 'match "failed ~e" v_2)))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        14
-                                        args))))
+                                                 (schemify_0 rhs_0 'fresh))))
+                                             (error
+                                              'match
+                                              "failed ~e"
+                                              v_2))))))
                                     (if (if (eq? 'define-values hd_0)
                                           (let ((a_0 (cdr (unwrap v_2))))
                                             (let ((p_0 (unwrap a_0)))
@@ -29854,16 +28562,11 @@
                                                           a_0))))
                                                  (let ((id_1 id_0))
                                                    (values id_1 rhs_0)))))))
-                                       (case-lambda
-                                        ((id_0 rhs_0)
+                                       (lambda (id_0 rhs_0)
                                          (list
                                           'define
                                           id_0
-                                          (schemify_0 rhs_0 'fresh)))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args))))
+                                          (schemify_0 rhs_0 'fresh))))
                                       (if (if (eq? 'define-values hd_0)
                                             (let ((a_0 (cdr (unwrap v_2))))
                                               (let ((p_0 (unwrap a_0)))
@@ -29898,16 +28601,11 @@
                                                             a_0))))
                                                    (let ((ids_1 ids_0))
                                                      (values ids_1 rhs_0)))))))
-                                         (case-lambda
-                                          ((ids_0 rhs_0)
+                                         (lambda (ids_0 rhs_0)
                                            (list
                                             'define-values
                                             ids_0
-                                            (schemify_0 rhs_0 'fresh)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
+                                            (schemify_0 rhs_0 'fresh))))
                                         (if (if (eq? 'quote hd_0)
                                               (let ((a_0 (cdr (unwrap v_2))))
                                                 (let ((p_0 (unwrap a_0)))
@@ -30199,41 +28897,26 @@
                                                                                                 (values
                                                                                                  ids_2
                                                                                                  rhss_1))))))
-                                                                                      (case-lambda
-                                                                                       ((ids85_0
-                                                                                         rhss86_0)
+                                                                                      (lambda (ids85_0
+                                                                                               rhss86_0)
                                                                                         (values
                                                                                          (cons
                                                                                           ids85_0
                                                                                           ids_0)
                                                                                          (cons
                                                                                           rhss86_0
-                                                                                          rhss_0)))
-                                                                                       (args
-                                                                                        (raise-binding-result-arity-error
-                                                                                         2
-                                                                                         args)))))
-                                                                                   (case-lambda
-                                                                                    ((ids_1
-                                                                                      rhss_1)
+                                                                                          rhss_0)))))
+                                                                                   (lambda (ids_1
+                                                                                            rhss_1)
                                                                                      (values
                                                                                       ids_1
-                                                                                      rhss_1))
-                                                                                    (args
-                                                                                     (raise-binding-result-arity-error
-                                                                                      2
-                                                                                      args)))))
-                                                                                (case-lambda
-                                                                                 ((ids_1
-                                                                                   rhss_1)
+                                                                                      rhss_1))))
+                                                                                (lambda (ids_1
+                                                                                         rhss_1)
                                                                                   (for-loop_0
                                                                                    ids_1
                                                                                    rhss_1
-                                                                                   rest_0))
-                                                                                 (args
-                                                                                  (raise-binding-result-arity-error
-                                                                                   2
-                                                                                   args)))))))
+                                                                                   rest_0))))))
                                                                          (values
                                                                           ids_0
                                                                           rhss_0)))))))
@@ -30241,21 +28924,16 @@
                                                                  null
                                                                  null
                                                                  a_0)))
-                                                             (case-lambda
-                                                              ((ids_0 rhss_0)
+                                                             (lambda (ids_0
+                                                                      rhss_0)
                                                                (let ((app_0
                                                                       (reverse$1
                                                                        ids_0)))
                                                                  (values
                                                                   app_0
                                                                   (reverse$1
-                                                                   rhss_0))))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                2
-                                                                args))))))
-                                                        (case-lambda
-                                                         ((ids_0 rhss_0)
+                                                                   rhss_0)))))))
+                                                        (lambda (ids_0 rhss_0)
                                                           (let ((bodys_0
                                                                  (let ((d_1
                                                                         (cdr
@@ -30268,13 +28946,8 @@
                                                               (values
                                                                ids_1
                                                                rhss_1
-                                                               bodys_0))))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))))
-                                                 (case-lambda
-                                                  ((ids_0 rhss_0 bodys_0)
+                                                               bodys_0))))))))
+                                                 (lambda (ids_0 rhss_0 bodys_0)
                                                    (if (if (pair? ids_0)
                                                          (if (null?
                                                               (cdr ids_0))
@@ -30449,28 +29122,18 @@
                                                                                                    (cons
                                                                                                     s-rhs_0
                                                                                                     rev-s-rhss_0)))))))))))
-                                                                                (case-lambda
-                                                                                 ((knowns_3
-                                                                                   rev-s-rhss_1)
+                                                                                (lambda (knowns_3
+                                                                                         rev-s-rhss_1)
                                                                                   (values
                                                                                    knowns_3
-                                                                                   rev-s-rhss_1))
-                                                                                 (args
-                                                                                  (raise-binding-result-arity-error
-                                                                                   2
-                                                                                   args)))))
-                                                                             (case-lambda
-                                                                              ((knowns_3
-                                                                                rev-s-rhss_1)
+                                                                                   rev-s-rhss_1))))
+                                                                             (lambda (knowns_3
+                                                                                      rev-s-rhss_1)
                                                                                (for-loop_0
                                                                                 knowns_3
                                                                                 rev-s-rhss_1
                                                                                 rest_0
-                                                                                rest_1))
-                                                                              (args
-                                                                               (raise-binding-result-arity-error
-                                                                                2
-                                                                                args))))))))
+                                                                                rest_1)))))))
                                                                     (values
                                                                      knowns_2
                                                                      rev-s-rhss_0)))))))
@@ -30479,9 +29142,8 @@
                                                             '()
                                                             ids_0
                                                             rhss_0))))
-                                                      (case-lambda
-                                                       ((new-knowns_0
-                                                         rev-s-rhss_0)
+                                                      (lambda (new-knowns_0
+                                                               rev-s-rhss_0)
                                                         (let ((s-rhss_0
                                                                (reverse$1
                                                                 rev-s-rhss_0)))
@@ -30631,15 +29293,7 @@
                                                            imports_0
                                                            mutated_0
                                                            simples_0
-                                                           unsafe-mode?_0)))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    3
-                                                    args))))
+                                                           unsafe-mode?_0)))))))
                                                 (if (if (eq? 'let-values hd_0)
                                                       (let ((a_0
                                                              (cdr
@@ -30844,8 +29498,7 @@
                                                                (values
                                                                 rhs_1
                                                                 bodys_0)))))))
-                                                   (case-lambda
-                                                    ((rhs_0 bodys_0)
+                                                   (lambda (rhs_0 bodys_0)
                                                      (let ((app_0
                                                             (schemify_0
                                                              rhs_0
@@ -30855,11 +29508,7 @@
                                                         app_0
                                                         (schemify-body_0
                                                          bodys_0
-                                                         wcm-state_2))))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      2
-                                                      args))))
+                                                         wcm-state_2)))))
                                                   (if (if (eq?
                                                            'let-values
                                                            hd_0)
@@ -31032,41 +29681,26 @@
                                                                                                     (values
                                                                                                      idss_2
                                                                                                      rhss_1))))))
-                                                                                          (case-lambda
-                                                                                           ((idss107_0
-                                                                                             rhss108_0)
+                                                                                          (lambda (idss107_0
+                                                                                                   rhss108_0)
                                                                                             (values
                                                                                              (cons
                                                                                               idss107_0
                                                                                               idss_0)
                                                                                              (cons
                                                                                               rhss108_0
-                                                                                              rhss_0)))
-                                                                                           (args
-                                                                                            (raise-binding-result-arity-error
-                                                                                             2
-                                                                                             args)))))
-                                                                                       (case-lambda
-                                                                                        ((idss_1
-                                                                                          rhss_1)
+                                                                                              rhss_0)))))
+                                                                                       (lambda (idss_1
+                                                                                                rhss_1)
                                                                                          (values
                                                                                           idss_1
-                                                                                          rhss_1))
-                                                                                        (args
-                                                                                         (raise-binding-result-arity-error
-                                                                                          2
-                                                                                          args)))))
-                                                                                    (case-lambda
-                                                                                     ((idss_1
-                                                                                       rhss_1)
+                                                                                          rhss_1))))
+                                                                                    (lambda (idss_1
+                                                                                             rhss_1)
                                                                                       (for-loop_0
                                                                                        idss_1
                                                                                        rhss_1
-                                                                                       rest_0))
-                                                                                     (args
-                                                                                      (raise-binding-result-arity-error
-                                                                                       2
-                                                                                       args)))))))
+                                                                                       rest_0))))))
                                                                              (values
                                                                               idss_0
                                                                               rhss_0)))))))
@@ -31074,22 +29708,17 @@
                                                                      null
                                                                      null
                                                                      a_0)))
-                                                                 (case-lambda
-                                                                  ((idss_0
-                                                                    rhss_0)
+                                                                 (lambda (idss_0
+                                                                          rhss_0)
                                                                    (let ((app_0
                                                                           (reverse$1
                                                                            idss_0)))
                                                                      (values
                                                                       app_0
                                                                       (reverse$1
-                                                                       rhss_0))))
-                                                                  (args
-                                                                   (raise-binding-result-arity-error
-                                                                    2
-                                                                    args))))))
-                                                            (case-lambda
-                                                             ((idss_0 rhss_0)
+                                                                       rhss_0)))))))
+                                                            (lambda (idss_0
+                                                                     rhss_0)
                                                               (let ((bodys_0
                                                                      (let ((d_1
                                                                             (cdr
@@ -31103,13 +29732,10 @@
                                                                   (values
                                                                    idss_1
                                                                    rhss_1
-                                                                   bodys_0))))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args)))))))
-                                                     (case-lambda
-                                                      ((idss_0 rhss_0 bodys_0)
+                                                                   bodys_0))))))))
+                                                     (lambda (idss_0
+                                                              rhss_0
+                                                              bodys_0)
                                                        (let ((or-part_0
                                                               (if (not
                                                                    (let ((or-part_0
@@ -31185,17 +29811,14 @@
                                                                 bodys_0
                                                                 wcm-state_2)
                                                                mutated_0
-                                                               target_0))
+                                                               target_0
+                                                               unsafe-mode?_0))
                                                             prim-knowns_0
                                                             knowns_1
                                                             imports_0
                                                             mutated_0
                                                             simples_0
-                                                            unsafe-mode?_0))))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        3
-                                                        args))))
+                                                            unsafe-mode?_0)))))
                                                     (if (if (eq?
                                                              'letrec-values
                                                              hd_0)
@@ -31555,9 +30178,8 @@
                                                                                 (values
                                                                                  id_1
                                                                                  rhs_0))))))))
-                                                                  (case-lambda
-                                                                   ((id_0
-                                                                     rhs_0)
+                                                                  (lambda (id_0
+                                                                           rhs_0)
                                                                     (let ((bodys_0
                                                                            (let ((d_1
                                                                                   (cdr
@@ -31571,15 +30193,10 @@
                                                                         (values
                                                                          id_1
                                                                          rhs_1
-                                                                         bodys_0))))
-                                                                   (args
-                                                                    (raise-binding-result-arity-error
-                                                                     2
-                                                                     args)))))))
-                                                           (case-lambda
-                                                            ((id_0
-                                                              rhs_0
-                                                              bodys_0)
+                                                                         bodys_0))))))))
+                                                           (lambda (id_0
+                                                                    rhs_0
+                                                                    bodys_0)
                                                              (schemify_0
                                                               (list*
                                                                'letrec-values
@@ -31588,11 +30205,7 @@
                                                                  (list id_0)
                                                                  rhs_0))
                                                                bodys_0)
-                                                              wcm-state_2))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args))))
+                                                              wcm-state_2)))
                                                           (if (if (eq?
                                                                    'letrec-values
                                                                    hd_0)
@@ -31795,41 +30408,26 @@
                                                                                                             (values
                                                                                                              ids_2
                                                                                                              rhss_1))))))
-                                                                                                  (case-lambda
-                                                                                                   ((ids118_0
-                                                                                                     rhss119_0)
+                                                                                                  (lambda (ids118_0
+                                                                                                           rhss119_0)
                                                                                                     (values
                                                                                                      (cons
                                                                                                       ids118_0
                                                                                                       ids_0)
                                                                                                      (cons
                                                                                                       rhss119_0
-                                                                                                      rhss_0)))
-                                                                                                   (args
-                                                                                                    (raise-binding-result-arity-error
-                                                                                                     2
-                                                                                                     args)))))
-                                                                                               (case-lambda
-                                                                                                ((ids_1
-                                                                                                  rhss_1)
+                                                                                                      rhss_0)))))
+                                                                                               (lambda (ids_1
+                                                                                                        rhss_1)
                                                                                                  (values
                                                                                                   ids_1
-                                                                                                  rhss_1))
-                                                                                                (args
-                                                                                                 (raise-binding-result-arity-error
-                                                                                                  2
-                                                                                                  args)))))
-                                                                                            (case-lambda
-                                                                                             ((ids_1
-                                                                                               rhss_1)
+                                                                                                  rhss_1))))
+                                                                                            (lambda (ids_1
+                                                                                                     rhss_1)
                                                                                               (for-loop_0
                                                                                                ids_1
                                                                                                rhss_1
-                                                                                               rest_0))
-                                                                                             (args
-                                                                                              (raise-binding-result-arity-error
-                                                                                               2
-                                                                                               args)))))))
+                                                                                               rest_0))))))
                                                                                      (values
                                                                                       ids_0
                                                                                       rhss_0)))))))
@@ -31837,23 +30435,17 @@
                                                                              null
                                                                              null
                                                                              a_0)))
-                                                                         (case-lambda
-                                                                          ((ids_0
-                                                                            rhss_0)
+                                                                         (lambda (ids_0
+                                                                                  rhss_0)
                                                                            (let ((app_0
                                                                                   (reverse$1
                                                                                    ids_0)))
                                                                              (values
                                                                               app_0
                                                                               (reverse$1
-                                                                               rhss_0))))
-                                                                          (args
-                                                                           (raise-binding-result-arity-error
-                                                                            2
-                                                                            args))))))
-                                                                    (case-lambda
-                                                                     ((ids_0
-                                                                       rhss_0)
+                                                                               rhss_0)))))))
+                                                                    (lambda (ids_0
+                                                                             rhss_0)
                                                                       (let ((bodys_0
                                                                              (let ((d_1
                                                                                     (cdr
@@ -31867,15 +30459,10 @@
                                                                           (values
                                                                            ids_1
                                                                            rhss_1
-                                                                           bodys_0))))
-                                                                     (args
-                                                                      (raise-binding-result-arity-error
-                                                                       2
-                                                                       args)))))))
-                                                             (case-lambda
-                                                              ((ids_0
-                                                                rhss_0
-                                                                bodys_0)
+                                                                           bodys_0))))))))
+                                                             (lambda (ids_0
+                                                                      rhss_0
+                                                                      bodys_0)
                                                                (call-with-values
                                                                 (lambda ()
                                                                   (begin
@@ -31956,28 +30543,18 @@
                                                                                                     (values
                                                                                                      rhs-knowns_0
                                                                                                      body-knowns_0))))))
-                                                                                          (case-lambda
-                                                                                           ((rhs-knowns_1
-                                                                                             body-knowns_1)
+                                                                                          (lambda (rhs-knowns_1
+                                                                                                   body-knowns_1)
                                                                                             (values
                                                                                              rhs-knowns_1
-                                                                                             body-knowns_1))
-                                                                                           (args
-                                                                                            (raise-binding-result-arity-error
-                                                                                             2
-                                                                                             args)))))
-                                                                                       (case-lambda
-                                                                                        ((rhs-knowns_1
-                                                                                          body-knowns_1)
+                                                                                             body-knowns_1))))
+                                                                                       (lambda (rhs-knowns_1
+                                                                                                body-knowns_1)
                                                                                          (for-loop_0
                                                                                           rhs-knowns_1
                                                                                           body-knowns_1
                                                                                           rest_0
-                                                                                          rest_1))
-                                                                                        (args
-                                                                                         (raise-binding-result-arity-error
-                                                                                          2
-                                                                                          args))))))))
+                                                                                          rest_1)))))))
                                                                               (values
                                                                                rhs-knowns_0
                                                                                body-knowns_0)))))))
@@ -31986,9 +30563,8 @@
                                                                       knowns_1
                                                                       ids_0
                                                                       rhss_0))))
-                                                                (case-lambda
-                                                                 ((rhs-knowns_0
-                                                                   body-knowns_0)
+                                                                (lambda (rhs-knowns_0
+                                                                         body-knowns_0)
                                                                   (unnest-let
                                                                    (letrec-conversion
                                                                     ids_0
@@ -32087,15 +30663,7 @@
                                                                    imports_0
                                                                    mutated_0
                                                                    simples_0
-                                                                   unsafe-mode?_0))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   2
-                                                                   args)))))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                3
-                                                                args))))
+                                                                   unsafe-mode?_0)))))
                                                             (if (if (eq?
                                                                      'letrec-values
                                                                      hd_0)
@@ -32273,41 +30841,26 @@
                                                                                                               (values
                                                                                                                idss_2
                                                                                                                rhss_1))))))
-                                                                                                    (case-lambda
-                                                                                                     ((idss129_0
-                                                                                                       rhss130_0)
+                                                                                                    (lambda (idss129_0
+                                                                                                             rhss130_0)
                                                                                                       (values
                                                                                                        (cons
                                                                                                         idss129_0
                                                                                                         idss_0)
                                                                                                        (cons
                                                                                                         rhss130_0
-                                                                                                        rhss_0)))
-                                                                                                     (args
-                                                                                                      (raise-binding-result-arity-error
-                                                                                                       2
-                                                                                                       args)))))
-                                                                                                 (case-lambda
-                                                                                                  ((idss_1
-                                                                                                    rhss_1)
+                                                                                                        rhss_0)))))
+                                                                                                 (lambda (idss_1
+                                                                                                          rhss_1)
                                                                                                    (values
                                                                                                     idss_1
-                                                                                                    rhss_1))
-                                                                                                  (args
-                                                                                                   (raise-binding-result-arity-error
-                                                                                                    2
-                                                                                                    args)))))
-                                                                                              (case-lambda
-                                                                                               ((idss_1
-                                                                                                 rhss_1)
+                                                                                                    rhss_1))))
+                                                                                              (lambda (idss_1
+                                                                                                       rhss_1)
                                                                                                 (for-loop_0
                                                                                                  idss_1
                                                                                                  rhss_1
-                                                                                                 rest_0))
-                                                                                               (args
-                                                                                                (raise-binding-result-arity-error
-                                                                                                 2
-                                                                                                 args)))))))
+                                                                                                 rest_0))))))
                                                                                        (values
                                                                                         idss_0
                                                                                         rhss_0)))))))
@@ -32315,23 +30868,17 @@
                                                                                null
                                                                                null
                                                                                a_0)))
-                                                                           (case-lambda
-                                                                            ((idss_0
-                                                                              rhss_0)
+                                                                           (lambda (idss_0
+                                                                                    rhss_0)
                                                                              (let ((app_0
                                                                                     (reverse$1
                                                                                      idss_0)))
                                                                                (values
                                                                                 app_0
                                                                                 (reverse$1
-                                                                                 rhss_0))))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args))))))
-                                                                      (case-lambda
-                                                                       ((idss_0
-                                                                         rhss_0)
+                                                                                 rhss_0)))))))
+                                                                      (lambda (idss_0
+                                                                               rhss_0)
                                                                         (let ((bodys_0
                                                                                (let ((d_1
                                                                                       (cdr
@@ -32345,15 +30892,10 @@
                                                                             (values
                                                                              idss_1
                                                                              rhss_1
-                                                                             bodys_0))))
-                                                                       (args
-                                                                        (raise-binding-result-arity-error
-                                                                         2
-                                                                         args)))))))
-                                                               (case-lambda
-                                                                ((idss_0
-                                                                  rhss_0
-                                                                  bodys_0)
+                                                                             bodys_0))))))))
+                                                               (lambda (idss_0
+                                                                        rhss_0
+                                                                        bodys_0)
                                                                  (let ((temp138_0
                                                                         (lambda (v_3
                                                                                  knowns_2)
@@ -32438,7 +30980,8 @@
                                                                                                                                null
                                                                                                                                rhs_1
                                                                                                                                '(void)
-                                                                                                                               target_0))))
+                                                                                                                               target_0
+                                                                                                                               unsafe-mode?_0))))
                                                                                                                           (if (if (pair?
                                                                                                                                    ids_0)
                                                                                                                                 (null?
@@ -32462,7 +31005,8 @@
                                                                                                                                        (list*
                                                                                                                                         'vector
                                                                                                                                         ids_0)
-                                                                                                                                       target_0))))
+                                                                                                                                       target_0
+                                                                                                                                       unsafe-mode?_0))))
                                                                                                                                 (list*
                                                                                                                                  app_0
                                                                                                                                  (reverse$1
@@ -32525,11 +31069,7 @@
                                                                              app_0
                                                                              (schemify-body_0
                                                                               bodys_0
-                                                                              wcm-state_2)))))))))
-                                                                (args
-                                                                 (raise-binding-result-arity-error
-                                                                  3
-                                                                  args))))
+                                                                              wcm-state_2))))))))))
                                                               (if (if (eq?
                                                                        'if
                                                                        hd_0)
@@ -32614,23 +31154,17 @@
                                                                                       (values
                                                                                        thn_1
                                                                                        els_0)))))))
-                                                                          (case-lambda
-                                                                           ((thn_0
-                                                                             els_0)
+                                                                          (lambda (thn_0
+                                                                                   els_0)
                                                                             (let ((tst_1
                                                                                    tst_0))
                                                                               (values
                                                                                tst_1
                                                                                thn_0
-                                                                               els_0)))
-                                                                           (args
-                                                                            (raise-binding-result-arity-error
-                                                                             2
-                                                                             args))))))))
-                                                                 (case-lambda
-                                                                  ((tst_0
-                                                                    thn_0
-                                                                    els_0)
+                                                                               els_0))))))))
+                                                                 (lambda (tst_0
+                                                                          thn_0
+                                                                          els_0)
                                                                    (let ((app_0
                                                                           (schemify_0
                                                                            tst_0
@@ -32645,11 +31179,7 @@
                                                                         app_1
                                                                         (schemify_0
                                                                          els_0
-                                                                         wcm-state_2)))))
-                                                                  (args
-                                                                   (raise-binding-result-arity-error
-                                                                    3
-                                                                    args))))
+                                                                         wcm-state_2))))))
                                                                 (if (if (eq?
                                                                          'with-continuation-mark
                                                                          hd_0)
@@ -32734,23 +31264,17 @@
                                                                                         (values
                                                                                          val_1
                                                                                          body_0)))))))
-                                                                            (case-lambda
-                                                                             ((val_0
-                                                                               body_0)
+                                                                            (lambda (val_0
+                                                                                     body_0)
                                                                               (let ((key_1
                                                                                      key_0))
                                                                                 (values
                                                                                  key_1
                                                                                  val_0
-                                                                                 body_0)))
-                                                                             (args
-                                                                              (raise-binding-result-arity-error
-                                                                               2
-                                                                               args))))))))
-                                                                   (case-lambda
-                                                                    ((key_0
-                                                                      val_0
-                                                                      body_0)
+                                                                                 body_0))))))))
+                                                                   (lambda (key_0
+                                                                            val_0
+                                                                            body_0)
                                                                      (let ((s-key_0
                                                                             (schemify_0
                                                                              key_0
@@ -32987,39 +31511,28 @@
                                                                                                                         (values
                                                                                                                          s-val2_1
                                                                                                                          s-body2_0)))))))
-                                                                                                            (case-lambda
-                                                                                                             ((s-val2_0
-                                                                                                               s-body2_0)
+                                                                                                            (lambda (s-val2_0
+                                                                                                                     s-body2_0)
                                                                                                               (let ((s-key2_1
                                                                                                                      s-key2_0))
                                                                                                                 (values
                                                                                                                  s-key2_1
                                                                                                                  s-val2_0
-                                                                                                                 s-body2_0)))
-                                                                                                             (args
-                                                                                                              (raise-binding-result-arity-error
-                                                                                                               2
-                                                                                                               args))))))))
-                                                                                                   (case-lambda
-                                                                                                    ((s-key2_0
-                                                                                                      s-val2_0
-                                                                                                      s-body2_0)
+                                                                                                                 s-body2_0))))))))
+                                                                                                   (lambda (s-key2_0
+                                                                                                            s-val2_0
+                                                                                                            s-body2_0)
                                                                                                      (let ((mode2_1
                                                                                                             mode2_0))
                                                                                                        (values
                                                                                                         mode2_1
                                                                                                         s-key2_0
                                                                                                         s-val2_0
-                                                                                                        s-body2_0)))
-                                                                                                    (args
-                                                                                                     (raise-binding-result-arity-error
-                                                                                                      3
-                                                                                                      args))))))))
-                                                                                          (case-lambda
-                                                                                           ((mode2_0
-                                                                                             s-key2_0
-                                                                                             s-val2_0
-                                                                                             s-body2_0)
+                                                                                                        s-body2_0))))))))
+                                                                                          (lambda (mode2_0
+                                                                                                   s-key2_0
+                                                                                                   s-val2_0
+                                                                                                   s-body2_0)
                                                                                             (if (if (always-eq/no-marks?
                                                                                                      s-key_0
                                                                                                      s-key2_0
@@ -33048,11 +31561,7 @@
                                                                                               (build-wcm_0
                                                                                                s-key_0
                                                                                                s-val_0
-                                                                                               s-body_0)))
-                                                                                           (args
-                                                                                            (raise-binding-result-arity-error
-                                                                                             4
-                                                                                             args))))
+                                                                                               s-body_0))))
                                                                                          (build-wcm_0
                                                                                           s-key_0
                                                                                           s-val_0
@@ -33060,11 +31569,7 @@
                                                                                    (build-wcm_0
                                                                                     s-key_0
                                                                                     s-val_0
-                                                                                    s-body_0)))))))))
-                                                                    (args
-                                                                     (raise-binding-result-arity-error
-                                                                      3
-                                                                      args))))
+                                                                                    s-body_0))))))))))
                                                                   (if (if (eq?
                                                                            'begin
                                                                            hd_0)
@@ -33229,9 +31734,8 @@
                                                                                          (values
                                                                                           exp_1
                                                                                           exps_0)))))))
-                                                                             (case-lambda
-                                                                              ((exp_0
-                                                                                exps_0)
+                                                                             (lambda (exp_0
+                                                                                      exps_0)
                                                                                (let ((app_0
                                                                                       (schemify_0
                                                                                        exp_0
@@ -33241,11 +31745,7 @@
                                                                                   app_0
                                                                                   (schemify-body_0
                                                                                    exps_0
-                                                                                   'fresh))))
-                                                                              (args
-                                                                               (raise-binding-result-arity-error
-                                                                                2
-                                                                                args))))
+                                                                                   'fresh)))))
                                                                             (if (if (eq?
                                                                                      'set!
                                                                                      hd_0)
@@ -33308,9 +31808,8 @@
                                                                                            (values
                                                                                             id_1
                                                                                             rhs_0)))))))
-                                                                               (case-lambda
-                                                                                ((id_0
-                                                                                  rhs_0)
+                                                                               (lambda (id_0
+                                                                                        rhs_0)
                                                                                  (let ((int-id_0
                                                                                         (unwrap
                                                                                          id_0)))
@@ -33389,11 +31888,7 @@
                                                                                                (list
                                                                                                 'set!
                                                                                                 id_0
-                                                                                                new-rhs_0)))))))))
-                                                                                (args
-                                                                                 (raise-binding-result-arity-error
-                                                                                  2
-                                                                                  args))))
+                                                                                                new-rhs_0))))))))))
                                                                               (if (if (eq?
                                                                                        'variable-reference-constant?
                                                                                        hd_0)
@@ -33732,9 +32227,8 @@
                                                                                                      (values
                                                                                                       exp1_1
                                                                                                       exp2_0)))))))
-                                                                                         (case-lambda
-                                                                                          ((exp1_0
-                                                                                            exp2_0)
+                                                                                         (lambda (exp1_0
+                                                                                                  exp2_0)
                                                                                            (let ((app_0
                                                                                                   (schemify_0
                                                                                                    exp1_0
@@ -33751,11 +32245,7 @@
                                                                                               imports_0
                                                                                               mutated_0
                                                                                               simples_0
-                                                                                              unsafe-mode?_0)))
-                                                                                          (args
-                                                                                           (raise-binding-result-arity-error
-                                                                                            2
-                                                                                            args))))
+                                                                                              unsafe-mode?_0))))
                                                                                         (if (if (eq?
                                                                                                  'equal-always?
                                                                                                  hd_0)
@@ -33818,9 +32308,8 @@
                                                                                                        (values
                                                                                                         exp1_1
                                                                                                         exp2_0)))))))
-                                                                                           (case-lambda
-                                                                                            ((exp1_0
-                                                                                              exp2_0)
+                                                                                           (lambda (exp1_0
+                                                                                                    exp2_0)
                                                                                              (let ((app_0
                                                                                                     (schemify_0
                                                                                                      exp1_0
@@ -33837,11 +32326,7 @@
                                                                                                 imports_0
                                                                                                 mutated_0
                                                                                                 simples_0
-                                                                                                unsafe-mode?_0)))
-                                                                                            (args
-                                                                                             (raise-binding-result-arity-error
-                                                                                              2
-                                                                                              args))))
+                                                                                                unsafe-mode?_0))))
                                                                                           (if (if (eq?
                                                                                                    'procedure-result-arity
                                                                                                    hd_0)
@@ -33951,9 +32436,8 @@
                                                                                                            (values
                                                                                                             generator_1
                                                                                                             receiver_0)))))))
-                                                                                               (case-lambda
-                                                                                                ((generator_0
-                                                                                                  receiver_0)
+                                                                                               (lambda (generator_0
+                                                                                                        receiver_0)
                                                                                                  (let ((c2_0
                                                                                                         (if (single-valued-lambda?
                                                                                                              generator_0
@@ -34058,9 +32542,8 @@
                                                                                                                            (values
                                                                                                                             id_1
                                                                                                                             body_0)))))))
-                                                                                                               (case-lambda
-                                                                                                                ((id_0
-                                                                                                                  body_0)
+                                                                                                               (lambda (id_0
+                                                                                                                        body_0)
                                                                                                                  (let ((app_0
                                                                                                                         (list
                                                                                                                          (list
@@ -34074,11 +32557,7 @@
                                                                                                                     app_0
                                                                                                                     (schemify_0
                                                                                                                      body_0
-                                                                                                                     'fresh))))
-                                                                                                                (args
-                                                                                                                 (raise-binding-result-arity-error
-                                                                                                                  2
-                                                                                                                  args))))
+                                                                                                                     'fresh)))))
                                                                                                               (if (if (eq?
                                                                                                                        'case-lambda
                                                                                                                        hd_1)
@@ -34181,9 +32660,8 @@
                                                                                                                                (values
                                                                                                                                 id_1
                                                                                                                                 body_0))))))))
-                                                                                                                 (case-lambda
-                                                                                                                  ((id_0
-                                                                                                                    body_0)
+                                                                                                                 (lambda (id_0
+                                                                                                                          body_0)
                                                                                                                    (let ((app_0
                                                                                                                           (list
                                                                                                                            (list
@@ -34197,11 +32675,7 @@
                                                                                                                       app_0
                                                                                                                       (schemify_0
                                                                                                                        body_0
-                                                                                                                       'fresh))))
-                                                                                                                  (args
-                                                                                                                   (raise-binding-result-arity-error
-                                                                                                                    2
-                                                                                                                    args))))
+                                                                                                                       'fresh)))))
                                                                                                                 #f)))
                                                                                                           #f)))
                                                                                                    (if c2_0
@@ -34252,11 +32726,7 @@
                                                                                                         imports_0
                                                                                                         mutated_0
                                                                                                         simples_0
-                                                                                                        unsafe-mode?_0)))))
-                                                                                                (args
-                                                                                                 (raise-binding-result-arity-error
-                                                                                                  2
-                                                                                                  args))))
+                                                                                                        unsafe-mode?_0))))))
                                                                                               (if (if (eq?
                                                                                                        'single-flonum-available?
                                                                                                        hd_0)
@@ -34374,9 +32844,8 @@
                                                                                                                       (values
                                                                                                                        binds_1
                                                                                                                        rator_0))))))))
-                                                                                                        (case-lambda
-                                                                                                         ((binds_0
-                                                                                                           rator_0)
+                                                                                                        (lambda (binds_0
+                                                                                                                 rator_0)
                                                                                                           (let ((rands_0
                                                                                                                  (let ((d_0
                                                                                                                         (cdr
@@ -34390,15 +32859,10 @@
                                                                                                               (values
                                                                                                                binds_1
                                                                                                                rator_1
-                                                                                                               rands_0))))
-                                                                                                         (args
-                                                                                                          (raise-binding-result-arity-error
-                                                                                                           2
-                                                                                                           args))))))
-                                                                                                   (case-lambda
-                                                                                                    ((binds_0
-                                                                                                      rator_0
-                                                                                                      rands_0)
+                                                                                                               rands_0)))))))
+                                                                                                   (lambda (binds_0
+                                                                                                            rator_0
+                                                                                                            rands_0)
                                                                                                      (schemify_0
                                                                                                       (list
                                                                                                        'letrec-values
@@ -34406,11 +32870,7 @@
                                                                                                        (list*
                                                                                                         rator_0
                                                                                                         rands_0))
-                                                                                                      wcm-state_2))
-                                                                                                    (args
-                                                                                                     (raise-binding-result-arity-error
-                                                                                                      3
-                                                                                                      args))))
+                                                                                                      wcm-state_2)))
                                                                                                   (if (let ((p_0
                                                                                                              (unwrap
                                                                                                               v_2)))
@@ -34443,9 +32903,8 @@
                                                                                                                (values
                                                                                                                 rator_1
                                                                                                                 exps_0))))))
-                                                                                                     (case-lambda
-                                                                                                      ((rator_0
-                                                                                                        exps_0)
+                                                                                                     (lambda (rator_0
+                                                                                                              exps_0)
                                                                                                        (letrec*
                                                                                                         ((left-left-lambda-convert_0
                                                                                                           (|#%name|
@@ -34507,9 +32966,8 @@
                                                                                                                                 (values
                                                                                                                                  formal-args_1
                                                                                                                                  bodys_0)))))))
-                                                                                                                    (case-lambda
-                                                                                                                     ((formal-args_0
-                                                                                                                       bodys_0)
+                                                                                                                    (lambda (formal-args_0
+                                                                                                                             bodys_0)
                                                                                                                       (letrec*
                                                                                                                        ((loop_0
                                                                                                                          (|#%name|
@@ -34578,11 +33036,7 @@
                                                                                                                        (loop_0
                                                                                                                         formal-args_0
                                                                                                                         exps_0
-                                                                                                                        '())))
-                                                                                                                     (args
-                                                                                                                      (raise-binding-result-arity-error
-                                                                                                                       2
-                                                                                                                       args))))
+                                                                                                                        '()))))
                                                                                                                    (if (if (eq?
                                                                                                                             'case-lambda
                                                                                                                             hd_1)
@@ -34646,9 +33100,8 @@
                                                                                                                                          (values
                                                                                                                                           formal-args_1
                                                                                                                                           bodys_0)))))))
-                                                                                                                             (case-lambda
-                                                                                                                              ((formal-args_0
-                                                                                                                                bodys_0)
+                                                                                                                             (lambda (formal-args_0
+                                                                                                                                      bodys_0)
                                                                                                                                (let ((rest_0
                                                                                                                                       (let ((d_1
                                                                                                                                              (cdr
@@ -34661,15 +33114,10 @@
                                                                                                                                    (values
                                                                                                                                     formal-args_1
                                                                                                                                     bodys_1
-                                                                                                                                    rest_0))))
-                                                                                                                              (args
-                                                                                                                               (raise-binding-result-arity-error
-                                                                                                                                2
-                                                                                                                                args)))))))
-                                                                                                                      (case-lambda
-                                                                                                                       ((formal-args_0
-                                                                                                                         bodys_0
-                                                                                                                         rest_0)
+                                                                                                                                    rest_0))))))))
+                                                                                                                      (lambda (formal-args_0
+                                                                                                                               bodys_0
+                                                                                                                               rest_0)
                                                                                                                         (let ((or-part_0
                                                                                                                                (left-left-lambda-convert_0
                                                                                                                                 (list*
@@ -34683,11 +33131,7 @@
                                                                                                                              (list*
                                                                                                                               'case-lambda
                                                                                                                               rest_0)
-                                                                                                                             inline-fuel_1))))
-                                                                                                                       (args
-                                                                                                                        (raise-binding-result-arity-error
-                                                                                                                         3
-                                                                                                                         args))))
+                                                                                                                             inline-fuel_1)))))
                                                                                                                      #f))))))))
                                                                                                         (let ((inline-rator_0
                                                                                                                (|#%name|
@@ -34708,9 +33152,8 @@
                                                                                                                               knowns_1
                                                                                                                               imports_0
                                                                                                                               mutated_0))
-                                                                                                                           (case-lambda
-                                                                                                                            ((k_0
-                                                                                                                              im_0)
+                                                                                                                           (lambda (k_0
+                                                                                                                                    im_0)
                                                                                                                              (if (known-procedure/can-inline?
                                                                                                                                   k_0)
                                                                                                                                (let ((app_0
@@ -34724,11 +33167,7 @@
                                                                                                                                   app_0
                                                                                                                                   (sub1
                                                                                                                                    inline-fuel_0)))
-                                                                                                                               #f))
-                                                                                                                            (args
-                                                                                                                             (raise-binding-result-arity-error
-                                                                                                                              2
-                                                                                                                              args))))
+                                                                                                                               #f)))
                                                                                                                           #f)
                                                                                                                         #f)))))))
                                                                                                           (let ((maybe-tmp_0
@@ -35092,9 +33531,8 @@
                                                                                                                                           knowns_1
                                                                                                                                           imports_0
                                                                                                                                           mutated_0))
-                                                                                                                                       (case-lambda
-                                                                                                                                        ((k_0
-                                                                                                                                          im_0)
+                                                                                                                                       (lambda (k_0
+                                                                                                                                                im_0)
                                                                                                                                          (let ((c7_0
                                                                                                                                                 (let ((or-part_2
                                                                                                                                                        (if (eq?
@@ -35270,15 +33708,7 @@
                                                                                                                                                                   imports_0
                                                                                                                                                                   mutated_0
                                                                                                                                                                   simples_0
-                                                                                                                                                                  unsafe-mode?_0))))))))))))))
-                                                                                                                                        (args
-                                                                                                                                         (raise-binding-result-arity-error
-                                                                                                                                          2
-                                                                                                                                          args)))))))))))))))))))))
-                                                                                                      (args
-                                                                                                       (raise-binding-result-arity-error
-                                                                                                        2
-                                                                                                        args))))
+                                                                                                                                                                  unsafe-mode?_0)))))))))))))))))))))))))))))))))
                                                                                                     (let ((u-v_0
                                                                                                            (unwrap
                                                                                                             v_2)))
@@ -35613,10 +34043,7 @@
                                                   a_0))))
                                          (let ((m_2 m_1))
                                            (values m_2 orig-id_0)))))))
-                               (case-lambda
-                                ((m_1 orig-id_0) orig-id_0)
-                                (args
-                                 (raise-binding-result-arity-error 2 args))))
+                               (lambda (m_1 orig-id_0) orig-id_0))
                               (if (if (eq? 'self hd_0)
                                     (let ((a_0 (cdr (unwrap m_0))))
                                       (let ((p_0 (unwrap a_0)))
@@ -35668,17 +34095,12 @@
                                                                         id_0)
                                                                        id_0)
                                                                       #t))
-                                                                   (case-lambda
-                                                                    ((key_0
-                                                                      val_0)
+                                                                   (lambda (key_0
+                                                                            val_0)
                                                                      (hash-set
                                                                       table_2
                                                                       key_0
-                                                                      val_0))
-                                                                    (args
-                                                                     (raise-binding-result-arity-error
-                                                                      2
-                                                                      args))))))
+                                                                      val_0)))))
                                                              (values
                                                               table_3))))
                                                       (for-loop_0
@@ -35738,8 +34160,7 @@
                                                     (values
                                                      m_1
                                                      orig-name_0)))))))
-                                        (case-lambda
-                                         ((m_0 orig-name_0)
+                                        (lambda (m_0 orig-name_0)
                                           (if (eq? orig-name_0 name_0)
                                             (let ((self-id_0
                                                    (extract-id_0 m_0 name_0)))
@@ -35751,11 +34172,7 @@
                                                 'letrec
                                                 (list (list name_0 v_1))
                                                 name_0)))
-                                            #f))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args))))
+                                            #f)))
                                        #f)))))
                             (if or-part_0
                               or-part_0
@@ -35806,15 +34223,12 @@
                                        convert-mode_0)
                                     (add-lift_0 e_0 lifts_0)
                                     (values (list 'quote e_0) lifts_0)))
-                                (case-lambda
-                                 ((get-e_0 new-lifts_0)
+                                (lambda (get-e_0 new-lifts_0)
                                   (values
                                    (if need-extract?_0
                                      (list 'jitified-extract-closed get-e_0)
                                      get-e_0)
-                                   new-lifts_0))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args)))))
+                                   new-lifts_0))))
                              (let ((e_0
                                     (|#%app|
                                      extractable-annotation_0
@@ -35848,40 +34262,25 @@
                                          (add-lift_0
                                           (lifts->datum_0 body-lifts_0)
                                           lifts_0))
-                                       (case-lambda
-                                        ((get-sub-lift_0 new-lifts_0)
+                                       (lambda (get-sub-lift_0 new-lifts_0)
                                          (values
                                           (cons get-sub-lift_0 captures_0)
-                                          new-lifts_0))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args)))))))
-                                (case-lambda
-                                 ((all-captures_0 new-lifts_0)
+                                          new-lifts_0))))))
+                                (lambda (all-captures_0 new-lifts_0)
                                   (call-with-values
                                    (lambda ()
                                      (if (convert-mode-need-lift?_0
                                           convert-mode_0)
                                        (add-lift_0 e_0 new-lifts_0)
                                        (values (list 'quote e_0) new-lifts_0)))
-                                   (case-lambda
-                                    ((get-e_0 newer-lifts_0)
+                                   (lambda (get-e_0 newer-lifts_0)
                                      (values
                                       (if need-extract?_0
                                         (list*
                                          (list 'jitified-extract get-e_0)
                                          all-captures_0)
                                         (list* get-e_0 all-captures_0))
-                                      newer-lifts_0))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args)))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   2
-                                   args))))))))))))))))))
+                                      newer-lifts_0)))))))))))))))))))
       (top_0
        (|#%name|
         top
@@ -35909,16 +34308,14 @@
                                  (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                    (let ((args_1 args_0))
                                      (values args_1 body_0)))))))
-                         (case-lambda
-                          ((args_0 body_0)
+                         (lambda (args_0 body_0)
                            (let ((new-body_0
                                   (jitify-schemified-body_0
                                    body_0
                                    (plain-add-args_0 env_0 args_0))))
                              (reannotate
                               v_1
-                              (list* 'lambda args_0 new-body_0))))
-                          (args (raise-binding-result-arity-error 2 args))))
+                              (list* 'lambda args_0 new-body_0)))))
                         (if (if (eq? 'let* hd_0)
                               (let ((a_0 (cdr (unwrap v_1))))
                                 (let ((p_0 (unwrap a_0)))
@@ -35945,16 +34342,14 @@
                                               a_0))))
                                      (let ((bindings_1 bindings_0))
                                        (values bindings_1 body_0)))))))
-                           (case-lambda
-                            ((bindings_0 body_0)
+                           (lambda (bindings_0 body_0)
                              (let ((new-body_0
                                     (loop_0
                                      body_0
                                      (add-bindings_0 env_0 bindings_0))))
                                (reannotate
                                 v_1
-                                (list 'let* bindings_0 new-body_0))))
-                            (args (raise-binding-result-arity-error 2 args))))
+                                (list 'let* bindings_0 new-body_0)))))
                           (error 'match "failed ~e" v_1)))))))))
              (loop_0 v_0 hash2610))))))
       (jitify-schemified-body_0
@@ -36042,8 +34437,8 @@
                                                                           (values
                                                                            var-id_1
                                                                            id_0)))))))
-                                                              (case-lambda
-                                                               ((var-id_0 id_0)
+                                                              (lambda (var-id_0
+                                                                       id_0)
                                                                 (let ((app_0
                                                                        (unwrap
                                                                         id_0)))
@@ -36053,11 +34448,7 @@
                                                                    (list
                                                                     'variable-ref
                                                                     (unwrap
-                                                                     var-id_0)))))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args))))
+                                                                     var-id_0))))))
                                                              (if (if (eq?
                                                                       'variable-set!/define
                                                                       hd_0)
@@ -36110,9 +34501,8 @@
                                                                             (values
                                                                              var-id_1
                                                                              id_0)))))))
-                                                                (case-lambda
-                                                                 ((var-id_0
-                                                                   id_0)
+                                                                (lambda (var-id_0
+                                                                         id_0)
                                                                   (let ((app_0
                                                                          (unwrap
                                                                           id_0)))
@@ -36122,11 +34512,7 @@
                                                                      (list
                                                                       'variable-ref
                                                                       (unwrap
-                                                                       var-id_0)))))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   2
-                                                                   args))))
+                                                                       var-id_0))))))
                                                                (if (if (eq?
                                                                         'call-with-module-prompt
                                                                         hd_0)
@@ -36247,9 +34633,8 @@
                                                                                 (values
                                                                                  ids_1
                                                                                  var-ids_0))))))))
-                                                                  (case-lambda
-                                                                   ((ids_0
-                                                                     var-ids_0)
+                                                                  (lambda (ids_0
+                                                                           var-ids_0)
                                                                     (begin
                                                                       (letrec*
                                                                        ((for-loop_1
@@ -36298,11 +34683,7 @@
                                                                        (for-loop_1
                                                                         env_2
                                                                         ids_0
-                                                                        var-ids_0))))
-                                                                   (args
-                                                                    (raise-binding-result-arity-error
-                                                                     2
-                                                                     args))))
+                                                                        var-ids_0)))))
                                                                  (if (if (eq?
                                                                           'define
                                                                           hd_0)
@@ -36365,17 +34746,12 @@
                                                                                 (values
                                                                                  id_1
                                                                                  rhs_0)))))))
-                                                                    (case-lambda
-                                                                     ((id_0
-                                                                       rhs_0)
+                                                                    (lambda (id_0
+                                                                             rhs_0)
                                                                       (plain-add-args_0
                                                                        env_2
                                                                        id_0
-                                                                       #f))
-                                                                     (args
-                                                                      (raise-binding-result-arity-error
-                                                                       2
-                                                                       args))))
+                                                                       #f)))
                                                                    (if (if (eq?
                                                                             'define-values
                                                                             hd_0)
@@ -36438,17 +34814,12 @@
                                                                                   (values
                                                                                    ids_1
                                                                                    rhs_0)))))))
-                                                                      (case-lambda
-                                                                       ((ids_0
-                                                                         rhs_0)
+                                                                      (lambda (ids_0
+                                                                               rhs_0)
                                                                         (plain-add-args_0
                                                                          env_2
                                                                          ids_0
-                                                                         #f))
-                                                                       (args
-                                                                        (raise-binding-result-arity-error
-                                                                         2
-                                                                         args))))
+                                                                         #f)))
                                                                      (if (if (eq?
                                                                               'begin
                                                                               hd_0)
@@ -36672,23 +35043,17 @@
                                                                                 (values
                                                                                  id_1
                                                                                  constance_0)))))))
-                                                                    (case-lambda
-                                                                     ((id_0
-                                                                       constance_0)
+                                                                    (lambda (id_0
+                                                                             constance_0)
                                                                       (let ((var-id_1
                                                                              var-id_0))
                                                                         (values
                                                                          var-id_1
                                                                          id_0
-                                                                         constance_0)))
-                                                                     (args
-                                                                      (raise-binding-result-arity-error
-                                                                       2
-                                                                       args))))))))
-                                                           (case-lambda
-                                                            ((var-id_0
-                                                              id_0
-                                                              constance_0)
+                                                                         constance_0))))))))
+                                                           (lambda (var-id_0
+                                                                    id_0
+                                                                    constance_0)
                                                              (begin
                                                                (if constance_0
                                                                  (set! top-env_0
@@ -36700,11 +35065,7 @@
                                                                        id_0)
                                                                       kw2846)))
                                                                  (void))
-                                                               v_1))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args))))
+                                                               v_1)))
                                                           (if (if (eq?
                                                                    'define
                                                                    hd_0)
@@ -36767,8 +35128,8 @@
                                                                          (values
                                                                           id_1
                                                                           rhs_0)))))))
-                                                             (case-lambda
-                                                              ((id_0 rhs_0)
+                                                             (lambda (id_0
+                                                                      rhs_0)
                                                                (let ((self-env_0
                                                                       (add-self_0
                                                                        top-env_0
@@ -36782,11 +35143,7 @@
                                                                    (jitify-top-expr_0
                                                                     rhs_0
                                                                     self-env_0
-                                                                    id_0)))))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                2
-                                                                args))))
+                                                                    id_0))))))
                                                             (if (if (eq?
                                                                      'define-values
                                                                      hd_0)
@@ -36849,8 +35206,8 @@
                                                                            (values
                                                                             ids_1
                                                                             rhs_0)))))))
-                                                               (case-lambda
-                                                                ((ids_0 rhs_0)
+                                                               (lambda (ids_0
+                                                                        rhs_0)
                                                                  (reannotate
                                                                   v_1
                                                                   (list
@@ -36859,11 +35216,7 @@
                                                                    (jitify-top-expr_0
                                                                     rhs_0
                                                                     top-env_0
-                                                                    #f))))
-                                                                (args
-                                                                 (raise-binding-result-arity-error
-                                                                  2
-                                                                  args))))
+                                                                    #f)))))
                                                               (if (if (eq?
                                                                        'begin
                                                                        hd_0)
@@ -36909,16 +35262,14 @@
                     convert-mode_0
                     name_0
                     #f))
-                 (case-lambda
-                  ((new-v_0 free_0 lifts_0)
+                 (lambda (new-v_0 free_0 lifts_0)
                    (if (no-lifts?_0 lifts_0)
                      new-v_0
                      (list
                       'let
                       (list
                        (list lifts-id (list 'quote (lifts->datum_0 lifts_0))))
-                      new-v_0)))
-                  (args (raise-binding-result-arity-error 3 args))))))))))
+                      new-v_0))))))))))
       (jitify-expr_0
        (|#%name|
         jitify-expr
@@ -36945,8 +35296,7 @@
                        (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                          (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                            (let ((args_1 args_0)) (values args_1 body_0)))))))
-                 (case-lambda
-                  ((args_0 body_0)
+                 (lambda (args_0 body_0)
                    (let ((convert?_0
                           (convert-mode-convert-lambda?_0 convert-mode_0 v_1)))
                      (let ((body-convert-mode_0
@@ -36982,8 +35332,9 @@
                                    body-convert-mode_0
                                    #f
                                    body-in-name_0))
-                                (case-lambda
-                                 ((new-body_0 lam-body-free_0 new-body-lifts_0)
+                                (lambda (new-body_0
+                                         lam-body-free_0
+                                         new-body-lifts_0)
                                   (let ((lam-free_0
                                          (remove-args_0
                                           lam-body-free_0
@@ -37012,21 +35363,11 @@
                                             convert-mode_0
                                             new-body-lifts_0
                                             lifts_0)))
-                                       (case-lambda
-                                        ((converted-v_0 new-lifts_0)
+                                       (lambda (converted-v_0 new-lifts_0)
                                          (values
                                           converted-v_0
                                           (union-free_0 free_0 lam-free_0)
-                                          new-lifts_0))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args)))))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   3
-                                   args)))))))))))
-                  (args (raise-binding-result-arity-error 2 args))))
+                                          new-lifts_0)))))))))))))))
                 (if (if (eq? 'case-lambda hd_0)
                       (let ((a_0 (cdr (unwrap v_1))))
                         (if (wrap-list? a_0)
@@ -37113,41 +35454,23 @@
                                                            (values
                                                             argss_2
                                                             bodys_1))))))
-                                                 (case-lambda
-                                                  ((argss8_0 bodys9_0)
+                                                 (lambda (argss8_0 bodys9_0)
                                                    (values
                                                     (cons argss8_0 argss_0)
-                                                    (cons bodys9_0 bodys_0)))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args)))))
-                                              (case-lambda
-                                               ((argss_1 bodys_1)
-                                                (values argss_1 bodys_1))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args)))))
-                                           (case-lambda
-                                            ((argss_1 bodys_1)
+                                                    (cons bodys9_0 bodys_0)))))
+                                              (lambda (argss_1 bodys_1)
+                                                (values argss_1 bodys_1))))
+                                           (lambda (argss_1 bodys_1)
                                              (for-loop_0
                                               argss_1
                                               bodys_1
-                                              rest_0))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args)))))))
+                                              rest_0))))))
                                     (values argss_0 bodys_0)))))))
                            (for-loop_0 null null d_0)))
-                        (case-lambda
-                         ((argss_0 bodys_0)
+                        (lambda (argss_0 bodys_0)
                           (let ((app_0 (reverse$1 argss_0)))
-                            (values app_0 (reverse$1 bodys_0))))
-                         (args (raise-binding-result-arity-error 2 args))))))
-                   (case-lambda
-                    ((argss_0 bodys_0)
+                            (values app_0 (reverse$1 bodys_0)))))))
+                   (lambda (argss_0 bodys_0)
                      (let ((convert?_0
                             (convert-mode-convert-lambda?_0
                              convert-mode_0
@@ -37217,10 +35540,9 @@
                                                                       body-convert-mode_0
                                                                       #f
                                                                       body-in-name_0))
-                                                                   (case-lambda
-                                                                    ((new-body_0
-                                                                      lam-body-free_0
-                                                                      new-body-lifts_0)
+                                                                   (lambda (new-body_0
+                                                                            lam-body-free_0
+                                                                            new-body-lifts_0)
                                                                      (let ((app_0
                                                                             (cons
                                                                              new-body_0
@@ -37232,37 +35554,23 @@
                                                                           lam-body-free_0
                                                                           args_0)
                                                                          lam-free_2)
-                                                                        new-body-lifts_0)))
-                                                                    (args
-                                                                     (raise-binding-result-arity-error
-                                                                      3
-                                                                      args))))))
-                                                              (case-lambda
-                                                               ((rev-new-bodys_1
-                                                                 lam-free_3
-                                                                 body-lifts_2)
+                                                                        new-body-lifts_0))))))
+                                                              (lambda (rev-new-bodys_1
+                                                                       lam-free_3
+                                                                       body-lifts_2)
                                                                 (values
                                                                  rev-new-bodys_1
                                                                  lam-free_3
-                                                                 body-lifts_2))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 3
-                                                                 args)))))
-                                                           (case-lambda
-                                                            ((rev-new-bodys_1
-                                                              lam-free_3
-                                                              body-lifts_2)
+                                                                 body-lifts_2))))
+                                                           (lambda (rev-new-bodys_1
+                                                                    lam-free_3
+                                                                    body-lifts_2)
                                                              (for-loop_0
                                                               rev-new-bodys_1
                                                               lam-free_3
                                                               body-lifts_2
                                                               rest_0
-                                                              rest_1))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args))))))))
+                                                              rest_1)))))))
                                                   (values
                                                    rev-new-bodys_0
                                                    lam-free_2
@@ -37273,8 +35581,9 @@
                                           body-lifts_0
                                           argss_0
                                           bodys_0))))))
-                                (case-lambda
-                                 ((rev-new-bodys_0 lam-free_0 new-body-lifts_0)
+                                (lambda (rev-new-bodys_0
+                                         lam-free_0
+                                         new-body-lifts_0)
                                   (let ((new-v_0
                                          (reannotate
                                           v_1
@@ -37343,21 +35652,11 @@
                                           convert-mode_0
                                           new-body-lifts_0
                                           lifts_0)))
-                                     (case-lambda
-                                      ((converted-v_0 new-lifts_0)
+                                     (lambda (converted-v_0 new-lifts_0)
                                        (values
                                         converted-v_0
                                         (union-free_0 free_0 lam-free_0)
-                                        new-lifts_0))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args))))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   3
-                                   args))))))))))
-                    (args (raise-binding-result-arity-error 2 args))))
+                                        new-lifts_0)))))))))))))
                   (if (if (eq? 'let hd_0) #t #f)
                     (jitify-let_0
                      v_1
@@ -37401,14 +35700,11 @@
                                 convert-mode_0
                                 name_0
                                 in-name_0))
-                             (case-lambda
-                              ((new-body_0 new-free_0 new-lifts_0)
+                             (lambda (new-body_0 new-free_0 new-lifts_0)
                                (values
                                 (reannotate v_1 (list* 'begin new-body_0))
                                 new-free_0
-                                new-lifts_0))
-                              (args
-                               (raise-binding-result-arity-error 3 args)))))
+                                new-lifts_0))))
                           (if (if (eq? 'begin-unsafe hd_0) #t #f)
                             (let ((vs_0 (let ((d_0 (cdr (unwrap v_1)))) d_0)))
                               (jitify-expr_0
@@ -37434,8 +35730,7 @@
                                               (let ((d_1 (cdr p_0))) d_1)))
                                          (let ((v0_1 v0_0))
                                            (values v0_1 vs_0)))))))
-                               (case-lambda
-                                ((v0_0 vs_0)
+                               (lambda (v0_0 vs_0)
                                  (call-with-values
                                   (lambda ()
                                     (jitify-expr_0
@@ -37447,8 +35742,7 @@
                                      (convert-mode-non-tail_0 convert-mode_0)
                                      name_0
                                      in-name_0))
-                                  (case-lambda
-                                   ((new-v0_0 v0-free_0 v0-lifts_0)
+                                  (lambda (new-v0_0 v0-free_0 v0-lifts_0)
                                     (call-with-values
                                      (lambda ()
                                        (jitify-body_0
@@ -37461,24 +35755,15 @@
                                          convert-mode_0)
                                         #f
                                         in-name_0))
-                                     (case-lambda
-                                      ((new-body_0 new-free_0 new-lifts_0)
+                                     (lambda (new-body_0
+                                              new-free_0
+                                              new-lifts_0)
                                        (values
                                         (reannotate
                                          v_1
                                          (list* 'begin0 new-v0_0 new-body_0))
                                         new-free_0
-                                        new-lifts_0))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        3
-                                        args)))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     3
-                                     args)))))
-                                (args
-                                 (raise-binding-result-arity-error 2 args))))
+                                        new-lifts_0)))))))
                               (if (if (eq? '$value hd_0)
                                     (let ((a_0 (cdr (unwrap v_1))))
                                       (let ((p_0 (unwrap a_0)))
@@ -37504,16 +35789,11 @@
                                       convert-mode_0
                                       name_0
                                       in-name_0))
-                                   (case-lambda
-                                    ((new-e_0 new-free_0 new-lifts_0)
+                                   (lambda (new-e_0 new-free_0 new-lifts_0)
                                      (values
                                       (reannotate v_1 (list '$value new-e_0))
                                       new-free_0
-                                      new-lifts_0))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      3
-                                      args)))))
+                                      new-lifts_0))))
                                 (if (if (eq? 'if hd_0)
                                       (let ((a_0 (cdr (unwrap v_1))))
                                         (let ((p_0 (unwrap a_0)))
@@ -37561,16 +35841,13 @@
                                                         (values
                                                          thn_1
                                                          els_0)))))))
-                                            (case-lambda
-                                             ((thn_0 els_0)
+                                            (lambda (thn_0 els_0)
                                               (let ((tst_1 tst_0))
-                                                (values tst_1 thn_0 els_0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               2
-                                               args))))))))
-                                   (case-lambda
-                                    ((tst_0 thn_0 els_0)
+                                                (values
+                                                 tst_1
+                                                 thn_0
+                                                 els_0))))))))
+                                   (lambda (tst_0 thn_0 els_0)
                                      (let ((sub-convert-mode_0
                                             (convert-mode-non-tail_0
                                              convert-mode_0)))
@@ -37585,10 +35862,9 @@
                                            sub-convert-mode_0
                                            #f
                                            in-name_0))
-                                        (case-lambda
-                                         ((new-tst_0
-                                           new-free/tst_0
-                                           new-lifts/tst_0)
+                                        (lambda (new-tst_0
+                                                 new-free/tst_0
+                                                 new-lifts/tst_0)
                                           (call-with-values
                                            (lambda ()
                                              (jitify-expr_0
@@ -37600,10 +35876,9 @@
                                               convert-mode_0
                                               name_0
                                               in-name_0))
-                                           (case-lambda
-                                            ((new-thn_0
-                                              new-free/thn_0
-                                              new-lifts/thn_0)
+                                           (lambda (new-thn_0
+                                                    new-free/thn_0
+                                                    new-lifts/thn_0)
                                              (call-with-values
                                               (lambda ()
                                                 (jitify-expr_0
@@ -37615,10 +35890,9 @@
                                                  convert-mode_0
                                                  name_0
                                                  in-name_0))
-                                              (case-lambda
-                                               ((new-els_0
-                                                 new-free/els_0
-                                                 new-lifts/els_0)
+                                              (lambda (new-els_0
+                                                       new-free/els_0
+                                                       new-lifts/els_0)
                                                 (values
                                                  (reannotate
                                                   v_1
@@ -37628,23 +35902,7 @@
                                                    new-thn_0
                                                    new-els_0))
                                                  new-free/els_0
-                                                 new-lifts/els_0))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 3
-                                                 args)))))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              3
-                                              args)))))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           3
-                                           args))))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      3
-                                      args))))
+                                                 new-lifts/els_0))))))))))
                                   (if (if (eq? 'with-continuation-mark* hd_0)
                                         (let ((a_0 (cdr (unwrap v_1))))
                                           (let ((p_0 (unwrap a_0)))
@@ -37716,31 +35974,20 @@
                                                                    (values
                                                                     val_1
                                                                     body_0)))))))
-                                                       (case-lambda
-                                                        ((val_0 body_0)
+                                                       (lambda (val_0 body_0)
                                                          (let ((key_1 key_0))
                                                            (values
                                                             key_1
                                                             val_0
-                                                            body_0)))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args))))))))
-                                              (case-lambda
-                                               ((key_0 val_0 body_0)
+                                                            body_0))))))))
+                                              (lambda (key_0 val_0 body_0)
                                                 (let ((mode_1 mode_0))
                                                   (values
                                                    mode_1
                                                    key_0
                                                    val_0
-                                                   body_0)))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 3
-                                                 args))))))))
-                                     (case-lambda
-                                      ((mode_0 key_0 val_0 body_0)
+                                                   body_0))))))))
+                                     (lambda (mode_0 key_0 val_0 body_0)
                                        (let ((sub-convert-mode_0
                                               (convert-mode-non-tail_0
                                                convert-mode_0)))
@@ -37755,10 +36002,9 @@
                                              sub-convert-mode_0
                                              #f
                                              in-name_0))
-                                          (case-lambda
-                                           ((new-key_0
-                                             new-free/key_0
-                                             new-lifts/key_0)
+                                          (lambda (new-key_0
+                                                   new-free/key_0
+                                                   new-lifts/key_0)
                                             (call-with-values
                                              (lambda ()
                                                (jitify-expr_0
@@ -37770,10 +36016,9 @@
                                                 sub-convert-mode_0
                                                 #f
                                                 in-name_0))
-                                             (case-lambda
-                                              ((new-val_0
-                                                new-free/val_0
-                                                new-lifts/val_0)
+                                             (lambda (new-val_0
+                                                      new-free/val_0
+                                                      new-lifts/val_0)
                                                (call-with-values
                                                 (lambda ()
                                                   (jitify-expr_0
@@ -37785,10 +36030,9 @@
                                                    convert-mode_0
                                                    name_0
                                                    in-name_0))
-                                                (case-lambda
-                                                 ((new-body_0
-                                                   new-free/body_0
-                                                   new-lifts/body_0)
+                                                (lambda (new-body_0
+                                                         new-free/body_0
+                                                         new-lifts/body_0)
                                                   (values
                                                    (reannotate
                                                     v_1
@@ -37799,23 +36043,7 @@
                                                      new-val_0
                                                      new-body_0))
                                                    new-free/body_0
-                                                   new-lifts/body_0))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   3
-                                                   args)))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                3
-                                                args)))))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             3
-                                             args))))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        4
-                                        args))))
+                                                   new-lifts/body_0))))))))))
                                     (if (if (eq? 'quote hd_0)
                                           (let ((a_0 (cdr (unwrap v_1))))
                                             (let ((p_0 (unwrap a_0)))
@@ -37863,8 +36091,7 @@
                                                             a_0))))
                                                    (let ((var_1 var_0))
                                                      (values var_1 rhs_0)))))))
-                                         (case-lambda
-                                          ((var_0 rhs_0)
+                                         (lambda (var_0 rhs_0)
                                            (call-with-values
                                             (lambda ()
                                               (jitify-expr_0
@@ -37877,10 +36104,9 @@
                                                 convert-mode_0)
                                                var_0
                                                in-name_0))
-                                            (case-lambda
-                                             ((new-rhs_0
-                                               new-free_0
-                                               new-lifts_0)
+                                            (lambda (new-rhs_0
+                                                     new-free_0
+                                                     new-lifts_0)
                                               (let ((id_0 (unwrap var_0)))
                                                 (let ((dest_0
                                                        (hash-ref
@@ -38118,15 +36344,7 @@
                                                         (values
                                                          new-v_0
                                                          newer-free_0
-                                                         new-lifts_0)))))))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               3
-                                               args)))))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
+                                                         new-lifts_0))))))))))
                                         (if (if (eq? 'call-with-values hd_0)
                                               (let ((a_0 (cdr (unwrap v_1))))
                                                 (let ((p_0 (unwrap a_0)))
@@ -38166,8 +36384,7 @@
                                                        (values
                                                         proc1_1
                                                         proc2_0)))))))
-                                           (case-lambda
-                                            ((proc1_0 proc2_0)
+                                           (lambda (proc1_0 proc2_0)
                                              (let ((proc-convert-mode_0
                                                     (convert-mode-called_0
                                                      convert-mode_0)))
@@ -38182,10 +36399,9 @@
                                                    proc-convert-mode_0
                                                    #f
                                                    in-name_0))
-                                                (case-lambda
-                                                 ((new-proc1_0
-                                                   new-free1_0
-                                                   new-lifts1_0)
+                                                (lambda (new-proc1_0
+                                                         new-free1_0
+                                                         new-lifts1_0)
                                                   (call-with-values
                                                    (lambda ()
                                                      (jitify-expr_0
@@ -38197,10 +36413,9 @@
                                                       proc-convert-mode_0
                                                       #f
                                                       in-name_0))
-                                                   (case-lambda
-                                                    ((new-proc2_0
-                                                      new-free2_0
-                                                      new-lifts2_0)
+                                                   (lambda (new-proc2_0
+                                                            new-free2_0
+                                                            new-lifts2_0)
                                                      (let ((call-with-values-id_0
                                                             (if (if (lambda?_0
                                                                      new-proc1_0)
@@ -38217,19 +36432,7 @@
                                                           new-proc1_0
                                                           new-proc2_0))
                                                         new-free2_0
-                                                        new-lifts2_0)))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      3
-                                                      args)))))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   3
-                                                   args))))))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
+                                                        new-lifts2_0)))))))))
                                           (if (if (eq?
                                                    'call-with-module-prompt
                                                    hd_0)
@@ -38257,8 +36460,7 @@
                                                          (values
                                                           proc_1
                                                           var-info_0)))))))
-                                             (case-lambda
-                                              ((proc_0 var-info_0)
+                                             (lambda (proc_0 var-info_0)
                                                (let ((proc-convert-mode_0
                                                       (convert-mode-called_0
                                                        convert-mode_0)))
@@ -38273,10 +36475,9 @@
                                                      proc-convert-mode_0
                                                      #f
                                                      in-name_0))
-                                                  (case-lambda
-                                                   ((new-proc_0
-                                                     new-free_0
-                                                     new-lifts_0)
+                                                  (lambda (new-proc_0
+                                                           new-free_0
+                                                           new-lifts_0)
                                                     (values
                                                      (reannotate
                                                       v_1
@@ -38285,15 +36486,7 @@
                                                        new-proc_0
                                                        var-info_0))
                                                      new-free_0
-                                                     new-lifts_0))
-                                                   (args
-                                                    (raise-binding-result-arity-error
-                                                     3
-                                                     args))))))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
+                                                     new-lifts_0))))))
                                             (if (if (eq?
                                                      'ffi-static-call-and-callback-core
                                                      hd_0)
@@ -38340,20 +36533,15 @@
                                                        convert-mode_0)
                                                       #f
                                                       in-name_0)))
-                                                 (case-lambda
-                                                  ((new-vs_0
-                                                    new-free_0
-                                                    new-lifts_0)
+                                                 (lambda (new-vs_0
+                                                          new-free_0
+                                                          new-lifts_0)
                                                    (values
                                                     (reannotate
                                                      v_1
                                                      (list* '|#%app| new-vs_0))
                                                     new-free_0
-                                                    new-lifts_0))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    3
-                                                    args))))
+                                                    new-lifts_0)))
                                                 (if (let ((p_0 (unwrap v_1)))
                                                       (if (pair? p_0)
                                                         (let ((a_0 (cdr p_0)))
@@ -38446,10 +36634,9 @@
                                                                      convert-mode_0)
                                                                     #f
                                                                     in-name_0)))
-                                                               (case-lambda
-                                                                ((new-vs_0
-                                                                  new-free_0
-                                                                  new-lifts_0)
+                                                               (lambda (new-vs_0
+                                                                        new-free_0
+                                                                        new-lifts_0)
                                                                  (values
                                                                   (reannotate
                                                                    v_1
@@ -38457,11 +36644,7 @@
                                                                     rator_0
                                                                     new-vs_0))
                                                                   new-free_0
-                                                                  new-lifts_0))
-                                                                (args
-                                                                 (raise-binding-result-arity-error
-                                                                  3
-                                                                  args)))))
+                                                                  new-lifts_0))))
                                                             (call-with-values
                                                              (lambda ()
                                                                (jitify-body_0
@@ -38474,20 +36657,15 @@
                                                                  convert-mode_0)
                                                                 #f
                                                                 in-name_0))
-                                                             (case-lambda
-                                                              ((new-vs_0
-                                                                new-free_0
-                                                                new-lifts_0)
+                                                             (lambda (new-vs_0
+                                                                      new-free_0
+                                                                      new-lifts_0)
                                                                (values
                                                                 (reannotate
                                                                  v_1
                                                                  new-vs_0)
                                                                 new-free_0
-                                                                new-lifts_0))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                3
-                                                                args)))))))))
+                                                                new-lifts_0))))))))
                                                   (let ((id_0 (unwrap v_1)))
                                                     (if (symbol? id_0)
                                                       (let ((dest_0
@@ -38705,10 +36883,8 @@
                             convert-mode_0
                             name_0
                             in-name_0))
-                         (case-lambda
-                          ((new-v_0 new-free_0 new-lifts_0)
-                           (values (list new-v_0) new-free_0 new-lifts_0))
-                          (args (raise-binding-result-arity-error 3 args))))
+                         (lambda (new-v_0 new-free_0 new-lifts_0)
+                           (values (list new-v_0) new-free_0 new-lifts_0)))
                         (call-with-values
                          (lambda ()
                            (let ((app_0 (wrap-car vs_1)))
@@ -38721,21 +36897,15 @@
                               (convert-mode-non-tail_0 convert-mode_0)
                               #f
                               in-name_0)))
-                         (case-lambda
-                          ((new-v_0 new-free_0 new-lifts_0)
+                         (lambda (new-v_0 new-free_0 new-lifts_0)
                            (call-with-values
                             (lambda ()
                               (loop_0 (wrap-cdr vs_1) new-free_0 new-lifts_0))
-                            (case-lambda
-                             ((new-rest_0 newer-free_0 newer-lifts_0)
+                            (lambda (new-rest_0 newer-free_0 newer-lifts_0)
                               (values
                                (cons new-v_0 new-rest_0)
                                newer-free_0
-                               newer-lifts_0))
-                             (args
-                              (raise-binding-result-arity-error 3 args)))))
-                          (args
-                           (raise-binding-result-arity-error 3 args)))))))))))
+                               newer-lifts_0))))))))))))
              (loop_0 vs_0 free_0 lifts_0))))))
       (jitify-let_0
        (|#%name|
@@ -38887,62 +37057,37 @@
                                                                      (values
                                                                       ids_2
                                                                       rhss_1))))))
-                                                           (case-lambda
-                                                            ((ids10_0 rhss11_0)
+                                                           (lambda (ids10_0
+                                                                    rhss11_0)
                                                              (values
                                                               (cons
                                                                ids10_0
                                                                ids_0)
                                                               (cons
                                                                rhss11_0
-                                                               rhss_0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
-                                                        (case-lambda
-                                                         ((ids_1 rhss_1)
+                                                               rhss_0)))))
+                                                        (lambda (ids_1 rhss_1)
                                                           (values
                                                            ids_1
-                                                           rhss_1))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))
-                                                     (case-lambda
-                                                      ((ids_1 rhss_1)
+                                                           rhss_1))))
+                                                     (lambda (ids_1 rhss_1)
                                                        (for-loop_0
                                                         ids_1
                                                         rhss_1
-                                                        rest_0))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args)))))))
+                                                        rest_0))))))
                                               (values ids_0 rhss_0)))))))
                                      (for-loop_0 null null a_0)))
-                                  (case-lambda
-                                   ((ids_0 rhss_0)
+                                  (lambda (ids_0 rhss_0)
                                     (let ((app_0 (reverse$1 ids_0)))
-                                      (values app_0 (reverse$1 rhss_0))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args))))))
-                             (case-lambda
-                              ((ids_0 rhss_0)
+                                      (values app_0 (reverse$1 rhss_0)))))))
+                             (lambda (ids_0 rhss_0)
                                (let ((body_0 (let ((d_1 (cdr p_1))) d_1)))
                                  (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                   (values ids_1 rhss_1 body_0))))
-                              (args
-                               (raise-binding-result-arity-error 2 args)))))))
-                      (case-lambda
-                       ((ids_0 rhss_0 body_0)
+                                   (values ids_1 rhss_1 body_0))))))))
+                      (lambda (ids_0 rhss_0 body_0)
                         (let ((let-form_1 let-form_0))
-                          (values let-form_1 ids_0 rhss_0 body_0)))
-                       (args (raise-binding-result-arity-error 3 args)))))))
-               (case-lambda
-                ((let-form_0 ids_0 rhss_0 body_0)
+                          (values let-form_1 ids_0 rhss_0 body_0)))))))
+               (lambda (let-form_0 ids_0 rhss_0 body_0)
                  (let ((rec?_0
                         (if (let ((tmp_0 (unwrap let-form_0)))
                               (if (if (eq? tmp_0 'letrec)
@@ -39006,46 +37151,31 @@
                                                               rhs-convert-mode_0
                                                               id_0
                                                               in-name_0))
-                                                           (case-lambda
-                                                            ((new-rhs_0
-                                                              rhs-free_0
-                                                              rhs-lifts_0)
+                                                           (lambda (new-rhs_0
+                                                                    rhs-free_0
+                                                                    rhs-lifts_0)
                                                              (values
                                                               (cons
                                                                new-rhs_0
                                                                rev-new-rhss_0)
                                                               rhs-free_0
-                                                              rhs-lifts_0))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args))))))
-                                                      (case-lambda
-                                                       ((rev-new-rhss_1
-                                                         free_4
-                                                         lifts_2)
+                                                              rhs-lifts_0)))))
+                                                      (lambda (rev-new-rhss_1
+                                                               free_4
+                                                               lifts_2)
                                                         (values
                                                          rev-new-rhss_1
                                                          free_4
-                                                         lifts_2))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         3
-                                                         args)))))
-                                                   (case-lambda
-                                                    ((rev-new-rhss_1
-                                                      free_4
-                                                      lifts_2)
+                                                         lifts_2))))
+                                                   (lambda (rev-new-rhss_1
+                                                            free_4
+                                                            lifts_2)
                                                      (for-loop_0
                                                       rev-new-rhss_1
                                                       free_4
                                                       lifts_2
                                                       rest_0
-                                                      rest_1))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      3
-                                                      args))))))))
+                                                      rest_1)))))))
                                           (values
                                            rev-new-rhss_0
                                            free_3
@@ -39056,8 +37186,7 @@
                                   lifts_0
                                   ids_0
                                   rhss_0))))))
-                        (case-lambda
-                         ((rev-new-rhss_0 rhs-free_0 rhs-lifts_0)
+                        (lambda (rev-new-rhss_0 rhs-free_0 rhs-lifts_0)
                           (let ((local-env_0
                                  (add-args/unbox_0
                                   env_0
@@ -39079,8 +37208,7 @@
                                 convert-mode_0
                                 name_0
                                 in-name_0))
-                             (case-lambda
-                              ((new-body_0 new-free_0 new-lifts_0)
+                             (lambda (new-body_0 new-free_0 new-lifts_0)
                                (let ((new-v_0
                                       (if (not rec?_0)
                                         (list*
@@ -39286,11 +37414,7 @@
                                    (values
                                     app_0
                                     (remove-args_0 new-free_0 ids_0)
-                                    new-lifts_0))))
-                              (args
-                               (raise-binding-result-arity-error 3 args))))))
-                         (args (raise-binding-result-arity-error 3 args))))))))
-                (args (raise-binding-result-arity-error 4 args))))
+                                    new-lifts_0)))))))))))))
               (error 'match "failed ~e" v_1))))))
       (mutable-box-bindings_0
        (|#%name|
@@ -39346,13 +37470,11 @@
                             (let ((id_0 (let ((a_0 (car p_0))) a_0)))
                               (let ((args_0 (let ((d_0 (cdr p_0))) d_0)))
                                 (let ((id_1 id_0)) (values id_1 args_0))))))
-                        (case-lambda
-                         ((id_0 args_0)
+                        (lambda (id_0 args_0)
                           (plain-add-args_0
                            (add-one_0 id_0)
                            args_0
-                           replace?3_0))
-                         (args (raise-binding-result-arity-error 2 args))))
+                           replace?3_0)))
                        (if (begin-unsafe
                             (let ((app_0 (unwrap '())))
                               (eq? app_0 (unwrap args5_0))))
@@ -39390,14 +37512,12 @@
                      (let ((id_0 (let ((a_0 (car p_0))) a_0)))
                        (let ((args_1 (let ((d_0 (cdr p_0))) d_0)))
                          (let ((id_1 id_0)) (values id_1 args_1))))))
-                 (case-lambda
-                  ((id_0 args_1)
+                 (lambda (id_0 args_1)
                    (add-args_0
                     (add-one_0 id_0)
                     args_1
                     mutables_0
-                    convert-mode_0))
-                  (args (raise-binding-result-arity-error 2 args))))
+                    convert-mode_0)))
                 (if (begin-unsafe
                      (let ((app_0 (unwrap '()))) (eq? app_0 (unwrap args_0))))
                   env_0
@@ -39433,15 +37553,13 @@
                      (let ((id_0 (let ((a_0 (car p_0))) a_0)))
                        (let ((args_1 (let ((d_0 (cdr p_0))) d_0)))
                          (let ((id_1 id_0)) (values id_1 args_1))))))
-                 (case-lambda
-                  ((id_0 args_1)
+                 (lambda (id_0 args_1)
                    (add-args/unbox_0
                     (add-one_0 id_0)
                     args_1
                     mutables_0
                     var-rec?_0
-                    convert-mode_0))
-                  (args (raise-binding-result-arity-error 2 args))))
+                    convert-mode_0)))
                 (if (begin-unsafe
                      (let ((app_0 (unwrap '()))) (eq? app_0 (unwrap args_0))))
                   env_0
@@ -39458,10 +37576,8 @@
                    (let ((id_0 (let ((a_0 (car p_0))) a_0)))
                      (let ((args_1 (let ((d_0 (cdr p_0))) d_0)))
                        (let ((id_1 id_0)) (values id_1 args_1))))))
-               (case-lambda
-                ((id_0 args_1)
-                 (remove-args_0 (hash-remove env_0 (unwrap id_0)) args_1))
-                (args (raise-binding-result-arity-error 2 args))))
+               (lambda (id_0 args_1)
+                 (remove-args_0 (hash-remove env_0 (unwrap id_0)) args_1)))
               (if (begin-unsafe
                    (let ((app_0 (unwrap '()))) (eq? app_0 (unwrap args_0))))
                 env_0
@@ -39833,13 +37949,11 @@
                         (if i_0
                           (call-with-values
                            (lambda () (hash-iterate-key+value a_0 i_0))
-                           (case-lambda
-                            ((k_0 v_1)
+                           (lambda (k_0 v_1)
                              (let ((b_2
                                     (let ((b_2 (hash-set b_1 k_0 v_1)))
                                       (values b_2))))
-                               (for-loop_0 b_2 (hash-iterate-next a_0 i_0))))
-                            (args (raise-binding-result-arity-error 2 args))))
+                               (for-loop_0 b_2 (hash-iterate-next a_0 i_0)))))
                           b_1))))))
                  (for-loop_0 b_0 (hash-iterate-first a_0)))))))))
       (body->expr_0
@@ -39872,13 +37986,11 @@
                        (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                          (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                            (let ((args_1 args_0)) (values args_1 body_0)))))))
-                 (case-lambda
-                  ((args_0 body_0)
+                 (lambda (args_0 body_0)
                    (body-find-mutable_0
                     (plain-add-args_0 env_0 args_0)
                     body_0
-                    accum_0))
-                  (args (raise-binding-result-arity-error 2 args))))
+                    accum_0)))
                 (if (if (eq? 'case-lambda hd_0)
                       (let ((a_0 (cdr (unwrap v_1))))
                         (if (wrap-list? a_0)
@@ -39965,41 +38077,25 @@
                                                            (values
                                                             argss_2
                                                             bodys_1))))))
-                                                 (case-lambda
-                                                  ((argss13_0 bodys14_0)
+                                                 (lambda (argss13_0 bodys14_0)
                                                    (values
                                                     (cons argss13_0 argss_0)
-                                                    (cons bodys14_0 bodys_0)))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args)))))
-                                              (case-lambda
-                                               ((argss_1 bodys_1)
-                                                (values argss_1 bodys_1))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args)))))
-                                           (case-lambda
-                                            ((argss_1 bodys_1)
+                                                    (cons
+                                                     bodys14_0
+                                                     bodys_0)))))
+                                              (lambda (argss_1 bodys_1)
+                                                (values argss_1 bodys_1))))
+                                           (lambda (argss_1 bodys_1)
                                              (for-loop_0
                                               argss_1
                                               bodys_1
-                                              rest_0))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args)))))))
+                                              rest_0))))))
                                     (values argss_0 bodys_0)))))))
                            (for-loop_0 null null d_0)))
-                        (case-lambda
-                         ((argss_0 bodys_0)
+                        (lambda (argss_0 bodys_0)
                           (let ((app_0 (reverse$1 argss_0)))
-                            (values app_0 (reverse$1 bodys_0))))
-                         (args (raise-binding-result-arity-error 2 args))))))
-                   (case-lambda
-                    ((argss_0 bodys_0)
+                            (values app_0 (reverse$1 bodys_0)))))))
+                   (lambda (argss_0 bodys_0)
                      (begin
                        (letrec*
                         ((for-loop_0
@@ -40026,8 +38122,7 @@
                                             rest_0
                                             rest_1))))))
                                  accum_1))))))
-                        (for-loop_0 accum_0 argss_0 bodys_0))))
-                    (args (raise-binding-result-arity-error 2 args))))
+                        (for-loop_0 accum_0 argss_0 bodys_0)))))
                   (if (if (eq? 'let hd_0) #t #f)
                     (find-mutable-in-let_0 env_0 v_1 accum_0)
                     (if (if (eq? 'letrec hd_0) #t #f)
@@ -40089,25 +38184,17 @@
                                                       (values
                                                        thn_1
                                                        els_0)))))))
-                                          (case-lambda
-                                           ((thn_0 els_0)
+                                          (lambda (thn_0 els_0)
                                             (let ((tst_1 tst_0))
-                                              (values tst_1 thn_0 els_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args))))))))
-                                 (case-lambda
-                                  ((tst_0 thn_0 els_0)
+                                              (values tst_1 thn_0 els_0))))))))
+                                 (lambda (tst_0 thn_0 els_0)
                                    (find-mutable_0
                                     env_0
                                     tst_0
                                     (find-mutable_0
                                      env_0
                                      thn_0
-                                     (find-mutable_0 env_0 els_0 accum_0))))
-                                  (args
-                                   (raise-binding-result-arity-error 3 args))))
+                                     (find-mutable_0 env_0 els_0 accum_0)))))
                                 (if (if (eq? 'with-continuation-mark* hd_0)
                                       (let ((a_0 (cdr (unwrap v_1))))
                                         (let ((p_0 (unwrap a_0)))
@@ -40175,42 +38262,30 @@
                                                                  (values
                                                                   val_1
                                                                   body_0)))))))
-                                                     (case-lambda
-                                                      ((val_0 body_0)
+                                                     (lambda (val_0 body_0)
                                                        (let ((key_1 key_0))
                                                          (values
                                                           key_1
                                                           val_0
-                                                          body_0)))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args))))))))
-                                            (case-lambda
-                                             ((key_0 val_0 body_0)
+                                                          body_0))))))))
+                                            (lambda (key_0 val_0 body_0)
                                               (let ((mode_1 mode_0))
                                                 (values
                                                  mode_1
                                                  key_0
                                                  val_0
-                                                 body_0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               3
-                                               args))))))))
-                                   (case-lambda
-                                    ((mode_0 key_0 val_0 body_0)
+                                                 body_0))))))))
+                                   (lambda (mode_0 key_0 val_0 body_0)
                                      (find-mutable_0
                                       env_0
                                       key_0
                                       (find-mutable_0
                                        env_0
                                        val_0
-                                       (find-mutable_0 env_0 body_0 accum_0))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      4
-                                      args))))
+                                       (find-mutable_0
+                                        env_0
+                                        body_0
+                                        accum_0)))))
                                   (if (if (eq? 'quote hd_0)
                                         (let ((a_0 (cdr (unwrap v_1))))
                                           (let ((p_0 (unwrap a_0)))
@@ -40254,19 +38329,14 @@
                                                           a_0))))
                                                  (let ((var_1 var_0))
                                                    (values var_1 rhs_0)))))))
-                                       (case-lambda
-                                        ((var_0 rhs_0)
+                                       (lambda (var_0 rhs_0)
                                          (let ((id_0 (unwrap var_0)))
                                            (find-mutable_0
                                             env_0
                                             rhs_0
                                             (if (hash-ref env_0 id_0 #f)
                                               (hash-set accum_0 id_0 #t)
-                                              accum_0))))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          2
-                                          args))))
+                                              accum_0)))))
                                       (if (if (eq?
                                                'ffi-static-call-and-callback-core
                                                hd_0)
@@ -40451,62 +38521,37 @@
                                                                      (values
                                                                       ids_2
                                                                       rhss_1))))))
-                                                           (case-lambda
-                                                            ((ids15_0 rhss16_0)
+                                                           (lambda (ids15_0
+                                                                    rhss16_0)
                                                              (values
                                                               (cons
                                                                ids15_0
                                                                ids_0)
                                                               (cons
                                                                rhss16_0
-                                                               rhss_0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
-                                                        (case-lambda
-                                                         ((ids_1 rhss_1)
+                                                               rhss_0)))))
+                                                        (lambda (ids_1 rhss_1)
                                                           (values
                                                            ids_1
-                                                           rhss_1))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))
-                                                     (case-lambda
-                                                      ((ids_1 rhss_1)
+                                                           rhss_1))))
+                                                     (lambda (ids_1 rhss_1)
                                                        (for-loop_0
                                                         ids_1
                                                         rhss_1
-                                                        rest_0))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args)))))))
+                                                        rest_0))))))
                                               (values ids_0 rhss_0)))))))
                                      (for-loop_0 null null a_0)))
-                                  (case-lambda
-                                   ((ids_0 rhss_0)
+                                  (lambda (ids_0 rhss_0)
                                     (let ((app_0 (reverse$1 ids_0)))
-                                      (values app_0 (reverse$1 rhss_0))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args))))))
-                             (case-lambda
-                              ((ids_0 rhss_0)
+                                      (values app_0 (reverse$1 rhss_0)))))))
+                             (lambda (ids_0 rhss_0)
                                (let ((body_0 (let ((d_1 (cdr p_1))) d_1)))
                                  (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                   (values ids_1 rhss_1 body_0))))
-                              (args
-                               (raise-binding-result-arity-error 2 args)))))))
-                      (case-lambda
-                       ((ids_0 rhss_0 body_0)
+                                   (values ids_1 rhss_1 body_0))))))))
+                      (lambda (ids_0 rhss_0 body_0)
                         (let ((let-form_1 let-form_0))
-                          (values let-form_1 ids_0 rhss_0 body_0)))
-                       (args (raise-binding-result-arity-error 3 args)))))))
-               (case-lambda
-                ((let-form_0 ids_0 rhss_0 body_0)
+                          (values let-form_1 ids_0 rhss_0 body_0)))))))
+               (lambda (let-form_0 ids_0 rhss_0 body_0)
                  (let ((local-env_0
                         (begin
                           (letrec*
@@ -40563,8 +38608,7 @@
                                              rest_0
                                              rest_1))))))
                                   accum_1))))))
-                         (for-loop_0 accum_0 ids_0 rhss_0)))))))
-                (args (raise-binding-result-arity-error 4 args))))
+                         (for-loop_0 accum_0 ids_0 rhss_0))))))))
               (error 'match "failed ~e" v_1))))))
       (init-convert-mode_0
        (|#%name|
@@ -40718,12 +38762,10 @@
                        (let ((args_0 (let ((a_0 (car p_0))) a_0)))
                          (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                            (let ((args_1 args_0)) (values args_1 body_0)))))))
-                 (case-lambda
-                  ((args_0 body_0)
+                 (lambda (args_0 body_0)
                    (let ((size_0 (body-record-sizes!_0 body_0 sizes_0)))
                      (begin-unsafe
-                      (begin (begin (hash-set! sizes_0 v_1 size_0) size_0)))))
-                  (args (raise-binding-result-arity-error 2 args))))
+                      (begin (begin (hash-set! sizes_0 v_1 size_0) size_0))))))
                 (if (if (eq? 'case-lambda hd_0)
                       (let ((a_0 (cdr (unwrap v_1))))
                         (if (wrap-list? a_0)
@@ -40895,16 +38937,10 @@
                                                       (values
                                                        thn_1
                                                        els_0)))))))
-                                          (case-lambda
-                                           ((thn_0 els_0)
+                                          (lambda (thn_0 els_0)
                                             (let ((tst_1 tst_0))
-                                              (values tst_1 thn_0 els_0)))
-                                           (args
-                                            (raise-binding-result-arity-error
-                                             2
-                                             args))))))))
-                                 (case-lambda
-                                  ((tst_0 thn_0 els_0)
+                                              (values tst_1 thn_0 els_0))))))))
+                                 (lambda (tst_0 thn_0 els_0)
                                    (let ((app_0
                                           (record-sizes!_0 tst_0 sizes_0)))
                                      (let ((app_1
@@ -40913,9 +38949,7 @@
                                         1
                                         app_0
                                         app_1
-                                        (record-sizes!_0 els_0 sizes_0)))))
-                                  (args
-                                   (raise-binding-result-arity-error 3 args))))
+                                        (record-sizes!_0 els_0 sizes_0))))))
                                 (if (if (eq? 'with-continuation-mark* hd_0)
                                       (let ((a_0 (cdr (unwrap v_1))))
                                         (let ((p_0 (unwrap a_0)))
@@ -40983,31 +39017,20 @@
                                                                  (values
                                                                   val_1
                                                                   body_0)))))))
-                                                     (case-lambda
-                                                      ((val_0 body_0)
+                                                     (lambda (val_0 body_0)
                                                        (let ((key_1 key_0))
                                                          (values
                                                           key_1
                                                           val_0
-                                                          body_0)))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args))))))))
-                                            (case-lambda
-                                             ((key_0 val_0 body_0)
+                                                          body_0))))))))
+                                            (lambda (key_0 val_0 body_0)
                                               (let ((mode_1 mode_0))
                                                 (values
                                                  mode_1
                                                  key_0
                                                  val_0
-                                                 body_0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               3
-                                               args))))))))
-                                   (case-lambda
-                                    ((mode_0 key_0 val_0 body_0)
+                                                 body_0))))))))
+                                   (lambda (mode_0 key_0 val_0 body_0)
                                      (let ((app_0
                                             (record-sizes!_0 key_0 sizes_0)))
                                        (let ((app_1
@@ -41016,11 +39039,7 @@
                                           1
                                           app_0
                                           app_1
-                                          (record-sizes!_0 body_0 sizes_0)))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      4
-                                      args))))
+                                          (record-sizes!_0 body_0 sizes_0))))))
                                   (if (if (eq? 'quote hd_0)
                                         (let ((a_0 (cdr (unwrap v_1))))
                                           (let ((p_0 (unwrap a_0)))
@@ -41239,13 +39258,10 @@
                               (let ((body_0 (let ((d_1 (cdr p_1))) d_1)))
                                 (let ((rhss_1 rhss_0))
                                   (values rhss_1 body_0)))))))
-                      (case-lambda
-                       ((rhss_0 body_0)
+                      (lambda (rhss_0 body_0)
                         (let ((let-form_1 let-form_0))
-                          (values let-form_1 rhss_0 body_0)))
-                       (args (raise-binding-result-arity-error 2 args)))))))
-               (case-lambda
-                ((let-form_0 rhss_0 body_0)
+                          (values let-form_1 rhss_0 body_0)))))))
+               (lambda (let-form_0 rhss_0 body_0)
                  (let ((app_0
                         (begin
                           (letrec*
@@ -41268,8 +39284,7 @@
                                           (for-loop_0 result_1 rest_0))))
                                     result_0))))))
                            (for-loop_0 0 rhss_0)))))
-                   (+ 1 app_0 (body-record-sizes!_0 body_0 sizes_0))))
-                (args (raise-binding-result-arity-error 3 args))))
+                   (+ 1 app_0 (body-record-sizes!_0 body_0 sizes_0)))))
               (error 'match "failed ~e" v_1)))))))
      (with-continuation-mark*
       authentic
@@ -41301,18 +39316,14 @@
                         (let ((ids_0 (let ((a_0 (car p_0))) a_0)))
                           (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                             (let ((ids_1 ids_0)) (values ids_1 body_0)))))))
-                  (case-lambda
-                   ((ids_0 body_0)
+                  (lambda (ids_0 body_0)
                     (call-with-values
                      (lambda () (xify-ids_0 ids_0 env_0))
-                     (case-lambda
-                      ((new-ids_0 new-env_0)
+                     (lambda (new-ids_0 new-env_0)
                        (list*
                         'lambda
                         new-ids_0
-                        (xify-body_0 body_0 new-env_0)))
-                      (args (raise-binding-result-arity-error 2 args)))))
-                   (args (raise-binding-result-arity-error 2 args))))
+                        (xify-body_0 body_0 new-env_0))))))
                  (if (if (eq? 'case-lambda hd_0)
                        (let ((a_0 (cdr (unwrap e_1)))) (wrap-list? a_0))
                        #f)
@@ -41480,59 +39491,35 @@
                                                                      (values
                                                                       ids_2
                                                                       rhss_1))))))
-                                                           (case-lambda
-                                                            ((ids1_0 rhss2_0)
+                                                           (lambda (ids1_0
+                                                                    rhss2_0)
                                                              (values
                                                               (cons
                                                                ids1_0
                                                                ids_0)
                                                               (cons
                                                                rhss2_0
-                                                               rhss_0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
-                                                        (case-lambda
-                                                         ((ids_1 rhss_1)
+                                                               rhss_0)))))
+                                                        (lambda (ids_1 rhss_1)
                                                           (values
                                                            ids_1
-                                                           rhss_1))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))
-                                                     (case-lambda
-                                                      ((ids_1 rhss_1)
+                                                           rhss_1))))
+                                                     (lambda (ids_1 rhss_1)
                                                        (for-loop_0
                                                         ids_1
                                                         rhss_1
-                                                        rest_0))
-                                                      (args
-                                                       (raise-binding-result-arity-error
-                                                        2
-                                                        args)))))))
+                                                        rest_0))))))
                                               (values ids_0 rhss_0)))))))
                                      (for-loop_0 null null a_0)))
-                                  (case-lambda
-                                   ((ids_0 rhss_0)
+                                  (lambda (ids_0 rhss_0)
                                     (let ((app_0 (reverse$1 ids_0)))
-                                      (values app_0 (reverse$1 rhss_0))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args))))))
-                             (case-lambda
-                              ((ids_0 rhss_0)
+                                      (values app_0 (reverse$1 rhss_0)))))))
+                             (lambda (ids_0 rhss_0)
                                (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                  (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                   (values ids_1 rhss_1 body_0))))
-                              (args
-                               (raise-binding-result-arity-error 2 args)))))))
-                      (case-lambda
-                       ((ids_0 rhss_0 body_0)
-                        (xify-let_0 'let ids_0 rhss_0 body_0 env_0))
-                       (args (raise-binding-result-arity-error 3 args))))
+                                   (values ids_1 rhss_1 body_0))))))))
+                      (lambda (ids_0 rhss_0 body_0)
+                        (xify-let_0 'let ids_0 rhss_0 body_0 env_0)))
                      (if (if (eq? 'letrec hd_0)
                            (let ((a_0 (cdr (unwrap e_1))))
                              (let ((p_0 (unwrap a_0)))
@@ -41671,61 +39658,36 @@
                                                                        (values
                                                                         ids_2
                                                                         rhss_1))))))
-                                                             (case-lambda
-                                                              ((ids3_0 rhss4_0)
+                                                             (lambda (ids3_0
+                                                                      rhss4_0)
                                                                (values
                                                                 (cons
                                                                  ids3_0
                                                                  ids_0)
                                                                 (cons
                                                                  rhss4_0
-                                                                 rhss_0)))
-                                                              (args
-                                                               (raise-binding-result-arity-error
-                                                                2
-                                                                args)))))
-                                                          (case-lambda
-                                                           ((ids_1 rhss_1)
+                                                                 rhss_0)))))
+                                                          (lambda (ids_1
+                                                                   rhss_1)
                                                             (values
                                                              ids_1
-                                                             rhss_1))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args)))))
-                                                       (case-lambda
-                                                        ((ids_1 rhss_1)
+                                                             rhss_1))))
+                                                       (lambda (ids_1 rhss_1)
                                                          (for-loop_0
                                                           ids_1
                                                           rhss_1
-                                                          rest_0))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args)))))))
+                                                          rest_0))))))
                                                 (values ids_0 rhss_0)))))))
                                        (for-loop_0 null null a_0)))
-                                    (case-lambda
-                                     ((ids_0 rhss_0)
+                                    (lambda (ids_0 rhss_0)
                                       (let ((app_0 (reverse$1 ids_0)))
-                                        (values app_0 (reverse$1 rhss_0))))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args))))))
-                               (case-lambda
-                                ((ids_0 rhss_0)
+                                        (values app_0 (reverse$1 rhss_0)))))))
+                               (lambda (ids_0 rhss_0)
                                  (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                    (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                     (values ids_1 rhss_1 body_0))))
-                                (args
-                                 (raise-binding-result-arity-error
-                                  2
-                                  args)))))))
-                        (case-lambda
-                         ((ids_0 rhss_0 body_0)
-                          (xify-let_0 'letrec ids_0 rhss_0 body_0 env_0))
-                         (args (raise-binding-result-arity-error 3 args))))
+                                     (values ids_1 rhss_1 body_0))))))))
+                        (lambda (ids_0 rhss_0 body_0)
+                          (xify-let_0 'letrec ids_0 rhss_0 body_0 env_0)))
                        (if (if (eq? 'letrec* hd_0)
                              (let ((a_0 (cdr (unwrap e_1))))
                                (let ((p_0 (unwrap a_0)))
@@ -41867,62 +39829,38 @@
                                                                          (values
                                                                           ids_2
                                                                           rhss_1))))))
-                                                               (case-lambda
-                                                                ((ids5_0
-                                                                  rhss6_0)
+                                                               (lambda (ids5_0
+                                                                        rhss6_0)
                                                                  (values
                                                                   (cons
                                                                    ids5_0
                                                                    ids_0)
                                                                   (cons
                                                                    rhss6_0
-                                                                   rhss_0)))
-                                                                (args
-                                                                 (raise-binding-result-arity-error
-                                                                  2
-                                                                  args)))))
-                                                            (case-lambda
-                                                             ((ids_1 rhss_1)
+                                                                   rhss_0)))))
+                                                            (lambda (ids_1
+                                                                     rhss_1)
                                                               (values
                                                                ids_1
-                                                               rhss_1))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args)))))
-                                                         (case-lambda
-                                                          ((ids_1 rhss_1)
+                                                               rhss_1))))
+                                                         (lambda (ids_1 rhss_1)
                                                            (for-loop_0
                                                             ids_1
                                                             rhss_1
-                                                            rest_0))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))))
+                                                            rest_0))))))
                                                   (values ids_0 rhss_0)))))))
                                          (for-loop_0 null null a_0)))
-                                      (case-lambda
-                                       ((ids_0 rhss_0)
+                                      (lambda (ids_0 rhss_0)
                                         (let ((app_0 (reverse$1 ids_0)))
-                                          (values app_0 (reverse$1 rhss_0))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         2
-                                         args))))))
-                                 (case-lambda
-                                  ((ids_0 rhss_0)
+                                          (values
+                                           app_0
+                                           (reverse$1 rhss_0)))))))
+                                 (lambda (ids_0 rhss_0)
                                    (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                      (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                       (values ids_1 rhss_1 body_0))))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    2
-                                    args)))))))
-                          (case-lambda
-                           ((ids_0 rhss_0 body_0)
-                            (xify-let_0 'letrec* ids_0 rhss_0 body_0 env_0))
-                           (args (raise-binding-result-arity-error 3 args))))
+                                       (values ids_1 rhss_1 body_0))))))))
+                          (lambda (ids_0 rhss_0 body_0)
+                            (xify-let_0 'letrec* ids_0 rhss_0 body_0 env_0)))
                          (if (if (eq? 'quote hd_0)
                                (let ((a_0 (cdr (unwrap e_1))))
                                  (let ((p_0 (unwrap a_0)))
@@ -41984,25 +39922,17 @@
                                                             a_0))))
                                                    (let ((thn_1 thn_0))
                                                      (values thn_1 els_0)))))))
-                                         (case-lambda
-                                          ((thn_0 els_0)
+                                         (lambda (thn_0 els_0)
                                            (let ((tst_1 tst_0))
-                                             (values tst_1 thn_0 els_0)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))))))
-                                (case-lambda
-                                 ((tst_0 thn_0 els_0)
+                                             (values tst_1 thn_0 els_0))))))))
+                                (lambda (tst_0 thn_0 els_0)
                                   (let ((app_0 (xify_0 tst_0 env_0)))
                                     (let ((app_1 (xify_0 thn_0 env_0)))
                                       (list
                                        'if
                                        app_0
                                        app_1
-                                       (xify_0 els_0 env_0)))))
-                                 (args
-                                  (raise-binding-result-arity-error 3 args))))
+                                       (xify_0 els_0 env_0))))))
                                (if (if (eq? 'with-continuation-mark* hd_0)
                                      (let ((a_0 (cdr (unwrap e_1))))
                                        (let ((p_0 (unwrap a_0)))
@@ -42069,31 +39999,20 @@
                                                                 (values
                                                                  val_1
                                                                  body_0)))))))
-                                                    (case-lambda
-                                                     ((val_0 body_0)
+                                                    (lambda (val_0 body_0)
                                                       (let ((key_1 key_0))
                                                         (values
                                                          key_1
                                                          val_0
-                                                         body_0)))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args))))))))
-                                           (case-lambda
-                                            ((key_0 val_0 body_0)
+                                                         body_0))))))))
+                                           (lambda (key_0 val_0 body_0)
                                              (let ((mode_1 mode_0))
                                                (values
                                                 mode_1
                                                 key_0
                                                 val_0
-                                                body_0)))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              3
-                                              args))))))))
-                                  (case-lambda
-                                   ((mode_0 key_0 val_0 body_0)
+                                                body_0))))))))
+                                  (lambda (mode_0 key_0 val_0 body_0)
                                     (let ((app_0 (xify_0 key_0 env_0)))
                                       (let ((app_1 (xify_0 val_0 env_0)))
                                         (list
@@ -42101,11 +40020,7 @@
                                          mode_0
                                          app_0
                                          app_1
-                                         (xify_0 body_0 env_0)))))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     4
-                                     args))))
+                                         (xify_0 body_0 env_0))))))
                                  (if (if (eq? 'set! hd_0)
                                        (let ((a_0 (cdr (unwrap e_1))))
                                          (let ((p_0 (unwrap a_0)))
@@ -42137,17 +40052,12 @@
                                                        a_0))))
                                               (let ((id_1 id_0))
                                                 (values id_1 rhs_0)))))))
-                                    (case-lambda
-                                     ((id_0 rhs_0)
+                                    (lambda (id_0 rhs_0)
                                       (let ((app_0 (xify_0 id_0 env_0)))
                                         (list
                                          'set!
                                          app_0
-                                         (xify_0 rhs_0 env_0))))
-                                     (args
-                                      (raise-binding-result-arity-error
-                                       2
-                                       args))))
+                                         (xify_0 rhs_0 env_0)))))
                                    (if (let ((p_0 (unwrap e_1)))
                                          (if (pair? p_0) #t #f))
                                      (xify-body_0 e_1 env_0)
@@ -42194,8 +40104,7 @@
           (begin
             (call-with-values
              (lambda () (xify-ids_0 ids_0 env_0))
-             (case-lambda
-              ((new-ids_0 new-env_0)
+             (lambda (new-ids_0 new-env_0)
                (let ((app_0
                       (reverse$1
                        (begin
@@ -42230,8 +40139,7 @@
                                               rest_1))))))
                                    fold-var_0))))))
                           (for-loop_0 null new-ids_0 rhss_0))))))
-                 (list* form_0 app_0 (xify-body_0 body_0 new-env_0))))
-              (args (raise-binding-result-arity-error 2 args))))))))
+                 (list* form_0 app_0 (xify-body_0 body_0 new-env_0)))))))))
       (xify-ids_0
        (|#%name|
         xify-ids
@@ -42251,17 +40159,14 @@
                    (lambda ()
                      (let ((app_0 (cdr ids_0)))
                        (xify-ids_0 app_0 (hash-set env_0 u-id_0 x_0))))
-                   (case-lambda
-                    ((rest-xs_0 rest-env_0)
-                     (values (cons x_0 rest-xs_0) rest-env_0))
-                    (args (raise-binding-result-arity-error 2 args))))))
+                   (lambda (rest-xs_0 rest-env_0)
+                     (values (cons x_0 rest-xs_0) rest-env_0)))))
               (if (null? ids_0)
                 (values '() env_0)
                 (call-with-values
                  (lambda () (xify-ids_0 (list ids_0) env_0))
-                 (case-lambda
-                  ((xs_0 new-env_0) (values (car xs_0) new-env_0))
-                  (args (raise-binding-result-arity-error 2 args)))))))))))
+                 (lambda (xs_0 new-env_0)
+                   (values (car xs_0) new-env_0))))))))))
      (xify_0 e_0 hash2610))))
 (define kernel (primitive-table '|#%kernel|))
 (define 1/syntax? (hash-ref kernel 'syntax?))
@@ -42823,8 +40728,7 @@
                                                 (values
                                                  v_0
                                                  (unsafe-vector-length v_0))))
-                                            (case-lambda
-                                             ((vec_0 len_0)
+                                            (lambda (vec_0 len_0)
                                               (letrec*
                                                ((for-loop_0
                                                  (|#%name|
@@ -42845,11 +40749,7 @@
                                                               1
                                                               pos_0))))
                                                         (values)))))))
-                                               (for-loop_0 0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               2
-                                               args))))
+                                               (for-loop_0 0))))
                                            (void))
                                          (if (hash? v_0)
                                            (hash-for-each
@@ -42874,11 +40774,10 @@
                                                        1
                                                        #f
                                                        1))
-                                                    (case-lambda
-                                                     ((v*_0
-                                                       start*_0
-                                                       stop*_0
-                                                       step*_0)
+                                                    (lambda (v*_0
+                                                             start*_0
+                                                             stop*_0
+                                                             step*_0)
                                                       (letrec*
                                                        ((for-loop_0
                                                          (|#%name|
@@ -42900,11 +40799,7 @@
                                                                       idx_0
                                                                       1))))
                                                                 (values)))))))
-                                                       (for-loop_0 start*_0)))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       4
-                                                       args))))
+                                                       (for-loop_0 start*_0))))
                                                    (void))
                                                  (if (srcloc? v_0)
                                                    (loop_0 (srcloc-source v_0))
@@ -43351,9 +41246,8 @@
                                                                                               (loop_1
                                                                                                v_0
                                                                                                0)))
-                                                                                           (case-lambda
-                                                                                            ((n_0
-                                                                                              normal-list?_0)
+                                                                                           (lambda (n_0
+                                                                                                    normal-list?_0)
                                                                                              (begin
                                                                                                (let ((byte_0
                                                                                                       (if normal-list?_0
@@ -43386,11 +41280,7 @@
                                                                                                            (loop_0
                                                                                                             v_1))))))))
                                                                                                 (ploop_0
-                                                                                                 v_0))))
-                                                                                            (args
-                                                                                             (raise-binding-result-arity-error
-                                                                                              2
-                                                                                              args))))
+                                                                                                 v_0)))))
                                                                                           (begin
                                                                                             (begin-unsafe
                                                                                              (write-byte
@@ -43425,9 +41315,8 @@
                                                                                                   v_0
                                                                                                   (unsafe-vector-length
                                                                                                    v_0))))
-                                                                                             (case-lambda
-                                                                                              ((vec_0
-                                                                                                len_0)
+                                                                                             (lambda (vec_0
+                                                                                                      len_0)
                                                                                                (letrec*
                                                                                                 ((for-loop_0
                                                                                                   (|#%name|
@@ -43450,11 +41339,7 @@
                                                                                                                pos_0))))
                                                                                                          (values)))))))
                                                                                                 (for-loop_0
-                                                                                                 0)))
-                                                                                              (args
-                                                                                               (raise-binding-result-arity-error
-                                                                                                2
-                                                                                                args))))
+                                                                                                 0))))
                                                                                             (void))
                                                                                           (if (flvector?
                                                                                                v_0)
@@ -43474,9 +41359,8 @@
                                                                                                     v_0
                                                                                                     (unsafe-flvector-length
                                                                                                      v_0))))
-                                                                                               (case-lambda
-                                                                                                ((vec_0
-                                                                                                  len_0)
+                                                                                               (lambda (vec_0
+                                                                                                        len_0)
                                                                                                  (letrec*
                                                                                                   ((for-loop_0
                                                                                                     (|#%name|
@@ -43500,11 +41384,7 @@
                                                                                                                  pos_0))))
                                                                                                            (values)))))))
                                                                                                   (for-loop_0
-                                                                                                   0)))
-                                                                                                (args
-                                                                                                 (raise-binding-result-arity-error
-                                                                                                  2
-                                                                                                  args))))
+                                                                                                   0))))
                                                                                               (void))
                                                                                             (if (fxvector?
                                                                                                  v_0)
@@ -43524,9 +41404,8 @@
                                                                                                       v_0
                                                                                                       (unsafe-fxvector-length
                                                                                                        v_0))))
-                                                                                                 (case-lambda
-                                                                                                  ((vec_0
-                                                                                                    len_0)
+                                                                                                 (lambda (vec_0
+                                                                                                          len_0)
                                                                                                    (letrec*
                                                                                                     ((for-loop_0
                                                                                                       (|#%name|
@@ -43550,11 +41429,7 @@
                                                                                                                    pos_0))))
                                                                                                              (values)))))))
                                                                                                     (for-loop_0
-                                                                                                     0)))
-                                                                                                  (args
-                                                                                                   (raise-binding-result-arity-error
-                                                                                                    2
-                                                                                                    args))))
+                                                                                                     0))))
                                                                                                 (void))
                                                                                               (if (box?
                                                                                                    v_0)
@@ -43600,11 +41475,10 @@
                                                                                                                 1
                                                                                                                 #f
                                                                                                                 1))
-                                                                                                             (case-lambda
-                                                                                                              ((v*_0
-                                                                                                                start*_0
-                                                                                                                stop*_0
-                                                                                                                step*_0)
+                                                                                                             (lambda (v*_0
+                                                                                                                      start*_0
+                                                                                                                      stop*_0
+                                                                                                                      step*_0)
                                                                                                                (letrec*
                                                                                                                 ((for-loop_0
                                                                                                                   (|#%name|
@@ -43627,11 +41501,7 @@
                                                                                                                                1))))
                                                                                                                          (values)))))))
                                                                                                                 (for-loop_0
-                                                                                                                 start*_0)))
-                                                                                                              (args
-                                                                                                               (raise-binding-result-arity-error
-                                                                                                                4
-                                                                                                                args))))
+                                                                                                                 start*_0))))
                                                                                                             (void)))))
                                                                                                     (if (hash?
                                                                                                          v_0)
@@ -43882,8 +41752,7 @@
                           (values
                            external-lifts_0
                            (unsafe-vector-length external-lifts_0))))
-                      (case-lambda
-                       ((vec_0 len_0)
+                      (lambda (vec_0 len_0)
                         (let ((start_0 0))
                           (let ((vec_1 vec_0) (len_1 len_0))
                             (begin
@@ -43909,8 +41778,7 @@
                                              (unsafe-fx+ 1 pos_0)
                                              (+ pos_1 1))))
                                         (values)))))))
-                               (for-loop_0 0 start_0))))))
-                       (args (raise-binding-result-arity-error 2 args))))
+                               (for-loop_0 0 start_0)))))))
                      (let ((len_0 (read-fasl-integer* init-i_0)))
                        (let ((i_0
                               (if (mpair? init-i_0)
@@ -45897,10 +43765,11 @@
           (begin
             (call-with-values
              (lambda () (compile-linklet-body_0 linklet-e_1 hash2610 0))
-             (case-lambda
-              ((compiled-body_0 num-body-vars_0 internal-var-syms_0)
-               (vector internal-var-syms_0 num-body-vars_0 compiled-body_0))
-              (args (raise-binding-result-arity-error 3 args))))))))
+             (lambda (compiled-body_0 num-body-vars_0 internal-var-syms_0)
+               (vector
+                internal-var-syms_0
+                num-body-vars_0
+                compiled-body_0)))))))
       (compile-linklet-body_0
        (|#%name|
         compile-linklet-body
@@ -45921,8 +43790,7 @@
                          (let ((vars+body_0 (let ((d_1 (cdr p_0))) d_1)))
                            (let ((args_1 args_0))
                              (values args_1 vars+body_0)))))))
-                 (case-lambda
-                  ((args_0 vars+body_0)
+                 (lambda (args_0 vars+body_0)
                    (call-with-values
                     (lambda ()
                       (letrec*
@@ -45991,8 +43859,7 @@
                                        (reverse$1 rev-create-vars_0)
                                        body_0))))))))))
                        (loop_0 '() vars+body_0)))
-                    (case-lambda
-                     ((create-vars_0 body_0)
+                    (lambda (create-vars_0 body_0)
                       (let ((mutated_0
                              (extract-list-mutated_0 body_0 hash2610)))
                         (let ((num-args_0 (length args_0)))
@@ -46373,27 +44240,17 @@
                                                                                                       app_0
                                                                                                       (add1
                                                                                                        num-body-vars_2))))
-                                                                                                 (case-lambda
-                                                                                                  ((env_4
-                                                                                                    num-body-vars_3)
+                                                                                                 (lambda (env_4
+                                                                                                          num-body-vars_3)
                                                                                                    (values
                                                                                                     env_4
-                                                                                                    num-body-vars_3))
-                                                                                                  (args
-                                                                                                   (raise-binding-result-arity-error
-                                                                                                    2
-                                                                                                    args)))))
-                                                                                              (case-lambda
-                                                                                               ((env_4
-                                                                                                 num-body-vars_3)
+                                                                                                    num-body-vars_3))))
+                                                                                              (lambda (env_4
+                                                                                                       num-body-vars_3)
                                                                                                 (for-loop_1
                                                                                                  env_4
                                                                                                  num-body-vars_3
-                                                                                                 rest_1))
-                                                                                               (args
-                                                                                                (raise-binding-result-arity-error
-                                                                                                 2
-                                                                                                 args)))))))
+                                                                                                 rest_1))))))
                                                                                        (values
                                                                                         env_3
                                                                                         num-body-vars_2)))))))
@@ -46451,27 +44308,17 @@
                                                                                                       e_4
                                                                                                       env_3
                                                                                                       num-body-vars_2))
-                                                                                                   (case-lambda
-                                                                                                    ((env_4
-                                                                                                      num-body-vars_3)
+                                                                                                   (lambda (env_4
+                                                                                                            num-body-vars_3)
                                                                                                      (values
                                                                                                       env_4
-                                                                                                      num-body-vars_3))
-                                                                                                    (args
-                                                                                                     (raise-binding-result-arity-error
-                                                                                                      2
-                                                                                                      args)))))
-                                                                                                (case-lambda
-                                                                                                 ((env_4
-                                                                                                   num-body-vars_3)
+                                                                                                      num-body-vars_3))))
+                                                                                                (lambda (env_4
+                                                                                                         num-body-vars_3)
                                                                                                   (for-loop_1
                                                                                                    env_4
                                                                                                    num-body-vars_3
-                                                                                                   rest_1))
-                                                                                                 (args
-                                                                                                  (raise-binding-result-arity-error
-                                                                                                   2
-                                                                                                   args)))))))
+                                                                                                   rest_1))))))
                                                                                          (values
                                                                                           env_3
                                                                                           num-body-vars_2)))))))
@@ -46486,26 +44333,17 @@
                                                              e_1
                                                              env_1
                                                              num-body-vars_0)))
-                                                         (case-lambda
-                                                          ((env_2
-                                                            num-body-vars_1)
+                                                         (lambda (env_2
+                                                                  num-body-vars_1)
                                                            (values
                                                             env_2
-                                                            num-body-vars_1))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))
-                                                      (case-lambda
-                                                       ((env_2 num-body-vars_1)
+                                                            num-body-vars_1))))
+                                                      (lambda (env_2
+                                                               num-body-vars_1)
                                                         (for-loop_0
                                                          env_2
                                                          num-body-vars_1
-                                                         rest_0))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args)))))))
+                                                         rest_0))))))
                                                (values
                                                 env_1
                                                 num-body-vars_0)))))))
@@ -46513,8 +44351,7 @@
                                        args+creates-env_0
                                        0
                                        body_0)))
-                                   (case-lambda
-                                    ((body-env_0 num-body-vars_0)
+                                   (lambda (body-env_0 num-body-vars_0)
                                      (let ((body-stack-depth_0
                                             (+
                                              num-body-vars_0
@@ -46729,13 +44566,7 @@
                                              (values
                                               new-body_0
                                               num-body-vars_0
-                                              internal-var-syms_0))))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args)))))))))))
-                     (args (raise-binding-result-arity-error 2 args)))))
-                  (args (raise-binding-result-arity-error 2 args))))
+                                              internal-var-syms_0)))))))))))))))))
                 (error 'match "failed ~e" v_0)))))))
       (compile-top-body_0
        (|#%name|
@@ -46783,11 +44614,8 @@
                                              (let ((d_0 (cdr p_0))) d_0)))
                                         (let ((subs_1 subs_0))
                                           (values subs_1 rest_0))))))
-                                (case-lambda
-                                 ((subs_0 rest_0)
-                                  (loop_0 (append subs_0 rest_0)))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args))))
+                                (lambda (subs_0 rest_0)
+                                  (loop_0 (append subs_0 rest_0))))
                                (if (let ((p_0 (unwrap body_1)))
                                      (if (pair? p_0) #t #f))
                                  (call-with-values
@@ -46798,8 +44626,7 @@
                                                (let ((d_0 (cdr p_0))) d_0)))
                                           (let ((e_1 e_0))
                                             (values e_1 rest_0))))))
-                                  (case-lambda
-                                   ((e_0 rest_0)
+                                  (lambda (e_0 rest_0)
                                     (let ((new-rest_0 (loop_0 rest_0)))
                                       (cons
                                        (compile-expr_0
@@ -46809,11 +44636,7 @@
                                         stk-i_0
                                         #t
                                         mutated_0)
-                                       new-rest_0)))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args))))
+                                       new-rest_0))))
                                  (error 'match "failed ~e" body_1)))))))))
                     (loop_0 body_0))))
               (if (null? bs_0)
@@ -46894,13 +44717,11 @@
                        (let ((ids_0 (let ((a_0 (car p_0))) a_0)))
                          (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                            (let ((ids_1 ids_0)) (values ids_1 body_0)))))))
-                 (case-lambda
-                  ((ids_0 body_0)
+                 (lambda (ids_0 body_0)
                    (call-with-values
                     (lambda ()
                       (args->env_0 ids_0 env_0 stack-depth_0 mutated_0))
-                    (case-lambda
-                     ((body-env_0 count_0 rest?_0)
+                    (lambda (body-env_0 count_0 rest?_0)
                       (let ((cmap_0 (make-hasheq)))
                         (let ((body-stack-depth_0 (+ stack-depth_0 count_0)))
                           (let ((body-stk-i_0
@@ -46929,8 +44750,7 @@
                                                         (hash-iterate-key+value
                                                          cmap_0
                                                          i_0))
-                                                      (case-lambda
-                                                       ((i_1 pos_0)
+                                                      (lambda (i_1 pos_0)
                                                         (let ((table_3
                                                                (let ((table_3
                                                                       (call-with-values
@@ -46940,28 +44760,19 @@
                                                                            -1
                                                                            pos_0)
                                                                           i_1))
-                                                                       (case-lambda
-                                                                        ((key_0
-                                                                          val_0)
+                                                                       (lambda (key_0
+                                                                                val_0)
                                                                          (hash-set
                                                                           table_2
                                                                           key_0
-                                                                          val_0))
-                                                                        (args
-                                                                         (raise-binding-result-arity-error
-                                                                          2
-                                                                          args))))))
+                                                                          val_0)))))
                                                                  (values
                                                                   table_3))))
                                                           (for-loop_0
                                                            table_3
                                                            (hash-iterate-next
                                                             cmap_0
-                                                            i_0))))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))
+                                                            i_0)))))
                                                      table_2))))))
                                             (for-loop_0
                                              table_1
@@ -47049,9 +44860,7 @@
                                           ids_0
                                           mutated_0
                                           body-env_0
-                                          body-stk-i_0))))))))))))
-                     (args (raise-binding-result-arity-error 3 args)))))
-                  (args (raise-binding-result-arity-error 2 args))))
+                                          body-stk-i_0)))))))))))))))
                 (if (if (eq? 'case-lambda hd_0)
                       (let ((a_0 (cdr (unwrap e_0))))
                         (if (wrap-list? a_0)
@@ -47137,41 +44946,25 @@
                                                            (values
                                                             idss_2
                                                             bodys_1))))))
-                                                 (case-lambda
-                                                  ((idss13_0 bodys14_0)
+                                                 (lambda (idss13_0 bodys14_0)
                                                    (values
                                                     (cons idss13_0 idss_0)
-                                                    (cons bodys14_0 bodys_0)))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args)))))
-                                              (case-lambda
-                                               ((idss_1 bodys_1)
-                                                (values idss_1 bodys_1))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args)))))
-                                           (case-lambda
-                                            ((idss_1 bodys_1)
+                                                    (cons
+                                                     bodys14_0
+                                                     bodys_0)))))
+                                              (lambda (idss_1 bodys_1)
+                                                (values idss_1 bodys_1))))
+                                           (lambda (idss_1 bodys_1)
                                              (for-loop_0
                                               idss_1
                                               bodys_1
-                                              rest_0))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args)))))))
+                                              rest_0))))))
                                     (values idss_0 bodys_0)))))))
                            (for-loop_0 null null d_0)))
-                        (case-lambda
-                         ((idss_0 bodys_0)
+                        (lambda (idss_0 bodys_0)
                           (let ((app_0 (reverse$1 idss_0)))
-                            (values app_0 (reverse$1 bodys_0))))
-                         (args (raise-binding-result-arity-error 2 args))))))
-                   (case-lambda
-                    ((idss_0 bodys_0)
+                            (values app_0 (reverse$1 bodys_0)))))))
+                   (lambda (idss_0 bodys_0)
                      (let ((lams_0
                             (reverse$1
                              (begin
@@ -47248,8 +45041,7 @@
                            'case-lambda
                            mask_0
                            (extract-procedure-wrap-data_0 e_0 realm_0)
-                           lams_0)))))
-                    (args (raise-binding-result-arity-error 2 args))))
+                           lams_0))))))
                   (if (if (eq? 'let hd_0)
                         (let ((a_0 (cdr (unwrap e_0))))
                           (let ((p_0 (unwrap a_0)))
@@ -47386,55 +45178,34 @@
                                                                     (values
                                                                      ids_2
                                                                      rhss_1))))))
-                                                          (case-lambda
-                                                           ((ids15_0 rhss16_0)
+                                                          (lambda (ids15_0
+                                                                   rhss16_0)
                                                             (values
                                                              (cons
                                                               ids15_0
                                                               ids_0)
                                                              (cons
                                                               rhss16_0
-                                                              rhss_0)))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args)))))
-                                                       (case-lambda
-                                                        ((ids_1 rhss_1)
-                                                         (values ids_1 rhss_1))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args)))))
-                                                    (case-lambda
-                                                     ((ids_1 rhss_1)
+                                                              rhss_0)))))
+                                                       (lambda (ids_1 rhss_1)
+                                                         (values
+                                                          ids_1
+                                                          rhss_1))))
+                                                    (lambda (ids_1 rhss_1)
                                                       (for-loop_0
                                                        ids_1
                                                        rhss_1
-                                                       rest_0))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args)))))))
+                                                       rest_0))))))
                                              (values ids_0 rhss_0)))))))
                                     (for-loop_0 null null a_0)))
-                                 (case-lambda
-                                  ((ids_0 rhss_0)
+                                 (lambda (ids_0 rhss_0)
                                    (let ((app_0 (reverse$1 ids_0)))
-                                     (values app_0 (reverse$1 rhss_0))))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    2
-                                    args))))))
-                            (case-lambda
-                             ((ids_0 rhss_0)
+                                     (values app_0 (reverse$1 rhss_0)))))))
+                            (lambda (ids_0 rhss_0)
                               (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                 (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                  (values ids_1 rhss_1 body_0))))
-                             (args
-                              (raise-binding-result-arity-error 2 args)))))))
-                     (case-lambda
-                      ((ids_0 rhss_0 body_0)
+                                  (values ids_1 rhss_1 body_0))))))))
+                     (lambda (ids_0 rhss_0 body_0)
                        (let ((len_0 (length ids_0)))
                          (let ((body-env_0
                                 (begin
@@ -47659,8 +45430,7 @@
                                             'let
                                             pos_0
                                             (list->vector new-rhss_0)
-                                            new-body_0))))))))))))
-                      (args (raise-binding-result-arity-error 3 args))))
+                                            new-body_0)))))))))))))
                     (if (if (eq? 'letrec hd_0) #t #f)
                       (compile-letrec_0
                        e_0
@@ -47729,8 +45499,7 @@
                                                 (let ((d_1 (cdr p_0))) d_1)))
                                            (let ((e_2 e_1))
                                              (values e_2 vs_0)))))))
-                                 (case-lambda
-                                  ((e_1 vs_0)
+                                 (lambda (e_1 vs_0)
                                    (let ((new-body_0
                                           (compile-body_0
                                            vs_0
@@ -47748,9 +45517,7 @@
                                        stk-i_0
                                        #f
                                        mutated_0)
-                                      new-body_0)))
-                                  (args
-                                   (raise-binding-result-arity-error 2 args))))
+                                      new-body_0))))
                                 (if (if (eq? '$value hd_0)
                                       (let ((a_0 (cdr (unwrap e_0))))
                                         (let ((p_0 (unwrap a_0)))
@@ -47824,16 +45591,13 @@
                                                           (values
                                                            thn_1
                                                            els_0)))))))
-                                              (case-lambda
-                                               ((thn_0 els_0)
+                                              (lambda (thn_0 els_0)
                                                 (let ((tst_1 tst_0))
-                                                  (values tst_1 thn_0 els_0)))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args))))))))
-                                     (case-lambda
-                                      ((tst_0 thn_0 els_0)
+                                                  (values
+                                                   tst_1
+                                                   thn_0
+                                                   els_0))))))))
+                                     (lambda (tst_0 thn_0 els_0)
                                        (let ((then-stk-i_0
                                               (stack-info-branch stk-i_0)))
                                          (let ((else-stk-i_0
@@ -47880,11 +45644,7 @@
                                                       (add-clears_0
                                                        new-else_0
                                                        else-stk-i_0
-                                                       all-clear_0))))))))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        3
-                                        args))))
+                                                       all-clear_0)))))))))))
                                     (if (if (eq? 'with-continuation-mark* hd_0)
                                           (let ((a_0 (cdr (unwrap e_0))))
                                             (let ((p_0 (unwrap a_0)))
@@ -47959,31 +45719,20 @@
                                                                      (values
                                                                       val_1
                                                                       body_0)))))))
-                                                         (case-lambda
-                                                          ((val_0 body_0)
+                                                         (lambda (val_0 body_0)
                                                            (let ((key_1 key_0))
                                                              (values
                                                               key_1
                                                               val_0
-                                                              body_0)))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args))))))))
-                                                (case-lambda
-                                                 ((key_0 val_0 body_0)
+                                                              body_0))))))))
+                                                (lambda (key_0 val_0 body_0)
                                                   (let ((mode_1 mode_0))
                                                     (values
                                                      mode_1
                                                      key_0
                                                      val_0
-                                                     body_0)))
-                                                 (args
-                                                  (raise-binding-result-arity-error
-                                                   3
-                                                   args))))))))
-                                       (case-lambda
-                                        ((mode_0 key_0 val_0 body_0)
+                                                     body_0))))))))
+                                       (lambda (mode_0 key_0 val_0 body_0)
                                          (let ((new-body_0
                                                 (compile-expr_0
                                                  body_0
@@ -48010,11 +45759,7 @@
                                                #f
                                                mutated_0)
                                               new-val_0
-                                              new-body_0))))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          4
-                                          args))))
+                                              new-body_0)))))
                                       (if (if (eq? 'quote hd_0)
                                             (let ((a_0 (cdr (unwrap e_0))))
                                               (let ((p_0 (unwrap a_0)))
@@ -48097,19 +45842,14 @@
                                                        (values
                                                         id_1
                                                         rhs_0)))))))
-                                           (case-lambda
-                                            ((id_0 rhs_0)
+                                           (lambda (id_0 rhs_0)
                                              (compile-assignment_0
                                               id_0
                                               rhs_0
                                               env_0
                                               stack-depth_0
                                               stk-i_0
-                                              mutated_0))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
+                                              mutated_0)))
                                           (if (if (eq? 'define hd_0)
                                                 (let ((a_0 (cdr (unwrap e_0))))
                                                   (let ((p_0 (unwrap a_0)))
@@ -48151,19 +45891,14 @@
                                                          (values
                                                           id_1
                                                           rhs_0)))))))
-                                             (case-lambda
-                                              ((id_0 rhs_0)
+                                             (lambda (id_0 rhs_0)
                                                (compile-assignment_0
                                                 id_0
                                                 rhs_0
                                                 env_0
                                                 stack-depth_0
                                                 stk-i_0
-                                                mutated_0))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
+                                                mutated_0)))
                                             (if (if (eq? 'define-values hd_0)
                                                   (let ((a_0
                                                          (cdr (unwrap e_0))))
@@ -48209,8 +45944,7 @@
                                                            (values
                                                             ids_1
                                                             rhs_0)))))))
-                                               (case-lambda
-                                                ((ids_0 rhs_0)
+                                               (lambda (ids_0 rhs_0)
                                                  (let ((gen-ids_0
                                                         (reverse$1
                                                          (begin
@@ -48309,11 +46043,7 @@
                                                     stack-depth_0
                                                     stk-i_0
                                                     tail?_0
-                                                    mutated_0)))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args))))
+                                                    mutated_0))))
                                               (if (if (eq?
                                                        'call-with-values
                                                        hd_0)
@@ -48413,20 +46143,15 @@
                                                                           (values
                                                                            ids_1
                                                                            body_0)))))))))
-                                                          (case-lambda
-                                                           ((ids_0 body_0)
+                                                          (lambda (ids_0
+                                                                   body_0)
                                                             (let ((proc1_1
                                                                    proc1_0))
                                                               (values
                                                                proc1_1
                                                                ids_0
-                                                               body_0)))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args))))))))
-                                                 (case-lambda
-                                                  ((proc1_0 ids_0 body_0)
+                                                               body_0))))))))
+                                                 (lambda (proc1_0 ids_0 body_0)
                                                    (compile-expr_0
                                                     (list
                                                      'call-with-values
@@ -48438,11 +46163,7 @@
                                                     stack-depth_0
                                                     stk-i_0
                                                     tail?_0
-                                                    mutated_0))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    3
-                                                    args))))
+                                                    mutated_0)))
                                                 (if (if (eq?
                                                          'call-with-values
                                                          hd_0)
@@ -48693,41 +46414,26 @@
                                                                                                         (values
                                                                                                          idss_2
                                                                                                          bodys_1))))))
-                                                                                              (case-lambda
-                                                                                               ((idss20_0
-                                                                                                 bodys21_0)
+                                                                                              (lambda (idss20_0
+                                                                                                       bodys21_0)
                                                                                                 (values
                                                                                                  (cons
                                                                                                   idss20_0
                                                                                                   idss_0)
                                                                                                  (cons
                                                                                                   bodys21_0
-                                                                                                  bodys_0)))
-                                                                                               (args
-                                                                                                (raise-binding-result-arity-error
-                                                                                                 2
-                                                                                                 args)))))
-                                                                                           (case-lambda
-                                                                                            ((idss_1
-                                                                                              bodys_1)
+                                                                                                  bodys_0)))))
+                                                                                           (lambda (idss_1
+                                                                                                    bodys_1)
                                                                                              (values
                                                                                               idss_1
-                                                                                              bodys_1))
-                                                                                            (args
-                                                                                             (raise-binding-result-arity-error
-                                                                                              2
-                                                                                              args)))))
-                                                                                        (case-lambda
-                                                                                         ((idss_1
-                                                                                           bodys_1)
+                                                                                              bodys_1))))
+                                                                                        (lambda (idss_1
+                                                                                                 bodys_1)
                                                                                           (for-loop_0
                                                                                            idss_1
                                                                                            bodys_1
-                                                                                           rest_0))
-                                                                                         (args
-                                                                                          (raise-binding-result-arity-error
-                                                                                           2
-                                                                                           args)))))))
+                                                                                           rest_0))))))
                                                                                  (values
                                                                                   idss_0
                                                                                   bodys_0)))))))
@@ -48735,34 +46441,26 @@
                                                                          null
                                                                          null
                                                                          d_2)))
-                                                                     (case-lambda
-                                                                      ((idss_0
-                                                                        bodys_0)
+                                                                     (lambda (idss_0
+                                                                              bodys_0)
                                                                        (let ((app_0
                                                                               (reverse$1
                                                                                idss_0)))
                                                                          (values
                                                                           app_0
                                                                           (reverse$1
-                                                                           bodys_0))))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        2
-                                                                        args))))))))
-                                                            (case-lambda
-                                                             ((idss_0 bodys_0)
+                                                                           bodys_0)))))))))
+                                                            (lambda (idss_0
+                                                                     bodys_0)
                                                               (let ((body_1
                                                                      body_0))
                                                                 (values
                                                                  body_1
                                                                  idss_0
-                                                                 bodys_0)))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args))))))))
-                                                   (case-lambda
-                                                    ((body_0 idss_0 bodys_0)
+                                                                 bodys_0))))))))
+                                                   (lambda (body_0
+                                                            idss_0
+                                                            bodys_0)
                                                      (let ((body-stk-is_0
                                                             (reverse$1
                                                              (begin
@@ -48844,10 +46542,9 @@
                                                                                                           env_0
                                                                                                           stack-depth_0
                                                                                                           mutated_0))
-                                                                                                       (case-lambda
-                                                                                                        ((new-env_0
-                                                                                                          count_0
-                                                                                                          rest?_0)
+                                                                                                       (lambda (new-env_0
+                                                                                                                count_0
+                                                                                                                rest?_0)
                                                                                                          (let ((new-stack-depth_0
                                                                                                                 (+
                                                                                                                  stack-depth_0
@@ -48882,11 +46579,7 @@
                                                                                                                     (count->mask
                                                                                                                      count_0
                                                                                                                      rest?_0)
-                                                                                                                    new-body_0)))))))
-                                                                                                        (args
-                                                                                                         (raise-binding-result-arity-error
-                                                                                                          3
-                                                                                                          args))))
+                                                                                                                    new-body_0))))))))
                                                                                                       fold-var_0)))
                                                                                                 (values
                                                                                                  fold-var_1))))
@@ -49035,11 +46728,7 @@
                                                                       (for-loop_0
                                                                        null
                                                                        initial-new-clauses_0
-                                                                       body-stk-is_0))))))))))))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      3
-                                                      args))))
+                                                                       body-stk-is_0)))))))))))))
                                                   (if (if (eq?
                                                            'call-with-module-prompt
                                                            hd_0)
@@ -49372,39 +47061,28 @@
                                                                                      (values
                                                                                       constances_1
                                                                                       vars_0)))))))
-                                                                         (case-lambda
-                                                                          ((constances_0
-                                                                            vars_0)
+                                                                         (lambda (constances_0
+                                                                                  vars_0)
                                                                            (let ((ids_1
                                                                                   ids_0))
                                                                              (values
                                                                               ids_1
                                                                               constances_0
-                                                                              vars_0)))
-                                                                          (args
-                                                                           (raise-binding-result-arity-error
-                                                                            2
-                                                                            args))))))))
-                                                                (case-lambda
-                                                                 ((ids_0
-                                                                   constances_0
-                                                                   vars_0)
+                                                                              vars_0))))))))
+                                                                (lambda (ids_0
+                                                                         constances_0
+                                                                         vars_0)
                                                                   (let ((body_1
                                                                          body_0))
                                                                     (values
                                                                      body_1
                                                                      ids_0
                                                                      constances_0
-                                                                     vars_0)))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   3
-                                                                   args))))))))
-                                                       (case-lambda
-                                                        ((body_0
-                                                          ids_0
-                                                          constances_0
-                                                          vars_0)
+                                                                     vars_0))))))))
+                                                       (lambda (body_0
+                                                                ids_0
+                                                                constances_0
+                                                                vars_0)
                                                          (let ((app_0
                                                                 (compile-body_0
                                                                  body_0
@@ -49424,11 +47102,7 @@
                                                              stack-depth_0
                                                              stk-i_0
                                                              #f
-                                                             mutated_0))))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          4
-                                                          args))))
+                                                             mutated_0)))))
                                                       (if (if (eq?
                                                                'variable-set!
                                                                hd_0)
@@ -49490,8 +47164,8 @@
                                                                      (values
                                                                       dest-id_1
                                                                       e_1)))))))
-                                                         (case-lambda
-                                                          ((dest-id_0 e_1)
+                                                         (lambda (dest-id_0
+                                                                  e_1)
                                                            (let ((dest-var_0
                                                                   (hash-ref
                                                                    env_0
@@ -49513,11 +47187,7 @@
                                                                  stk-i_0)
                                                                 new-expr_0
                                                                 #f
-                                                                #f))))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args))))
+                                                                #f)))))
                                                         (if (if (eq?
                                                                  'variable-set!/define
                                                                  hd_0)
@@ -49652,23 +47322,17 @@
                                                                                 (values
                                                                                  e_2
                                                                                  constance_0)))))))
-                                                                    (case-lambda
-                                                                     ((e_1
-                                                                       constance_0)
+                                                                    (lambda (e_1
+                                                                             constance_0)
                                                                       (let ((dest-id_1
                                                                              dest-id_0))
                                                                         (values
                                                                          dest-id_1
                                                                          e_1
-                                                                         constance_0)))
-                                                                     (args
-                                                                      (raise-binding-result-arity-error
-                                                                       2
-                                                                       args))))))))
-                                                           (case-lambda
-                                                            ((dest-id_0
-                                                              e_1
-                                                              constance_0)
+                                                                         constance_0))))))))
+                                                           (lambda (dest-id_0
+                                                                    e_1
+                                                                    constance_0)
                                                              (let ((dest-var_0
                                                                     (hash-ref
                                                                      env_0
@@ -49690,11 +47354,7 @@
                                                                    stk-i_0)
                                                                   new-expr_0
                                                                   constance_0
-                                                                  #t))))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              3
-                                                              args))))
+                                                                  #t)))))
                                                           (if (if (eq?
                                                                    'variable-ref
                                                                    hd_0)
@@ -50086,48 +47746,29 @@
                                                               (values
                                                                ids_2
                                                                rhss_1))))))
-                                                    (case-lambda
-                                                     ((ids42_0 rhss43_0)
+                                                    (lambda (ids42_0 rhss43_0)
                                                       (values
                                                        (cons ids42_0 ids_0)
-                                                       (cons rhss43_0 rhss_0)))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args)))))
-                                                 (case-lambda
-                                                  ((ids_1 rhss_1)
-                                                   (values ids_1 rhss_1))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args)))))
-                                              (case-lambda
-                                               ((ids_1 rhss_1)
+                                                       (cons
+                                                        rhss43_0
+                                                        rhss_0)))))
+                                                 (lambda (ids_1 rhss_1)
+                                                   (values ids_1 rhss_1))))
+                                              (lambda (ids_1 rhss_1)
                                                 (for-loop_0
                                                  ids_1
                                                  rhss_1
-                                                 rest_0))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args)))))))
+                                                 rest_0))))))
                                        (values ids_0 rhss_0)))))))
                               (for-loop_0 null null a_0)))
-                           (case-lambda
-                            ((ids_0 rhss_0)
+                           (lambda (ids_0 rhss_0)
                              (let ((app_0 (reverse$1 ids_0)))
-                               (values app_0 (reverse$1 rhss_0))))
-                            (args
-                             (raise-binding-result-arity-error 2 args))))))
-                      (case-lambda
-                       ((ids_0 rhss_0)
+                               (values app_0 (reverse$1 rhss_0)))))))
+                      (lambda (ids_0 rhss_0)
                         (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                           (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                            (values ids_1 rhss_1 body_0))))
-                       (args (raise-binding-result-arity-error 2 args)))))))
-               (case-lambda
-                ((ids_0 rhss_0 body_0)
+                            (values ids_1 rhss_1 body_0))))))))
+               (lambda (ids_0 rhss_0 body_0)
                  (let ((count_0 (length ids_0)))
                    (let ((make-env_0
                           (|#%name|
@@ -50209,8 +47850,7 @@
                                       'letrec
                                       pos_0
                                       new-rhss_0
-                                      new-body_0))))))))))))
-                (args (raise-binding-result-arity-error 3 args))))
+                                      new-body_0)))))))))))))
               (error 'match "failed ~e" e_0))))))
       (compile-apply_0
        (|#%name|
@@ -50283,9 +47923,8 @@
                        (let ((ids_0 (let ((a_0 (car p_0))) a_0)))
                          (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                            (let ((ids_1 ids_0)) (values ids_1 body_0)))))))
-                 (case-lambda
-                  ((ids_0 body_0) (extract-list-mutated_0 body_0 mutated_0))
-                  (args (raise-binding-result-arity-error 2 args))))
+                 (lambda (ids_0 body_0)
+                   (extract-list-mutated_0 body_0 mutated_0)))
                 (if (if (eq? 'case-lambda hd_0)
                       (let ((a_0 (cdr (unwrap e_0))))
                         (if (wrap-list? a_0)
@@ -50371,41 +48010,25 @@
                                                            (values
                                                             idss_2
                                                             bodys_1))))))
-                                                 (case-lambda
-                                                  ((idss51_0 bodys52_0)
+                                                 (lambda (idss51_0 bodys52_0)
                                                    (values
                                                     (cons idss51_0 idss_0)
-                                                    (cons bodys52_0 bodys_0)))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args)))))
-                                              (case-lambda
-                                               ((idss_1 bodys_1)
-                                                (values idss_1 bodys_1))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 2
-                                                 args)))))
-                                           (case-lambda
-                                            ((idss_1 bodys_1)
+                                                    (cons
+                                                     bodys52_0
+                                                     bodys_0)))))
+                                              (lambda (idss_1 bodys_1)
+                                                (values idss_1 bodys_1))))
+                                           (lambda (idss_1 bodys_1)
                                              (for-loop_0
                                               idss_1
                                               bodys_1
-                                              rest_0))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args)))))))
+                                              rest_0))))))
                                     (values idss_0 bodys_0)))))))
                            (for-loop_0 null null d_0)))
-                        (case-lambda
-                         ((idss_0 bodys_0)
+                        (lambda (idss_0 bodys_0)
                           (let ((app_0 (reverse$1 idss_0)))
-                            (values app_0 (reverse$1 bodys_0))))
-                         (args (raise-binding-result-arity-error 2 args))))))
-                   (case-lambda
-                    ((idss_0 bodys_0)
+                            (values app_0 (reverse$1 bodys_0)))))))
+                   (lambda (idss_0 bodys_0)
                      (begin
                        (letrec*
                         ((for-loop_0
@@ -50424,8 +48047,7 @@
                                               (values mutated_2))))
                                        (for-loop_0 mutated_2 rest_0))))
                                  mutated_1))))))
-                        (for-loop_0 mutated_0 bodys_0))))
-                    (args (raise-binding-result-arity-error 2 args))))
+                        (for-loop_0 mutated_0 bodys_0)))))
                   (if (if (eq? 'let hd_0)
                         (let ((a_0 (cdr (unwrap e_0))))
                           (let ((p_0 (unwrap a_0)))
@@ -50562,59 +48184,37 @@
                                                                     (values
                                                                      ids_2
                                                                      rhss_1))))))
-                                                          (case-lambda
-                                                           ((ids53_0 rhss54_0)
+                                                          (lambda (ids53_0
+                                                                   rhss54_0)
                                                             (values
                                                              (cons
                                                               ids53_0
                                                               ids_0)
                                                              (cons
                                                               rhss54_0
-                                                              rhss_0)))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args)))))
-                                                       (case-lambda
-                                                        ((ids_1 rhss_1)
-                                                         (values ids_1 rhss_1))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args)))))
-                                                    (case-lambda
-                                                     ((ids_1 rhss_1)
+                                                              rhss_0)))))
+                                                       (lambda (ids_1 rhss_1)
+                                                         (values
+                                                          ids_1
+                                                          rhss_1))))
+                                                    (lambda (ids_1 rhss_1)
                                                       (for-loop_0
                                                        ids_1
                                                        rhss_1
-                                                       rest_0))
-                                                     (args
-                                                      (raise-binding-result-arity-error
-                                                       2
-                                                       args)))))))
+                                                       rest_0))))))
                                              (values ids_0 rhss_0)))))))
                                     (for-loop_0 null null a_0)))
-                                 (case-lambda
-                                  ((ids_0 rhss_0)
+                                 (lambda (ids_0 rhss_0)
                                    (let ((app_0 (reverse$1 ids_0)))
-                                     (values app_0 (reverse$1 rhss_0))))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    2
-                                    args))))))
-                            (case-lambda
-                             ((ids_0 rhss_0)
+                                     (values app_0 (reverse$1 rhss_0)))))))
+                            (lambda (ids_0 rhss_0)
                               (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                 (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                  (values ids_1 rhss_1 body_0))))
-                             (args
-                              (raise-binding-result-arity-error 2 args)))))))
-                     (case-lambda
-                      ((ids_0 rhss_0 body_0)
+                                  (values ids_1 rhss_1 body_0))))))))
+                     (lambda (ids_0 rhss_0 body_0)
                        (extract-list-mutated_0
                         body_0
-                        (extract-list-mutated_0 rhss_0 mutated_0)))
-                      (args (raise-binding-result-arity-error 3 args))))
+                        (extract-list-mutated_0 rhss_0 mutated_0))))
                     (if (if (eq? 'letrec hd_0)
                           (let ((a_0 (cdr (unwrap e_0))))
                             (let ((p_0 (unwrap a_0)))
@@ -50752,62 +48352,37 @@
                                                                       (values
                                                                        ids_2
                                                                        rhss_1))))))
-                                                            (case-lambda
-                                                             ((ids55_0
-                                                               rhss56_0)
+                                                            (lambda (ids55_0
+                                                                     rhss56_0)
                                                               (values
                                                                (cons
                                                                 ids55_0
                                                                 ids_0)
                                                                (cons
                                                                 rhss56_0
-                                                                rhss_0)))
-                                                             (args
-                                                              (raise-binding-result-arity-error
-                                                               2
-                                                               args)))))
-                                                         (case-lambda
-                                                          ((ids_1 rhss_1)
+                                                                rhss_0)))))
+                                                         (lambda (ids_1 rhss_1)
                                                            (values
                                                             ids_1
-                                                            rhss_1))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))
-                                                      (case-lambda
-                                                       ((ids_1 rhss_1)
+                                                            rhss_1))))
+                                                      (lambda (ids_1 rhss_1)
                                                         (for-loop_0
                                                          ids_1
                                                          rhss_1
-                                                         rest_0))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args)))))))
+                                                         rest_0))))))
                                                (values ids_0 rhss_0)))))))
                                       (for-loop_0 null null a_0)))
-                                   (case-lambda
-                                    ((ids_0 rhss_0)
+                                   (lambda (ids_0 rhss_0)
                                      (let ((app_0 (reverse$1 ids_0)))
-                                       (values app_0 (reverse$1 rhss_0))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args))))))
-                              (case-lambda
-                               ((ids_0 rhss_0)
+                                       (values app_0 (reverse$1 rhss_0)))))))
+                              (lambda (ids_0 rhss_0)
                                 (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                   (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                    (values ids_1 rhss_1 body_0))))
-                               (args
-                                (raise-binding-result-arity-error 2 args)))))))
-                       (case-lambda
-                        ((ids_0 rhss_0 body_0)
+                                    (values ids_1 rhss_1 body_0))))))))
+                       (lambda (ids_0 rhss_0 body_0)
                          (extract-list-mutated_0
                           body_0
-                          (extract-list-mutated_0 rhss_0 mutated_0)))
-                        (args (raise-binding-result-arity-error 3 args))))
+                          (extract-list-mutated_0 rhss_0 mutated_0))))
                       (if (if (eq? 'letrec* hd_0)
                             (let ((a_0 (cdr (unwrap e_0))))
                               (let ((p_0 (unwrap a_0)))
@@ -50948,64 +48523,38 @@
                                                                         (values
                                                                          ids_2
                                                                          rhss_1))))))
-                                                              (case-lambda
-                                                               ((ids57_0
-                                                                 rhss58_0)
+                                                              (lambda (ids57_0
+                                                                       rhss58_0)
                                                                 (values
                                                                  (cons
                                                                   ids57_0
                                                                   ids_0)
                                                                  (cons
                                                                   rhss58_0
-                                                                  rhss_0)))
-                                                               (args
-                                                                (raise-binding-result-arity-error
-                                                                 2
-                                                                 args)))))
-                                                           (case-lambda
-                                                            ((ids_1 rhss_1)
+                                                                  rhss_0)))))
+                                                           (lambda (ids_1
+                                                                    rhss_1)
                                                              (values
                                                               ids_1
-                                                              rhss_1))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
-                                                        (case-lambda
-                                                         ((ids_1 rhss_1)
+                                                              rhss_1))))
+                                                        (lambda (ids_1 rhss_1)
                                                           (for-loop_0
                                                            ids_1
                                                            rhss_1
-                                                           rest_0))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))))
+                                                           rest_0))))))
                                                  (values ids_0 rhss_0)))))))
                                         (for-loop_0 null null a_0)))
-                                     (case-lambda
-                                      ((ids_0 rhss_0)
+                                     (lambda (ids_0 rhss_0)
                                        (let ((app_0 (reverse$1 ids_0)))
-                                         (values app_0 (reverse$1 rhss_0))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args))))))
-                                (case-lambda
-                                 ((ids_0 rhss_0)
+                                         (values app_0 (reverse$1 rhss_0)))))))
+                                (lambda (ids_0 rhss_0)
                                   (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                     (let ((ids_1 ids_0) (rhss_1 rhss_0))
-                                      (values ids_1 rhss_1 body_0))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   2
-                                   args)))))))
-                         (case-lambda
-                          ((ids_0 rhss_0 body_0)
+                                      (values ids_1 rhss_1 body_0))))))))
+                         (lambda (ids_0 rhss_0 body_0)
                            (extract-list-mutated_0
                             body_0
-                            (extract-list-mutated_0 rhss_0 mutated_0)))
-                          (args (raise-binding-result-arity-error 3 args))))
+                            (extract-list-mutated_0 rhss_0 mutated_0))))
                         (if (if (eq? 'begin hd_0) #t #f)
                           (let ((vs_0 (let ((d_0 (cdr (unwrap e_0)))) d_0)))
                             (extract-list-mutated_0 vs_0 mutated_0))
@@ -51099,16 +48648,13 @@
                                                         (values
                                                          thn_1
                                                          els_0)))))))
-                                            (case-lambda
-                                             ((thn_0 els_0)
+                                            (lambda (thn_0 els_0)
                                               (let ((tst_1 tst_0))
-                                                (values tst_1 thn_0 els_0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               2
-                                               args))))))))
-                                   (case-lambda
-                                    ((tst_0 thn_0 els_0)
+                                                (values
+                                                 tst_1
+                                                 thn_0
+                                                 els_0))))))))
+                                   (lambda (tst_0 thn_0 els_0)
                                      (let ((tst-mutated_0
                                             (extract-expr-mutated_0
                                              tst_0
@@ -51119,11 +48665,7 @@
                                                tst-mutated_0)))
                                          (extract-expr-mutated_0
                                           els_0
-                                          thn-mutated_0))))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      3
-                                      args))))
+                                          thn-mutated_0)))))
                                   (if (if (eq? 'with-continuation-mark* hd_0)
                                         (let ((a_0 (cdr (unwrap e_0))))
                                           (let ((p_0 (unwrap a_0)))
@@ -51195,31 +48737,20 @@
                                                                    (values
                                                                     val_1
                                                                     body_0)))))))
-                                                       (case-lambda
-                                                        ((val_0 body_0)
+                                                       (lambda (val_0 body_0)
                                                          (let ((key_1 key_0))
                                                            (values
                                                             key_1
                                                             val_0
-                                                            body_0)))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          2
-                                                          args))))))))
-                                              (case-lambda
-                                               ((key_0 val_0 body_0)
+                                                            body_0))))))))
+                                              (lambda (key_0 val_0 body_0)
                                                 (let ((mode_1 mode_0))
                                                   (values
                                                    mode_1
                                                    key_0
                                                    val_0
-                                                   body_0)))
-                                               (args
-                                                (raise-binding-result-arity-error
-                                                 3
-                                                 args))))))))
-                                     (case-lambda
-                                      ((mode_0 key_0 val_0 body_0)
+                                                   body_0))))))))
+                                     (lambda (mode_0 key_0 val_0 body_0)
                                        (let ((key-mutated_0
                                               (extract-expr-mutated_0
                                                key_0
@@ -51230,11 +48761,7 @@
                                                  key-mutated_0)))
                                            (extract-expr-mutated_0
                                             body_0
-                                            val-mutated_0))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        4
-                                        args))))
+                                            val-mutated_0)))))
                                     (if (if (eq? 'quote hd_0)
                                           (let ((a_0 (cdr (unwrap e_0))))
                                             (let ((p_0 (unwrap a_0)))
@@ -51286,8 +48813,7 @@
                                                             a_0))))
                                                    (let ((id_1 id_0))
                                                      (values id_1 rhs_0)))))))
-                                         (case-lambda
-                                          ((id_0 rhs_0)
+                                         (lambda (id_0 rhs_0)
                                            (let ((new-mutated_0
                                                   (hash-set
                                                    mutated_0
@@ -51295,11 +48821,7 @@
                                                    #t)))
                                              (extract-expr-mutated_0
                                               rhs_0
-                                              new-mutated_0)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
+                                              new-mutated_0))))
                                         (if (if (eq? 'define hd_0)
                                               (let ((a_0 (cdr (unwrap e_0))))
                                                 (let ((p_0 (unwrap a_0)))
@@ -51339,15 +48861,10 @@
                                                        (values
                                                         id_1
                                                         rhs_0)))))))
-                                           (case-lambda
-                                            ((id_0 rhs_0)
+                                           (lambda (id_0 rhs_0)
                                              (extract-expr-mutated_0
                                               rhs_0
-                                              mutated_0))
-                                            (args
-                                             (raise-binding-result-arity-error
-                                              2
-                                              args))))
+                                              mutated_0)))
                                           (if (if (eq? 'define-values hd_0)
                                                 (let ((a_0 (cdr (unwrap e_0))))
                                                   (let ((p_0 (unwrap a_0)))
@@ -51389,15 +48906,10 @@
                                                          (values
                                                           ids_1
                                                           rhs_0)))))))
-                                             (case-lambda
-                                              ((ids_0 rhs_0)
+                                             (lambda (ids_0 rhs_0)
                                                (extract-expr-mutated_0
                                                 rhs_0
-                                                mutated_0))
-                                              (args
-                                               (raise-binding-result-arity-error
-                                                2
-                                                args))))
+                                                mutated_0)))
                                             (if (if (eq? 'variable-set! hd_0)
                                                   (let ((a_0
                                                          (cdr (unwrap e_0))))
@@ -51444,15 +48956,10 @@
                                                            (values
                                                             dest-id_1
                                                             e_1)))))))
-                                               (case-lambda
-                                                ((dest-id_0 e_1)
+                                               (lambda (dest-id_0 e_1)
                                                  (extract-expr-mutated_0
                                                   e_1
-                                                  mutated_0))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args))))
+                                                  mutated_0)))
                                               (if (if (eq?
                                                        'variable-set!/define
                                                        hd_0)
@@ -51575,27 +49082,20 @@
                                                                       (values
                                                                        e_2
                                                                        constance_0)))))))
-                                                          (case-lambda
-                                                           ((e_1 constance_0)
+                                                          (lambda (e_1
+                                                                   constance_0)
                                                             (let ((dest-id_1
                                                                    dest-id_0))
                                                               (values
                                                                dest-id_1
                                                                e_1
-                                                               constance_0)))
-                                                           (args
-                                                            (raise-binding-result-arity-error
-                                                             2
-                                                             args))))))))
-                                                 (case-lambda
-                                                  ((dest-id_0 e_1 constance_0)
+                                                               constance_0))))))))
+                                                 (lambda (dest-id_0
+                                                          e_1
+                                                          constance_0)
                                                    (extract-expr-mutated_0
                                                     e_1
-                                                    mutated_0))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    3
-                                                    args))))
+                                                    mutated_0)))
                                                 (if (if (eq?
                                                          'variable-ref
                                                          hd_0)
@@ -52057,11 +49557,9 @@
                 (if (pair? b64_0)
                   (call-with-values
                    (lambda () (stack-ref stack65_0 (car b64_0)))
-                   (case-lambda
-                    ((new-stack_0 vec_0)
+                   (lambda (new-stack_0 vec_0)
                      (let ((val_0 (unsafe-vector*-ref vec_0 (cdr b64_0))))
-                       (if return-mode63_0 (values new-stack_0 val_0) val_0)))
-                    (args (raise-binding-result-arity-error 2 args))))
+                       (if return-mode63_0 (values new-stack_0 val_0) val_0))))
                   (if (symbol? b64_0)
                     (let ((val_0 (hash-ref primitives b64_0)))
                       (if return-mode63_0 (values stack65_0 val_0) val_0))
@@ -52100,8 +49598,7 @@
                                                         (hash-iterate-key+value
                                                          return-mode63_0
                                                          i_0))
-                                                      (case-lambda
-                                                       ((k_0 v_0)
+                                                      (lambda (k_0 v_0)
                                                         (with-continuation-mark*
                                                          general
                                                          k_0
@@ -52109,11 +49606,7 @@
                                                          (loop_0
                                                           (hash-iterate-next
                                                            return-mode63_0
-                                                           i_0))))
-                                                       (args
-                                                        (raise-binding-result-arity-error
-                                                         2
-                                                         args))))))))))
+                                                           i_0)))))))))))
                                             (loop_0
                                              (hash-iterate-first
                                               return-mode63_0))))
@@ -52161,8 +49654,7 @@
                                                              (hash-iterate-key+value
                                                               return-mode63_0
                                                               i_0))
-                                                           (case-lambda
-                                                            ((k_0 v_0)
+                                                           (lambda (k_0 v_0)
                                                              (with-continuation-mark*
                                                               general
                                                               k_0
@@ -52170,11 +49662,7 @@
                                                               (loop_0
                                                                (hash-iterate-next
                                                                 return-mode63_0
-                                                                i_0))))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args))))))))))
+                                                                i_0)))))))))))
                                                  (loop_0
                                                   (hash-iterate-first
                                                    return-mode63_0))))
@@ -52244,8 +49732,8 @@
                                                                   (hash-iterate-key+value
                                                                    return-mode63_0
                                                                    i_0))
-                                                                (case-lambda
-                                                                 ((k_0 v_0)
+                                                                (lambda (k_0
+                                                                         v_0)
                                                                   (with-continuation-mark*
                                                                    general
                                                                    k_0
@@ -52253,11 +49741,7 @@
                                                                    (loop_0
                                                                     (hash-iterate-next
                                                                      return-mode63_0
-                                                                     i_0))))
-                                                                 (args
-                                                                  (raise-binding-result-arity-error
-                                                                   2
-                                                                   args))))))))))
+                                                                     i_0)))))))))))
                                                       (loop_0
                                                        (hash-iterate-first
                                                         return-mode63_0))))
@@ -52297,8 +49781,10 @@
                                             2
                                             #f
                                             1))
-                                         (case-lambda
-                                          ((v*_0 start*_0 stop*_0 step*_0)
+                                         (lambda (v*_0
+                                                  start*_0
+                                                  stop*_0
+                                                  step*_0)
                                            (letrec*
                                             ((for-loop_0
                                               (|#%name|
@@ -52340,41 +49826,27 @@
                                                                  1
                                                                  #f
                                                                  vals_0)))))
-                                                           (case-lambda
-                                                            ((stack_2
-                                                              rev-rands_1)
+                                                           (lambda (stack_2
+                                                                    rev-rands_1)
                                                              (values
                                                               stack_2
-                                                              rev-rands_1))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
-                                                        (case-lambda
-                                                         ((stack_2 rev-rands_1)
+                                                              rev-rands_1))))
+                                                        (lambda (stack_2
+                                                                 rev-rands_1)
                                                           (for-loop_0
                                                            stack_2
                                                            rev-rands_1
                                                            (unsafe-fx+
                                                             idx_0
-                                                            1)))
-                                                         (args
-                                                          (raise-binding-result-arity-error
-                                                           2
-                                                           args)))))
+                                                            1)))))
                                                      (values
                                                       stack_1
                                                       rev-rands_0)))))))
                                             (for-loop_0
                                              rand-stack_0
                                              null
-                                             start*_0)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            4
-                                            args)))))
-                                      (case-lambda
-                                       ((stack_1 rev-rands_0)
+                                             start*_0)))))
+                                      (lambda (stack_1 rev-rands_0)
                                         (let ((rands_0
                                                (reverse$1 rev-rands_0)))
                                           (if return-mode63_0
@@ -52406,8 +49878,8 @@
                                                                  (hash-iterate-key+value
                                                                   return-mode63_0
                                                                   i_0))
-                                                               (case-lambda
-                                                                ((k_0 v_0)
+                                                               (lambda (k_0
+                                                                        v_0)
                                                                  (with-continuation-mark*
                                                                   general
                                                                   k_0
@@ -52415,11 +49887,7 @@
                                                                   (loop_0
                                                                    (hash-iterate-next
                                                                     return-mode63_0
-                                                                    i_0))))
-                                                                (args
-                                                                 (raise-binding-result-arity-error
-                                                                  2
-                                                                  args))))))))))
+                                                                    i_0)))))))))))
                                                      (loop_0
                                                       (hash-iterate-first
                                                        return-mode63_0))))
@@ -52430,11 +49898,7 @@
                                                      values
                                                      stack_1
                                                      vs_0)))))))
-                                            (apply rator_0 rands_0))))
-                                       (args
-                                        (raise-binding-result-arity-error
-                                         2
-                                         args))))))))
+                                            (apply rator_0 rands_0)))))))))
                               ((rand-stack_0 . vals_0)
                                (apply
                                 raise-result-arity-error
@@ -52453,14 +49917,11 @@
                             (let ((s_0 (unsafe-vector*-ref b64_0 1)))
                               (call-with-values
                                (lambda () (stack-ref stack65_0 s_0))
-                               (case-lambda
-                                ((new-stack_0 bx_0)
+                               (lambda (new-stack_0 bx_0)
                                  (let ((val_0 (unsafe-unbox* bx_0)))
                                    (if return-mode63_0
                                      (values new-stack_0 val_0)
-                                     val_0)))
-                                (args
-                                 (raise-binding-result-arity-error 2 args)))))
+                                     val_0)))))
                             (if (if (eq?
                                      'unbox/checked
                                      (unsafe-vector*-ref b64_0 0))
@@ -52471,8 +49932,7 @@
                                   (let ((s_1 s_0))
                                     (call-with-values
                                      (lambda () (stack-ref stack65_0 s_1))
-                                     (case-lambda
-                                      ((new-stack_0 bx_0)
+                                     (lambda (new-stack_0 bx_0)
                                        (let ((v_0 (unsafe-unbox* bx_0)))
                                          (let ((val_0
                                                 (check-not-unsafe-undefined
@@ -52480,11 +49940,7 @@
                                                  name_0)))
                                            (if return-mode63_0
                                              (values new-stack_0 val_0)
-                                             val_0))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args)))))))
+                                             val_0))))))))
                               (if (if (eq?
                                        'ref-variable
                                        (unsafe-vector*-ref b64_0 0))
@@ -52493,19 +49949,14 @@
                                 (let ((s_0 (unsafe-vector*-ref b64_0 1)))
                                   (call-with-values
                                    (lambda () (stack-ref stack65_0 s_0))
-                                   (case-lambda
-                                    ((new-stack_0 var_0)
+                                   (lambda (new-stack_0 var_0)
                                      (let ((val_0
                                             (|#%app|
                                              1/variable-ref/no-check
                                              var_0)))
                                        (if return-mode63_0
                                          (values new-stack_0 val_0)
-                                         val_0)))
-                                    (args
-                                     (raise-binding-result-arity-error
-                                      2
-                                      args)))))
+                                         val_0)))))
                                 (if (if (eq?
                                          'ref-variable/checked
                                          (unsafe-vector*-ref b64_0 0))
@@ -52514,17 +49965,12 @@
                                   (let ((s_0 (unsafe-vector*-ref b64_0 1)))
                                     (call-with-values
                                      (lambda () (stack-ref stack65_0 s_0))
-                                     (case-lambda
-                                      ((new-stack_0 var_0)
+                                     (lambda (new-stack_0 var_0)
                                        (let ((val_0
                                               (|#%app| 1/variable-ref var_0)))
                                          (if return-mode63_0
                                            (values new-stack_0 val_0)
-                                           val_0)))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args)))))
+                                           val_0)))))
                                   (if (if (eq?
                                            'let
                                            (unsafe-vector*-ref b64_0 0))
@@ -52740,21 +50186,16 @@
                                                                        app_0
                                                                        (add1
                                                                         i_0))))
-                                                                  (case-lambda
-                                                                   ((new-stack_0
-                                                                     boxes_0)
+                                                                  (lambda (new-stack_0
+                                                                           boxes_0)
                                                                     (values
                                                                      new-stack_0
                                                                      (cons
                                                                       bx_0
-                                                                      boxes_0)))
-                                                                   (args
-                                                                    (raise-binding-result-arity-error
-                                                                     2
-                                                                     args)))))))))))
+                                                                      boxes_0)))))))))))
                                                       (loop_0 stack65_0 0)))
-                                                   (case-lambda
-                                                    ((body-stack_0 boxes_0)
+                                                   (lambda (body-stack_0
+                                                            boxes_0)
                                                      (letrec*
                                                       ((loop_0
                                                         (|#%name|
@@ -52806,11 +50247,7 @@
                                                       (loop_0
                                                        0
                                                        body-stack_0
-                                                       boxes_0)))
-                                                    (args
-                                                     (raise-binding-result-arity-error
-                                                      2
-                                                      args)))))))))
+                                                       boxes_0)))))))))
                                         (if (eq?
                                              'begin
                                              (unsafe-vector*-ref b64_0 0))
@@ -53252,9 +50689,8 @@
                                                                           (values
                                                                            stack_1
                                                                            vals_0))))
-                                                                     (case-lambda
-                                                                      ((new-stack_0
-                                                                        vs_0)
+                                                                     (lambda (new-stack_0
+                                                                              vs_0)
                                                                        (let ((len_0
                                                                               (length
                                                                                vs_0)))
@@ -53309,11 +50745,7 @@
                                                                                                  full-mask_0))))))))))))))
                                                                           (loop_0
                                                                            clauses_0
-                                                                           0))))
-                                                                      (args
-                                                                       (raise-binding-result-arity-error
-                                                                        2
-                                                                        args)))))))))
+                                                                           0))))))))))
                                                           (if (if (eq?
                                                                    'cwmp0
                                                                    (unsafe-vector*-ref
@@ -53456,9 +50888,8 @@
                                                                              (capture-closure_0
                                                                               close-vec_1
                                                                               stack65_0))
-                                                                           (case-lambda
-                                                                            ((new-stack_0
-                                                                              captured_0)
+                                                                           (lambda (new-stack_0
+                                                                                    captured_0)
                                                                              (let ((val_0
                                                                                     (|#%app|
                                                                                      make-interp-procedure*
@@ -53473,11 +50904,7 @@
                                                                                  (values
                                                                                   new-stack_0
                                                                                   val_0)
-                                                                                 val_0)))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args)))))))))
+                                                                                 val_0)))))))))
                                                                 (if (if (eq?
                                                                          'case-lambda
                                                                          (unsafe-vector*-ref
@@ -53520,9 +50947,8 @@
                                                                                             i_0
                                                                                             1)
                                                                                            stack_1))
-                                                                                        (case-lambda
-                                                                                         ((rest-stack_0
-                                                                                           rest-captureds_0)
+                                                                                        (lambda (rest-stack_0
+                                                                                                 rest-captureds_0)
                                                                                           (call-with-values
                                                                                            (lambda ()
                                                                                              (let ((v_0
@@ -53558,28 +50984,18 @@
                                                                                                  (error
                                                                                                   'interp-match
                                                                                                   "no matching clause"))))
-                                                                                           (case-lambda
-                                                                                            ((new-stack_0
-                                                                                              captured_0)
+                                                                                           (lambda (new-stack_0
+                                                                                                    captured_0)
                                                                                              (values
                                                                                               new-stack_0
                                                                                               (cons
                                                                                                captured_0
-                                                                                               rest-captureds_0)))
-                                                                                            (args
-                                                                                             (raise-binding-result-arity-error
-                                                                                              2
-                                                                                              args)))))
-                                                                                         (args
-                                                                                          (raise-binding-result-arity-error
-                                                                                           2
-                                                                                           args))))))))))
+                                                                                               rest-captureds_0))))))))))))
                                                                               (loop_0
                                                                                3
                                                                                stack65_0)))
-                                                                           (case-lambda
-                                                                            ((new-stack_0
-                                                                              captureds_0)
+                                                                           (lambda (new-stack_0
+                                                                                    captureds_0)
                                                                              (let ((val_0
                                                                                     (|#%app|
                                                                                      make-interp-procedure*
@@ -53653,11 +51069,7 @@
                                                                                  (values
                                                                                   new-stack_0
                                                                                   val_0)
-                                                                                 val_0)))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args))))))))
+                                                                                 val_0))))))))
                                                                   (if (if (eq?
                                                                            'set-variable!
                                                                            (unsafe-vector*-ref
@@ -53692,9 +51104,8 @@
                                                                                  (stack-ref
                                                                                   stack65_0
                                                                                   s_1))
-                                                                               (case-lambda
-                                                                                ((var-stack_0
-                                                                                  var_0)
+                                                                               (lambda (var-stack_0
+                                                                                        var_0)
                                                                                  (call-with-values
                                                                                   (lambda ()
                                                                                     (interpret_1
@@ -53727,11 +51138,7 @@
                                                                                      #f
                                                                                      1
                                                                                      #f
-                                                                                     vals_0)))))
-                                                                                (args
-                                                                                 (raise-binding-result-arity-error
-                                                                                  2
-                                                                                  args)))))))))
+                                                                                     vals_0)))))))))))
                                                                     (if (if (eq?
                                                                              'set!-indirect
                                                                              (unsafe-vector*-ref
@@ -53760,9 +51167,8 @@
                                                                                  (stack-ref
                                                                                   stack65_0
                                                                                   s_1))
-                                                                               (case-lambda
-                                                                                ((vec-stack_0
-                                                                                  vec_0)
+                                                                               (lambda (vec-stack_0
+                                                                                        vec_0)
                                                                                  (call-with-values
                                                                                   (lambda ()
                                                                                     (interpret_1
@@ -53789,11 +51195,7 @@
                                                                                      #f
                                                                                      1
                                                                                      #f
-                                                                                     vals_0)))))
-                                                                                (args
-                                                                                 (raise-binding-result-arity-error
-                                                                                  2
-                                                                                  args))))))))
+                                                                                     vals_0))))))))))
                                                                       (if (if (eq?
                                                                                'set!-boxed
                                                                                (unsafe-vector*-ref
@@ -53822,9 +51224,8 @@
                                                                                    (stack-ref
                                                                                     stack65_0
                                                                                     s_1))
-                                                                                 (case-lambda
-                                                                                  ((bx-stack_0
-                                                                                    bx_0)
+                                                                                 (lambda (bx-stack_0
+                                                                                          bx_0)
                                                                                    (call-with-values
                                                                                     (lambda ()
                                                                                       (interpret_1
@@ -53850,11 +51251,7 @@
                                                                                        #f
                                                                                        1
                                                                                        #f
-                                                                                       vals_0)))))
-                                                                                  (args
-                                                                                   (raise-binding-result-arity-error
-                                                                                    2
-                                                                                    args))))))))
+                                                                                       vals_0))))))))))
                                                                         (if (if (eq?
                                                                                  'set!-boxed/checked
                                                                                  (unsafe-vector*-ref
@@ -53883,9 +51280,8 @@
                                                                                      (stack-ref
                                                                                       stack65_0
                                                                                       s_1))
-                                                                                   (case-lambda
-                                                                                    ((bx-stack_0
-                                                                                      bx_0)
+                                                                                   (lambda (bx-stack_0
+                                                                                            bx_0)
                                                                                      (call-with-values
                                                                                       (lambda ()
                                                                                         (interpret_1
@@ -53915,11 +51311,7 @@
                                                                                          #f
                                                                                          1
                                                                                          #f
-                                                                                         vals_0)))))
-                                                                                    (args
-                                                                                     (raise-binding-result-arity-error
-                                                                                      2
-                                                                                      args))))))))
+                                                                                         vals_0))))))))))
                                                                           (error
                                                                            'interp-match
                                                                            "no matching clause")))))))))))))))))))))))))))
@@ -53952,15 +51344,12 @@
                            (stack-ref
                             stack_2
                             (unsafe-vector*-ref close-vec_0 i_0)))
-                         (case-lambda
-                          ((val-stack_0 val_0)
+                         (lambda (val-stack_0 val_0)
                            (let ((app_0 (add1 i_0)))
                              (loop_0
                               app_0
                               val-stack_0
-                              (stack-set captured_0 (- -1 i_0) val_0))))
-                          (args
-                           (raise-binding-result-arity-error 2 args))))))))))
+                              (stack-set captured_0 (- -1 i_0) val_0)))))))))))
                (loop_0 0 stack_1 #f)))))))
       (apply-function_0
        (|#%name|
@@ -54282,11 +51671,9 @@
                                    (let ((body_0 (let ((d_1 (cdr p_0))) d_1)))
                                      (let ((rhss_1 rhss_0))
                                        (values rhss_1 body_0)))))))
-                           (case-lambda
-                            ((rhss_0 body_0)
+                           (lambda (rhss_0 body_0)
                              (let ((app_0 (cons rhss_0 body_0)))
-                               (body-leftover-size_0 app_0 (sub1 size_1))))
-                            (args (raise-binding-result-arity-error 2 args))))
+                               (body-leftover-size_0 app_0 (sub1 size_1)))))
                           (if (if (eq? 'letrec-values hd_0)
                                 (let ((a_0 (cdr (unwrap e_1))))
                                   (let ((p_0 (unwrap a_0)))
@@ -54432,12 +51819,9 @@
                                             (let ((d_1 (cdr p_0))) d_1)))
                                        (let ((rhss_1 rhss_0))
                                          (values rhss_1 body_0)))))))
-                             (case-lambda
-                              ((rhss_0 body_0)
+                             (lambda (rhss_0 body_0)
                                (let ((app_0 (cons rhss_0 body_0)))
-                                 (body-leftover-size_0 app_0 (sub1 size_1))))
-                              (args
-                               (raise-binding-result-arity-error 2 args))))
+                                 (body-leftover-size_0 app_0 (sub1 size_1)))))
                             (if (if (eq? 'if hd_0)
                                   (let ((a_0 (cdr (unwrap e_1))))
                                     (let ((p_0 (unwrap a_0)))
@@ -54480,23 +51864,15 @@
                                                            a_0))))
                                                   (let ((thn_1 thn_0))
                                                     (values thn_1 els_0)))))))
-                                        (case-lambda
-                                         ((thn_0 els_0)
+                                        (lambda (thn_0 els_0)
                                           (let ((tst_1 tst_0))
-                                            (values tst_1 thn_0 els_0)))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args))))))))
-                               (case-lambda
-                                ((tst_0 thn_0 els_0)
+                                            (values tst_1 thn_0 els_0))))))))
+                               (lambda (tst_0 thn_0 els_0)
                                  (leftover-size_0
                                   els_0
                                   (leftover-size_0
                                    thn_0
-                                   (leftover-size_0 tst_0 (sub1 size_1)))))
-                                (args
-                                 (raise-binding-result-arity-error 3 args))))
+                                   (leftover-size_0 tst_0 (sub1 size_1))))))
                               (if (if (eq? 'with-continuation-mark* hd_0)
                                     (let ((a_0 (cdr (unwrap e_1))))
                                       (let ((p_0 (unwrap a_0)))
@@ -54552,23 +51928,18 @@
                                                         (values
                                                          val_1
                                                          body_0)))))))
-                                            (case-lambda
-                                             ((val_0 body_0)
+                                            (lambda (val_0 body_0)
                                               (let ((key_1 key_0))
-                                                (values key_1 val_0 body_0)))
-                                             (args
-                                              (raise-binding-result-arity-error
-                                               2
-                                               args)))))))))
-                                 (case-lambda
-                                  ((key_0 val_0 body_0)
+                                                (values
+                                                 key_1
+                                                 val_0
+                                                 body_0)))))))))
+                                 (lambda (key_0 val_0 body_0)
                                    (leftover-size_0
                                     body_0
                                     (leftover-size_0
                                      val_0
-                                     (leftover-size_0 key_0 (sub1 size_1)))))
-                                  (args
-                                   (raise-binding-result-arity-error 3 args))))
+                                     (leftover-size_0 key_0 (sub1 size_1))))))
                                 (if (if (eq? 'begin-unsafe hd_0) #t #f)
                                   (let ((body_0
                                          (let ((d_0 (cdr (unwrap e_1)))) d_0)))
@@ -54633,15 +52004,10 @@
                                                             a_0))))
                                                    (let ((id_1 id_0))
                                                      (values id_1 rhs_0)))))))
-                                         (case-lambda
-                                          ((id_0 rhs_0)
+                                         (lambda (id_0 rhs_0)
                                            (leftover-size_0
                                             rhs_0
-                                            (sub1 size_1)))
-                                          (args
-                                           (raise-binding-result-arity-error
-                                            2
-                                            args))))
+                                            (sub1 size_1))))
                                         (if (if (eq?
                                                  '|#%variable-reference|
                                                  hd_0)
@@ -54707,8 +52073,7 @@
                        (call-with-values
                         (lambda ()
                           (begin (values v_0 (unsafe-vector-length v_0))))
-                        (case-lambda
-                         ((vec_0 len_0)
+                        (lambda (vec_0 len_0)
                           (letrec*
                            ((for-loop_0
                              (|#%name|
@@ -54734,8 +52099,7 @@
                                                   size_3)))
                                             (next-k-proc_0 size_4)))))
                                     size_3))))))
-                           (for-loop_0 size_2 0)))
-                         (args (raise-binding-result-arity-error 2 args)))))
+                           (for-loop_0 size_2 0)))))
                      (if (prefab-struct-key v_0)
                        (s-expr-leftover-size_0 (struct->vector v_0) size_1)
                        (if (hash? v_0)
@@ -54751,8 +52115,7 @@
                                        (call-with-values
                                         (lambda ()
                                           (hash-iterate-key+value v_0 i_0))
-                                        (case-lambda
-                                         ((k_0 v_1)
+                                        (lambda (k_0 v_1)
                                           (let ((next-k-proc_0
                                                  (|#%name|
                                                   next-k-proc
@@ -54771,11 +52134,7 @@
                                                       (s-expr-leftover-size_0
                                                        k_0
                                                        size_3))))
-                                                (next-k-proc_0 size_4)))))
-                                         (args
-                                          (raise-binding-result-arity-error
-                                           2
-                                           args))))
+                                                (next-k-proc_0 size_4))))))
                                        size_3))))))
                               (for-loop_0 size_2 (hash-iterate-first v_0)))))
                          (sub1 size_1))))))))))))

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -618,8 +618,7 @@
         (void)
         (call-with-values
          (lambda () (procedure-keywords f_0))
-         (case-lambda
-          ((required-keywords_0 optional-keywords_0)
+         (lambda (required-keywords_0 optional-keywords_0)
            (let ((app_0
                   (if (pair? required-keywords_0)
                     (string-append
@@ -721,8 +720,7 @@
                                            app_5
                                            (loop_0 (cdr ls_1))))))))))
                                (loop_0 ls_0)))))
-                           null))))))))))
-          (args (raise-binding-result-arity-error 2 args))))))))
+                           null)))))))))))))))
 (define gen-map
   (lambda (f_0 ls_0)
     (begin
@@ -975,26 +973,18 @@
                            (if i_0
                              (call-with-values
                               (lambda () (hash-iterate-key+value table7_0 i_0))
-                              (case-lambda
-                               ((k1_0 v1_0)
+                              (lambda (k1_0 v1_0)
                                 (let ((acc_2
                                        (let ((acc_2
                                               (call-with-values
                                                (lambda ()
                                                  (|#%app| f8_0 k1_0 v1_0))
-                                               (case-lambda
-                                                ((k2_0 v2_0)
-                                                 (hash-set acc_1 k2_0 v2_0))
-                                                (args
-                                                 (raise-binding-result-arity-error
-                                                  2
-                                                  args))))))
+                                               (lambda (k2_0 v2_0)
+                                                 (hash-set acc_1 k2_0 v2_0)))))
                                          (values acc_2))))
                                   (for-loop_0
                                    acc_2
-                                   (hash-iterate-next table7_0 i_0))))
-                               (args
-                                (raise-binding-result-arity-error 2 args))))
+                                   (hash-iterate-next table7_0 i_0)))))
                              acc_1))))))
                     (for-loop_0 acc_0 (hash-iterate-first table7_0))))
                  (begin
@@ -1009,21 +999,14 @@
                                (call-with-values
                                 (lambda ()
                                   (hash-iterate-key+value table7_0 i_0))
-                                (case-lambda
-                                 ((k1_0 v1_0)
+                                (lambda (k1_0 v1_0)
                                   (begin
                                     (call-with-values
                                      (lambda () (|#%app| f8_0 k1_0 v1_0))
-                                     (case-lambda
-                                      ((k2_0 v2_0) (hash-set! acc_0 k2_0 v2_0))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args))))
+                                     (lambda (k2_0 v2_0)
+                                       (hash-set! acc_0 k2_0 v2_0)))
                                     (for-loop_0
-                                     (hash-iterate-next table7_0 i_0))))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args))))
+                                     (hash-iterate-next table7_0 i_0)))))
                                (values)))))))
                       (for-loop_0 (hash-iterate-first table7_0))))
                    (void)
@@ -1536,8 +1519,7 @@
               (node-left t_0)
               (call-with-values
                (lambda () (max-key+value (node-left t_0)))
-               (case-lambda
-                ((move-key_0 move-val_0)
+               (lambda (move-key_0 move-val_0)
                  (let ((new-left_0 (delete (node-left t_0) move-key_0 <?_0)))
                    (let ((new-t_0
                           (combine
@@ -1556,8 +1538,7 @@
                           new-t_0
                           node-left
                           node-right
-                          combine))))))
-                (args (raise-binding-result-arity-error 2 args)))))))))))
+                          combine))))))))))))))
 (define delete-at
   (lambda (t_0 key_0 <?_0 node-to_0 node-from_0 combine_0 reverse-combine_0)
     (let ((new-to_0 (delete (|#%app| node-to_0 t_0) key_0 <?_0)))
@@ -1853,8 +1834,7 @@
        (void)
        (call-with-values
         (lambda () (min-key+value (unsafe-place-local-ref cell.3$1)))
-        (case-lambda
-         ((timeout-at_0 threads_0)
+        (lambda (timeout-at_0 threads_0)
           (if (<= timeout-at_0 (current-inexact-monotonic-milliseconds))
             (if (null? threads_0)
               (void)
@@ -1875,8 +1855,7 @@
                             (values)))))))
                    (for-loop_0 (hash-iterate-first threads_0))))
                 (void)))
-            (void)))
-         (args (raise-binding-result-arity-error 2 args))))))
+            (void))))))
    (lambda () (|#%app| host:get-wakeup-handle))
    (lambda (h_0) (|#%app| host:wakeup h_0))
    (lambda ()
@@ -1889,9 +1868,7 @@
             (begin-unsafe (not t_0))))
        (call-with-values
         (lambda () (min-key+value (unsafe-place-local-ref cell.3$1)))
-        (case-lambda
-         ((timeout-at_0 threads_0) timeout-at_0)
-         (args (raise-binding-result-arity-error 2 args))))
+        (lambda (timeout-at_0 threads_0) timeout-at_0))
        #f))
    (lambda (t_0 sleep-until_0)
      (begin
@@ -3114,9 +3091,8 @@
                                                                               v_0
                                                                               (unsafe-vector-length
                                                                                v_0))))
-                                                                         (case-lambda
-                                                                          ((vec_0
-                                                                            len_0)
+                                                                         (lambda (vec_0
+                                                                                  len_0)
                                                                            (letrec*
                                                                             ((for-loop_0
                                                                               (|#%name|
@@ -3155,11 +3131,7 @@
                                                                                      result_0))))))
                                                                             (for-loop_0
                                                                              #t
-                                                                             0)))
-                                                                          (args
-                                                                           (raise-binding-result-arity-error
-                                                                            2
-                                                                            args)))))))
+                                                                             0)))))))
                                                                   #f)
                                                                 #f)))
                                                          (if or-part_10
@@ -3189,9 +3161,8 @@
                                                                                   vec_0
                                                                                   (unsafe-vector-length
                                                                                    vec_0)))))
-                                                                           (case-lambda
-                                                                            ((vec_0
-                                                                              len_0)
+                                                                           (lambda (vec_0
+                                                                                    len_0)
                                                                              (letrec*
                                                                               ((for-loop_0
                                                                                 (|#%name|
@@ -3230,11 +3201,7 @@
                                                                                        result_0))))))
                                                                               (for-loop_0
                                                                                #t
-                                                                               0)))
-                                                                            (args
-                                                                             (raise-binding-result-arity-error
-                                                                              2
-                                                                              args)))))))
+                                                                               0)))))))
                                                                     #f)))
                                                              (if or-part_11
                                                                or-part_11
@@ -3278,9 +3245,8 @@
                                                                                                (hash-iterate-key+value
                                                                                                 v_0
                                                                                                 i_0))
-                                                                                             (case-lambda
-                                                                                              ((k_0
-                                                                                                v_1)
+                                                                                             (lambda (k_0
+                                                                                                      v_1)
                                                                                                (let ((result_1
                                                                                                       (let ((result_1
                                                                                                              (if (loop_0
@@ -3306,11 +3272,7 @@
                                                                                                     (hash-iterate-next
                                                                                                      v_0
                                                                                                      i_0))
-                                                                                                   result_1)))
-                                                                                              (args
-                                                                                               (raise-binding-result-arity-error
-                                                                                                2
-                                                                                                args))))
+                                                                                                   result_1))))
                                                                                             result_0))))))
                                                                                    (for-loop_0
                                                                                     #t
@@ -3467,8 +3429,8 @@
                                                                 v_1
                                                                 (unsafe-vector-length
                                                                  v_1))))
-                                                           (case-lambda
-                                                            ((vec_0 len_1)
+                                                           (lambda (vec_0
+                                                                    len_1)
                                                              (letrec*
                                                               ((for-loop_0
                                                                 (|#%name|
@@ -3514,11 +3476,7 @@
                                                                        i_0))))))
                                                               (for-loop_0
                                                                0
-                                                               0)))
-                                                            (args
-                                                             (raise-binding-result-arity-error
-                                                              2
-                                                              args)))))
+                                                               0)))))
                                                         v_2)))))))
                                            (let ((c1_0
                                                   (immutable-prefab-struct-key
@@ -3543,11 +3501,10 @@
                                                           1
                                                           #f
                                                           1))
-                                                       (case-lambda
-                                                        ((v*_0
-                                                          start*_0
-                                                          stop*_0
-                                                          step*_0)
+                                                       (lambda (v*_0
+                                                                start*_0
+                                                                stop*_0
+                                                                step*_0)
                                                          (letrec*
                                                           ((for-loop_0
                                                             (|#%name|
@@ -3578,11 +3535,7 @@
                                                                    fold-var_0))))))
                                                           (for-loop_0
                                                            null
-                                                           start*_0)))
-                                                        (args
-                                                         (raise-binding-result-arity-error
-                                                          4
-                                                          args)))))))))
+                                                           start*_0)))))))))
                                                (if (hash? v_1)
                                                  (let ((ph_0
                                                         (make-placeholder #f)))
@@ -3684,8 +3637,7 @@
                                   (lambda ()
                                     (begin
                                       (values v_1 (unsafe-vector-length v_1))))
-                                  (case-lambda
-                                   ((vec_0 len_1)
+                                  (lambda (vec_0 len_1)
                                     (letrec*
                                      ((for-loop_0
                                        (|#%name|
@@ -3721,11 +3673,7 @@
                                                      (unsafe-fx+ 1 pos_0))
                                                     i_1)))
                                               i_0))))))
-                                     (for-loop_0 0 0)))
-                                   (args
-                                    (raise-binding-result-arity-error
-                                     2
-                                     args)))))
+                                     (for-loop_0 0 0)))))
                                v_2)))))
                       (let ((c3_0 (immutable-prefab-struct-key v_1)))
                         (if c3_0
@@ -3741,8 +3689,7 @@
                                 1
                                 #f
                                 1))
-                             (case-lambda
-                              ((v*_0 start*_0 stop*_0 step*_0)
+                             (lambda (v*_0 start*_0 stop*_0 step*_0)
                                (letrec*
                                 ((for-loop_0
                                   (|#%name|
@@ -3764,9 +3711,7 @@
                                               fold-var_1
                                               (unsafe-fx+ idx_0 1))))
                                          fold-var_0))))))
-                                (for-loop_0 null start*_0)))
-                              (args
-                               (raise-binding-result-arity-error 4 args))))))
+                                (for-loop_0 null start*_0))))))
                           (if (hash? v_1)
                             (let ((temp15_0
                                    (lambda (k_0 v_2)
@@ -5432,8 +5377,7 @@
                             (if i_0
                               (call-with-values
                                (lambda () (hash-iterate-key+value ht_0 i_0 #f))
-                               (case-lambda
-                                ((child_0 callback_0)
+                               (lambda (child_0 callback_0)
                                  (begin
                                    (if child_0
                                      (let ((gc-root?_0
@@ -5455,9 +5399,7 @@
                                         child_0
                                         callback_0))
                                      (void))
-                                   (for-loop_0 (hash-iterate-next ht_0 i_0))))
-                                (args
-                                 (raise-binding-result-arity-error 2 args))))
+                                   (for-loop_0 (hash-iterate-next ht_0 i_0)))))
                               (values)))))))
                      (for-loop_0 (hash-iterate-first ht_0)))))
                 (let ((self-ref_0 (custodian-self-reference c_0)))
@@ -5587,12 +5529,7 @@
                                        (do-custodian-shutdown-all c_0)
                                        (values))
                                      (values)))
-                                 (case-lambda
-                                  (() (for-loop_0 rest_0))
-                                  (args
-                                   (raise-binding-result-arity-error
-                                    0
-                                    args))))))
+                                 (lambda () (for-loop_0 rest_0)))))
                             (values)))))))
                    (for-loop_0 queued_0)))
                 (void)
@@ -5639,8 +5576,7 @@
                                     (call-with-values
                                      (lambda ()
                                        (hash-iterate-key+value ht_0 i_0 #f))
-                                     (case-lambda
-                                      ((child_0 callback_0)
+                                     (lambda (child_0 callback_0)
                                        (begin
                                          (if child_0
                                            (if (if only-at-exit?27_0
@@ -5667,11 +5603,7 @@
                                                (void)))
                                            (void))
                                          (for-loop_0
-                                          (hash-iterate-next ht_0 i_0))))
-                                      (args
-                                       (raise-binding-result-arity-error
-                                        2
-                                        args))))
+                                          (hash-iterate-next ht_0 i_0)))))
                                     (values)))))))
                            (for-loop_0 (hash-iterate-first ht_0)))))
                       (begin
@@ -6052,7 +5984,7 @@
 (define memory-limit-lock (|#%app| host:make-mutex))
 (define compute-memory-sizes 0)
 (define computed-memory-sizes? #f)
-(define effect_2497
+(define effect_2420
   (begin
     (void
      (|#%app|
@@ -6154,17 +6086,13 @@
                                                     pl_0
                                                     accum-roots_1
                                                     accum-custs_1))
-                                                 (case-lambda
-                                                  ((new-roots_0 new-custs_0)
+                                                 (lambda (new-roots_0
+                                                          new-custs_0)
                                                    (loop_0
                                                     (cdr roots_1)
                                                     local-accum-roots_0
                                                     new-roots_0
-                                                    new-custs_0))
-                                                  (args
-                                                   (raise-binding-result-arity-error
-                                                    2
-                                                    args))))
+                                                    new-custs_0)))
                                                 (if (1/place? (car roots_1))
                                                   (let ((pl_1 (car roots_1)))
                                                     (let ((c_1
@@ -6185,18 +6113,13 @@
                                                             pl_1
                                                             accum-roots_1
                                                             accum-custs_1))
-                                                         (case-lambda
-                                                          ((new-roots_0
-                                                            new-custs_0)
+                                                         (lambda (new-roots_0
+                                                                  new-custs_0)
                                                            (loop_0
                                                             (cdr roots_1)
                                                             local-accum-roots_0
                                                             new-roots_0
-                                                            new-custs_0))
-                                                          (args
-                                                           (raise-binding-result-arity-error
-                                                            2
-                                                            args)))))))
+                                                            new-custs_0))))))
                                                   (let ((root_0 (car roots_1)))
                                                     (let ((new-local-roots_0
                                                            (cons
@@ -6248,8 +6171,7 @@
                       initial-place
                       null
                       null)))
-                  (case-lambda
-                   ((roots_0 custs_0)
+                  (lambda (roots_0 custs_0)
                     (|#%app|
                      call-with-size-increments_0
                      roots_0
@@ -6443,8 +6365,7 @@
                                (void)
                                (set! compute-memory-sizes
                                  (sub1 compute-memory-sizes)))
-                             (set! computed-memory-sizes? #t)))))))
-                   (args (raise-binding-result-arity-error 2 args))))))))))))
+                             (set! computed-memory-sizes? #t))))))))))))))))
     (void)))
 (define effect_2597
   (begin
@@ -9931,8 +9852,7 @@
               (call-with-values
                (lambda ()
                  (cross-commits-and-abandons commits14_0 abandons15_0))
-               (case-lambda
-                ((extended-commits_0 guarded-abandons_0)
+               (lambda (extended-commits_0 guarded-abandons_0)
                  (letrec*
                   ((loop_0
                     (|#%name|
@@ -9985,8 +9905,7 @@
                                       (cdr evts_0)
                                       (if first_0 first_0 sr_0)
                                       sr_0))))))))))))
-                  (loop_0 evts17_0 #f #f)))
-                (args (raise-binding-result-arity-error 2 args)))))))))
+                  (loop_0 evts17_0 #f #f)))))))))
     (case-lambda
      ((who_0 evts_0) (evts->syncers_0 who_0 evts_0 null null null))
      ((who_0 evts_0 wraps_0 commits_0 abandons15_0)
@@ -10150,8 +10069,7 @@
                                    just-poll?20_0
                                    fast-only?21_0
                                    sched-info_0))
-                                (case-lambda
-                                 ((same?_0 new-evt_0)
+                                (lambda (same?_0 new-evt_0)
                                   (if same?_0
                                     (loop_0
                                      (syncer-next sr_0)
@@ -10170,9 +10088,7 @@
                                          sr_0
                                          (add1 retries_0)
                                          polled-all-so-far?_0
-                                         no-wrappers?_0)))))
-                                 (args
-                                  (raise-binding-result-arity-error 2 args)))))
+                                         no-wrappers?_0)))))))
                              (let ((ctx_0
                                     (poll-ctx3.1
                                      just-poll?20_0
@@ -10181,8 +10097,7 @@
                                      #f)))
                                (call-with-values
                                 (lambda () (evt-poll (syncer-evt sr_0) ctx_0))
-                                (case-lambda
-                                 ((results_0 new-evt_0)
+                                (lambda (results_0 new-evt_0)
                                   (if results_0
                                     (begin
                                       (syncing-done! s32_0 sr_0)
@@ -10485,11 +10400,7 @@
                                                      sr_0
                                                      (add1 retries_0)
                                                      polled-all-so-far?_0
-                                                     no-wrappers?_0)))))))))))
-                                 (args
-                                  (raise-binding-result-arity-error
-                                   2
-                                   args))))))))))))))))
+                                                     no-wrappers?_0))))))))))))))))))))))))
           (loop_0 (syncing-syncers s32_0) 0 #t #t)))))))
 (define make-result
   (lambda (sr_0 results_0 success-k_0)
@@ -10619,8 +10530,7 @@
                         (if retry_0
                           (call-with-values
                            (lambda () (|#%app| retry_0))
-                           (case-lambda
-                            ((result_0 ready?_0)
+                           (lambda (result_0 ready?_0)
                              (if ready?_0
                                (begin
                                  (set-syncer-wraps!
@@ -10629,8 +10539,7 @@
                                    (lambda args_0 result_0)
                                    (syncer-wraps sr_0)))
                                  (syncing-done! s_0 sr_0))
-                               (void)))
-                            (args (raise-binding-result-arity-error 2 args))))
+                               (void))))
                           (void))))
                     (void))
                   (loop_0 (syncer-next sr_0)))
@@ -13914,8 +13823,7 @@
                (let ((started_0 (|#%app| host:make-condition)))
                  (call-with-values
                   (lambda () (1/place-channel))
-                  (case-lambda
-                   ((place-pch_0 child-pch_0)
+                  (lambda (place-pch_0 child-pch_0)
                     (let ((orig-plumber_0 (1/make-plumber)))
                       (let ((new-place_0
                              (let ((current-place15_0
@@ -14005,13 +13913,12 @@
                                           in_0
                                           out_0
                                           err_0))
-                                       (case-lambda
-                                        ((parent-in_0
-                                          parent-out_0
-                                          parent-err_0
-                                          child-in-fd_0
-                                          child-out-fd_0
-                                          child-err-fd_0)
+                                       (lambda (parent-in_0
+                                                parent-out_0
+                                                parent-err_0
+                                                child-in-fd_0
+                                                child-out-fd_0
+                                                child-err-fd_0)
                                          (begin
                                            (|#%app| host:mutex-acquire lock_0)
                                            (let ((host-thread_0
@@ -14195,12 +14102,7 @@
                                                 new-place_0
                                                 parent-in_0
                                                 parent-out_0
-                                                parent-err_0)))))
-                                        (args
-                                         (raise-binding-result-arity-error
-                                          6
-                                          args))))))))))))))
-                   (args (raise-binding-result-arity-error 2 args)))))))))))))
+                                                parent-err_0))))))))))))))))))))))))))
 (define 1/place-break
   (let ((place-break_0
          (|#%name|
@@ -14370,8 +14272,7 @@
                    (call-with-values
                     (lambda ()
                       (begin (values vec_0 (unsafe-vector-length vec_0))))
-                    (case-lambda
-                     ((vec_1 len_0)
+                    (lambda (vec_1 len_0)
                       (letrec*
                        ((for-loop_0
                          (|#%name|
@@ -14386,8 +14287,7 @@
                                       (void))
                                     (for-loop_0 (unsafe-fx+ 1 pos_0))))
                                 (values)))))))
-                       (for-loop_0 0)))
-                     (args (raise-binding-result-arity-error 2 args))))
+                       (for-loop_0 0))))
                    (void)
                    (set-place-pumpers! p_0 #f))
                  (void))
@@ -14628,8 +14528,7 @@
                               (call-with-values
                                (lambda ()
                                  (hash-iterate-key+value waiters_0 i_0))
-                               (case-lambda
-                                ((pl_0 s_0)
+                               (lambda (pl_0 s_0)
                                  (begin
                                    (begin
                                      (|#%app|
@@ -14644,9 +14543,7 @@
                                       (place-lock pl_0))
                                      (wakeup-waiting pl_0))
                                    (for-loop_0
-                                    (hash-iterate-next waiters_0 i_0))))
-                                (args
-                                 (raise-binding-result-arity-error 2 args))))
+                                    (hash-iterate-next waiters_0 i_0)))))
                               (values)))))))
                      (for-loop_0 (hash-iterate-first waiters_0))))
                   (void)))))

--- a/racket/src/schemify/left-to-right.rkt
+++ b/racket/src/schemify/left-to-right.rkt
@@ -48,13 +48,13 @@
 
 ;; Convert a `let-values` to nested `let-values`es to
 ;; enforce order
-(define (left-to-right/let-values idss rhss bodys mutated target)
+(define (left-to-right/let-values idss rhss bodys mutated target unsafe-mode?)
   (cond
     [(null? (cdr idss))
      (define e (if (null? (cdr bodys))
                    (car bodys)
                    `(begin . ,bodys)))
-     (make-let-values (car idss) (car rhss) e target)]
+     (make-let-values (car idss) (car rhss) e target unsafe-mode?)]
    [else
     (let loop ([idss idss] [rhss rhss] [binds null])
       (cond
@@ -63,7 +63,8 @@
          (car idss) (car rhss)
          `(let ,binds
             . ,bodys)
-         target)]
+         target
+	 unsafe-mode?)]
        [else
         (define ids (car idss))
         (make-let-values
@@ -72,7 +73,8 @@
          (loop (cdr idss) (cdr rhss) (append (for/list ([id (in-wrap-list ids)])
                                                `[,id ,id])
                                              binds))
-         target)]))]))
+         target
+	 unsafe-mode?)]))]))
 
 ;; Convert an application to enforce left-to-right evaluation order.
 (define (left-to-right/app rator rands app-form target
@@ -143,7 +145,7 @@
           
 ;; ----------------------------------------
 
-(define (make-let-values ids rhs body target)
+(define (make-let-values ids rhs body target unsafe-mode?)
   (cond
    [(and (pair? ids) (null? (cdr ids)))
     `(let ([,(car ids) ,rhs]) ,body)]
@@ -153,7 +155,7 @@
        `(begin ,rhs ,body)]
       [`,_
        (cond
-         [(aim? target 'cify)
+         [(or unsafe-mode? (aim? target 'cify))
           ;; No checking
           `(call-with-values (lambda () ,rhs)
              (lambda ,ids ,body))]

--- a/racket/src/schemify/schemify.rkt
+++ b/racket/src/schemify/schemify.rkt
@@ -608,7 +608,8 @@
                                              (schemify rhs 'fresh))
                                            (schemify-body bodys wcm-state)
                                            mutated
-                                           target)
+                                           target
+					   unsafe-mode?)
                  prim-knowns knowns imports mutated simples unsafe-mode?))]
            [`(letrec-values () ,bodys ...)
             (schemify `(begin . ,bodys) wcm-state)]
@@ -666,12 +667,12 @@
                                 (cond
                                   [(null? ids)
                                    `([,(deterministic-gensym "lr")
-                                      ,(make-let-values null rhs '(void) target)])]
+                                      ,(make-let-values null rhs '(void) target unsafe-mode?)])]
                                   [(and (pair? ids) (null? (cdr ids)))
                                    `([,(car ids) ,rhs])]
                                   [else
                                    (define lr (deterministic-gensym "lr"))
-                                   `([,lr ,(make-let-values ids rhs `(vector . ,ids) target)]
+                                   `([,lr ,(make-let-values ids rhs `(vector . ,ids) target unsafe-mode?)]
                                      ,@(for/list ([id (in-list ids)]
                                                   [pos (in-naturals)])
                                          `[,id (unsafe-vector*-ref ,lr ,pos)]))]))))


### PR DESCRIPTION
This simplifies a lot of generated code, so much that I wonder if @mflatt already thought of this and decided against it.
