### PR TITLE
ChezScheme: replace call to iconv procedure with ICONV macro

### DIFF
--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -2281,7 +2281,7 @@ static size_t iconv_fixup(iconv_t cd, char **src, size_t *srcleft, char **dst, s
   size_t orig_srcleft = *srcleft, orig_dstleft = *dstleft, srcuntried = 0;
 
   while (1) {
-    r = iconv((iconv_t)cd, src, srcleft, dst, dstleft);
+    r = ICONV((iconv_t)cd, src, srcleft, dst, dstleft);
     if ((r == (size_t)-1)
         && (errno == E2BIG)
         && ((*srcleft < orig_srcleft) || (*dstleft < orig_dstleft))) {


### PR DESCRIPTION
The availability of the iconv procedure varies with different build settings, so I believe the ICONV macro should be used here instead.
