### PR TITLE
`chaperone-treelist` fixes and doc edits

### DIFF
--- a/pkgs/racket-test-core/tests/racket/treelist.rktl
+++ b/pkgs/racket-test-core/tests/racket/treelist.rktl
@@ -179,6 +179,7 @@
   (test-bad (treelist-sort small-treelist cons #:key cons))
   (test-bad (chaperone-treelist 0 #:state #f #:ref void #:set void #:insert void #:append void #:prepend void #:delete void #:take void #:drop void))
   (test-bad (chaperone-treelist small-treelist #f #:state #f #:ref #f #:set void #:insert void #:append void #:prepend void #:delete void #:take void #:drop void))
+  (test-bad (chaperone-treelist small-treelist #:state #f #:ref #f #:set void #:insert void #:append void #:prepend void #:delete void #:take void #:drop void))
   (test-bad (chaperone-treelist small-treelist #:state #f #:ref (lambda (x) x) #:set void #:insert void #:append void #:prepend void #:delete void #:take void #:drop void))
   (test-bad (chaperone-treelist small-treelist #:state #f #:ref void #:set (lambda (x) x) #:insert void #:append void #:prepend void #:delete void #:take void #:drop void))
   (test-bad (chaperone-treelist small-treelist #:state #f #:ref void #:set void #:insert (lambda (x) x) #:append void #:prepend void #:delete void #:take void #:drop void))
@@ -353,6 +354,10 @@
   (test-bad (mutable-treelist-sort! small-treelist 0))
   (test-bad (mutable-treelist-sort! small-treelist add1))
   (test-bad (mutable-treelist-sort! small-treelist cons #:key cons))
+  (test-bad (chaperone-mutable-treelist (treelist 1 2 3 5) #:ref void #:set void #:insert void #:append void))
+  (test-bad (chaperone-mutable-treelist small-treelist #:ref #f #:set void #:insert void #:append void))
+  (test-bad (impersonate-mutable-treelist (treelist 1 2 3 5) #:ref void #:set void #:insert void #:append void))
+  (test-bad (impersonate-mutable-treelist small-treelist #:ref #f #:set void #:insert void #:append void))
 
   (void))
 

--- a/racket/collects/racket/treelist.rkt
+++ b/racket/collects/racket/treelist.rkt
@@ -1425,9 +1425,10 @@ minimum required storage. |#
   (define prev (treelist-wrapper-prev w))
   (define v (treelist-ref prev index))
   (define ref (procs-ref (treelist-wrapper-procs w)))
-  (if ref
-      (check-chaperone who (treelist-wrapper-chaperone? w) (ref prev index v (treelist-wrapper-state w)) v)
-      v))
+  (check-chaperone who
+                   (treelist-wrapper-chaperone? w)
+                   (ref prev index v (treelist-wrapper-state w))
+                   v))
 
 (define (treelist-first/slow tl)
   (define who 'treelist-first)


### PR DESCRIPTION
This PR has two bug fixes and several documentation edits related to `chaperone-treelist`.

The bugs:

1. ~https://github.com/racket/racket/commit/4530cd9559fb63110da7351ad5ff6b034f16f754 documented that `#:ref` could be `#f`, but `check-chaperone-arguments` didn't actually allow it. This is fixed in ed70e7ffcb8cc91505759675eeaf3d50637c2636.~
3. The documented contract for `#:append2` had the wrong number of arguments (i.e. one of the state arguments was missing).

I would be happy to split this PR up further if either of those fixes seem important enough to put into 8.13 at this late stage: I only wish I had discovered them sooner!

The other non-documentation change in this PR is that I made `#:ref` optional.

Several things that I have *not* done (yet?):

1. ~At one point I considered whether `#:state` should also be optional, but I decided against it: if there were really a use-case for chaperoning for which state was irrelevant, it would be better to provide an alternate function that wouldn't need the corresponding arguments and return values, either.~
2. I'd like to do something about places that say procedures `must accept @racket[tl]` and produce results `chaperoned with the same procedures and properties as @racket[tl]`. The argument `tl` is without the layer of chaperoning added by this call to `chaperone-treelist`, so `treelist-chaperone-state` and impersonator-property accesses on that `tl` won't work. Perhaps pedantically, the argument `tl` might also be a derived treelist, rather than the `tl` from the formal arguments to `chaperone-treelist`. That also means the result treelist more precisely gets "the same procedures and properties" added by this call to `chaperone-treelist`, or something like that. But I haven't yet figured out a concise way of writing (the important parts of) that.
4. In the example I added, `tl` and `state` are italicized as though by `@var{}`, whereas `pos`, `v`, `other`, and `other-state` are not. They could easily all be italicized via `_`, but it might be more correct to italicize none of them.
5. After the paragraph beginning `When two chaperoned treelists are given to @racket[treelist-append] and @racket[append2-proc] is not used`, I'd like to say more about what happens when `append2-proc` *is* used, but I'm still confirming that I understand the details I think I want to write.

More generally I have some observations now that I've (finally) experimented with the improved treelist chaperoning a bit, but I probably won't finish writing those up tonight and, having found the bugs here, I didn't want to delay reporting them. (In brief, this still seems like a fine direction.)