### PR TITLE
Use authentic in core linklets

### DIFF
--- a/racket/src/cs/schemified/regexp.scm
+++ b/racket/src/cs/schemified/regexp.scm
@@ -878,13 +878,13 @@
 (define rx:line-end 'line-end)
 (define rx:word-boundary 'word-boundary)
 (define rx:not-word-boundary 'not-word-boundary)
-(define finish_2542
+(define finish_2124
   (make-struct-type-install-properties
    '(rx:alts)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1)
@@ -898,46 +898,24 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2414 (finish_2542 struct:rx:alts))
+(define effect_2414 (finish_2124 struct:rx:alts))
 (define rx:alts1.1
   (|#%name|
    rx:alts
    (record-constructor
     (make-record-constructor-descriptor struct:rx:alts #f #f))))
-(define rx:alts?_2576 (|#%name| rx:alts? (record-predicate struct:rx:alts)))
-(define rx:alts?
-  (|#%name|
-   rx:alts?
-   (lambda (v)
-     (if (rx:alts?_2576 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:alts?_2576 (impersonator-val v)) #f))))))
+(define rx:alts? (|#%name| rx:alts? (record-predicate struct:rx:alts)))
 (define rx:alts-rx_2530
   (|#%name| rx:alts-rx1 (record-accessor struct:rx:alts 0)))
-(define rx:alts-rx_2265
-  (|#%name|
-   rx:alts-rx1
-   (lambda (s)
-     (if (rx:alts?_2576 s)
-       (rx:alts-rx_2530 s)
-       ($value (impersonate-ref rx:alts-rx_2530 struct:rx:alts 0 s 'rx1))))))
 (define rx:alts-rx_2917
   (|#%name| rx:alts-rx2 (record-accessor struct:rx:alts 1)))
-(define rx:alts-rx_1912
-  (|#%name|
-   rx:alts-rx2
-   (lambda (s)
-     (if (rx:alts?_2576 s)
-       (rx:alts-rx_2917 s)
-       ($value (impersonate-ref rx:alts-rx_2917 struct:rx:alts 1 s 'rx2))))))
-(define finish_2732
+(define finish_3074
   (make-struct-type-install-properties
    '(rx:sequence)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1)
@@ -951,56 +929,27 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2459 (finish_2732 struct:rx:sequence))
+(define effect_2459 (finish_3074 struct:rx:sequence))
 (define rx:sequence2.1
   (|#%name|
    rx:sequence
    (record-constructor
     (make-record-constructor-descriptor struct:rx:sequence #f #f))))
-(define rx:sequence?_3213
-  (|#%name| rx:sequence? (record-predicate struct:rx:sequence)))
 (define rx:sequence?
-  (|#%name|
-   rx:sequence?
-   (lambda (v)
-     (if (rx:sequence?_3213 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:sequence?_3213 (impersonator-val v)) #f))))))
-(define rx:sequence-rxs_2380
-  (|#%name| rx:sequence-rxs (record-accessor struct:rx:sequence 0)))
+  (|#%name| rx:sequence? (record-predicate struct:rx:sequence)))
 (define rx:sequence-rxs
-  (|#%name|
-   rx:sequence-rxs
-   (lambda (s)
-     (if (rx:sequence?_3213 s)
-       (rx:sequence-rxs_2380 s)
-       ($value
-        (impersonate-ref rx:sequence-rxs_2380 struct:rx:sequence 0 s 'rxs))))))
-(define rx:sequence-needs-backtrack?_2458
-  (|#%name|
-   rx:sequence-needs-backtrack?
-   (record-accessor struct:rx:sequence 1)))
+  (|#%name| rx:sequence-rxs (record-accessor struct:rx:sequence 0)))
 (define rx:sequence-needs-backtrack?
   (|#%name|
    rx:sequence-needs-backtrack?
-   (lambda (s)
-     (if (rx:sequence?_3213 s)
-       (rx:sequence-needs-backtrack?_2458 s)
-       ($value
-        (impersonate-ref
-         rx:sequence-needs-backtrack?_2458
-         struct:rx:sequence
-         1
-         s
-         'needs-backtrack?))))))
-(define finish_2954
+   (record-accessor struct:rx:sequence 1)))
+(define finish_2409
   (make-struct-type-install-properties
    '(rx:group)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1)
@@ -1014,47 +963,23 @@
    #f
    #f
    '(2 . 0)))
-(define effect_1819 (finish_2954 struct:rx:group))
+(define effect_1819 (finish_2409 struct:rx:group))
 (define rx:group3.1
   (|#%name|
    rx:group
    (record-constructor
     (make-record-constructor-descriptor struct:rx:group #f #f))))
-(define rx:group?_3085 (|#%name| rx:group? (record-predicate struct:rx:group)))
-(define rx:group?
-  (|#%name|
-   rx:group?
-   (lambda (v)
-     (if (rx:group?_3085 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:group?_3085 (impersonator-val v)) #f))))))
-(define rx:group-rx_2903
-  (|#%name| rx:group-rx (record-accessor struct:rx:group 0)))
-(define rx:group-rx
-  (|#%name|
-   rx:group-rx
-   (lambda (s)
-     (if (rx:group?_3085 s)
-       (rx:group-rx_2903 s)
-       ($value (impersonate-ref rx:group-rx_2903 struct:rx:group 0 s 'rx))))))
-(define rx:group-number_2715
-  (|#%name| rx:group-number (record-accessor struct:rx:group 1)))
+(define rx:group? (|#%name| rx:group? (record-predicate struct:rx:group)))
+(define rx:group-rx (|#%name| rx:group-rx (record-accessor struct:rx:group 0)))
 (define rx:group-number
-  (|#%name|
-   rx:group-number
-   (lambda (s)
-     (if (rx:group?_3085 s)
-       (rx:group-number_2715 s)
-       ($value
-        (impersonate-ref rx:group-number_2715 struct:rx:group 1 s 'number))))))
-(define finish_1837
+  (|#%name| rx:group-number (record-accessor struct:rx:group 1)))
+(define finish_2710
   (make-struct-type-install-properties
    '(rx:repeat)
    4
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1 2 3)
@@ -1068,74 +993,28 @@
    #f
    #f
    '(4 . 0)))
-(define effect_2312 (finish_1837 struct:rx:repeat))
+(define effect_2312 (finish_2710 struct:rx:repeat))
 (define rx:repeat4.1
   (|#%name|
    rx:repeat
    (record-constructor
     (make-record-constructor-descriptor struct:rx:repeat #f #f))))
-(define rx:repeat?_2609
-  (|#%name| rx:repeat? (record-predicate struct:rx:repeat)))
-(define rx:repeat?
-  (|#%name|
-   rx:repeat?
-   (lambda (v)
-     (if (rx:repeat?_2609 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:repeat?_2609 (impersonator-val v)) #f))))))
-(define rx:repeat-rx_2269
-  (|#%name| rx:repeat-rx (record-accessor struct:rx:repeat 0)))
+(define rx:repeat? (|#%name| rx:repeat? (record-predicate struct:rx:repeat)))
 (define rx:repeat-rx
-  (|#%name|
-   rx:repeat-rx
-   (lambda (s)
-     (if (rx:repeat?_2609 s)
-       (rx:repeat-rx_2269 s)
-       ($value
-        (impersonate-ref rx:repeat-rx_2269 struct:rx:repeat 0 s 'rx))))))
-(define rx:repeat-min_2947
-  (|#%name| rx:repeat-min (record-accessor struct:rx:repeat 1)))
+  (|#%name| rx:repeat-rx (record-accessor struct:rx:repeat 0)))
 (define rx:repeat-min
-  (|#%name|
-   rx:repeat-min
-   (lambda (s)
-     (if (rx:repeat?_2609 s)
-       (rx:repeat-min_2947 s)
-       ($value
-        (impersonate-ref rx:repeat-min_2947 struct:rx:repeat 1 s 'min))))))
-(define rx:repeat-max_2564
-  (|#%name| rx:repeat-max (record-accessor struct:rx:repeat 2)))
+  (|#%name| rx:repeat-min (record-accessor struct:rx:repeat 1)))
 (define rx:repeat-max
-  (|#%name|
-   rx:repeat-max
-   (lambda (s)
-     (if (rx:repeat?_2609 s)
-       (rx:repeat-max_2564 s)
-       ($value
-        (impersonate-ref rx:repeat-max_2564 struct:rx:repeat 2 s 'max))))))
-(define rx:repeat-non-greedy?_2609
-  (|#%name| rx:repeat-non-greedy? (record-accessor struct:rx:repeat 3)))
+  (|#%name| rx:repeat-max (record-accessor struct:rx:repeat 2)))
 (define rx:repeat-non-greedy?
-  (|#%name|
-   rx:repeat-non-greedy?
-   (lambda (s)
-     (if (rx:repeat?_2609 s)
-       (rx:repeat-non-greedy?_2609 s)
-       ($value
-        (impersonate-ref
-         rx:repeat-non-greedy?_2609
-         struct:rx:repeat
-         3
-         s
-         'non-greedy?))))))
-(define finish_3260
+  (|#%name| rx:repeat-non-greedy? (record-accessor struct:rx:repeat 3)))
+(define finish_2057
   (make-struct-type-install-properties
    '(rx:maybe)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1)
@@ -1149,52 +1028,23 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2202 (finish_3260 struct:rx:maybe))
+(define effect_2202 (finish_2057 struct:rx:maybe))
 (define rx:maybe5.1
   (|#%name|
    rx:maybe
    (record-constructor
     (make-record-constructor-descriptor struct:rx:maybe #f #f))))
-(define rx:maybe?_2766 (|#%name| rx:maybe? (record-predicate struct:rx:maybe)))
-(define rx:maybe?
-  (|#%name|
-   rx:maybe?
-   (lambda (v)
-     (if (rx:maybe?_2766 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:maybe?_2766 (impersonator-val v)) #f))))))
-(define rx:maybe-rx_2762
-  (|#%name| rx:maybe-rx (record-accessor struct:rx:maybe 0)))
-(define rx:maybe-rx
-  (|#%name|
-   rx:maybe-rx
-   (lambda (s)
-     (if (rx:maybe?_2766 s)
-       (rx:maybe-rx_2762 s)
-       ($value (impersonate-ref rx:maybe-rx_2762 struct:rx:maybe 0 s 'rx))))))
-(define rx:maybe-non-greedy?_2749
-  (|#%name| rx:maybe-non-greedy? (record-accessor struct:rx:maybe 1)))
+(define rx:maybe? (|#%name| rx:maybe? (record-predicate struct:rx:maybe)))
+(define rx:maybe-rx (|#%name| rx:maybe-rx (record-accessor struct:rx:maybe 0)))
 (define rx:maybe-non-greedy?
-  (|#%name|
-   rx:maybe-non-greedy?
-   (lambda (s)
-     (if (rx:maybe?_2766 s)
-       (rx:maybe-non-greedy?_2749 s)
-       ($value
-        (impersonate-ref
-         rx:maybe-non-greedy?_2749
-         struct:rx:maybe
-         1
-         s
-         'non-greedy?))))))
-(define finish_2500
+  (|#%name| rx:maybe-non-greedy? (record-accessor struct:rx:maybe 1)))
+(define finish_2914
   (make-struct-type-install-properties
    '(rx:conditional)
    6
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1 2 3 4 5)
@@ -1208,123 +1058,35 @@
    #f
    #f
    '(6 . 0)))
-(define effect_2905 (finish_2500 struct:rx:conditional))
+(define effect_2905 (finish_2914 struct:rx:conditional))
 (define rx:conditional6.1
   (|#%name|
    rx:conditional
    (record-constructor
     (make-record-constructor-descriptor struct:rx:conditional #f #f))))
-(define rx:conditional?_2616
-  (|#%name| rx:conditional? (record-predicate struct:rx:conditional)))
 (define rx:conditional?
-  (|#%name|
-   rx:conditional?
-   (lambda (v)
-     (if (rx:conditional?_2616 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (rx:conditional?_2616 (impersonator-val v))
-          #f))))))
-(define rx:conditional-tst_3132
-  (|#%name| rx:conditional-tst (record-accessor struct:rx:conditional 0)))
+  (|#%name| rx:conditional? (record-predicate struct:rx:conditional)))
 (define rx:conditional-tst
-  (|#%name|
-   rx:conditional-tst
-   (lambda (s)
-     (if (rx:conditional?_2616 s)
-       (rx:conditional-tst_3132 s)
-       ($value
-        (impersonate-ref
-         rx:conditional-tst_3132
-         struct:rx:conditional
-         0
-         s
-         'tst))))))
+  (|#%name| rx:conditional-tst (record-accessor struct:rx:conditional 0)))
 (define rx:conditional-rx_2590
   (|#%name| rx:conditional-rx1 (record-accessor struct:rx:conditional 1)))
-(define rx:conditional-rx_2162
-  (|#%name|
-   rx:conditional-rx1
-   (lambda (s)
-     (if (rx:conditional?_2616 s)
-       (rx:conditional-rx_2590 s)
-       ($value
-        (impersonate-ref
-         rx:conditional-rx_2590
-         struct:rx:conditional
-         1
-         s
-         'rx1))))))
 (define rx:conditional-rx_3084
   (|#%name| rx:conditional-rx2 (record-accessor struct:rx:conditional 2)))
-(define rx:conditional-rx_2328
-  (|#%name|
-   rx:conditional-rx2
-   (lambda (s)
-     (if (rx:conditional?_2616 s)
-       (rx:conditional-rx_3084 s)
-       ($value
-        (impersonate-ref
-         rx:conditional-rx_3084
-         struct:rx:conditional
-         2
-         s
-         'rx2))))))
-(define rx:conditional-n-start_1886
-  (|#%name| rx:conditional-n-start (record-accessor struct:rx:conditional 3)))
 (define rx:conditional-n-start
-  (|#%name|
-   rx:conditional-n-start
-   (lambda (s)
-     (if (rx:conditional?_2616 s)
-       (rx:conditional-n-start_1886 s)
-       ($value
-        (impersonate-ref
-         rx:conditional-n-start_1886
-         struct:rx:conditional
-         3
-         s
-         'n-start))))))
-(define rx:conditional-num-n_2530
-  (|#%name| rx:conditional-num-n (record-accessor struct:rx:conditional 4)))
+  (|#%name| rx:conditional-n-start (record-accessor struct:rx:conditional 3)))
 (define rx:conditional-num-n
-  (|#%name|
-   rx:conditional-num-n
-   (lambda (s)
-     (if (rx:conditional?_2616 s)
-       (rx:conditional-num-n_2530 s)
-       ($value
-        (impersonate-ref
-         rx:conditional-num-n_2530
-         struct:rx:conditional
-         4
-         s
-         'num-n))))))
-(define rx:conditional-needs-backtrack?_2562
-  (|#%name|
-   rx:conditional-needs-backtrack?
-   (record-accessor struct:rx:conditional 5)))
+  (|#%name| rx:conditional-num-n (record-accessor struct:rx:conditional 4)))
 (define rx:conditional-needs-backtrack?
   (|#%name|
    rx:conditional-needs-backtrack?
-   (lambda (s)
-     (if (rx:conditional?_2616 s)
-       (rx:conditional-needs-backtrack?_2562 s)
-       ($value
-        (impersonate-ref
-         rx:conditional-needs-backtrack?_2562
-         struct:rx:conditional
-         5
-         s
-         'needs-backtrack?))))))
-(define finish_2488
+   (record-accessor struct:rx:conditional 5)))
+(define finish_2954
   (make-struct-type-install-properties
    '(rx:lookahead)
    4
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1 2 3)
@@ -1338,86 +1100,29 @@
    #f
    #f
    '(4 . 0)))
-(define effect_2486 (finish_2488 struct:rx:lookahead))
+(define effect_2486 (finish_2954 struct:rx:lookahead))
 (define rx:lookahead7.1
   (|#%name|
    rx:lookahead
    (record-constructor
     (make-record-constructor-descriptor struct:rx:lookahead #f #f))))
-(define rx:lookahead?_3136
-  (|#%name| rx:lookahead? (record-predicate struct:rx:lookahead)))
 (define rx:lookahead?
-  (|#%name|
-   rx:lookahead?
-   (lambda (v)
-     (if (rx:lookahead?_3136 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (rx:lookahead?_3136 (impersonator-val v))
-          #f))))))
-(define rx:lookahead-rx_2682
-  (|#%name| rx:lookahead-rx (record-accessor struct:rx:lookahead 0)))
+  (|#%name| rx:lookahead? (record-predicate struct:rx:lookahead)))
 (define rx:lookahead-rx
-  (|#%name|
-   rx:lookahead-rx
-   (lambda (s)
-     (if (rx:lookahead?_3136 s)
-       (rx:lookahead-rx_2682 s)
-       ($value
-        (impersonate-ref rx:lookahead-rx_2682 struct:rx:lookahead 0 s 'rx))))))
-(define rx:lookahead-match?_1967
-  (|#%name| rx:lookahead-match? (record-accessor struct:rx:lookahead 1)))
+  (|#%name| rx:lookahead-rx (record-accessor struct:rx:lookahead 0)))
 (define rx:lookahead-match?
-  (|#%name|
-   rx:lookahead-match?
-   (lambda (s)
-     (if (rx:lookahead?_3136 s)
-       (rx:lookahead-match?_1967 s)
-       ($value
-        (impersonate-ref
-         rx:lookahead-match?_1967
-         struct:rx:lookahead
-         1
-         s
-         'match?))))))
-(define rx:lookahead-n-start_2202
-  (|#%name| rx:lookahead-n-start (record-accessor struct:rx:lookahead 2)))
+  (|#%name| rx:lookahead-match? (record-accessor struct:rx:lookahead 1)))
 (define rx:lookahead-n-start
-  (|#%name|
-   rx:lookahead-n-start
-   (lambda (s)
-     (if (rx:lookahead?_3136 s)
-       (rx:lookahead-n-start_2202 s)
-       ($value
-        (impersonate-ref
-         rx:lookahead-n-start_2202
-         struct:rx:lookahead
-         2
-         s
-         'n-start))))))
-(define rx:lookahead-num-n_2643
-  (|#%name| rx:lookahead-num-n (record-accessor struct:rx:lookahead 3)))
+  (|#%name| rx:lookahead-n-start (record-accessor struct:rx:lookahead 2)))
 (define rx:lookahead-num-n
-  (|#%name|
-   rx:lookahead-num-n
-   (lambda (s)
-     (if (rx:lookahead?_3136 s)
-       (rx:lookahead-num-n_2643 s)
-       ($value
-        (impersonate-ref
-         rx:lookahead-num-n_2643
-         struct:rx:lookahead
-         3
-         s
-         'num-n))))))
-(define finish_3095
+  (|#%name| rx:lookahead-num-n (record-accessor struct:rx:lookahead 3)))
+(define finish_1844
   (make-struct-type-install-properties
    '(rx:lookbehind)
    6
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1 4 5)
@@ -1431,155 +1136,37 @@
    #f
    #f
    '(6 . 12)))
-(define effect_2468 (finish_3095 struct:rx:lookbehind))
+(define effect_2468 (finish_1844 struct:rx:lookbehind))
 (define rx:lookbehind8.1
   (|#%name|
    rx:lookbehind
    (record-constructor
     (make-record-constructor-descriptor struct:rx:lookbehind #f #f))))
-(define rx:lookbehind?_3001
-  (|#%name| rx:lookbehind? (record-predicate struct:rx:lookbehind)))
 (define rx:lookbehind?
-  (|#%name|
-   rx:lookbehind?
-   (lambda (v)
-     (if (rx:lookbehind?_3001 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (rx:lookbehind?_3001 (impersonator-val v))
-          #f))))))
-(define rx:lookbehind-rx_2597
-  (|#%name| rx:lookbehind-rx (record-accessor struct:rx:lookbehind 0)))
+  (|#%name| rx:lookbehind? (record-predicate struct:rx:lookbehind)))
 (define rx:lookbehind-rx
-  (|#%name|
-   rx:lookbehind-rx
-   (lambda (s)
-     (if (rx:lookbehind?_3001 s)
-       (rx:lookbehind-rx_2597 s)
-       ($value
-        (impersonate-ref
-         rx:lookbehind-rx_2597
-         struct:rx:lookbehind
-         0
-         s
-         'rx))))))
-(define rx:lookbehind-match?_2428
-  (|#%name| rx:lookbehind-match? (record-accessor struct:rx:lookbehind 1)))
+  (|#%name| rx:lookbehind-rx (record-accessor struct:rx:lookbehind 0)))
 (define rx:lookbehind-match?
-  (|#%name|
-   rx:lookbehind-match?
-   (lambda (s)
-     (if (rx:lookbehind?_3001 s)
-       (rx:lookbehind-match?_2428 s)
-       ($value
-        (impersonate-ref
-         rx:lookbehind-match?_2428
-         struct:rx:lookbehind
-         1
-         s
-         'match?))))))
-(define rx:lookbehind-lb-min_2372
-  (|#%name| rx:lookbehind-lb-min (record-accessor struct:rx:lookbehind 2)))
+  (|#%name| rx:lookbehind-match? (record-accessor struct:rx:lookbehind 1)))
 (define rx:lookbehind-lb-min
-  (|#%name|
-   rx:lookbehind-lb-min
-   (lambda (s)
-     (if (rx:lookbehind?_3001 s)
-       (rx:lookbehind-lb-min_2372 s)
-       ($value
-        (impersonate-ref
-         rx:lookbehind-lb-min_2372
-         struct:rx:lookbehind
-         2
-         s
-         'lb-min))))))
-(define rx:lookbehind-lb-max_3076
-  (|#%name| rx:lookbehind-lb-max (record-accessor struct:rx:lookbehind 3)))
+  (|#%name| rx:lookbehind-lb-min (record-accessor struct:rx:lookbehind 2)))
 (define rx:lookbehind-lb-max
-  (|#%name|
-   rx:lookbehind-lb-max
-   (lambda (s)
-     (if (rx:lookbehind?_3001 s)
-       (rx:lookbehind-lb-max_3076 s)
-       ($value
-        (impersonate-ref
-         rx:lookbehind-lb-max_3076
-         struct:rx:lookbehind
-         3
-         s
-         'lb-max))))))
-(define rx:lookbehind-n-start_2946
-  (|#%name| rx:lookbehind-n-start (record-accessor struct:rx:lookbehind 4)))
+  (|#%name| rx:lookbehind-lb-max (record-accessor struct:rx:lookbehind 3)))
 (define rx:lookbehind-n-start
-  (|#%name|
-   rx:lookbehind-n-start
-   (lambda (s)
-     (if (rx:lookbehind?_3001 s)
-       (rx:lookbehind-n-start_2946 s)
-       ($value
-        (impersonate-ref
-         rx:lookbehind-n-start_2946
-         struct:rx:lookbehind
-         4
-         s
-         'n-start))))))
-(define rx:lookbehind-num-n_2613
-  (|#%name| rx:lookbehind-num-n (record-accessor struct:rx:lookbehind 5)))
+  (|#%name| rx:lookbehind-n-start (record-accessor struct:rx:lookbehind 4)))
 (define rx:lookbehind-num-n
-  (|#%name|
-   rx:lookbehind-num-n
-   (lambda (s)
-     (if (rx:lookbehind?_3001 s)
-       (rx:lookbehind-num-n_2613 s)
-       ($value
-        (impersonate-ref
-         rx:lookbehind-num-n_2613
-         struct:rx:lookbehind
-         5
-         s
-         'num-n))))))
-(define set-rx:lookbehind-lb-min!_2809
-  (|#%name| set-rx:lookbehind-lb-min! (record-mutator struct:rx:lookbehind 2)))
+  (|#%name| rx:lookbehind-num-n (record-accessor struct:rx:lookbehind 5)))
 (define set-rx:lookbehind-lb-min!
-  (|#%name|
-   set-rx:lookbehind-lb-min!
-   (lambda (s v)
-     (if (rx:lookbehind?_3001 s)
-       (set-rx:lookbehind-lb-min!_2809 s v)
-       ($value
-        (impersonate-set!
-         set-rx:lookbehind-lb-min!_2809
-         struct:rx:lookbehind
-         2
-         2
-         s
-         v
-         'lb-min))))))
-(define set-rx:lookbehind-lb-max!_2352
-  (|#%name| set-rx:lookbehind-lb-max! (record-mutator struct:rx:lookbehind 3)))
+  (|#%name| set-rx:lookbehind-lb-min! (record-mutator struct:rx:lookbehind 2)))
 (define set-rx:lookbehind-lb-max!
-  (|#%name|
-   set-rx:lookbehind-lb-max!
-   (lambda (s v)
-     (if (rx:lookbehind?_3001 s)
-       (set-rx:lookbehind-lb-max!_2352 s v)
-       ($value
-        (impersonate-set!
-         set-rx:lookbehind-lb-max!_2352
-         struct:rx:lookbehind
-         3
-         3
-         s
-         v
-         'lb-max))))))
-(define finish_2346
+  (|#%name| set-rx:lookbehind-lb-max! (record-mutator struct:rx:lookbehind 3)))
+(define finish_1951
   (make-struct-type-install-properties
    '(rx:cut)
    4
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1 2 3)
@@ -1593,71 +1180,26 @@
    #f
    #f
    '(4 . 0)))
-(define effect_2158 (finish_2346 struct:rx:cut))
+(define effect_2158 (finish_1951 struct:rx:cut))
 (define rx:cut9.1
   (|#%name|
    rx:cut
    (record-constructor
     (make-record-constructor-descriptor struct:rx:cut #f #f))))
-(define rx:cut?_2453 (|#%name| rx:cut? (record-predicate struct:rx:cut)))
-(define rx:cut?
-  (|#%name|
-   rx:cut?
-   (lambda (v)
-     (if (rx:cut?_2453 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:cut?_2453 (impersonator-val v)) #f))))))
-(define rx:cut-rx_2624 (|#%name| rx:cut-rx (record-accessor struct:rx:cut 0)))
-(define rx:cut-rx
-  (|#%name|
-   rx:cut-rx
-   (lambda (s)
-     (if (rx:cut?_2453 s)
-       (rx:cut-rx_2624 s)
-       ($value (impersonate-ref rx:cut-rx_2624 struct:rx:cut 0 s 'rx))))))
-(define rx:cut-n-start_2924
-  (|#%name| rx:cut-n-start (record-accessor struct:rx:cut 1)))
+(define rx:cut? (|#%name| rx:cut? (record-predicate struct:rx:cut)))
+(define rx:cut-rx (|#%name| rx:cut-rx (record-accessor struct:rx:cut 0)))
 (define rx:cut-n-start
-  (|#%name|
-   rx:cut-n-start
-   (lambda (s)
-     (if (rx:cut?_2453 s)
-       (rx:cut-n-start_2924 s)
-       ($value
-        (impersonate-ref rx:cut-n-start_2924 struct:rx:cut 1 s 'n-start))))))
-(define rx:cut-num-n_2085
-  (|#%name| rx:cut-num-n (record-accessor struct:rx:cut 2)))
-(define rx:cut-num-n
-  (|#%name|
-   rx:cut-num-n
-   (lambda (s)
-     (if (rx:cut?_2453 s)
-       (rx:cut-num-n_2085 s)
-       ($value
-        (impersonate-ref rx:cut-num-n_2085 struct:rx:cut 2 s 'num-n))))))
-(define rx:cut-needs-backtrack?_2736
-  (|#%name| rx:cut-needs-backtrack? (record-accessor struct:rx:cut 3)))
+  (|#%name| rx:cut-n-start (record-accessor struct:rx:cut 1)))
+(define rx:cut-num-n (|#%name| rx:cut-num-n (record-accessor struct:rx:cut 2)))
 (define rx:cut-needs-backtrack?
-  (|#%name|
-   rx:cut-needs-backtrack?
-   (lambda (s)
-     (if (rx:cut?_2453 s)
-       (rx:cut-needs-backtrack?_2736 s)
-       ($value
-        (impersonate-ref
-         rx:cut-needs-backtrack?_2736
-         struct:rx:cut
-         3
-         s
-         'needs-backtrack?))))))
-(define finish_1921
+  (|#%name| rx:cut-needs-backtrack? (record-accessor struct:rx:cut 3)))
+(define finish_2358
   (make-struct-type-install-properties
    '(rx:reference)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1)
@@ -1671,58 +1213,27 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2306 (finish_1921 struct:rx:reference))
+(define effect_2306 (finish_2358 struct:rx:reference))
 (define rx:reference10.1
   (|#%name|
    rx:reference
    (record-constructor
     (make-record-constructor-descriptor struct:rx:reference #f #f))))
-(define rx:reference?_2938
-  (|#%name| rx:reference? (record-predicate struct:rx:reference)))
 (define rx:reference?
-  (|#%name|
-   rx:reference?
-   (lambda (v)
-     (if (rx:reference?_2938 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (rx:reference?_2938 (impersonator-val v))
-          #f))))))
-(define rx:reference-n_2302
-  (|#%name| rx:reference-n (record-accessor struct:rx:reference 0)))
+  (|#%name| rx:reference? (record-predicate struct:rx:reference)))
 (define rx:reference-n
-  (|#%name|
-   rx:reference-n
-   (lambda (s)
-     (if (rx:reference?_2938 s)
-       (rx:reference-n_2302 s)
-       ($value
-        (impersonate-ref rx:reference-n_2302 struct:rx:reference 0 s 'n))))))
-(define rx:reference-case-sensitive?_2306
-  (|#%name|
-   rx:reference-case-sensitive?
-   (record-accessor struct:rx:reference 1)))
+  (|#%name| rx:reference-n (record-accessor struct:rx:reference 0)))
 (define rx:reference-case-sensitive?
   (|#%name|
    rx:reference-case-sensitive?
-   (lambda (s)
-     (if (rx:reference?_2938 s)
-       (rx:reference-case-sensitive?_2306 s)
-       ($value
-        (impersonate-ref
-         rx:reference-case-sensitive?_2306
-         struct:rx:reference
-         1
-         s
-         'case-sensitive?))))))
-(define finish_2471
+   (record-accessor struct:rx:reference 1)))
+(define finish_2696
   (make-struct-type-install-properties
    '(rx:range)
    1
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0)
@@ -1736,38 +1247,22 @@
    #f
    #f
    '(1 . 0)))
-(define effect_2071 (finish_2471 struct:rx:range))
+(define effect_2071 (finish_2696 struct:rx:range))
 (define rx:range11.1
   (|#%name|
    rx:range
    (record-constructor
     (make-record-constructor-descriptor struct:rx:range #f #f))))
-(define rx:range?_1948 (|#%name| rx:range? (record-predicate struct:rx:range)))
-(define rx:range?
-  (|#%name|
-   rx:range?
-   (lambda (v)
-     (if (rx:range?_1948 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:range?_1948 (impersonator-val v)) #f))))))
-(define rx:range-range_2664
-  (|#%name| rx:range-range (record-accessor struct:rx:range 0)))
+(define rx:range? (|#%name| rx:range? (record-predicate struct:rx:range)))
 (define rx:range-range
-  (|#%name|
-   rx:range-range
-   (lambda (s)
-     (if (rx:range?_1948 s)
-       (rx:range-range_2664 s)
-       ($value
-        (impersonate-ref rx:range-range_2664 struct:rx:range 0 s 'range))))))
-(define finish_2339
+  (|#%name| rx:range-range (record-accessor struct:rx:range 0)))
+(define finish_2757
   (make-struct-type-install-properties
    '(rx:unicode-categories)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    #f
    #f
    '(0 1)
@@ -1781,60 +1276,24 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2341 (finish_2339 struct:rx:unicode-categories))
+(define effect_2341 (finish_2757 struct:rx:unicode-categories))
 (define rx:unicode-categories12.1
   (|#%name|
    rx:unicode-categories
    (record-constructor
     (make-record-constructor-descriptor struct:rx:unicode-categories #f #f))))
-(define rx:unicode-categories?_2156
-  (|#%name|
-   rx:unicode-categories?
-   (record-predicate struct:rx:unicode-categories)))
 (define rx:unicode-categories?
   (|#%name|
    rx:unicode-categories?
-   (lambda (v)
-     (if (rx:unicode-categories?_2156 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (rx:unicode-categories?_2156 (impersonator-val v))
-          #f))))))
-(define rx:unicode-categories-symlist_1950
-  (|#%name|
-   rx:unicode-categories-symlist
-   (record-accessor struct:rx:unicode-categories 0)))
+   (record-predicate struct:rx:unicode-categories)))
 (define rx:unicode-categories-symlist
   (|#%name|
    rx:unicode-categories-symlist
-   (lambda (s)
-     (if (rx:unicode-categories?_2156 s)
-       (rx:unicode-categories-symlist_1950 s)
-       ($value
-        (impersonate-ref
-         rx:unicode-categories-symlist_1950
-         struct:rx:unicode-categories
-         0
-         s
-         'symlist))))))
-(define rx:unicode-categories-match?_2521
-  (|#%name|
-   rx:unicode-categories-match?
-   (record-accessor struct:rx:unicode-categories 1)))
+   (record-accessor struct:rx:unicode-categories 0)))
 (define rx:unicode-categories-match?
   (|#%name|
    rx:unicode-categories-match?
-   (lambda (s)
-     (if (rx:unicode-categories?_2156 s)
-       (rx:unicode-categories-match?_2521 s)
-       ($value
-        (impersonate-ref
-         rx:unicode-categories-match?_2521
-         struct:rx:unicode-categories
-         1
-         s
-         'match?))))))
+   (record-accessor struct:rx:unicode-categories 1)))
 (define needs-backtrack?
   (lambda (rx_0)
     (if (rx:alts? rx_0)
@@ -2000,14 +1459,13 @@
         rx1_0
         (if (if (rx:range? rx1_0) (rx:range? rx2_0) #f)
           (rx-range
-           (let ((app_0 (rx:range-range rx1_0)))
-             (range-union app_0 (rx:range-range rx2_0)))
+           (range-union (rx:range-range rx1_0) (rx:range-range rx2_0))
            limit-c_0)
           (if (if (rx:range? rx1_0)
-                (if (rx:alts? rx2_0) (rx:range? (rx:alts-rx_2265 rx2_0)) #f)
+                (if (rx:alts? rx2_0) (rx:range? (rx:alts-rx_2530 rx2_0)) #f)
                 #f)
-            (let ((app_0 (rx-alts rx1_0 (rx:alts-rx_2265 rx2_0) limit-c_0)))
-              (rx-alts app_0 (rx:alts-rx_1912 rx2_0) limit-c_0))
+            (let ((app_0 (rx-alts rx1_0 (rx:alts-rx_2530 rx2_0) limit-c_0)))
+              (rx-alts app_0 (rx:alts-rx_2917 rx2_0) limit-c_0))
             (if (if (rx:range? rx1_0) (integer? rx2_0) #f)
               (rx-range (range-add (rx:range-range rx1_0) rx2_0) limit-c_0)
               (if (if (rx:range? rx2_0) (integer? rx1_0) #f)
@@ -2029,13 +1487,13 @@
      num-n_0
      (let ((or-part_0 (needs-backtrack? pces1_0)))
        (if or-part_0 or-part_0 (needs-backtrack? pces2_0))))))
-(define finish_2581
+(define finish_2184
   (make-struct-type-install-properties
    '(parse-config)
    7
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1 2 3 4 5 6)
@@ -2049,137 +1507,36 @@
    #f
    #f
    '(7 . 0)))
-(define effect_2622 (finish_2581 struct:parse-config))
+(define effect_2622 (finish_2184 struct:parse-config))
 (define parse-config1.1
   (|#%name|
    parse-config
    (record-constructor
     (make-record-constructor-descriptor struct:parse-config #f #f))))
-(define parse-config?_2003
-  (|#%name| parse-config? (record-predicate struct:parse-config)))
 (define parse-config?
-  (|#%name|
-   parse-config?
-   (lambda (v)
-     (if (parse-config?_2003 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (parse-config?_2003 (impersonator-val v))
-          #f))))))
-(define parse-config-who_2100
-  (|#%name| parse-config-who (record-accessor struct:parse-config 0)))
+  (|#%name| parse-config? (record-predicate struct:parse-config)))
 (define parse-config-who
-  (|#%name|
-   parse-config-who
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-who_2100 s)
-       ($value
-        (impersonate-ref
-         parse-config-who_2100
-         struct:parse-config
-         0
-         s
-         'who))))))
-(define parse-config-px?_2965
-  (|#%name| parse-config-px? (record-accessor struct:parse-config 1)))
+  (|#%name| parse-config-who (record-accessor struct:parse-config 0)))
 (define parse-config-px?
-  (|#%name|
-   parse-config-px?
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-px?_2965 s)
-       ($value
-        (impersonate-ref
-         parse-config-px?_2965
-         struct:parse-config
-         1
-         s
-         'px?))))))
-(define parse-config-case-sensitive?_2517
-  (|#%name|
-   parse-config-case-sensitive?
-   (record-accessor struct:parse-config 2)))
+  (|#%name| parse-config-px? (record-accessor struct:parse-config 1)))
 (define parse-config-case-sensitive?
   (|#%name|
    parse-config-case-sensitive?
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-case-sensitive?_2517 s)
-       ($value
-        (impersonate-ref
-         parse-config-case-sensitive?_2517
-         struct:parse-config
-         2
-         s
-         'case-sensitive?))))))
-(define parse-config-multi-line?_2034
-  (|#%name| parse-config-multi-line? (record-accessor struct:parse-config 3)))
+   (record-accessor struct:parse-config 2)))
 (define parse-config-multi-line?
-  (|#%name|
-   parse-config-multi-line?
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-multi-line?_2034 s)
-       ($value
-        (impersonate-ref
-         parse-config-multi-line?_2034
-         struct:parse-config
-         3
-         s
-         'multi-line?))))))
-(define parse-config-group-number-box_2275
-  (|#%name|
-   parse-config-group-number-box
-   (record-accessor struct:parse-config 4)))
+  (|#%name| parse-config-multi-line? (record-accessor struct:parse-config 3)))
 (define parse-config-group-number-box
   (|#%name|
    parse-config-group-number-box
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-group-number-box_2275 s)
-       ($value
-        (impersonate-ref
-         parse-config-group-number-box_2275
-         struct:parse-config
-         4
-         s
-         'group-number-box))))))
-(define parse-config-references?-box_2624
-  (|#%name|
-   parse-config-references?-box
-   (record-accessor struct:parse-config 5)))
+   (record-accessor struct:parse-config 4)))
 (define parse-config-references?-box
   (|#%name|
    parse-config-references?-box
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-references?-box_2624 s)
-       ($value
-        (impersonate-ref
-         parse-config-references?-box_2624
-         struct:parse-config
-         5
-         s
-         'references?-box))))))
-(define parse-config-error-handler?_2788
-  (|#%name|
-   parse-config-error-handler?
-   (record-accessor struct:parse-config 6)))
+   (record-accessor struct:parse-config 5)))
 (define parse-config-error-handler?
   (|#%name|
    parse-config-error-handler?
-   (lambda (s)
-     (if (parse-config?_2003 s)
-       (parse-config-error-handler?_2788 s)
-       ($value
-        (impersonate-ref
-         parse-config-error-handler?_2788
-         struct:parse-config
-         6
-         s
-         'error-handler?))))))
+   (record-accessor struct:parse-config 6)))
 (define make-parse-config.1
   (|#%name|
    make-parse-config
@@ -2196,36 +1553,26 @@
 (define config-case-sensitive
   (lambda (config_0 cs?_0)
     (if (parse-config? config_0)
-      (let ((app_0 (parse-config-who config_0)))
-        (let ((app_1 (parse-config-px? config_0)))
-          (let ((app_2 (parse-config-multi-line? config_0)))
-            (let ((app_3 (parse-config-group-number-box config_0)))
-              (let ((app_4 (parse-config-references?-box config_0)))
-                (parse-config1.1
-                 app_0
-                 app_1
-                 cs?_0
-                 app_2
-                 app_3
-                 app_4
-                 (parse-config-error-handler? config_0)))))))
+      (parse-config1.1
+       (parse-config-who config_0)
+       (parse-config-px? config_0)
+       cs?_0
+       (parse-config-multi-line? config_0)
+       (parse-config-group-number-box config_0)
+       (parse-config-references?-box config_0)
+       (parse-config-error-handler? config_0))
       (raise-argument-error 'struct-copy "parse-config?" config_0))))
 (define config-multi-line
   (lambda (config_0 mm?_0)
     (if (parse-config? config_0)
-      (let ((app_0 (parse-config-who config_0)))
-        (let ((app_1 (parse-config-px? config_0)))
-          (let ((app_2 (parse-config-case-sensitive? config_0)))
-            (let ((app_3 (parse-config-group-number-box config_0)))
-              (let ((app_4 (parse-config-references?-box config_0)))
-                (parse-config1.1
-                 app_0
-                 app_1
-                 app_2
-                 mm?_0
-                 app_3
-                 app_4
-                 (parse-config-error-handler? config_0)))))))
+      (parse-config1.1
+       (parse-config-who config_0)
+       (parse-config-px? config_0)
+       (parse-config-case-sensitive? config_0)
+       mm?_0
+       (parse-config-group-number-box config_0)
+       (parse-config-references?-box config_0)
+       (parse-config-error-handler? config_0))
       (raise-argument-error 'struct-copy "parse-config?" config_0))))
 (define config-group-number
   (lambda (config_0) (unbox (parse-config-group-number-box config_0))))
@@ -3054,17 +2401,13 @@
                        'any)))
                 (values rx_0 (add1 pos_0)))
               (if (eqv? tmp_0 '#\x5e)
-                (let ((app_0
-                       (if (parse-config-multi-line? config_0)
-                         'line-start
-                         'start)))
-                  (values app_0 (add1 pos_0)))
+                (values
+                 (if (parse-config-multi-line? config_0) 'line-start 'start)
+                 (add1 pos_0))
                 (if (eqv? tmp_0 '#\x24)
-                  (let ((app_0
-                         (if (parse-config-multi-line? config_0)
-                           'line-end
-                           'end)))
-                    (values app_0 (add1 pos_0)))
+                  (values
+                   (if (parse-config-multi-line? config_0) 'line-end 'end)
+                   (add1 pos_0))
                   (parse-literal s_0 pos_0 config_0))))))))))
 (define parse-parenthesized-atom
   (lambda (s_0 pos_0 config_0)
@@ -3568,11 +2911,11 @@
                                    (if (rx:alts? rx_1)
                                      (call-with-values
                                       (lambda ()
-                                        (validate_0 (rx:alts-rx_2265 rx_1)))
+                                        (validate_0 (rx:alts-rx_2530 rx_1)))
                                       (lambda (min1_0 max1_0 lb1_0)
                                         (call-with-values
                                          (lambda ()
-                                           (validate_0 (rx:alts-rx_1912 rx_1)))
+                                           (validate_0 (rx:alts-rx_2917 rx_1)))
                                          (lambda (min2_0 max2_0 lb2_0)
                                            (let ((app_0 (min min1_0 min2_0)))
                                              (let ((app_1 (max max1_0 max2_0)))
@@ -3711,7 +3054,7 @@
                                                   (call-with-values
                                                    (lambda ()
                                                      (validate_0
-                                                      (rx:conditional-rx_2162
+                                                      (rx:conditional-rx_2590
                                                        rx_1)))
                                                    (lambda (min1_0
                                                             max1_0
@@ -3719,7 +3062,7 @@
                                                      (call-with-values
                                                       (lambda ()
                                                         (validate_0
-                                                         (rx:conditional-rx_2328
+                                                         (rx:conditional-rx_3084
                                                           rx_1)))
                                                       (lambda (min2_0
                                                                max2_0
@@ -3874,8 +3217,8 @@
             (if (string? rx_0)
               (string->bytes/utf-8 rx_0)
               (if (rx:alts? rx_0)
-                (let ((app_0 (convert (rx:alts-rx_2265 rx_0))))
-                  (rx-alts app_0 (convert (rx:alts-rx_1912 rx_0)) 255))
+                (let ((app_0 (convert (rx:alts-rx_2530 rx_0))))
+                  (rx-alts app_0 (convert (rx:alts-rx_2917 rx_0)) 255))
                 (if (rx:sequence? rx_0)
                   (let ((new-rxs_0
                          (reverse$1
@@ -3912,13 +3255,11 @@
                     (if (rx:repeat? rx_0)
                       (if (rx:repeat? rx_0)
                         (let ((rx4_0 (convert (rx:repeat-rx rx_0))))
-                          (let ((app_0 (rx:repeat-min rx_0)))
-                            (let ((app_1 (rx:repeat-max rx_0)))
-                              (rx:repeat4.1
-                               rx4_0
-                               app_0
-                               app_1
-                               (rx:repeat-non-greedy? rx_0)))))
+                          (rx:repeat4.1
+                           rx4_0
+                           (rx:repeat-min rx_0)
+                           (rx:repeat-max rx_0)
+                           (rx:repeat-non-greedy? rx_0)))
                         (raise-argument-error 'struct-copy "rx:repeat?" rx_0))
                       (if (rx:maybe? rx_0)
                         (if (rx:maybe? rx_0)
@@ -3927,9 +3268,9 @@
                           (raise-argument-error 'struct-copy "rx:maybe?" rx_0))
                         (if (rx:conditional? rx_0)
                           (let ((new-rx1_0
-                                 (convert (rx:conditional-rx_2162 rx_0))))
+                                 (convert (rx:conditional-rx_2590 rx_0))))
                             (let ((new-rx2_0
-                                   (convert (rx:conditional-rx_2328 rx_0))))
+                                   (convert (rx:conditional-rx_3084 rx_0))))
                               (if (rx:conditional? rx_0)
                                 (let ((tst6_0
                                        (convert (rx:conditional-tst rx_0))))
@@ -3940,15 +3281,13 @@
                                              or-part_0
                                              (needs-backtrack? new-rx2_0)))))
                                     (let ((tst6_1 tst6_0))
-                                      (let ((app_0
-                                             (rx:conditional-n-start rx_0)))
-                                        (rx:conditional6.1
-                                         tst6_1
-                                         new-rx1_0
-                                         new-rx2_0
-                                         app_0
-                                         (rx:conditional-num-n rx_0)
-                                         needs-backtrack?9_0)))))
+                                      (rx:conditional6.1
+                                       tst6_1
+                                       new-rx1_0
+                                       new-rx2_0
+                                       (rx:conditional-n-start rx_0)
+                                       (rx:conditional-num-n rx_0)
+                                       needs-backtrack?9_0))))
                                 (raise-argument-error
                                  'struct-copy
                                  "rx:conditional?"
@@ -3956,13 +3295,11 @@
                           (if (rx:lookahead? rx_0)
                             (if (rx:lookahead? rx_0)
                               (let ((rx10_0 (convert (rx:lookahead-rx rx_0))))
-                                (let ((app_0 (rx:lookahead-match? rx_0)))
-                                  (let ((app_1 (rx:lookahead-n-start rx_0)))
-                                    (rx:lookahead7.1
-                                     rx10_0
-                                     app_0
-                                     app_1
-                                     (rx:lookahead-num-n rx_0)))))
+                                (rx:lookahead7.1
+                                 rx10_0
+                                 (rx:lookahead-match? rx_0)
+                                 (rx:lookahead-n-start rx_0)
+                                 (rx:lookahead-num-n rx_0)))
                               (raise-argument-error
                                'struct-copy
                                "rx:lookahead?"
@@ -3971,19 +3308,17 @@
                               (if (rx:lookbehind? rx_0)
                                 (let ((rx11_0
                                        (convert (rx:lookbehind-rx rx_0))))
-                                  (let ((app_0 (rx:lookbehind-match? rx_0)))
-                                    (let ((app_1 (rx:lookbehind-lb-min rx_0)))
+                                  (let ((app_0 (rx:lookbehind-lb-min rx_0)))
+                                    (let ((app_1 (rx:lookbehind-lb-max rx_0)))
                                       (let ((app_2
-                                             (rx:lookbehind-lb-max rx_0)))
-                                        (let ((app_3
-                                               (rx:lookbehind-n-start rx_0)))
-                                          (rx:lookbehind8.1
-                                           rx11_0
-                                           app_0
-                                           app_1
-                                           app_2
-                                           app_3
-                                           (rx:lookbehind-num-n rx_0)))))))
+                                             (rx:lookbehind-n-start rx_0)))
+                                        (rx:lookbehind8.1
+                                         rx11_0
+                                         (rx:lookbehind-match? rx_0)
+                                         app_0
+                                         app_1
+                                         app_2
+                                         (rx:lookbehind-num-n rx_0))))))
                                 (raise-argument-error
                                  'struct-copy
                                  "rx:lookbehind?"
@@ -3993,12 +3328,11 @@
                                   (if (rx:cut? rx_0)
                                     (let ((needs-backtrack?13_0
                                            (needs-backtrack? rx_0)))
-                                      (let ((app_0 (rx:cut-n-start rx_0)))
-                                        (rx:cut9.1
-                                         new-rx_0
-                                         app_0
-                                         (rx:cut-num-n rx_0)
-                                         needs-backtrack?13_0)))
+                                      (rx:cut9.1
+                                       new-rx_0
+                                       (rx:cut-n-start rx_0)
+                                       (rx:cut-num-n rx_0)
+                                       needs-backtrack?13_0))
                                     (raise-argument-error
                                      'struct-copy
                                      "rx:cut?"
@@ -4205,12 +3539,12 @@
                       (anchored? (car rxs_0))))))))))
          (loop_0 (rx:sequence-rxs rx_0)))
         (if (rx:alts? rx_0)
-          (if (anchored? (rx:alts-rx_2265 rx_0))
-            (anchored? (rx:alts-rx_1912 rx_0))
+          (if (anchored? (rx:alts-rx_2530 rx_0))
+            (anchored? (rx:alts-rx_2917 rx_0))
             #f)
           (if (rx:conditional? rx_0)
-            (if (anchored? (rx:conditional-rx_2162 rx_0))
-              (anchored? (rx:conditional-rx_2328 rx_0))
+            (if (anchored? (rx:conditional-rx_2590 rx_0))
+              (anchored? (rx:conditional-rx_3084 rx_0))
               #f)
             (if (rx:group? rx_0)
               (anchored? (rx:group-rx rx_0))
@@ -4261,10 +3595,10 @@
                (for-loop_0 #f lst_0))))
           (if (rx:conditional? rx_0)
             (let ((or-part_0
-                   (something-expensive? (rx:conditional-rx_2162 rx_0))))
+                   (something-expensive? (rx:conditional-rx_2590 rx_0))))
               (if or-part_0
                 or-part_0
-                (something-expensive? (rx:conditional-rx_2328 rx_0))))
+                (something-expensive? (rx:conditional-rx_3084 rx_0))))
             (if (rx:group? rx_0)
               (something-expensive? (rx:group-rx rx_0))
               (if (rx:cut? rx_0)
@@ -4429,11 +3763,11 @@
                         (start-range rx_1)))))))))
            (loop_0 (rx:sequence-rxs rx_0)))
           (if (rx:alts? rx_0)
-            (let ((app_0 (start-range (rx:alts-rx_2265 rx_0))))
-              (union app_0 (start-range (rx:alts-rx_1912 rx_0))))
+            (let ((app_0 (start-range (rx:alts-rx_2530 rx_0))))
+              (union app_0 (start-range (rx:alts-rx_2917 rx_0))))
             (if (rx:conditional? rx_0)
-              (let ((app_0 (start-range (rx:conditional-rx_2162 rx_0))))
-                (union app_0 (start-range (rx:conditional-rx_2328 rx_0))))
+              (let ((app_0 (start-range (rx:conditional-rx_2590 rx_0))))
+                (union app_0 (start-range (rx:conditional-rx_3084 rx_0))))
               (if (rx:group? rx_0)
                 (start-range (rx:group-rx rx_0))
                 (if (rx:cut? rx_0)
@@ -4476,13 +3810,13 @@
                                       (zero-sized? (rx:cut-rx rx_0))
                                       #f)))))))))))))))))))
 (define union (lambda (a_0 b_0) (if a_0 (if b_0 (range-union a_0 b_0) #f) #f)))
-(define finish_2590
+(define finish_3069
   (make-struct-type-install-properties
    '(lazy-bytes)
    13
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(2 3 4 5 6 7 8 9 12)
@@ -4496,267 +3830,50 @@
    #f
    #f
    '(13 . 3075)))
-(define effect_2741 (finish_2590 struct:lazy-bytes))
+(define effect_2741 (finish_3069 struct:lazy-bytes))
 (define lazy-bytes1.1
   (|#%name|
    lazy-bytes
    (record-constructor
     (make-record-constructor-descriptor struct:lazy-bytes #f #f))))
-(define lazy-bytes?_2654
-  (|#%name| lazy-bytes? (record-predicate struct:lazy-bytes)))
 (define lazy-bytes?
-  (|#%name|
-   lazy-bytes?
-   (lambda (v)
-     (if (lazy-bytes?_2654 v)
-       #t
-       ($value
-        (if (impersonator? v) (lazy-bytes?_2654 (impersonator-val v)) #f))))))
-(define lazy-bytes-bstr_2345
-  (|#%name| lazy-bytes-bstr (record-accessor struct:lazy-bytes 0)))
+  (|#%name| lazy-bytes? (record-predicate struct:lazy-bytes)))
 (define lazy-bytes-bstr
-  (|#%name|
-   lazy-bytes-bstr
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-bstr_2345 s)
-       ($value
-        (impersonate-ref lazy-bytes-bstr_2345 struct:lazy-bytes 0 s 'bstr))))))
-(define lazy-bytes-end_2914
-  (|#%name| lazy-bytes-end (record-accessor struct:lazy-bytes 1)))
+  (|#%name| lazy-bytes-bstr (record-accessor struct:lazy-bytes 0)))
 (define lazy-bytes-end
-  (|#%name|
-   lazy-bytes-end
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-end_2914 s)
-       ($value
-        (impersonate-ref lazy-bytes-end_2914 struct:lazy-bytes 1 s 'end))))))
-(define lazy-bytes-in_2568
-  (|#%name| lazy-bytes-in (record-accessor struct:lazy-bytes 2)))
+  (|#%name| lazy-bytes-end (record-accessor struct:lazy-bytes 1)))
 (define lazy-bytes-in
-  (|#%name|
-   lazy-bytes-in
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-in_2568 s)
-       ($value
-        (impersonate-ref lazy-bytes-in_2568 struct:lazy-bytes 2 s 'in))))))
-(define lazy-bytes-skip-amt_2649
-  (|#%name| lazy-bytes-skip-amt (record-accessor struct:lazy-bytes 3)))
+  (|#%name| lazy-bytes-in (record-accessor struct:lazy-bytes 2)))
 (define lazy-bytes-skip-amt
-  (|#%name|
-   lazy-bytes-skip-amt
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-skip-amt_2649 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-skip-amt_2649
-         struct:lazy-bytes
-         3
-         s
-         'skip-amt))))))
-(define lazy-bytes-prefix-len_2565
-  (|#%name| lazy-bytes-prefix-len (record-accessor struct:lazy-bytes 4)))
+  (|#%name| lazy-bytes-skip-amt (record-accessor struct:lazy-bytes 3)))
 (define lazy-bytes-prefix-len
-  (|#%name|
-   lazy-bytes-prefix-len
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-prefix-len_2565 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-prefix-len_2565
-         struct:lazy-bytes
-         4
-         s
-         'prefix-len))))))
-(define lazy-bytes-peek?_2174
-  (|#%name| lazy-bytes-peek? (record-accessor struct:lazy-bytes 5)))
+  (|#%name| lazy-bytes-prefix-len (record-accessor struct:lazy-bytes 4)))
 (define lazy-bytes-peek?
-  (|#%name|
-   lazy-bytes-peek?
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-peek?_2174 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-peek?_2174
-         struct:lazy-bytes
-         5
-         s
-         'peek?))))))
-(define lazy-bytes-immediate-only?_2496
-  (|#%name| lazy-bytes-immediate-only? (record-accessor struct:lazy-bytes 6)))
+  (|#%name| lazy-bytes-peek? (record-accessor struct:lazy-bytes 5)))
 (define lazy-bytes-immediate-only?
-  (|#%name|
-   lazy-bytes-immediate-only?
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-immediate-only?_2496 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-immediate-only?_2496
-         struct:lazy-bytes
-         6
-         s
-         'immediate-only?))))))
-(define lazy-bytes-progress-evt_2923
-  (|#%name| lazy-bytes-progress-evt (record-accessor struct:lazy-bytes 7)))
+  (|#%name| lazy-bytes-immediate-only? (record-accessor struct:lazy-bytes 6)))
 (define lazy-bytes-progress-evt
-  (|#%name|
-   lazy-bytes-progress-evt
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-progress-evt_2923 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-progress-evt_2923
-         struct:lazy-bytes
-         7
-         s
-         'progress-evt))))))
-(define lazy-bytes-out_2340
-  (|#%name| lazy-bytes-out (record-accessor struct:lazy-bytes 8)))
+  (|#%name| lazy-bytes-progress-evt (record-accessor struct:lazy-bytes 7)))
 (define lazy-bytes-out
-  (|#%name|
-   lazy-bytes-out
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-out_2340 s)
-       ($value
-        (impersonate-ref lazy-bytes-out_2340 struct:lazy-bytes 8 s 'out))))))
-(define lazy-bytes-max-lookbehind_2217
-  (|#%name| lazy-bytes-max-lookbehind (record-accessor struct:lazy-bytes 9)))
+  (|#%name| lazy-bytes-out (record-accessor struct:lazy-bytes 8)))
 (define lazy-bytes-max-lookbehind
-  (|#%name|
-   lazy-bytes-max-lookbehind
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-max-lookbehind_2217 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-max-lookbehind_2217
-         struct:lazy-bytes
-         9
-         s
-         'max-lookbehind))))))
-(define lazy-bytes-failed?_2073
-  (|#%name| lazy-bytes-failed? (record-accessor struct:lazy-bytes 10)))
+  (|#%name| lazy-bytes-max-lookbehind (record-accessor struct:lazy-bytes 9)))
 (define lazy-bytes-failed?
-  (|#%name|
-   lazy-bytes-failed?
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-failed?_2073 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-failed?_2073
-         struct:lazy-bytes
-         10
-         s
-         'failed?))))))
-(define lazy-bytes-discarded-count_3290
-  (|#%name| lazy-bytes-discarded-count (record-accessor struct:lazy-bytes 11)))
+  (|#%name| lazy-bytes-failed? (record-accessor struct:lazy-bytes 10)))
 (define lazy-bytes-discarded-count
-  (|#%name|
-   lazy-bytes-discarded-count
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-discarded-count_3290 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-discarded-count_3290
-         struct:lazy-bytes
-         11
-         s
-         'discarded-count))))))
-(define lazy-bytes-max-peek_2492
-  (|#%name| lazy-bytes-max-peek (record-accessor struct:lazy-bytes 12)))
+  (|#%name| lazy-bytes-discarded-count (record-accessor struct:lazy-bytes 11)))
 (define lazy-bytes-max-peek
-  (|#%name|
-   lazy-bytes-max-peek
-   (lambda (s)
-     (if (lazy-bytes?_2654 s)
-       (lazy-bytes-max-peek_2492 s)
-       ($value
-        (impersonate-ref
-         lazy-bytes-max-peek_2492
-         struct:lazy-bytes
-         12
-         s
-         'max-peek))))))
-(define set-lazy-bytes-bstr!_2695
-  (|#%name| set-lazy-bytes-bstr! (record-mutator struct:lazy-bytes 0)))
+  (|#%name| lazy-bytes-max-peek (record-accessor struct:lazy-bytes 12)))
 (define set-lazy-bytes-bstr!
-  (|#%name|
-   set-lazy-bytes-bstr!
-   (lambda (s v)
-     (if (lazy-bytes?_2654 s)
-       (set-lazy-bytes-bstr!_2695 s v)
-       ($value
-        (impersonate-set!
-         set-lazy-bytes-bstr!_2695
-         struct:lazy-bytes
-         0
-         0
-         s
-         v
-         'bstr))))))
-(define set-lazy-bytes-end!_2897
-  (|#%name| set-lazy-bytes-end! (record-mutator struct:lazy-bytes 1)))
+  (|#%name| set-lazy-bytes-bstr! (record-mutator struct:lazy-bytes 0)))
 (define set-lazy-bytes-end!
-  (|#%name|
-   set-lazy-bytes-end!
-   (lambda (s v)
-     (if (lazy-bytes?_2654 s)
-       (set-lazy-bytes-end!_2897 s v)
-       ($value
-        (impersonate-set!
-         set-lazy-bytes-end!_2897
-         struct:lazy-bytes
-         1
-         1
-         s
-         v
-         'end))))))
-(define set-lazy-bytes-failed?!_2421
-  (|#%name| set-lazy-bytes-failed?! (record-mutator struct:lazy-bytes 10)))
+  (|#%name| set-lazy-bytes-end! (record-mutator struct:lazy-bytes 1)))
 (define set-lazy-bytes-failed?!
-  (|#%name|
-   set-lazy-bytes-failed?!
-   (lambda (s v)
-     (if (lazy-bytes?_2654 s)
-       (set-lazy-bytes-failed?!_2421 s v)
-       ($value
-        (impersonate-set!
-         set-lazy-bytes-failed?!_2421
-         struct:lazy-bytes
-         10
-         10
-         s
-         v
-         'failed?))))))
-(define set-lazy-bytes-discarded-count!_2738
-  (|#%name|
-   set-lazy-bytes-discarded-count!
-   (record-mutator struct:lazy-bytes 11)))
+  (|#%name| set-lazy-bytes-failed?! (record-mutator struct:lazy-bytes 10)))
 (define set-lazy-bytes-discarded-count!
   (|#%name|
    set-lazy-bytes-discarded-count!
-   (lambda (s v)
-     (if (lazy-bytes?_2654 s)
-       (set-lazy-bytes-discarded-count!_2738 s v)
-       ($value
-        (impersonate-set!
-         set-lazy-bytes-discarded-count!_2738
-         struct:lazy-bytes
-         11
-         11
-         s
-         v
-         'discarded-count))))))
+   (record-mutator struct:lazy-bytes 11)))
 (define make-lazy-bytes
   (lambda (in_0
            skip-amt_0
@@ -4853,24 +3970,22 @@
               (if (< len_0 (unsafe-bytes-length bstr_0))
                 (let ((n_0
                        (let ((app_0
-                              (if (lazy-bytes-immediate-only? s_0)
-                                peek-bytes-avail!*
-                                peek-bytes-avail!)))
-                         (let ((app_1
-                                (let ((app_1
-                                       (- len_0 (lazy-bytes-prefix-len s_0))))
-                                  (+
-                                   app_1
-                                   (lazy-bytes-skip-amt s_0)
-                                   discarded-count_0))))
-                           (let ((app_2 (lazy-bytes-progress-evt s_0)))
-                             (|#%app|
-                              app_0
-                              bstr_0
-                              app_1
-                              app_2
-                              (lazy-bytes-in s_0)
-                              len_0))))))
+                              (let ((app_0
+                                     (- len_0 (lazy-bytes-prefix-len s_0))))
+                                (+
+                                 app_0
+                                 (lazy-bytes-skip-amt s_0)
+                                 discarded-count_0))))
+                         (let ((app_1 (lazy-bytes-progress-evt s_0)))
+                           (|#%app|
+                            (if (lazy-bytes-immediate-only? s_0)
+                              peek-bytes-avail!*
+                              peek-bytes-avail!)
+                            bstr_0
+                            app_0
+                            app_1
+                            (lazy-bytes-in s_0)
+                            len_0)))))
                   (if (eof-object? n_0)
                     #f
                     (if (not (fixnum? n_0))
@@ -6657,12 +5772,12 @@
                                          (if (rx:alts? rx_1)
                                            (let ((app_0
                                                   (compile_0
-                                                   (rx:alts-rx_2265 rx_1)
+                                                   (rx:alts-rx_2530 rx_1)
                                                    next-m_0)))
                                              (alts-matcher
                                               app_0
                                               (compile_0
-                                               (rx:alts-rx_1912 rx_1)
+                                               (rx:alts-rx_2917 rx_1)
                                                next-m_0)))
                                            (if (rx:maybe? rx_1)
                                              (if (rx:maybe-non-greedy? rx_1)
@@ -6770,14 +5885,11 @@
                                                         (rx:group-number
                                                          rx_1)))
                                                    (let ((m_0
-                                                          (let ((app_0
-                                                                 (rx:group-rx
-                                                                  rx_1)))
-                                                            (compile_0
-                                                             app_0
-                                                             (group-set-matcher
-                                                              n_0
-                                                              next-m_0)))))
+                                                          (compile_0
+                                                           (rx:group-rx rx_1)
+                                                           (group-set-matcher
+                                                            n_0
+                                                            next-m_0))))
                                                      (group-push-matcher
                                                       n_0
                                                       m_0)))
@@ -6814,12 +5926,12 @@
                                                                rx_1)))
                                                          (let ((m1_0
                                                                 (compile_0
-                                                                 (rx:conditional-rx_2162
+                                                                 (rx:conditional-rx_2590
                                                                   rx_1)
                                                                  next-m_0)))
                                                            (let ((m2_0
                                                                   (compile_0
-                                                                   (rx:conditional-rx_2328
+                                                                   (rx:conditional-rx_3084
                                                                     rx_1)
                                                                    next-m_0)))
                                                              (if (rx:reference?
@@ -6836,73 +5948,65 @@
                                                                       (compile_0
                                                                        tst_0
                                                                        done-m)))
-                                                                 (let ((app_1
-                                                                        (rx:conditional-n-start
-                                                                         rx_1)))
-                                                                   (conditional/look-matcher
-                                                                    app_0
-                                                                    m1_0
-                                                                    m2_0
-                                                                    app_1
-                                                                    (rx:conditional-num-n
-                                                                     rx_1))))))))
+                                                                 (conditional/look-matcher
+                                                                  app_0
+                                                                  m1_0
+                                                                  m2_0
+                                                                  (rx:conditional-n-start
+                                                                   rx_1)
+                                                                  (rx:conditional-num-n
+                                                                   rx_1)))))))
                                                        (if (rx:lookahead? rx_1)
                                                          (let ((app_0
-                                                                (rx:lookahead-match?
-                                                                 rx_1)))
+                                                                (compile_0
+                                                                 (rx:lookahead-rx
+                                                                  rx_1)
+                                                                 done-m)))
                                                            (let ((app_1
-                                                                  (compile_0
-                                                                   (rx:lookahead-rx
-                                                                    rx_1)
-                                                                   done-m)))
-                                                             (let ((app_2
-                                                                    (rx:lookahead-n-start
-                                                                     rx_1)))
-                                                               (lookahead-matcher
-                                                                app_0
-                                                                app_1
-                                                                app_2
-                                                                (rx:lookahead-num-n
-                                                                 rx_1)
-                                                                next-m_0))))
+                                                                  (rx:lookahead-n-start
+                                                                   rx_1)))
+                                                             (lookahead-matcher
+                                                              (rx:lookahead-match?
+                                                               rx_1)
+                                                              app_0
+                                                              app_1
+                                                              (rx:lookahead-num-n
+                                                               rx_1)
+                                                              next-m_0)))
                                                          (if (rx:lookbehind?
                                                               rx_1)
                                                            (let ((app_0
-                                                                  (rx:lookbehind-match?
+                                                                  (rx:lookbehind-lb-min
                                                                    rx_1)))
                                                              (let ((app_1
-                                                                    (rx:lookbehind-lb-min
+                                                                    (rx:lookbehind-lb-max
                                                                      rx_1)))
                                                                (let ((app_2
-                                                                      (rx:lookbehind-lb-max
-                                                                       rx_1)))
+                                                                      (compile_0
+                                                                       (rx:lookbehind-rx
+                                                                        rx_1)
+                                                                       limit-m)))
                                                                  (let ((app_3
-                                                                        (compile_0
-                                                                         (rx:lookbehind-rx
-                                                                          rx_1)
-                                                                         limit-m)))
-                                                                   (let ((app_4
-                                                                          (rx:lookbehind-n-start
-                                                                           rx_1)))
-                                                                     (lookbehind-matcher
-                                                                      app_0
-                                                                      app_1
-                                                                      app_2
-                                                                      app_3
-                                                                      app_4
-                                                                      (rx:lookbehind-num-n
-                                                                       rx_1)
-                                                                      next-m_0))))))
+                                                                        (rx:lookbehind-n-start
+                                                                         rx_1)))
+                                                                   (lookbehind-matcher
+                                                                    (rx:lookbehind-match?
+                                                                     rx_1)
+                                                                    app_0
+                                                                    app_1
+                                                                    app_2
+                                                                    app_3
+                                                                    (rx:lookbehind-num-n
+                                                                     rx_1)
+                                                                    next-m_0)))))
                                                            (if (rx:unicode-categories?
                                                                 rx_1)
-                                                             (let ((app_0
-                                                                    (rx:unicode-categories-symlist
-                                                                     rx_1)))
-                                                               (unicode-categories-matcher
-                                                                app_0
-                                                                (rx:unicode-categories-match?
-                                                                 rx_1)
-                                                                next-m_0))
+                                                             (unicode-categories-matcher
+                                                              (rx:unicode-categories-symlist
+                                                               rx_1)
+                                                              (rx:unicode-categories-match?
+                                                               rx_1)
+                                                              next-m_0)
                                                              (error
                                                               'compile/bt
                                                               "internal error: unrecognized ~s"
@@ -6919,20 +6023,20 @@
           (if (rx:range? rx_0)
             (range-matcher* (compile-range (rx:range-range rx_0)) max_0)
             #f))))))
-(define finish_2797
+(define finish_1953
   (make-struct-type-install-properties
    '(regexp)
    10
    0
    #f
    (list
+    (cons prop:authentic #t)
     (cons
      prop:equal+hash
      (list
       (lambda (a_0 b_0 eql?_0)
-        (if (let ((app_0 (rx:regexp-px? a_0))) (eq? app_0 (rx:regexp-px? b_0)))
-          (let ((app_0 (rx:regexp-source a_0)))
-            (equal? app_0 (rx:regexp-source b_0)))
+        (if (eq? (rx:regexp-px? a_0) (rx:regexp-px? b_0))
+          (equal? (rx:regexp-source a_0) (rx:regexp-source b_0))
           #f))
       (lambda (a_0 hc_0) (|#%app| hc_0 (rx:regexp-source a_0)))
       (lambda (a_0 hc_0) (|#%app| hc_0 (rx:regexp-source a_0)))))
@@ -6956,166 +6060,33 @@
    #f
    #f
    '(10 . 0)))
-(define effect_2726 (finish_2797 struct:rx:regexp))
+(define effect_2726 (finish_1953 struct:rx:regexp))
 (define rx:regexp1.1
   (|#%name|
    rx:regexp
    (record-constructor
     (make-record-constructor-descriptor struct:rx:regexp #f #f))))
-(define rx:regexp?_2382 (|#%name| regexp? (record-predicate struct:rx:regexp)))
-(define rx:regexp?
-  (|#%name|
-   regexp?
-   (lambda (v)
-     (if (rx:regexp?_2382 v)
-       #t
-       ($value
-        (if (impersonator? v) (rx:regexp?_2382 (impersonator-val v)) #f))))))
-(define rx:regexp-bytes?_3116
-  (|#%name| regexp-bytes? (record-accessor struct:rx:regexp 0)))
+(define rx:regexp? (|#%name| regexp? (record-predicate struct:rx:regexp)))
 (define rx:regexp-bytes?
-  (|#%name|
-   regexp-bytes?
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-bytes?_3116 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-bytes?_3116
-         struct:rx:regexp
-         0
-         s
-         'bytes?))))))
-(define rx:regexp-px?_2839
-  (|#%name| regexp-px? (record-accessor struct:rx:regexp 1)))
+  (|#%name| regexp-bytes? (record-accessor struct:rx:regexp 0)))
 (define rx:regexp-px?
-  (|#%name|
-   regexp-px?
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-px?_2839 s)
-       ($value
-        (impersonate-ref rx:regexp-px?_2839 struct:rx:regexp 1 s 'px?))))))
-(define rx:regexp-source_2786
-  (|#%name| regexp-source (record-accessor struct:rx:regexp 2)))
+  (|#%name| regexp-px? (record-accessor struct:rx:regexp 1)))
 (define rx:regexp-source
-  (|#%name|
-   regexp-source
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-source_2786 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-source_2786
-         struct:rx:regexp
-         2
-         s
-         'source))))))
-(define rx:regexp-matcher_2640
-  (|#%name| regexp-matcher (record-accessor struct:rx:regexp 3)))
+  (|#%name| regexp-source (record-accessor struct:rx:regexp 2)))
 (define rx:regexp-matcher
-  (|#%name|
-   regexp-matcher
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-matcher_2640 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-matcher_2640
-         struct:rx:regexp
-         3
-         s
-         'matcher))))))
-(define rx:regexp-num-groups_2013
-  (|#%name| regexp-num-groups (record-accessor struct:rx:regexp 4)))
+  (|#%name| regexp-matcher (record-accessor struct:rx:regexp 3)))
 (define rx:regexp-num-groups
-  (|#%name|
-   regexp-num-groups
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-num-groups_2013 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-num-groups_2013
-         struct:rx:regexp
-         4
-         s
-         'num-groups))))))
-(define rx:regexp-references?_2683
-  (|#%name| regexp-references? (record-accessor struct:rx:regexp 5)))
+  (|#%name| regexp-num-groups (record-accessor struct:rx:regexp 4)))
 (define rx:regexp-references?
-  (|#%name|
-   regexp-references?
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-references?_2683 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-references?_2683
-         struct:rx:regexp
-         5
-         s
-         'references?))))))
-(define rx:regexp-max-lookbehind_2091
-  (|#%name| regexp-max-lookbehind (record-accessor struct:rx:regexp 6)))
+  (|#%name| regexp-references? (record-accessor struct:rx:regexp 5)))
 (define rx:regexp-max-lookbehind
-  (|#%name|
-   regexp-max-lookbehind
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-max-lookbehind_2091 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-max-lookbehind_2091
-         struct:rx:regexp
-         6
-         s
-         'max-lookbehind))))))
-(define rx:regexp-anchored?_2381
-  (|#%name| regexp-anchored? (record-accessor struct:rx:regexp 7)))
+  (|#%name| regexp-max-lookbehind (record-accessor struct:rx:regexp 6)))
 (define rx:regexp-anchored?
-  (|#%name|
-   regexp-anchored?
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-anchored?_2381 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-anchored?_2381
-         struct:rx:regexp
-         7
-         s
-         'anchored?))))))
-(define rx:regexp-must-string_2180
-  (|#%name| regexp-must-string (record-accessor struct:rx:regexp 8)))
+  (|#%name| regexp-anchored? (record-accessor struct:rx:regexp 7)))
 (define rx:regexp-must-string
-  (|#%name|
-   regexp-must-string
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-must-string_2180 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-must-string_2180
-         struct:rx:regexp
-         8
-         s
-         'must-string))))))
-(define rx:regexp-start-range_2644
-  (|#%name| regexp-start-range (record-accessor struct:rx:regexp 9)))
+  (|#%name| regexp-must-string (record-accessor struct:rx:regexp 8)))
 (define rx:regexp-start-range
-  (|#%name|
-   regexp-start-range
-   (lambda (s)
-     (if (rx:regexp?_2382 s)
-       (rx:regexp-start-range_2644 s)
-       ($value
-        (impersonate-ref
-         rx:regexp-start-range_2644
-         struct:rx:regexp
-         9
-         s
-         'start-range))))))
+  (|#%name| regexp-start-range (record-accessor struct:rx:regexp 9)))
 (define make-regexp
   (lambda (who_0 orig-p_0 px?_0 as-bytes?_0 handler_0)
     (call-with-continuation-prompt

--- a/racket/src/cs/schemified/schemify.scm
+++ b/racket/src/cs/schemified/schemify.scm
@@ -4770,13 +4770,13 @@
          (let ((app_0
                 (if (string? prefix_0) prefix_0 (symbol->string prefix_0))))
            (string-append app_0 (number->string (unbox b_0)))))))))
-(define finish_2816
+(define finish_2868
   (make-struct-type-install-properties
    '(import)
    4
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1 2 3)
@@ -4790,65 +4790,26 @@
    #f
    #f
    '(4 . 0)))
-(define effect_2192 (finish_2816 struct:import))
+(define effect_2192 (finish_2868 struct:import))
 (define import1.1
   (|#%name|
    import
    (record-constructor
     (make-record-constructor-descriptor struct:import #f #f))))
-(define import?_2699 (|#%name| import? (record-predicate struct:import)))
-(define import?
-  (|#%name|
-   import?
-   (lambda (v)
-     (if (import?_2699 v)
-       #t
-       ($value
-        (if (impersonator? v) (import?_2699 (impersonator-val v)) #f))))))
-(define import-grp_3110
-  (|#%name| import-grp (record-accessor struct:import 0)))
-(define import-grp
-  (|#%name|
-   import-grp
-   (lambda (s)
-     (if (import?_2699 s)
-       (import-grp_3110 s)
-       ($value (impersonate-ref import-grp_3110 struct:import 0 s 'grp))))))
-(define import-id_2226 (|#%name| import-id (record-accessor struct:import 1)))
-(define import-id
-  (|#%name|
-   import-id
-   (lambda (s)
-     (if (import?_2699 s)
-       (import-id_2226 s)
-       ($value (impersonate-ref import-id_2226 struct:import 1 s 'id))))))
-(define import-int-id_2707
-  (|#%name| import-int-id (record-accessor struct:import 2)))
+(define import? (|#%name| import? (record-predicate struct:import)))
+(define import-grp (|#%name| import-grp (record-accessor struct:import 0)))
+(define import-id (|#%name| import-id (record-accessor struct:import 1)))
 (define import-int-id
-  (|#%name|
-   import-int-id
-   (lambda (s)
-     (if (import?_2699 s)
-       (import-int-id_2707 s)
-       ($value
-        (impersonate-ref import-int-id_2707 struct:import 2 s 'int-id))))))
-(define import-ext-id_2460
-  (|#%name| import-ext-id (record-accessor struct:import 3)))
+  (|#%name| import-int-id (record-accessor struct:import 2)))
 (define import-ext-id
-  (|#%name|
-   import-ext-id
-   (lambda (s)
-     (if (import?_2699 s)
-       (import-ext-id_2460 s)
-       ($value
-        (impersonate-ref import-ext-id_2460 struct:import 3 s 'ext-id))))))
-(define finish_1986
+  (|#%name| import-ext-id (record-accessor struct:import 3)))
+(define finish_2201
   (make-struct-type-install-properties
    '(import-group)
    6
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1)
@@ -4862,188 +4823,40 @@
    #f
    #f
    '(6 . 60)))
-(define effect_2739 (finish_1986 struct:import-group))
+(define effect_2739 (finish_2201 struct:import-group))
 (define import-group2.1
   (|#%name|
    import-group
    (record-constructor
     (make-record-constructor-descriptor struct:import-group #f #f))))
-(define import-group?_1821
-  (|#%name| import-group? (record-predicate struct:import-group)))
 (define import-group?
-  (|#%name|
-   import-group?
-   (lambda (v)
-     (if (import-group?_1821 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (import-group?_1821 (impersonator-val v))
-          #f))))))
-(define import-group-index_2302
-  (|#%name| import-group-index (record-accessor struct:import-group 0)))
+  (|#%name| import-group? (record-predicate struct:import-group)))
 (define import-group-index
-  (|#%name|
-   import-group-index
-   (lambda (s)
-     (if (import-group?_1821 s)
-       (import-group-index_2302 s)
-       ($value
-        (impersonate-ref
-         import-group-index_2302
-         struct:import-group
-         0
-         s
-         'index))))))
-(define import-group-key_2439
-  (|#%name| import-group-key (record-accessor struct:import-group 1)))
+  (|#%name| import-group-index (record-accessor struct:import-group 0)))
 (define import-group-key
-  (|#%name|
-   import-group-key
-   (lambda (s)
-     (if (import-group?_1821 s)
-       (import-group-key_2439 s)
-       ($value
-        (impersonate-ref
-         import-group-key_2439
-         struct:import-group
-         1
-         s
-         'key))))))
-(define import-group-knowns/proc_2775
-  (|#%name| import-group-knowns/proc (record-accessor struct:import-group 2)))
+  (|#%name| import-group-key (record-accessor struct:import-group 1)))
 (define import-group-knowns/proc
-  (|#%name|
-   import-group-knowns/proc
-   (lambda (s)
-     (if (import-group?_1821 s)
-       (import-group-knowns/proc_2775 s)
-       ($value
-        (impersonate-ref
-         import-group-knowns/proc_2775
-         struct:import-group
-         2
-         s
-         'knowns/proc))))))
-(define import-group-converter_2731
-  (|#%name| import-group-converter (record-accessor struct:import-group 3)))
+  (|#%name| import-group-knowns/proc (record-accessor struct:import-group 2)))
 (define import-group-converter
-  (|#%name|
-   import-group-converter
-   (lambda (s)
-     (if (import-group?_1821 s)
-       (import-group-converter_2731 s)
-       ($value
-        (impersonate-ref
-         import-group-converter_2731
-         struct:import-group
-         3
-         s
-         'converter))))))
-(define import-group-import-keys_2577
-  (|#%name| import-group-import-keys (record-accessor struct:import-group 4)))
+  (|#%name| import-group-converter (record-accessor struct:import-group 3)))
 (define import-group-import-keys
-  (|#%name|
-   import-group-import-keys
-   (lambda (s)
-     (if (import-group?_1821 s)
-       (import-group-import-keys_2577 s)
-       ($value
-        (impersonate-ref
-         import-group-import-keys_2577
-         struct:import-group
-         4
-         s
-         'import-keys))))))
-(define import-group-imports_2122
-  (|#%name| import-group-imports (record-accessor struct:import-group 5)))
+  (|#%name| import-group-import-keys (record-accessor struct:import-group 4)))
 (define import-group-imports
-  (|#%name|
-   import-group-imports
-   (lambda (s)
-     (if (import-group?_1821 s)
-       (import-group-imports_2122 s)
-       ($value
-        (impersonate-ref
-         import-group-imports_2122
-         struct:import-group
-         5
-         s
-         'imports))))))
-(define set-import-group-knowns/proc!_2971
-  (|#%name|
-   set-import-group-knowns/proc!
-   (record-mutator struct:import-group 2)))
+  (|#%name| import-group-imports (record-accessor struct:import-group 5)))
 (define set-import-group-knowns/proc!
   (|#%name|
    set-import-group-knowns/proc!
-   (lambda (s v)
-     (if (import-group?_1821 s)
-       (set-import-group-knowns/proc!_2971 s v)
-       ($value
-        (impersonate-set!
-         set-import-group-knowns/proc!_2971
-         struct:import-group
-         2
-         2
-         s
-         v
-         'knowns/proc))))))
-(define set-import-group-converter!_2381
-  (|#%name|
-   set-import-group-converter!
-   (record-mutator struct:import-group 3)))
+   (record-mutator struct:import-group 2)))
 (define set-import-group-converter!
   (|#%name|
    set-import-group-converter!
-   (lambda (s v)
-     (if (import-group?_1821 s)
-       (set-import-group-converter!_2381 s v)
-       ($value
-        (impersonate-set!
-         set-import-group-converter!_2381
-         struct:import-group
-         3
-         3
-         s
-         v
-         'converter))))))
-(define set-import-group-import-keys!_2611
-  (|#%name|
-   set-import-group-import-keys!
-   (record-mutator struct:import-group 4)))
+   (record-mutator struct:import-group 3)))
 (define set-import-group-import-keys!
   (|#%name|
    set-import-group-import-keys!
-   (lambda (s v)
-     (if (import-group?_1821 s)
-       (set-import-group-import-keys!_2611 s v)
-       ($value
-        (impersonate-set!
-         set-import-group-import-keys!_2611
-         struct:import-group
-         4
-         4
-         s
-         v
-         'import-keys))))))
-(define set-import-group-imports!_2489
-  (|#%name| set-import-group-imports! (record-mutator struct:import-group 5)))
+   (record-mutator struct:import-group 4)))
 (define set-import-group-imports!
-  (|#%name|
-   set-import-group-imports!
-   (lambda (s v)
-     (if (import-group?_1821 s)
-       (set-import-group-imports!_2489 s v)
-       ($value
-        (impersonate-set!
-         set-import-group-imports!_2489
-         struct:import-group
-         5
-         5
-         s
-         v
-         'imports))))))
+  (|#%name| set-import-group-imports! (record-mutator struct:import-group 5)))
 (define import-group-knowns
   (lambda (grp_0)
     (let ((knowns/proc_0 (import-group-knowns/proc grp_0)))
@@ -5070,9 +4883,7 @@
           (if converter_0 (|#%app| converter_0 v_0) v_0))
         v_0))))
 (define import-lookup
-  (lambda (im_0)
-    (let ((app_0 (import-grp im_0)))
-      (import-group-lookup app_0 (import-ext-id im_0)))))
+  (lambda (im_0) (import-group-lookup (import-grp im_0) (import-ext-id im_0))))
 (define hash-ref-either
   (lambda (knowns_0 imports_0 key_0)
     (let ((or-part_0 (hash-ref knowns_0 key_0 #f)))
@@ -5199,13 +5010,13 @@
             (|#%app| inc-index!_0)
             (|#%app| add-group!_0 grp_0)
             grp_0))))))
-(define finish_2351
+(define finish_2670
   (make-struct-type-install-properties
    '(export)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1)
@@ -5219,39 +5030,54 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2782 (finish_2351 struct:export))
+(define effect_2782 (finish_2670 struct:export))
 (define export1.1
   (|#%name|
    export
    (record-constructor
     (make-record-constructor-descriptor struct:export #f #f))))
-(define export?_2921 (|#%name| export? (record-predicate struct:export)))
-(define export?
-  (|#%name|
-   export?
-   (lambda (v)
-     (if (export?_2921 v)
-       #t
-       ($value
-        (if (impersonator? v) (export?_2921 (impersonator-val v)) #f))))))
-(define export-id_2664 (|#%name| export-id (record-accessor struct:export 0)))
-(define export-id
-  (|#%name|
-   export-id
-   (lambda (s)
-     (if (export?_2921 s)
-       (export-id_2664 s)
-       ($value (impersonate-ref export-id_2664 struct:export 0 s 'id))))))
-(define export-ext-id_2745
-  (|#%name| export-ext-id (record-accessor struct:export 1)))
+(define export? (|#%name| export? (record-predicate struct:export)))
+(define export-id (|#%name| export-id (record-accessor struct:export 0)))
 (define export-ext-id
+  (|#%name| export-ext-id (record-accessor struct:export 1)))
+(define finish_2581
+  (make-struct-type-install-properties
+   '(export-like)
+   3
+   0
+   struct:export
+   (list (cons prop:authentic #t))
+   (current-inspector)
+   #f
+   '(0 1)
+   #f
+   'export-like))
+(define struct:export-like
+  (make-record-type-descriptor
+   'export-like
+   struct:export
+   (|#%nongenerative-uid| export-like)
+   #f
+   #f
+   '(3 . 4)))
+(define effect_2157 (finish_2581 struct:export-like))
+(define export-like2.1
   (|#%name|
-   export-ext-id
-   (lambda (s)
-     (if (export?_2921 s)
-       (export-ext-id_2745 s)
-       ($value
-        (impersonate-ref export-ext-id_2745 struct:export 1 s 'ext-id))))))
+   export-like
+   (record-constructor
+    (make-record-constructor-descriptor struct:export-like #f #f))))
+(define export-like?
+  (|#%name| export-like? (record-predicate struct:export-like)))
+(define export-like-id
+  (|#%name| export-like-id (record-accessor struct:export-like 0)))
+(define export-like-ext-id
+  (|#%name| export-like-ext-id (record-accessor struct:export-like 1)))
+(define export-like-referenced?
+  (|#%name| export-like-referenced? (record-accessor struct:export-like 2)))
+(define set-export-like-referenced?!
+  (|#%name|
+   set-export-like-referenced?!
+   (record-mutator struct:export-like 2)))
 (define check-fxvector
   (lambda (v_0)
     (if (fxvector? v_0)
@@ -5261,13 +5087,13 @@
   (|#%name|
    not-an-fX
    (lambda (who_0 v_0) (begin (raise-argument-error who_0 "fixnum?" v_0)))))
-(define finish_2682
+(define finish_2648
   (make-struct-type-install-properties
    '(too-early)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1)
@@ -5281,47 +5107,17 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2833 (finish_2682 struct:too-early))
+(define effect_2833 (finish_2648 struct:too-early))
 (define too-early1.1
   (|#%name|
    too-early
    (record-constructor
     (make-record-constructor-descriptor struct:too-early #f #f))))
-(define too-early?_1816
-  (|#%name| too-early? (record-predicate struct:too-early)))
-(define too-early?
-  (|#%name|
-   too-early?
-   (lambda (v)
-     (if (too-early?_1816 v)
-       #t
-       ($value
-        (if (impersonator? v) (too-early?_1816 (impersonator-val v)) #f))))))
-(define too-early-name_2356
-  (|#%name| too-early-name (record-accessor struct:too-early 0)))
+(define too-early? (|#%name| too-early? (record-predicate struct:too-early)))
 (define too-early-name
-  (|#%name|
-   too-early-name
-   (lambda (s)
-     (if (too-early?_1816 s)
-       (too-early-name_2356 s)
-       ($value
-        (impersonate-ref too-early-name_2356 struct:too-early 0 s 'name))))))
-(define too-early-set!ed?_2625
-  (|#%name| too-early-set!ed? (record-accessor struct:too-early 1)))
+  (|#%name| too-early-name (record-accessor struct:too-early 0)))
 (define too-early-set!ed?
-  (|#%name|
-   too-early-set!ed?
-   (lambda (s)
-     (if (too-early?_1816 s)
-       (too-early-set!ed?_2625 s)
-       ($value
-        (impersonate-ref
-         too-early-set!ed?_2625
-         struct:too-early
-         1
-         s
-         'set!ed?))))))
+  (|#%name| too-early-set!ed? (record-accessor struct:too-early 1)))
 (define delayed-mutated-state? (lambda (v_0) (procedure? v_0)))
 (define simple-mutated-state?
   (lambda (v_0)
@@ -8978,13 +8774,13 @@
       (if (begin-unsafe (pair? (unwrap args_0)))
         (arithmetic-shift (args-arity-mask (wrap-cdr args_0)) 1)
         -1))))
-(define finish_2858
+(define finish_2575
   (make-struct-type-install-properties
    '(struct-type-info)
    11
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1 2 3 4 5 6 7 8 9 10)
@@ -8998,209 +8794,56 @@
    #f
    #f
    '(11 . 0)))
-(define effect_2037 (finish_2858 struct:struct-type-info))
+(define effect_2037 (finish_2575 struct:struct-type-info))
 (define struct-type-info1.1
   (|#%name|
    struct-type-info
    (record-constructor
     (make-record-constructor-descriptor struct:struct-type-info #f #f))))
-(define struct-type-info?_2591
-  (|#%name| struct-type-info? (record-predicate struct:struct-type-info)))
 (define struct-type-info?
-  (|#%name|
-   struct-type-info?
-   (lambda (v)
-     (if (struct-type-info?_2591 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (struct-type-info?_2591 (impersonator-val v))
-          #f))))))
-(define struct-type-info-name_2272
-  (|#%name| struct-type-info-name (record-accessor struct:struct-type-info 0)))
+  (|#%name| struct-type-info? (record-predicate struct:struct-type-info)))
 (define struct-type-info-name
-  (|#%name|
-   struct-type-info-name
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-name_2272 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-name_2272
-         struct:struct-type-info
-         0
-         s
-         'name))))))
-(define struct-type-info-parent_2983
-  (|#%name|
-   struct-type-info-parent
-   (record-accessor struct:struct-type-info 1)))
+  (|#%name| struct-type-info-name (record-accessor struct:struct-type-info 0)))
 (define struct-type-info-parent
   (|#%name|
    struct-type-info-parent
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-parent_2983 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-parent_2983
-         struct:struct-type-info
-         1
-         s
-         'parent))))))
-(define struct-type-info-immediate-field-count_2698
-  (|#%name|
-   struct-type-info-immediate-field-count
-   (record-accessor struct:struct-type-info 2)))
+   (record-accessor struct:struct-type-info 1)))
 (define struct-type-info-immediate-field-count
   (|#%name|
    struct-type-info-immediate-field-count
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-immediate-field-count_2698 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-immediate-field-count_2698
-         struct:struct-type-info
-         2
-         s
-         'immediate-field-count))))))
-(define struct-type-info-field-count_2405
-  (|#%name|
-   struct-type-info-field-count
-   (record-accessor struct:struct-type-info 3)))
+   (record-accessor struct:struct-type-info 2)))
 (define struct-type-info-field-count
   (|#%name|
    struct-type-info-field-count
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-field-count_2405 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-field-count_2405
-         struct:struct-type-info
-         3
-         s
-         'field-count))))))
-(define struct-type-info-pure-constructor?_2558
-  (|#%name|
-   struct-type-info-pure-constructor?
-   (record-accessor struct:struct-type-info 4)))
+   (record-accessor struct:struct-type-info 3)))
 (define struct-type-info-pure-constructor?
   (|#%name|
    struct-type-info-pure-constructor?
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-pure-constructor?_2558 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-pure-constructor?_2558
-         struct:struct-type-info
-         4
-         s
-         'pure-constructor?))))))
-(define struct-type-info-authentic?_2530
-  (|#%name|
-   struct-type-info-authentic?
-   (record-accessor struct:struct-type-info 5)))
+   (record-accessor struct:struct-type-info 4)))
 (define struct-type-info-authentic?
   (|#%name|
    struct-type-info-authentic?
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-authentic?_2530 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-authentic?_2530
-         struct:struct-type-info
-         5
-         s
-         'authentic?))))))
-(define struct-type-info-sealed?_2632
-  (|#%name|
-   struct-type-info-sealed?
-   (record-accessor struct:struct-type-info 6)))
+   (record-accessor struct:struct-type-info 5)))
 (define struct-type-info-sealed?
   (|#%name|
    struct-type-info-sealed?
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-sealed?_2632 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-sealed?_2632
-         struct:struct-type-info
-         6
-         s
-         'sealed?))))))
-(define struct-type-info-prefab-immutables_2507
-  (|#%name|
-   struct-type-info-prefab-immutables
-   (record-accessor struct:struct-type-info 7)))
+   (record-accessor struct:struct-type-info 6)))
 (define struct-type-info-prefab-immutables
   (|#%name|
    struct-type-info-prefab-immutables
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-prefab-immutables_2507 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-prefab-immutables_2507
-         struct:struct-type-info
-         7
-         s
-         'prefab-immutables))))))
-(define struct-type-info-non-prefab-immutables_2796
-  (|#%name|
-   struct-type-info-non-prefab-immutables
-   (record-accessor struct:struct-type-info 8)))
+   (record-accessor struct:struct-type-info 7)))
 (define struct-type-info-non-prefab-immutables
   (|#%name|
    struct-type-info-non-prefab-immutables
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-non-prefab-immutables_2796 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-non-prefab-immutables_2796
-         struct:struct-type-info
-         8
-         s
-         'non-prefab-immutables))))))
-(define struct-type-info-constructor-name-expr_2430
-  (|#%name|
-   struct-type-info-constructor-name-expr
-   (record-accessor struct:struct-type-info 9)))
+   (record-accessor struct:struct-type-info 8)))
 (define struct-type-info-constructor-name-expr
   (|#%name|
    struct-type-info-constructor-name-expr
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-constructor-name-expr_2430 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-constructor-name-expr_2430
-         struct:struct-type-info
-         9
-         s
-         'constructor-name-expr))))))
-(define struct-type-info-rest_2501
-  (|#%name|
-   struct-type-info-rest
-   (record-accessor struct:struct-type-info 10)))
+   (record-accessor struct:struct-type-info 9)))
 (define struct-type-info-rest
   (|#%name|
    struct-type-info-rest
-   (lambda (s)
-     (if (struct-type-info?_2591 s)
-       (struct-type-info-rest_2501 s)
-       ($value
-        (impersonate-ref
-         struct-type-info-rest_2501
-         struct:struct-type-info
-         10
-         s
-         'rest))))))
+   (record-accessor struct:struct-type-info 10)))
 (define struct-type-info-rest-properties-list-pos 0)
 (define make-struct-type-info
   (lambda (v_0 prim-knowns_0 knowns_0 imports_0 mutated_0)
@@ -14448,12 +14091,10 @@
                                                 (hash-set
                                                  needed_0
                                                  u-v_0
-                                                 (let ((app_0
-                                                        (import-ext-id c2_0)))
-                                                   (cons
-                                                    app_0
-                                                    (import-group-index
-                                                     (import-grp c2_0)))))
+                                                 (cons
+                                                  (import-ext-id c2_0)
+                                                  (import-group-index
+                                                   (import-grp c2_0))))
                                                 #f)))))
                                       needed_0))))))))))))))))
       #f)))
@@ -16831,18 +16472,14 @@
                                                 (hash-set
                                                  knowns_2
                                                  app_0
-                                                 (let ((app_1
-                                                        (struct-type-info-field-count
-                                                         info_0)))
-                                                   (let ((app_2
-                                                          (struct-type-info-pure-constructor?
-                                                           info_0)))
-                                                     (known-struct-type
-                                                      type_0
-                                                      app_1
-                                                      app_2
-                                                      (struct-type-info-sealed?
-                                                       info_0))))))
+                                                 (known-struct-type
+                                                  type_0
+                                                  (struct-type-info-field-count
+                                                   info_0)
+                                                  (struct-type-info-pure-constructor?
+                                                   info_0)
+                                                  (struct-type-info-sealed?
+                                                   info_0))))
                                               info_0)))))))
                                  (nothing_0)))))
                           (if (let ((p_0 (unwrap v_0)))
@@ -17035,32 +16672,26 @@
                                                  (hash-set
                                                   knowns_0
                                                   app_0
-                                                  (let ((app_1
-                                                         (struct-type-info-authentic?
-                                                          info_0)))
-                                                    (known-struct-predicate
-                                                     2
-                                                     type_0
-                                                     struct:s_0
-                                                     app_1
-                                                     (struct-type-info-sealed?
-                                                      info_0)))))))
+                                                  (known-struct-predicate
+                                                   2
+                                                   type_0
+                                                   struct:s_0
+                                                   (struct-type-info-authentic?
+                                                    info_0)
+                                                   (struct-type-info-sealed?
+                                                    info_0))))))
                                           (let ((app_0 (unwrap struct:s_0)))
                                             (hash-set
                                              knowns_1
                                              app_0
-                                             (let ((app_1
-                                                    (struct-type-info-field-count
-                                                     info_0)))
-                                               (let ((app_2
-                                                      (struct-type-info-pure-constructor?
-                                                       info_0)))
-                                                 (known-struct-type
-                                                  type_0
-                                                  app_1
-                                                  app_2
-                                                  (struct-type-info-sealed?
-                                                   info_0))))))))
+                                             (known-struct-type
+                                              type_0
+                                              (struct-type-info-field-count
+                                               info_0)
+                                              (struct-type-info-pure-constructor?
+                                               info_0)
+                                              (struct-type-info-sealed?
+                                               info_0))))))
                                       info_0))
                                    (maybe-immediate-values_0)))))
                             (if (let ((p_0 (unwrap v_0)))
@@ -19372,51 +19003,47 @@
                                               #f
                                               (list
                                                'quote
-                                               (let ((app_5
-                                                      (struct-type-info-immediate-field-count
-                                                       sti_0)))
-                                                 (list*
-                                                  app_5
-                                                  (let ((n_0
-                                                         (struct-type-info-immediate-field-count
-                                                          sti_0)))
-                                                    (let ((mask_0
-                                                           (sub1
-                                                            (arithmetic-shift
-                                                             1
-                                                             n_0))))
-                                                      (let ((c1_0
-                                                             (struct-type-info-non-prefab-immutables
-                                                              sti_0)))
-                                                        (if c1_0
-                                                          (letrec*
-                                                           ((loop_0
-                                                             (|#%name|
-                                                              loop
-                                                              (lambda (imms_0
-                                                                       mask_1)
-                                                                (begin
-                                                                  (if (null?
-                                                                       imms_0)
-                                                                    mask_1
-                                                                    (let ((m_0
-                                                                           (bitwise-not
-                                                                            (arithmetic-shift
-                                                                             1
-                                                                             (car
-                                                                              imms_0)))))
-                                                                      (let ((app_6
-                                                                             (cdr
-                                                                              imms_0)))
-                                                                        (loop_0
-                                                                         app_6
-                                                                         (bitwise-and
-                                                                          mask_1
-                                                                          m_0))))))))))
-                                                           (loop_0
-                                                            c1_0
-                                                            mask_0))
-                                                          mask_0)))))))))))))))
+                                               (list*
+                                                (struct-type-info-immediate-field-count
+                                                 sti_0)
+                                                (let ((n_0
+                                                       (struct-type-info-immediate-field-count
+                                                        sti_0)))
+                                                  (let ((mask_0
+                                                         (sub1
+                                                          (arithmetic-shift
+                                                           1
+                                                           n_0))))
+                                                    (let ((c1_0
+                                                           (struct-type-info-non-prefab-immutables
+                                                            sti_0)))
+                                                      (if c1_0
+                                                        (letrec*
+                                                         ((loop_0
+                                                           (|#%name|
+                                                            loop
+                                                            (lambda (imms_0
+                                                                     mask_1)
+                                                              (begin
+                                                                (if (null?
+                                                                     imms_0)
+                                                                  mask_1
+                                                                  (let ((m_0
+                                                                         (bitwise-not
+                                                                          (arithmetic-shift
+                                                                           1
+                                                                           (car
+                                                                            imms_0)))))
+                                                                    (let ((app_5
+                                                                           (cdr
+                                                                            imms_0)))
+                                                                      (loop_0
+                                                                       app_5
+                                                                       (bitwise-and
+                                                                        mask_1
+                                                                        m_0))))))))))
+                                                         (loop_0 c1_0 mask_0))
+                                                        mask_0))))))))))))))
                                (list*
                                 app_1
                                 (let ((app_2
@@ -19556,24 +19183,18 @@
                                                                       ""))
                                                                  (let ((post_0
                                                                         "?"))
-                                                                   (let ((sep_1
-                                                                          sep_0)
-                                                                         (st_1
-                                                                          st_0)
-                                                                         (pre_1
-                                                                          pre_0))
-                                                                     (begin-unsafe
-                                                                      (string->symbol
-                                                                       (let ((app_4
-                                                                              (symbol->immutable-string
-                                                                               st_1)))
-                                                                         (string-append-immutable
-                                                                          pre_1
-                                                                          app_4
-                                                                          sep_1
-                                                                          (symbol->immutable-string
-                                                                           '||)
-                                                                          post_0))))))))))
+                                                                   (begin-unsafe
+                                                                    (string->symbol
+                                                                     (let ((app_4
+                                                                            (symbol->immutable-string
+                                                                             st_0)))
+                                                                       (string-append-immutable
+                                                                        pre_0
+                                                                        app_4
+                                                                        sep_0
+                                                                        (symbol->immutable-string
+                                                                         '||)
+                                                                        post_0)))))))))
                                                         (let ((proc-expr_0
                                                                (list
                                                                 'record-predicate
@@ -19611,24 +19232,18 @@
                                                                             ""))
                                                                        (let ((post_0
                                                                               "?"))
-                                                                         (let ((sep_1
-                                                                                sep_0)
-                                                                               (st_1
-                                                                                st_0)
-                                                                               (pre_1
-                                                                                pre_0))
-                                                                           (begin-unsafe
-                                                                            (string->symbol
-                                                                             (let ((app_5
-                                                                                    (symbol->immutable-string
-                                                                                     st_1)))
-                                                                               (string-append-immutable
-                                                                                pre_1
-                                                                                app_5
-                                                                                sep_1
-                                                                                (symbol->immutable-string
-                                                                                 '||)
-                                                                                post_0))))))))))
+                                                                         (begin-unsafe
+                                                                          (string->symbol
+                                                                           (let ((app_5
+                                                                                  (symbol->immutable-string
+                                                                                   st_0)))
+                                                                             (string-append-immutable
+                                                                              pre_0
+                                                                              app_5
+                                                                              sep_0
+                                                                              (symbol->immutable-string
+                                                                               '||)
+                                                                              post_0)))))))))
                                                               (let ((proc-expr_0
                                                                      (list
                                                                       'lambda
@@ -19772,24 +19387,18 @@
                                                                                                                    "-"))
                                                                                                               (let ((post_0
                                                                                                                      ""))
-                                                                                                                (let ((sep_1
-                                                                                                                       sep_0)
-                                                                                                                      (st_1
-                                                                                                                       st_0)
-                                                                                                                      (pre_1
-                                                                                                                       pre_0))
-                                                                                                                  (begin-unsafe
-                                                                                                                   (string->symbol
-                                                                                                                    (let ((app_6
-                                                                                                                           (symbol->immutable-string
-                                                                                                                            st_1)))
-                                                                                                                      (string-append-immutable
-                                                                                                                       pre_1
-                                                                                                                       app_6
-                                                                                                                       sep_1
-                                                                                                                       (symbol->immutable-string
-                                                                                                                        field/proc-name_0)
-                                                                                                                       post_0))))))))))))
+                                                                                                                (begin-unsafe
+                                                                                                                 (string->symbol
+                                                                                                                  (let ((app_6
+                                                                                                                         (symbol->immutable-string
+                                                                                                                          st_0)))
+                                                                                                                    (string-append-immutable
+                                                                                                                     pre_0
+                                                                                                                     app_6
+                                                                                                                     sep_0
+                                                                                                                     (symbol->immutable-string
+                                                                                                                      field/proc-name_0)
+                                                                                                                     post_0)))))))))))
                                                                                                  (let ((raw-def_0
                                                                                                         (list
                                                                                                          'define
@@ -19898,24 +19507,18 @@
                                                                                                                      "-"))
                                                                                                                 (let ((post_0
                                                                                                                        "!"))
-                                                                                                                  (let ((sep_1
-                                                                                                                         sep_0)
-                                                                                                                        (st_1
-                                                                                                                         st_0)
-                                                                                                                        (pre_1
-                                                                                                                         pre_0))
-                                                                                                                    (begin-unsafe
-                                                                                                                     (string->symbol
-                                                                                                                      (let ((app_6
-                                                                                                                             (symbol->immutable-string
-                                                                                                                              st_1)))
-                                                                                                                        (string-append-immutable
-                                                                                                                         pre_1
-                                                                                                                         app_6
-                                                                                                                         sep_1
-                                                                                                                         (symbol->immutable-string
-                                                                                                                          field/proc-name_0)
-                                                                                                                         post_0))))))))))))
+                                                                                                                  (begin-unsafe
+                                                                                                                   (string->symbol
+                                                                                                                    (let ((app_6
+                                                                                                                           (symbol->immutable-string
+                                                                                                                            st_0)))
+                                                                                                                      (string-append-immutable
+                                                                                                                       pre_0
+                                                                                                                       app_6
+                                                                                                                       sep_0
+                                                                                                                       (symbol->immutable-string
+                                                                                                                        field/proc-name_0)
+                                                                                                                       post_0)))))))))))
                                                                                                    (let ((raw-def_0
                                                                                                           (list
                                                                                                            'define
@@ -19943,13 +19546,11 @@
                                                                                                      (let ((abs-pos_0
                                                                                                             (+
                                                                                                              pos_0
-                                                                                                             (let ((app_6
-                                                                                                                    (struct-type-info-field-count
-                                                                                                                     sti_0)))
-                                                                                                               (-
-                                                                                                                app_6
-                                                                                                                (struct-type-info-immediate-field-count
-                                                                                                                 sti_0))))))
+                                                                                                             (-
+                                                                                                              (struct-type-info-field-count
+                                                                                                               sti_0)
+                                                                                                              (struct-type-info-immediate-field-count
+                                                                                                               sti_0)))))
                                                                                                        (let ((err-args_0
                                                                                                               (|#%name|
                                                                                                                err-args
@@ -26210,14 +25811,12 @@
                                    (let ((fold-var_1
                                           (let ((fold-var_1
                                                  (cons
-                                                  (let ((app_0
-                                                         (export-id ex_0)))
-                                                    (list
-                                                     'define
-                                                     app_0
-                                                     (list
-                                                      'make-internal-variable
-                                                      (list 'quote int-id_0))))
+                                                  (list
+                                                   'define
+                                                   (export-id ex_0)
+                                                   (list
+                                                    'make-internal-variable
+                                                    (list 'quote int-id_0)))
                                                   fold-var_0)))
                                             (values fold-var_1))))
                                      (for-loop_0
@@ -33842,13 +33441,13 @@
                            (schemify-body_0 (cdr l_0) wcm-state_2))))))))))
              (schemify_0 v_1 wcm-state_1)))))))
      (schemify/knowns_0 knowns_0 8 wcm-state_0 v_0))))
-(define finish_2118
+(define finish_2608
   (make-struct-type-install-properties
    '(convert-mode)
    4
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1 2 3)
@@ -33862,86 +33461,24 @@
    #f
    #f
    '(4 . 0)))
-(define effect_2443 (finish_2118 struct:convert-mode))
+(define effect_2443 (finish_2608 struct:convert-mode))
 (define convert-mode1.1
   (|#%name|
    convert-mode
    (record-constructor
     (make-record-constructor-descriptor struct:convert-mode #f #f))))
-(define convert-mode?_2433
-  (|#%name| convert-mode? (record-predicate struct:convert-mode)))
 (define convert-mode?
-  (|#%name|
-   convert-mode?
-   (lambda (v)
-     (if (convert-mode?_2433 v)
-       #t
-       ($value
-        (if (impersonator? v)
-          (convert-mode?_2433 (impersonator-val v))
-          #f))))))
-(define convert-mode-sizes_3279
-  (|#%name| convert-mode-sizes (record-accessor struct:convert-mode 0)))
+  (|#%name| convert-mode? (record-predicate struct:convert-mode)))
 (define convert-mode-sizes
-  (|#%name|
-   convert-mode-sizes
-   (lambda (s)
-     (if (convert-mode?_2433 s)
-       (convert-mode-sizes_3279 s)
-       ($value
-        (impersonate-ref
-         convert-mode-sizes_3279
-         struct:convert-mode
-         0
-         s
-         'sizes))))))
-(define convert-mode-called?_2733
-  (|#%name| convert-mode-called? (record-accessor struct:convert-mode 1)))
+  (|#%name| convert-mode-sizes (record-accessor struct:convert-mode 0)))
 (define convert-mode-called?
-  (|#%name|
-   convert-mode-called?
-   (lambda (s)
-     (if (convert-mode?_2433 s)
-       (convert-mode-called?_2733 s)
-       ($value
-        (impersonate-ref
-         convert-mode-called?_2733
-         struct:convert-mode
-         1
-         s
-         'called?))))))
-(define convert-mode-lift?_2529
-  (|#%name| convert-mode-lift? (record-accessor struct:convert-mode 2)))
+  (|#%name| convert-mode-called? (record-accessor struct:convert-mode 1)))
 (define convert-mode-lift?
-  (|#%name|
-   convert-mode-lift?
-   (lambda (s)
-     (if (convert-mode?_2433 s)
-       (convert-mode-lift?_2529 s)
-       ($value
-        (impersonate-ref
-         convert-mode-lift?_2529
-         struct:convert-mode
-         2
-         s
-         'lift?))))))
-(define convert-mode-no-more-conversions?_2511
-  (|#%name|
-   convert-mode-no-more-conversions?
-   (record-accessor struct:convert-mode 3)))
+  (|#%name| convert-mode-lift? (record-accessor struct:convert-mode 2)))
 (define convert-mode-no-more-conversions?
   (|#%name|
    convert-mode-no-more-conversions?
-   (lambda (s)
-     (if (convert-mode?_2433 s)
-       (convert-mode-no-more-conversions?_2511 s)
-       ($value
-        (impersonate-ref
-         convert-mode-no-more-conversions?_2511
-         struct:convert-mode
-         3
-         s
-         'no-more-conversions?))))))
+   (record-accessor struct:convert-mode 3)))
 (define lifts-id (string->uninterned-symbol "_jits"))
 (define jitify-schemified-linklet
   (lambda (v_0
@@ -38656,13 +38193,11 @@
           (begin
             (if (convert-mode? cm_0)
               (if (convert-mode? cm_0)
-                (let ((app_0 (convert-mode-sizes cm_0)))
-                  (let ((app_1 (convert-mode-lift? cm_0)))
-                    (convert-mode1.1
-                     app_0
-                     #f
-                     app_1
-                     (convert-mode-no-more-conversions? cm_0))))
+                (convert-mode1.1
+                 (convert-mode-sizes cm_0)
+                 #f
+                 (convert-mode-lift? cm_0)
+                 (convert-mode-no-more-conversions? cm_0))
                 (raise-argument-error 'struct-copy "convert-mode?" cm_0))
               (if (eq? 'no-lift (cdr cm_0))
                 '(not-called . no-lift)
@@ -38674,13 +38209,11 @@
           (begin
             (if (convert-mode? cm_0)
               (if (convert-mode? cm_0)
-                (let ((app_0 (convert-mode-sizes cm_0)))
-                  (let ((app_1 (convert-mode-lift? cm_0)))
-                    (convert-mode1.1
-                     app_0
-                     #t
-                     app_1
-                     (convert-mode-no-more-conversions? cm_0))))
+                (convert-mode1.1
+                 (convert-mode-sizes cm_0)
+                 #t
+                 (convert-mode-lift? cm_0)
+                 (convert-mode-no-more-conversions? cm_0))
                 (raise-argument-error 'struct-copy "convert-mode?" cm_0))
               (if (eq? 'no-lift (cdr cm_0))
                 '(called . no-lift)
@@ -42777,13 +42310,13 @@
                         (if (|#%app| need-exposed?_0 q_0)
                           #t
                           (if (extflonum? q_0) #t #f))))))))))))))
-(define finish_3138
+(define finish_2489
   (make-struct-type-install-properties
    '(to-unfasl)
    3
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1 2)
@@ -42797,57 +42330,19 @@
    #f
    #f
    '(3 . 0)))
-(define effect_2898 (finish_3138 struct:to-unfasl))
+(define effect_2898 (finish_2489 struct:to-unfasl))
 (define to-unfasl1.1
   (|#%name|
    to-unfasl
    (record-constructor
     (make-record-constructor-descriptor struct:to-unfasl #f #f))))
-(define to-unfasl?_2342
-  (|#%name| to-unfasl? (record-predicate struct:to-unfasl)))
-(define to-unfasl?
-  (|#%name|
-   to-unfasl?
-   (lambda (v)
-     (if (to-unfasl?_2342 v)
-       #t
-       ($value
-        (if (impersonator? v) (to-unfasl?_2342 (impersonator-val v)) #f))))))
-(define to-unfasl-bstr_2318
-  (|#%name| to-unfasl-bstr (record-accessor struct:to-unfasl 0)))
+(define to-unfasl? (|#%name| to-unfasl? (record-predicate struct:to-unfasl)))
 (define to-unfasl-bstr
-  (|#%name|
-   to-unfasl-bstr
-   (lambda (s)
-     (if (to-unfasl?_2342 s)
-       (to-unfasl-bstr_2318 s)
-       ($value
-        (impersonate-ref to-unfasl-bstr_2318 struct:to-unfasl 0 s 'bstr))))))
-(define to-unfasl-externals_2291
-  (|#%name| to-unfasl-externals (record-accessor struct:to-unfasl 1)))
+  (|#%name| to-unfasl-bstr (record-accessor struct:to-unfasl 0)))
 (define to-unfasl-externals
-  (|#%name|
-   to-unfasl-externals
-   (lambda (s)
-     (if (to-unfasl?_2342 s)
-       (to-unfasl-externals_2291 s)
-       ($value
-        (impersonate-ref
-         to-unfasl-externals_2291
-         struct:to-unfasl
-         1
-         s
-         'externals))))))
-(define to-unfasl-wrt_2425
-  (|#%name| to-unfasl-wrt (record-accessor struct:to-unfasl 2)))
+  (|#%name| to-unfasl-externals (record-accessor struct:to-unfasl 1)))
 (define to-unfasl-wrt
-  (|#%name|
-   to-unfasl-wrt
-   (lambda (s)
-     (if (to-unfasl?_2342 s)
-       (to-unfasl-wrt_2425 s)
-       ($value
-        (impersonate-ref to-unfasl-wrt_2425 struct:to-unfasl 2 s 'wrt))))))
+  (|#%name| to-unfasl-wrt (record-accessor struct:to-unfasl 2)))
 (define empty-literals?
   (lambda (v_0) (if (vector? v_0) (eqv? 0 (vector-length v_0)) #f)))
 (define fasl-literals
@@ -42893,8 +42388,7 @@
                      (to-unfasl-wrt v_0)))
                   (let ((temp7_0 (to-unfasl-bstr v_0)))
                     (let ((temp10_0 (to-unfasl-externals v_0)))
-                      (let ((temp7_1 temp7_0))
-                        (fasl->s-exp.1 #t temp10_0 #t temp7_1)))))))
+                      (fasl->s-exp.1 #t temp10_0 #t temp7_0))))))
             (letrec*
              ((loop_0
                (|#%name|
@@ -43235,13 +42729,13 @@
                          app_2
                          (stack-set stack_1 pos_1 (car vals_1))))))))))))
          (loop_0 pos_0 vals_0 count_0 stack_0))))))
-(define finish_2471
+(define finish_2254
   (make-struct-type-install-properties
    '(stack-info)
    5
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1)
@@ -43255,154 +42749,36 @@
    #f
    #f
    '(5 . 28)))
-(define effect_2334 (finish_2471 struct:stack-info))
+(define effect_2334 (finish_2254 struct:stack-info))
 (define stack-info4.1
   (|#%name|
    stack-info
    (record-constructor
     (make-record-constructor-descriptor struct:stack-info #f #f))))
-(define stack-info?_2054
-  (|#%name| stack-info? (record-predicate struct:stack-info)))
 (define stack-info?
-  (|#%name|
-   stack-info?
-   (lambda (v)
-     (if (stack-info?_2054 v)
-       #t
-       ($value
-        (if (impersonator? v) (stack-info?_2054 (impersonator-val v)) #f))))))
-(define stack-info-capture-depth_2245
-  (|#%name| stack-info-capture-depth (record-accessor struct:stack-info 0)))
+  (|#%name| stack-info? (record-predicate struct:stack-info)))
 (define stack-info-capture-depth
-  (|#%name|
-   stack-info-capture-depth
-   (lambda (s)
-     (if (stack-info?_2054 s)
-       (stack-info-capture-depth_2245 s)
-       ($value
-        (impersonate-ref
-         stack-info-capture-depth_2245
-         struct:stack-info
-         0
-         s
-         'capture-depth))))))
-(define stack-info-closure-map_2860
-  (|#%name| stack-info-closure-map (record-accessor struct:stack-info 1)))
+  (|#%name| stack-info-capture-depth (record-accessor struct:stack-info 0)))
 (define stack-info-closure-map
-  (|#%name|
-   stack-info-closure-map
-   (lambda (s)
-     (if (stack-info?_2054 s)
-       (stack-info-closure-map_2860 s)
-       ($value
-        (impersonate-ref
-         stack-info-closure-map_2860
-         struct:stack-info
-         1
-         s
-         'closure-map))))))
-(define stack-info-use-map_2830
-  (|#%name| stack-info-use-map (record-accessor struct:stack-info 2)))
+  (|#%name| stack-info-closure-map (record-accessor struct:stack-info 1)))
 (define stack-info-use-map
-  (|#%name|
-   stack-info-use-map
-   (lambda (s)
-     (if (stack-info?_2054 s)
-       (stack-info-use-map_2830 s)
-       ($value
-        (impersonate-ref
-         stack-info-use-map_2830
-         struct:stack-info
-         2
-         s
-         'use-map))))))
-(define stack-info-local-use-map_2796
-  (|#%name| stack-info-local-use-map (record-accessor struct:stack-info 3)))
+  (|#%name| stack-info-use-map (record-accessor struct:stack-info 2)))
 (define stack-info-local-use-map
-  (|#%name|
-   stack-info-local-use-map
-   (lambda (s)
-     (if (stack-info?_2054 s)
-       (stack-info-local-use-map_2796 s)
-       ($value
-        (impersonate-ref
-         stack-info-local-use-map_2796
-         struct:stack-info
-         3
-         s
-         'local-use-map))))))
-(define stack-info-non-tail-call-later?_2901
-  (|#%name|
-   stack-info-non-tail-call-later?
-   (record-accessor struct:stack-info 4)))
+  (|#%name| stack-info-local-use-map (record-accessor struct:stack-info 3)))
 (define stack-info-non-tail-call-later?
   (|#%name|
    stack-info-non-tail-call-later?
-   (lambda (s)
-     (if (stack-info?_2054 s)
-       (stack-info-non-tail-call-later?_2901 s)
-       ($value
-        (impersonate-ref
-         stack-info-non-tail-call-later?_2901
-         struct:stack-info
-         4
-         s
-         'non-tail-call-later?))))))
-(define set-stack-info-use-map!_2735
-  (|#%name| set-stack-info-use-map! (record-mutator struct:stack-info 2)))
+   (record-accessor struct:stack-info 4)))
 (define set-stack-info-use-map!
-  (|#%name|
-   set-stack-info-use-map!
-   (lambda (s v)
-     (if (stack-info?_2054 s)
-       (set-stack-info-use-map!_2735 s v)
-       ($value
-        (impersonate-set!
-         set-stack-info-use-map!_2735
-         struct:stack-info
-         2
-         2
-         s
-         v
-         'use-map))))))
-(define set-stack-info-local-use-map!_2852
-  (|#%name|
-   set-stack-info-local-use-map!
-   (record-mutator struct:stack-info 3)))
+  (|#%name| set-stack-info-use-map! (record-mutator struct:stack-info 2)))
 (define set-stack-info-local-use-map!
   (|#%name|
    set-stack-info-local-use-map!
-   (lambda (s v)
-     (if (stack-info?_2054 s)
-       (set-stack-info-local-use-map!_2852 s v)
-       ($value
-        (impersonate-set!
-         set-stack-info-local-use-map!_2852
-         struct:stack-info
-         3
-         3
-         s
-         v
-         'local-use-map))))))
-(define set-stack-info-non-tail-call-later?!_2871
-  (|#%name|
-   set-stack-info-non-tail-call-later?!
-   (record-mutator struct:stack-info 4)))
+   (record-mutator struct:stack-info 3)))
 (define set-stack-info-non-tail-call-later?!
   (|#%name|
    set-stack-info-non-tail-call-later?!
-   (lambda (s v)
-     (if (stack-info?_2054 s)
-       (set-stack-info-non-tail-call-later?!_2871 s v)
-       ($value
-        (impersonate-set!
-         set-stack-info-non-tail-call-later?!_2871
-         struct:stack-info
-         4
-         4
-         s
-         v
-         'non-tail-call-later?))))))
+   (record-mutator struct:stack-info 4)))
 (define make-stack-info.1
   (|#%name|
    make-stack-info
@@ -43462,15 +42838,13 @@
                          pos_0)))))))))))))
 (define stack-info-branch
   (lambda (stk-i_0)
-    (let ((app_0 (stack-info-capture-depth stk-i_0)))
-      (let ((app_1 (stack-info-closure-map stk-i_0)))
-        (let ((app_2 (stack-info-use-map stk-i_0)))
-          (stack-info4.1
-           app_0
-           app_1
-           app_2
-           hash2610
-           (stack-info-non-tail-call-later? stk-i_0)))))))
+    (let ((app_0 (stack-info-use-map stk-i_0)))
+      (stack-info4.1
+       (stack-info-capture-depth stk-i_0)
+       (stack-info-closure-map stk-i_0)
+       app_0
+       hash2610
+       (stack-info-non-tail-call-later? stk-i_0)))))
 (define stack-info-branch-need-clears?
   (lambda (stk-i_0) (stack-info-non-tail-call-later? stk-i_0)))
 (define stack-info-merge!
@@ -43584,13 +42958,13 @@
 (define stack-info-non-tail!
   (lambda (stk-i_0 stack-depth_0)
     (set-stack-info-non-tail-call-later?! stk-i_0 #t)))
-(define finish_2360
+(define finish_2657
   (make-struct-type-install-properties
    '(indirect)
    2
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0 1)
@@ -43604,53 +42978,24 @@
    #f
    #f
    '(2 . 0)))
-(define effect_2125 (finish_2360 struct:indirect))
+(define effect_2125 (finish_2657 struct:indirect))
 (define indirect1.1
   (|#%name|
    indirect
    (record-constructor
     (make-record-constructor-descriptor struct:indirect #f #f))))
-(define indirect?_2680 (|#%name| indirect? (record-predicate struct:indirect)))
-(define indirect?
-  (|#%name|
-   indirect?
-   (lambda (v)
-     (if (indirect?_2680 v)
-       #t
-       ($value
-        (if (impersonator? v) (indirect?_2680 (impersonator-val v)) #f))))))
-(define indirect-pos_2819
-  (|#%name| indirect-pos (record-accessor struct:indirect 0)))
+(define indirect? (|#%name| indirect? (record-predicate struct:indirect)))
 (define indirect-pos
-  (|#%name|
-   indirect-pos
-   (lambda (s)
-     (if (indirect?_2680 s)
-       (indirect-pos_2819 s)
-       ($value
-        (impersonate-ref indirect-pos_2819 struct:indirect 0 s 'pos))))))
-(define indirect-element_2353
-  (|#%name| indirect-element (record-accessor struct:indirect 1)))
+  (|#%name| indirect-pos (record-accessor struct:indirect 0)))
 (define indirect-element
-  (|#%name|
-   indirect-element
-   (lambda (s)
-     (if (indirect?_2680 s)
-       (indirect-element_2353 s)
-       ($value
-        (impersonate-ref
-         indirect-element_2353
-         struct:indirect
-         1
-         s
-         'element))))))
-(define finish_2373
+  (|#%name| indirect-element (record-accessor struct:indirect 1)))
+(define finish_2990
   (make-struct-type-install-properties
    '(boxed)
    1
    0
    #f
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '(0)
@@ -43664,36 +43009,21 @@
    #f
    #f
    '(1 . 0)))
-(define effect_2970 (finish_2373 struct:boxed))
+(define effect_2970 (finish_2990 struct:boxed))
 (define boxed2.1
   (|#%name|
    boxed
    (record-constructor
     (make-record-constructor-descriptor struct:boxed #f #f))))
-(define boxed?_2226 (|#%name| boxed? (record-predicate struct:boxed)))
-(define boxed?
-  (|#%name|
-   boxed?
-   (lambda (v)
-     (if (boxed?_2226 v)
-       #t
-       ($value
-        (if (impersonator? v) (boxed?_2226 (impersonator-val v)) #f))))))
-(define boxed-pos_2515 (|#%name| boxed-pos (record-accessor struct:boxed 0)))
-(define boxed-pos
-  (|#%name|
-   boxed-pos
-   (lambda (s)
-     (if (boxed?_2226 s)
-       (boxed-pos_2515 s)
-       ($value (impersonate-ref boxed-pos_2515 struct:boxed 0 s 'pos))))))
-(define finish_2767
+(define boxed? (|#%name| boxed? (record-predicate struct:boxed)))
+(define boxed-pos (|#%name| boxed-pos (record-accessor struct:boxed 0)))
+(define finish_2131
   (make-struct-type-install-properties
    '(boxed/check)
    0
    0
    struct:boxed
-   null
+   (list (cons prop:authentic #t))
    (current-inspector)
    #f
    '()
@@ -43707,22 +43037,14 @@
    #f
    #f
    '(0 . 0)))
-(define effect_2937 (finish_2767 struct:boxed/check))
+(define effect_2937 (finish_2131 struct:boxed/check))
 (define boxed/check3.1
   (|#%name|
    boxed/check
    (record-constructor
     (make-record-constructor-descriptor struct:boxed/check #f #f))))
-(define boxed/check?_2060
-  (|#%name| boxed/check? (record-predicate struct:boxed/check)))
 (define boxed/check?
-  (|#%name|
-   boxed/check?
-   (lambda (v)
-     (if (boxed/check?_2060 v)
-       #t
-       ($value
-        (if (impersonator? v) (boxed/check?_2060 (impersonator-val v)) #f))))))
+  (|#%name| boxed/check? (record-predicate struct:boxed/check)))
 (define primitives hash2610)
 (define strip-annotations (lambda (e_0) e_0))
 (define make-internal-variable (lambda (name_0) (box unsafe-undefined)))

--- a/racket/src/regexp/match/lazy-bytes.rkt
+++ b/racket/src/regexp/match/lazy-bytes.rkt
@@ -24,7 +24,8 @@
                     max-lookbehind   ; bytes before current counter to preserve, if `out`
                     [failed? #:mutable] ; set to #t if `progress-evt` fires or read blocks
                     [discarded-count #:mutable] ; bytes discarded, if not `peek?`
-                    max-peek))       ; maximum number of bytes to peek or #f
+                    max-peek)        ; maximum number of bytes to peek or #f
+  #:authentic)
 
 (define (make-lazy-bytes in skip-amt prefix
                          peek? immediate-only? progress-evt

--- a/racket/src/regexp/match/regexp.rkt
+++ b/racket/src/regexp/match/regexp.rkt
@@ -25,6 +25,7 @@
                    anchored?    ; starts with `^`?
                    must-string  ; shortcut: a byte string that must appear in a match
                    start-range) ; shortcut: a range that must match the initial byte
+        #:authentic
         #:reflection-name 'regexp
         #:property prop:custom-write (lambda (rx port mode)
                                        (write-bytes (if (rx:regexp-px? rx)

--- a/racket/src/regexp/parse/ast.rkt
+++ b/racket/src/regexp/parse/ast.rkt
@@ -17,20 +17,20 @@
 ;; byte string : match content sequence
 ;; string : match content sequence
 
-(struct rx:alts (rx1 rx2) #:transparent)
-(struct rx:sequence (rxs needs-backtrack?) #:transparent)
-(struct rx:group (rx number) #:transparent)
-(struct rx:repeat (rx min max non-greedy?) #:transparent)
-(struct rx:maybe (rx non-greedy?) #:transparent) ; special case in size validation
-(struct rx:conditional (tst rx1 rx2 n-start num-n needs-backtrack?) #:transparent)
-(struct rx:lookahead (rx match? n-start num-n) #:transparent)
+(struct rx:alts (rx1 rx2) #:transparent #:authentic)
+(struct rx:sequence (rxs needs-backtrack?) #:transparent #:authentic)
+(struct rx:group (rx number) #:transparent #:authentic)
+(struct rx:repeat (rx min max non-greedy?) #:transparent #:authentic)
+(struct rx:maybe (rx non-greedy?) #:transparent #:authentic) ; special case in size validation
+(struct rx:conditional (tst rx1 rx2 n-start num-n needs-backtrack?) #:transparent #:authentic)
+(struct rx:lookahead (rx match? n-start num-n) #:transparent #:authentic)
 (struct rx:lookbehind (rx match? [lb-min #:mutable] [lb-max #:mutable] ; min & max set by `validate`
                           n-start num-n)
-        #:transparent)
-(struct rx:cut (rx n-start num-n needs-backtrack?) #:transparent)
-(struct rx:reference (n case-sensitive?) #:transparent)
-(struct rx:range (range) #:transparent)
-(struct rx:unicode-categories (symlist match?) #:transparent)
+        #:transparent #:authentic)
+(struct rx:cut (rx n-start num-n needs-backtrack?) #:transparent #:authentic)
+(struct rx:reference (n case-sensitive?) #:transparent #:authentic)
+(struct rx:range (range) #:transparent #:authentic)
+(struct rx:unicode-categories (symlist match?) #:transparent #:authentic)
 
 ;; We need to backtrack for `rx` if it has alternatives;
 ;; we also count as backtracking anything complex enough

--- a/racket/src/regexp/parse/config.rkt
+++ b/racket/src/regexp/parse/config.rkt
@@ -13,7 +13,8 @@
                       multi-line?
                       group-number-box
                       references?-box
-                      error-handler?))
+                      error-handler?)
+  #:authentic)
 
 (define (make-parse-config #:who [who 'regexp]
                            #:px? [px? #f]

--- a/racket/src/schemify/export.rkt
+++ b/racket/src/schemify/export.rkt
@@ -1,6 +1,6 @@
 #lang racket/base
 (provide (struct-out export))
 
-(struct export (id ext-id))
+(struct export (id ext-id) #:authentic)
 
-(struct export-like export (id ext-id [referenced? #:mutable]))
+(struct export-like export (id ext-id [referenced? #:mutable]) #:authentic)

--- a/racket/src/schemify/fasl-literal.rkt
+++ b/racket/src/schemify/fasl-literal.rkt
@@ -28,7 +28,7 @@
     ;; non-serializable values is someone else's problem
     [else #f]))
 
-(struct to-unfasl (bstr externals wrt))
+(struct to-unfasl (bstr externals wrt) #:authentic)
 
 (define (empty-literals? v)
   (and (vector? v)

--- a/racket/src/schemify/import.rkt
+++ b/racket/src/schemify/import.rkt
@@ -13,13 +13,14 @@
          
          make-add-import!)
 
-(struct import (grp id int-id ext-id))
+(struct import (grp id int-id ext-id) #:authentic)
 (struct import-group (index
                       key
                       [knowns/proc #:mutable]  ; starts as a procedure to get table
                       [converter #:mutable]    ; converts table entries to `known`s (i.e., lazy conversion)
                       [import-keys #:mutable]  ; vector of imports, used for inlining
-                      [imports #:mutable]))    ; starts as declared imports, but inlining can grow
+                      [imports #:mutable])    ; starts as declared imports, but inlining can grow
+  #:authentic)
 
 (define (import-group-knowns grp)
   (define knowns/proc (import-group-knowns/proc grp))

--- a/racket/src/schemify/interp-stack.rkt
+++ b/racket/src/schemify/interp-stack.rkt
@@ -74,7 +74,8 @@
                     closure-map     ; hash table to collect variables beyond boundary to capture
                     [use-map #:mutable] ; table of uses; an entry here means the binding is used later
                     [local-use-map #:mutable] ; subset of `use-map` used to tracked needed merging for branches
-                    [non-tail-call-later? #:mutable])) ; non-tail call afterward?
+                    [non-tail-call-later? #:mutable]) ; non-tail call afterward?
+  #:authentic)
 
 (define (make-stack-info #:capture-depth [capture-depth #f]
                          #:closure-map [closure-map #hasheq()]

--- a/racket/src/schemify/interpret.rkt
+++ b/racket/src/schemify/interpret.rkt
@@ -28,9 +28,9 @@
          interpretable-jitified-linklet
          interpret-linklet)
 
-(struct indirect (pos element))
-(struct boxed (pos))
-(struct boxed/check boxed ())
+(struct indirect (pos element) #:authentic)
+(struct boxed (pos) #:authentic)
+(struct boxed/check boxed () #:authentic)
 
 (define primitives '#hasheq())
 (define strip-annotations (lambda (e) e))

--- a/racket/src/schemify/jitify.rkt
+++ b/racket/src/schemify/jitify.rkt
@@ -34,7 +34,7 @@
 
 (provide jitify-schemified-linklet)
 
-(struct convert-mode (sizes called? lift? no-more-conversions?))
+(struct convert-mode (sizes called? lift? no-more-conversions?) #:authentic)
 
 (define lifts-id (string->uninterned-symbol "_jits"))
 

--- a/racket/src/schemify/lift.rkt
+++ b/racket/src/schemify/lift.rkt
@@ -40,12 +40,12 @@
 
 (struct liftable (expr ; a `lambda` or `case-lambda` RHS of the binding
                   [frees #:mutable] ; set of variables free in `expr`, plus any lifted bindings
-                  [binds #:mutable])) ; set of variables bound in `expr`
+                  [binds #:mutable]) ; set of variables bound in `expr`
+  #:authentic)
+(struct indirected ([check? #:mutable]) #:authentic)
 
-(struct indirected ([check? #:mutable]))
-
-(struct mutator (orig)) ; `orig` maps back to the original identifier
-(struct var-ref (orig)) ; ditto
+(struct mutator (orig) #:authentic) ; `orig` maps back to the original identifier
+(struct var-ref (orig) #:authentic) ; ditto
 
 ;; As we traverse expressions, we thread through free- and
 ;; bound-variable sets

--- a/racket/src/schemify/mutated-state.rkt
+++ b/racket/src/schemify/mutated-state.rkt
@@ -47,7 +47,7 @@
          state->set!ed-state)
 
 ;; Used for `letrec` bindings to record a name:
-(struct too-early (name set!ed?))
+(struct too-early (name set!ed?) #:authentic)
 
 (define (delayed-mutated-state? v) (procedure? v))
 

--- a/racket/src/schemify/struct-type-info.rkt
+++ b/racket/src/schemify/struct-type-info.rkt
@@ -21,7 +21,8 @@
                                prefab-immutables ; #f or immutable expression to be quoted
                                non-prefab-immutables ; #f or immutable expression to be quoted
                                constructor-name-expr  ; an expression
-                               rest)) ; argument expressions after auto-field value
+                               rest) ; argument expressions after auto-field value
+  #:authentic)
 (define struct-type-info-rest-properties-list-pos 0)
 
 ;; Parse `make-struct-type` forms, returning a `struct-type-info`


### PR DESCRIPTION
This changes all the appropriate structs in the regexp and schemify core linklets to use `#:authentic`. It may have some small performance improvements, but mostly it shrinks the generated code size.