### PR TITLE
Define `λ` through the renaming mechanism.

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -2091,7 +2091,13 @@ optional keyword argument whose value is not provided; optional
 by-position arguments include @racket[#f] for each non-provided
 argument, and then the sequence of optional-argument values is
 followed by a parallel sequence of booleans to indicate whether each
-optional-argument value was provided.}
+optional-argument value was provided.
+
+@history[#:changed "8.13.0.5" @elem{
+Adjusted binding so that @racket[(free-identifier=? #'λ #'lambda)] produces
+@racket[#t].
+}]
+}
 
 
 @defform/subs[(case-lambda [formals body ...+] ...)

--- a/pkgs/racket-test-core/tests/racket/procs.rktl
+++ b/pkgs/racket-test-core/tests/racket/procs.rktl
@@ -449,10 +449,6 @@
 (test -4 procedure-arity-mask apply)
 
 ;; ------------------------------------------------------------
-;; Check if `lambda` and `λ` access the same binding.
-(test #t free-identifier=? #'lambda #'λ)
-
-;; ------------------------------------------------------------
 ;; Check arity reporting for methods.
 
 (map

--- a/pkgs/racket-test-core/tests/racket/procs.rktl
+++ b/pkgs/racket-test-core/tests/racket/procs.rktl
@@ -449,6 +449,10 @@
 (test -4 procedure-arity-mask apply)
 
 ;; ------------------------------------------------------------
+;; Check if `lambda` and `λ` access the same binding.
+(test #t free-identifier=? #'lambda #'λ)
+
+;; ------------------------------------------------------------
 ;; Check arity reporting for methods.
 
 (map

--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -8,6 +8,7 @@
          racket/case)
 
 ;; ----------------------------------------
+(test #t free-identifier=? #'lambda #'λ)
 
 (test 0 'with-handlers (with-handlers () 0))
 (test 1 'with-handlers (with-handlers ([void void]) 1))

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -469,7 +469,7 @@
         (local-expand
          expr
          'expression
-         (append locals (list #'lambda #'λ) expand-stop-names)
+         (append locals (list #'lambda) expand-stop-names)
          def-ctx))
       ;; Checks whether the vars sequence is well-formed
       (define (vars-ok? vars)
@@ -511,19 +511,17 @@
          #f))
       ;; -- transform loop starts here --
       (let loop ([stx orig-stx][can-expand? #t][name name][locals null])
-        (syntax-case (disarm stx) (#%plain-lambda lambda λ case-lambda letrec-values let-values)
+        (syntax-case (disarm stx) (#%plain-lambda lambda case-lambda letrec-values let-values)
           [(lam vars body1 body ...)
            (or (and (free-identifier=? #'lam #'#%plain-lambda)
                     (vars-ok? (syntax vars)))
-               (and (or (free-identifier=? #'lam #'lambda)
-                        (free-identifier=? #'lam #'λ))
+               (and (free-identifier=? #'lam #'lambda)
                     (kw-vars-ok? (syntax vars))))
            (if xform?
                (with-syntax ([the-obj the-obj]
                              [the-finder the-finder]
                              [name (mk-name name)])
-                 (with-syntax ([vars (if (or (free-identifier=? #'lam #'lambda)
-                                             (free-identifier=? #'lam #'λ))
+                 (with-syntax ([vars (if (free-identifier=? #'lam #'lambda)
                                          (let loop ([vars #'vars])
                                            (cond
                                              [(identifier? vars) vars]
@@ -561,8 +559,6 @@
           [(#%plain-lambda . _)
            (bad "ill-formed lambda expression for method" stx)]
           [(lambda . _)
-           (bad "ill-formed lambda expression for method" stx)]
-          [(λ . _)
            (bad "ill-formed lambda expression for method" stx)]
           [(case-lam [vars body1 body ...] ...)
            (and (free-identifier=? #'case-lam #'case-lambda)

--- a/racket/collects/racket/private/kw.rkt
+++ b/racket/collects/racket/private/kw.rkt
@@ -29,7 +29,8 @@
                        "stxcase-scheme.rkt"
                        "qqstx.rkt"))
 
-  (#%provide new-lambda new-λ
+  (#%provide new-lambda
+             (rename new-lambda new-λ)
              new-define
              new-app
              make-keyword-procedure
@@ -916,23 +917,20 @@
                            'needed-kws
                            'kws))))]))))))]))
   
-  (define-syntaxes (new-lambda new-λ)
-    (let ([new-lambda
-           (lambda (stx)
-             (if (eq? (syntax-local-context) 'expression)
-                 (parse-lambda
-                  stx
-                  #f
-                  (lambda (e) e)
-                  (lambda (impl kwimpl wrap core-id unpack-id n-req
-                                opt-not-supplieds opt-not-supplied-srclocs
-                                rest? req-kws all-kws all-kw-not-supplied-srclocs)
-                    (quasisyntax/loc stx
-                      (let ([#,core-id #,impl])
-                        (let ([#,unpack-id #,kwimpl])
-                          #,wrap)))))
-                 (quasisyntax/loc stx (#%expression #,stx))))])
-      (values new-lambda new-lambda)))
+  (define-syntax (new-lambda stx)
+    (if (eq? (syntax-local-context) 'expression)
+        (parse-lambda
+         stx
+         #f
+         (lambda (e) e)
+         (lambda (impl kwimpl wrap core-id unpack-id n-req
+                       opt-not-supplieds opt-not-supplied-srclocs
+                       rest? req-kws all-kws all-kw-not-supplied-srclocs)
+           (quasisyntax/loc stx
+             (let ([#,core-id #,impl])
+               (let ([#,unpack-id #,kwimpl])
+                 #,wrap)))))
+        (quasisyntax/loc stx (#%expression #,stx))))
   
   (define (missing-kw proc . args)
     (apply
@@ -1176,8 +1174,7 @@
                         (define #,id #,rhs)))]
              [can-opt? (lambda (lam-id)
                          (and (identifier? lam-id)
-                              (or (free-identifier=? lam-id #'new-lambda)
-                                  (free-identifier=? lam-id #'new-λ))
+                              (free-identifier=? lam-id #'new-lambda)
                               (let ([ctx (syntax-local-context)])
                                 (or (and (memq ctx '(module module-begin))
                                          (compile-enforce-module-constants))


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Feature
- [x] tests included

### Description of change
<!-- Please provide a description of the change here. -->

To put it simply, this PR has the following changes:

Before changes:
```racket
(#%provide new-lambda new-λ)

(define-syntaxes (new-lambda new-λ)
   (let ([new-lambda ...])
     (values new-lambda new-lambda)))
```

After changes:
```racket
(#%provide new-lambda (rename new-lambda new-λ))

(define-syntax (new-lambda stx) ...)

```

I didn't know how to check the impact of this change on all packages, so I just ran `raco setup` and found no exception.

See also https://github.com/racket/racket/pull/4989#discussion_r1594165915.
