### PR TITLE
Fix the `one-arg-check` function

### DIFF
--- a/pkgs/racket-test-core/tests/racket/vector.rktl
+++ b/pkgs/racket-test-core/tests/racket/vector.rktl
@@ -190,6 +190,8 @@
   (err/rt-test (fn 2 #(1 2 3)))
   (err/rt-test (f cons #(1 2 3)))
   (err/rt-test (fn cons #(1 2 3)))
+  (err/rt-test (f values '(1 2 3)) exn:fail:contract? #rx"vector-filter")
+  (err/rt-test (fn values '(1 2 3)) exn:fail:contract? #rx"vector-filter-not")
   (arity-test f  2 2)
   (arity-test fn 2 2))
 

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -96,7 +96,7 @@
   (unless (and (procedure? f) (procedure-arity-includes? f 1))
     (raise-argument-error name "(any/c . -> . any/c)" 0 f))
   (unless (vector? v)
-    (raise-argument-error name "vector?" 1 v)))
+    (raise-argument-error name "vector?" v)))
 
 (define (vector-filter f v)
   (one-arg-check f v 'vector-filter)

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -94,7 +94,9 @@
 ;; uses name for error reporting
 (define (one-arg-check f v name)
   (unless (and (procedure? f) (procedure-arity-includes? f 1))
-    (raise-argument-error name "(any/c . -> . any/c)" 0 f)))
+    (raise-argument-error name "(any/c . -> . any/c)" 0 f))
+  (unless (vector? v)
+    (raise-argument-error name "vector?" 1 v)))
 
 (define (vector-filter f v)
   (one-arg-check f v 'vector-filter)

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -94,9 +94,9 @@
 ;; uses name for error reporting
 (define (one-arg-check f v name)
   (unless (and (procedure? f) (procedure-arity-includes? f 1))
-    (raise-argument-error name "(any/c . -> . any/c)" 0 f))
+    (raise-argument-error name "(any/c . -> . any/c)" 0 f v))
   (unless (vector? v)
-    (raise-argument-error name "vector?" v)))
+    (raise-argument-error name "vector?" 1 f v)))
 
 (define (vector-filter f v)
   (one-arg-check f v 'vector-filter)


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [x] Tests included

### Description of change
Fix the checker of `vector-filter` and `vector-filter-not`. It should check whether the second argument is a `vector?` according to its comment.

```
Welcome to Racket v8.13 [cs].
> (vector-filter (lambda (x) x) (list 1))
in-vector: contract violation
  expected: vector
  given: '(1)
 [,bt for context]
```

This is definitely a bugfix, but I have problems in including tests. Is it necessary? Where can I include new tests?
