### PR TITLE
more consistently apply `'definition-intended-as-local` property

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/splicing.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/splicing.scrbl
@@ -55,7 +55,7 @@ once during compilation as in @racket[let-syntax], etc.
 
 If a definition within a splicing form is intended to be local to the
 splicing body, then the identifier should have a true value for the
-@racket['definition-intended-as-local] @tech{syntax property}. For
+@indexed-racket['definition-intended-as-local] @tech{syntax property}. For
 example, @racket[splicing-let] itself adds the property to
 locally-bound identifiers as it expands to a sequence of definitions,
 so that nesting @racket[splicing-let] within a splicing form works as


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [x] tests included
- [x] documentation

### Description of change
Clean up `racket/splicing` to more consistently apply the `'definition-intended-as-local` syntax property for every splicing form through the `splicing-let-start/def` internal form, which fixes #4993 and a similar bug for `splicing-letrec-syntaxes+values`.  In addition, fix multiple body forms in `splicing-letrec-syntaxes+values`.

Add test cases for `splicing-letrec-syntaxes+values` and `splicing-local` (which have different implementations than other splicing forms), and update an old test case that did not test what it was supposed to test.

Update the doc to index the `'definition-intended-as-local` syntax property.