### PR TITLE
raco test: set current-test-invocation-directory

### DIFF
--- a/pkgs/compiler-lib/compiler/commands/test.rkt
+++ b/pkgs/compiler-lib/compiler/commands/test.rkt
@@ -1151,6 +1151,7 @@
   "Save stdout and stderr to file, overwrite if it exists."
   (set! default-output-file file)]
  #:args file-or-directory-or-collects-or-pkgs
+ (current-test-invocation-directory (current-directory))
  (define (test)
    (define file-or-directory
      (maybe-expand-package-deps file-or-directory-or-collects-or-pkgs))

--- a/pkgs/compiler-lib/info.rkt
+++ b/pkgs/compiler-lib/info.rkt
@@ -12,7 +12,7 @@
 
 (define pkg-authors '(mflatt))
 
-(define version "1.13")
+(define version "1.14")
 
 (define license
   '(Apache-2.0 OR MIT))

--- a/pkgs/compiler-lib/raco/testing.rkt
+++ b/pkgs/compiler-lib/raco/testing.rkt
@@ -4,10 +4,25 @@
 
 (provide test-log-enabled?
          test-log!
-         test-report)
+         test-report
+         current-test-invocation-directory)
+
+;; records the original "raco test" directory while raco test changes directory
+;; to invoke tests
+(define current-test-invocation-directory
+  (make-parameter
+   #f
+   (λ (path)
+     (cond
+       [(path-string? path) (path->directory-path (simplify-path path))]
+       [(not path) path]
+       [else (raise-argument-error 'current-test-invocation-directory
+                                   "(or/c #f path-string?)"
+                                   path)]))
+   'current-test-invocation-directory))
 
 (define test-log-enabled?
-  (make-parameter #t (lambda (v) (and v #t))))
+  (make-parameter #t (lambda (v) (and v #t)) 'test-log-enabled?))
 
 (define TOTAL 0)
 (define FAILED 0)

--- a/pkgs/racket-doc/scribblings/raco/test.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/test.scrbl
@@ -407,4 +407,19 @@ with @exec{raco test} should also use this library to log test results.
  counted in the test log, such as when testing a custom check's failure
  behavior.}
 
+@defparam*[current-test-invocation-directory
+            path
+            (or/c #f path-string?)
+            (or/c #f path?)
+            #:value #f]{
+Contains the directory from which tests were invoked by, @emph{e.g.}, @exec{raco
+test}. This may differ from @racket[current-directory] when the test runner
+changes directory before invoking a specific test file and should be set by test
+runners to reflect the directory from which they were originally invoked.
+
+This should be used by test reports to display appropriate path names.
+
+@history[#:added "1.14"]
+}
+
 @history[#:added "1.13"]


### PR DESCRIPTION
Running "raco test foo/bar/test.rkt" will cause Racket to change directory to "foo/bar" before invoking "test.rkt", and error messages are printed relative to (current-directory) like

    raco test: "foo/bar/test.rkt"
    --------------------
    fail
    FAILURE
    name:       check-equal?
    location:   test.rkt:5:0
    actual:     1
    expected:   2
    --------------------
    1/1 test failures

For an editor to consume this, it has to post-process the output to correlate "raco test: path" with "location: partial path" (which is difficult when running tests in parallel). This is not ideal; output with

    location:   foo/bar/test.rkt:5:0

is immediately useable by editors for jumping to the error.

Expose the original directory in which "raco test" was launched so that rackunit (or other test frameworks) can appropriately adjust filepaths when reporting errors.

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation
