### PR TITLE
correctly call `abort-current-continuation` in `register-finalizer`

### DIFF
--- a/racket/collects/ffi/unsafe.rkt
+++ b/racket/collects/ffi/unsafe.rkt
@@ -2284,7 +2284,9 @@
                                             (exn-message exn)
                                             (format "~s" exn))
                                         #f)
-                           (abort-current-continuation void))
+                           (abort-current-continuation
+                            (default-continuation-prompt-tag)
+                            void))
                          (lambda ()
                            (let loop () (will-execute killer-executor) (loop))))))
                      (retry-loop)))))))


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [ ] tests included (*I’d be happy to include some tests, but I wasn’t sure how to test this.*)

### Description of change
Fix #4927.