### PR TITLE
net/smtp and net/imap: add XOAUTH2 authentication support

### DIFF
--- a/pkgs/net-doc/net/scribblings/imap.scrbl
+++ b/pkgs/net-doc/net/scribblings/imap.scrbl
@@ -57,7 +57,8 @@ opaque), @racket[#f] otherwise.}
                        [password (or/c string? bytes?)]
                        [mailbox (or/c string? bytes?)]
                        [#:tls? tls? any/c #f]
-                       [#:try-tls? try-tls? any/c #t])
+                       [#:try-tls? try-tls? any/c #t]
+                       [#:xoauth2? xoauth2? any/c #f])
          (values imap-connection? exact-nonnegative-integer? exact-nonnegative-integer?)]{
 
 Establishes an IMAP connection to the given server using the given
@@ -66,7 +67,10 @@ username and password, and selects the specified mailbox. If
 communicating using the IMAP protocol. If @racket[tls?] is @racket[#f]
 but @racket[try-tls?] is true, then after the IMAP connection is
 initially established, the connection is switched to a TLS connection
-if the server supports it.
+if the server supports it. If @racket[xoauth2?] is true, then
+authentication uses @tt{XOAUTH2}, and @racket[password] is used
+as an access token (which must obtained somehow before
+calling @racket[imap-connect]).
 
 The first result value represents the connection.
 The second and third return values indicate the total number of
@@ -81,7 +85,9 @@ name.)
 
 Updated message-count and recent-count values are available through
 @racket[imap-messages] and @racket[imap-recent]. See also @racket[imap-new?] and
-@racket[imap-reset-new!].}
+@racket[imap-reset-new!].
+
+@history[#:changed "1.2" @elem{Added the @racket[xoauth2?] argument.}]}
 
 
 @defparam[imap-port-number k (integer-in 0 65535)]{
@@ -96,11 +102,14 @@ is @racket[143].}
                         [password (or/c string? bytes?)]
                         [mailbox (or/c string? bytes?)]
                         [#:tls? tls? any/c #f]
-                        [#:try-tls? try-tls? any/c #t])
+                        [#:try-tls? try-tls? any/c #t]
+                        [#:xoauth2? xoauth2? any/c #f])
          (values imap-connection? exact-nonnegative-integer? exact-nonnegative-integer?)]{
 
 Like @racket[imap-connect], but given input and output ports (e.g.,
-ports for an SSL session) instead of a server address.}
+ports for an SSL session) instead of a server address.
+
+@history[#:changed "1.2" @elem{Added the @racket[xoauth2?] argument.}]}
 
 
 @defproc[(imap-disconnect [imap imap-connection?]) void?]{

--- a/pkgs/net-doc/net/scribblings/smtp.scrbl
+++ b/pkgs/net-doc/net/scribblings/smtp.scrbl
@@ -27,6 +27,7 @@ module assume that the given string arguments are well-formed.
                             [#:port-no port-no/k (integer-in 0 65535) 25]
                             [#:auth-user user (or/c string? #f) #f]
                             [#:auth-passwd pw (or/c string? #f) #f]
+                            [#:xoauth2? xoauth2? any/c #f]
                             [#:tcp-connect connect
                                            (string? (integer-in 0 65535)
                                             . -> . (values input-port? output-port?))
@@ -63,8 +64,11 @@ an extra argument after keywords---specifies the IP port to use in
 contacting the SMTP server.
 
 The optional @racket[user] and @racket[pw]
-arguments supply a username and password for authenticated SMTP (using
-the AUTH PLAIN protocol).
+arguments supply a username and password for authenticated SMTP using
+the AUTH PLAIN protocol. If @racket[xoauth2?] is true, then
+authentication uses the AUTH XOAUTH2 protocol, instead, and @racket[pw] is used
+as an access token (which must obtained somehow before
+calling @racket[smtp-send-message]).
 
 The optional @racket[connect] argument supplies a
 connection procedure to be used in place of @racket[tcp-connect]. For
@@ -87,7 +91,9 @@ For encrypted communication, normally either @racket[ssl-connect]
 should be supplied for @racket[connect], or
 @racket[ports->ssl-ports] should be supplied for
 @racket[encode]---one or the other (depending on what the server
-expects), rather than both.}
+expects), rather than both.
+
+@history[#:changed "1.2" @elem{Added the @racket[xoauth2?] argument.}]}
 
 @defparam[smtp-sending-end-of-message proc (-> any)]{
 

--- a/pkgs/net-lib/info.rkt
+++ b/pkgs/net-lib/info.rkt
@@ -11,4 +11,4 @@
 (define license
   '(Apache-2.0 OR MIT))
 
-(define version "1.1")
+(define version "1.2")

--- a/pkgs/net-lib/net/private/xoauth2.rkt
+++ b/pkgs/net-lib/net/private/xoauth2.rkt
@@ -1,0 +1,10 @@
+#lang racket/base
+(require net/base64)
+
+(provide xoauth2-encode)
+
+(define (xoauth2-encode username password)
+  (base64-encode
+   (string->bytes/utf-8
+    (string-append "user=" username "\x01auth=Bearer " password "\x01\x01"))
+   #""))


### PR DESCRIPTION
Also, change debugging logging `net/smtp` to use a logger.