### PR TITLE
Fix kill-thread description in threads.scrbl

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/threads.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/threads.scrbl
@@ -149,10 +149,10 @@ Terminates the specified thread immediately, or suspends the thread if
 @racket[thd] was created with
 @racket[thread/suspend-to-kill]. Terminating the main thread exits the
 application.  If @racket[thd] has already terminated,
-@racket[kill-thread] does nothing.  If the @tech{current custodian}
-does not manage @racket[thd] (and none of its subordinates manages
-@racket[thd]), the @exnraise[exn:fail:contract], and the thread is not
-killed or suspended.
+@racket[kill-thread] does nothing.  If the @tech{current custodian} 
+does not solely manage @racket[thd] (i.e., some custodian of @racket[thd]
+is not the current custodian or a subordinate), the 
+@exnraise[exn:fail:contract], and the thread is not killed or suspended.
 
 Unless otherwise noted, procedures provided by Racket (and GRacket) are
 kill-safe and suspend-safe; that is, killing or suspending a thread


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->

This is an update to the reference documentation for kill-thread.

Like thread-suspend, kill-thread fails if it is managed by a custodian that is not current-custodian or one of its subordinates.  This new kill-thread description is based on the phrasing already used for the thread-suspend description.