### PR TITLE
preserve source locations in `lib`, `file`, `planet`, and `submod` require forms

### DIFF
--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -82,7 +82,6 @@
     (let ([t (lambda (stx)
                (check-lib-form stx)
                (let* ([stx (xlate-path stx)]
-                      [mod-path (syntax->datum stx)]
                       [namess (syntax-local-module-exports stx)])
                  (values
                   (apply
@@ -95,7 +94,7 @@
                                                  name
                                                  stx)
                                                 name
-                                                mod-path
+                                                stx
                                                 mode
                                                 0
                                                 mode


### PR DESCRIPTION
Prior to this commit, the fully expanded form of this program:

```
#lang racket/base
(module m racket/base
  (provide abcdef)
  (define abcdef 1))

(require (for-syntax racket/base))
(define-syntax (use stx)
  (syntax-case stx ()
    [(_ id)
     ((make-interned-syntax-introducer 'outer) #'id)]))

(require (for-space outer (submod "." m)))
(use abcdef)
```

has a `#%require` to the `(submod "." m)` that doesn't have a source location in it. If you use `'m` instead of `(submod "." m)` then there is a source location at that same spot. (There are actually two `#%require`s and only one is missing the source location but, from Check Syntax's point of view, it is the important one.)

Without the source location (but with the [changes up to this point](https://github.com/racket/drracket/commit/c1cb520b2600f76a4f208833351fe046773492c3) in drracket), no arrow gets drawn, but it does get drawn with this commit included.

I'm not sure of a good way to add a test case for this in the racket repo (although if there is a spot, I'm happy to do it) but it is certainly to add a test case to [this file](https://github.com/racket/drracket/blob/master/drracket-tool-test/tests/check-syntax/syncheck-direct.rkt), that I can do if we take this commit.

I'm slightly worried about this commit, as the binding of `mod-path` is used in only this one place so it seems like the syntax information was explicitly stripped. But maybe that's because of a constraint that existed a long time ago (this code is fairly old; it seems to predate `lib` as something you can use in `require`, actually!). I've not found any problems created by this change.