### PR TITLE
zuo: fix some compiler warnings

### DIFF
--- a/.github/workflows/zuo-cflags.yml
+++ b/.github/workflows/zuo-cflags.yml
@@ -1,0 +1,31 @@
+---
+name: Zuo with Strict Compiler Flags
+
+on:  # yamllint disable-line rule:truthy
+  push:
+    branches:
+      - master
+    paths:
+      - "racket/src/zuo/**"
+  pull_request:
+    paths:
+      - "racket/src/zuo/**"
+
+jobs:
+  build-linux:
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-direcotry: "racket/src/zuo"
+
+    env:
+      CFLAGS: "-Werror -Wall -Wextra -Wstrict-prototypes -Wold-style-definition -Wshadow -Wpointer-arith -Wcast-qual -pedantic -O2 -std=c11"
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 100
+      - name: Compile
+        run: cc $CFLAGS zuo.c -o zuo
+      - name: Check
+        run: ./zuo build.zuo check

--- a/racket/src/zuo/zuo.h
+++ b/racket/src/zuo/zuo.h
@@ -35,7 +35,7 @@ typedef struct zuo_t zuo_ext_t;
    primitives will effectively remove them by using the image's
    `kernel-env`.
  */
-ZUO_EXPORT void zuo_ext_primitive_init();
+ZUO_EXPORT void zuo_ext_primitive_init(void);
 
 /* Add more primitives only after calling `zuo_ext_primitive_init`: */
 typedef zuo_ext_t *(*zuo_ext_primitive_t)(zuo_ext_t *args_list);
@@ -51,12 +51,12 @@ ZUO_EXPORT void zuo_ext_image_init(char *boot_image_file);
 /* After calling `zuo_ext_image_init`, the following functions are available: */
 
 /* Functions that get a constant: */
-ZUO_EXPORT zuo_ext_t *zuo_ext_false();
-ZUO_EXPORT zuo_ext_t *zuo_ext_true();
-ZUO_EXPORT zuo_ext_t *zuo_ext_null();
-ZUO_EXPORT zuo_ext_t *zuo_ext_void();
-ZUO_EXPORT zuo_ext_t *zuo_ext_eof();
-ZUO_EXPORT zuo_ext_t *zuo_ext_empty_hash();
+ZUO_EXPORT zuo_ext_t *zuo_ext_false(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_true(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_null(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_void(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_eof(void);
+ZUO_EXPORT zuo_ext_t *zuo_ext_empty_hash(void);
 
 /* Other data constructors and accessors: */
 ZUO_EXPORT zuo_ext_t *zuo_ext_integer(long long i);
@@ -74,7 +74,7 @@ ZUO_EXPORT zuo_ext_t *zuo_ext_hash_set(zuo_ext_t *ht, zuo_ext_t *key, zuo_ext_t 
 /* To get more functions, use a symbol key to look them up in the
    kernel environment via `zuo_ext_hash_ref` --- but don't try to
    load, evaluate, or use any modules, yet: */
-ZUO_EXPORT zuo_ext_t *zuo_ext_kernel_env();
+ZUO_EXPORT zuo_ext_t *zuo_ext_kernel_env(void);
 
 /* At this stage, use `zuo_ext_apply` to apply primitives that don't
    evaluate. After `zuo_ext_runtime_init`, use this to apply and
@@ -115,7 +115,7 @@ ZUO_EXPORT zuo_ext_t *zuo_ext_eval_module(zuo_ext_t *as_module_path, const char 
 /* For saving and retriving a value across an evaluation, which is
    when a GC might happen: */
 ZUO_EXPORT void zuo_ext_stash_push(zuo_ext_t *v);
-ZUO_EXPORT zuo_ext_t *zuo_ext_stash_pop();
+ZUO_EXPORT zuo_ext_t *zuo_ext_stash_pop(void);
 
 #endif
 


### PR DESCRIPTION
I figured a patch gave a better starting point for discussion, but I admit I'm not confident in some of these changes and I'm opening this mostly to generate conversation.

For the unused parameters, I considered introducing
```
#define UNUSED(x) (void)x
```
but didn't know if that fit the project style. I certainly didn't think we want to deal with compiler-specific attributes like `__unused`.

---

I often compile with a CFLAGS that looks like

-Wall -Wextra -Wstrict-prototypes -Wold-style-definition -Wshadow -Wpointer-arith -Wcast-qual -pedantic -O2 -std=c11

(I actually typically include -Wmissing-prototypes but Zuo produces many warnings from that which are probably harmless.) These changes cover the generated warnings (mostly shadowed variables, unused function arguments, and missing void parameter lists). Interesting cases are in the commit message.

./zuo build.zuo check passes after all these changes are compiled.

Here's the remaining warning:
```
zuo.c:979:21: warning: comparison of integers of different signs: 'zuo_int32_t' (aka 'int') and 'unsigned long long' [-Wsign-compare]
      for (i = 0; i < len / sizeof(zuo_int32_t); i++)
                  ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~
```

My understanding of C and integer arithmetic is woefully incomplete, so I'm not sure if casting (on which side of <?) is appropriate or if there is a better solution.