### PR TITLE
Fix equal-always? on fl/fxvector, stencil-vector

### DIFF
--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -118,6 +118,10 @@
 (test #t equal? 2 2)
 (test #t equal? (make-vector 5 'a) (make-vector 5 'a))
 (test #t equal? (box "a") (box "a"))
+(test #t equal? (make-flvector 5 0.0) (make-flvector 5 0.0))
+(test #t equal? (make-fxvector 5 0) (make-fxvector 5 0))
+(test #t equal? (stencil-vector #b10010 'a 'b) (stencil-vector #b10010 'a 'b))
+
 (test #f equal? "" (string #\null))
 
 (test #f equal? 'a "a")
@@ -158,6 +162,9 @@
 (test #f equal-always? (make-hash '((a . 1))) (make-hash '((a . 1))))
 (test #f equal-always? (mcons 'a '()) (mcons 'a '()))
 (test #f equal-always? (string #\a) (string #\a))
+(test #f equal-always? (make-flvector 5 0.0) (make-flvector 5 0.0))
+(test #f equal-always? (make-fxvector 5 0) (make-fxvector 5 0))
+(test #f equal-always? (stencil-vector #b10010 'a 'b) (stencil-vector #b10010 'a 'b))
 
 (let ()
   (struct s (x) #:property prop:procedure 0)

--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -121,6 +121,15 @@
 (test #t equal? (make-flvector 5 0.0) (make-flvector 5 0.0))
 (test #t equal? (make-fxvector 5 0) (make-fxvector 5 0))
 (test #t equal? (stencil-vector #b10010 'a 'b) (stencil-vector #b10010 'a 'b))
+(test #t eq?
+      (equal-hash-code (make-flvector 5 0.0))
+      (equal-hash-code (make-flvector 5 0.0)))
+(test #t eq?
+      (equal-hash-code (make-fxvector 5 0))
+      (equal-hash-code (make-fxvector 5 0)))
+(test #t eq?
+      (equal-hash-code (stencil-vector #b10010 'a 'b))
+      (equal-hash-code (stencil-vector #b10010 'a 'b)))
 
 (test #f equal? "" (string #\null))
 
@@ -165,6 +174,15 @@
 (test #f equal-always? (make-flvector 5 0.0) (make-flvector 5 0.0))
 (test #f equal-always? (make-fxvector 5 0) (make-fxvector 5 0))
 (test #f equal-always? (stencil-vector #b10010 'a 'b) (stencil-vector #b10010 'a 'b))
+(test #f eq?
+      (equal-always-hash-code (make-flvector 5 0.0))
+      (equal-always-hash-code (make-flvector 5 0.0)))
+(test #f eq?
+      (equal-always-hash-code (make-fxvector 5 0))
+      (equal-always-hash-code (make-fxvector 5 0)))
+(test #f eq?
+      (equal-always-hash-code (stencil-vector #b10010 'a 'b))
+      (equal-always-hash-code (stencil-vector #b10010 'a 'b)))
 
 (let ()
   (struct s (x) #:property prop:procedure 0)

--- a/racket/src/cs/rumble/equal.ss
+++ b/racket/src/cs/rumble/equal.ss
@@ -104,6 +104,7 @@
                                      (equal? a b ctx)))))))]
            [(stencil-vector? a)
             (and (stencil-vector? b)
+                 (not (or (eq? mode 'chaperone-of?) (eq? mode 'equal-always?)))
                  (fx= (stencil-vector-mask a) (stencil-vector-mask b))
                  (let ([len (stencil-vector-length a)]
                        [ctx (deeper-context ctx)])

--- a/racket/src/cs/rumble/equal.ss
+++ b/racket/src/cs/rumble/equal.ss
@@ -169,15 +169,11 @@
                                            (|#%app| rec-equal? orig-a orig-b eql? (or (eq? mode 'equal?)
                                                                                       (eq? mode 'impersonator-of?)))
                                            (|#%app| rec-equal? orig-a orig-b eql?)))])))))])))]
-           [(and (or (eq? mode 'chaperone-of?) (eq? mode 'equal-always?))
-                 ;; Mutable strings and bytevectors must be `eq?` for `chaperone-of?` and `equal-always?`
-                 (or (mutable-string? a)
-                     (mutable-string? b)
-                     (mutable-bytevector? a)
-                     (mutable-bytevector? b)))
-            #f]
            [else
-            (#%equal? a b)])))))
+            (and (or (not (or (eq? mode 'chaperone-of?) (eq? mode 'equal-always?)))
+                     (and (immutable-string? a) (immutable-string? b))
+                     (and (immutable-bytevector? a) (immutable-bytevector? b)))
+                 (#%equal? a b))])))))
 
 (define (equal? a b) (do-equal? a b 'equal? #f))
 (define (impersonator-of? a b) (do-equal? a b 'impersonator-of? #f))


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [x] tests included

### Description of change
<!-- Please provide a description of the change here. -->

Fixes `equal-always?` and `chaperone-of?` on `flvector`, `fxvector`, and `stencil-vector`, to return false on different values with the same contents at the time, because they are mutable.

Fixes #4983.

- [x] equality tests
- [x] hash-code tests
- [x] Racket CS
- [x] Racket BC