### PR TITLE
Update mlists.scrbl

### DIFF
--- a/pkgs/racket-doc/compatibility/scribblings/mlists.scrbl
+++ b/pkgs/racket-doc/compatibility/scribblings/mlists.scrbl
@@ -100,6 +100,24 @@ Like @racket[mreverse], but destructively reverses the
 Like @racket[map], but for @tech[#:doc reference]{mutable lists}.}
 
 
+@defproc[(mmandmap [proc procedure?] [mlst mlist?] ...+)
+         mlist?]{
+
+Like @racket[andmap], but for @tech[#:doc reference]{mutable lists}.}
+
+
+@defproc[(mmormap [proc procedure?] [mlst mlist?] ...+)
+         mlist?]{
+
+Like @racket[ormap], but for @tech[#:doc reference]{mutable lists}.}
+
+
+@defproc[(mmremw [proc procedure?] [mlst mlist?] ...+)
+         mlist?]{
+
+Like @racket[remw], but for @tech[#:doc reference]{mutable lists}.}
+
+
 @defproc[(mfor-each [proc procedure?] [mlst mlist?] ...+)
          void?]{
 


### PR DESCRIPTION
Added documentation entries for the following mlist functions:
- mmandmap ([andmap](https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Fprivate%2Fmap..rkt%29._andmap%29%29) equivalent for mlists)
- mmormap ([ormap](https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Fprivate%2Fmap..rkt%29._ormap%29%29) equivalent for mlists)
- mmremw ([remw](https://docs.racket-lang.org/reference/pairs.html#%28def._%28%28lib._racket%2Fprivate%2Flist..rkt%29._remv%29%29) equivalent for mlists)
