### PR TITLE
Chez+racket: support building with cosmopolitan libc

### DIFF
--- a/racket/src/ChezScheme/c/expeditor.c
+++ b/racket/src/ChezScheme/c/expeditor.c
@@ -677,7 +677,7 @@ static void s_ee_set_color(int color_id, IBOOL background) {
 # include <unistd.h>
 # include <time.h>
 #endif
-#if !defined(__GLIBC__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__linux__) && !defined(__EMSCRIPTEN__) && !defined(NO_USELOCALE)
+#if !defined(__GLIBC__) && !defined(__COSMOPOLITAN__) && !defined(__OpenBSD__) && !defined(__NetBSD__) && !defined(__linux__) && !defined(__EMSCRIPTEN__) && !defined(NO_USELOCALE)
 # include <xlocale.h>
 #endif
 

--- a/racket/src/ChezScheme/c/prim5.c
+++ b/racket/src/ChezScheme/c/prim5.c
@@ -749,8 +749,8 @@ static ptr s_system(const char *s) {
 #ifdef WIN32
   return Sinteger(status);
 #else
-  if WIFEXITED(status) return Sinteger(WEXITSTATUS(status));
-  if WIFSIGNALED(status) return Sinteger(-WTERMSIG(status));
+  if (WIFEXITED(status)) return Sinteger(WEXITSTATUS(status));
+  if (WIFSIGNALED(status)) return Sinteger(-WTERMSIG(status));
   S_error("system", "cannot determine subprocess exit status");
   return 0 /* not reached */;
 #endif /* WIN32 */

--- a/racket/src/ChezScheme/c/version.h
+++ b/racket/src/ChezScheme/c/version.h
@@ -86,7 +86,7 @@ FORCEINLINE void store_unaligned_uptr(uptr *addr, uptr val) {
 /*****************************************/
 /* Operating systems                     */
 
-#if defined(__linux__) || defined(__GNU__) /* Hurd */
+#if defined(__linux__) || defined(__COSMOPOLITAN__) || defined(__GNU__) /* Hurd */
 #define NOBLOCK O_NONBLOCK
 #define LOAD_SHARED_OBJECT
 #define USE_MMAP

--- a/racket/src/cs/c/main.c
+++ b/racket/src/cs/c/main.c
@@ -158,6 +158,16 @@ static int bytes_main(int argc, char **argv,
   racket_boot_t racket_boot_p;
   long boot_rsrc_offset = 0;
 #endif
+#ifdef __COSMOPOLITAN__
+  #define CZIP_PETITE_BOOT "/zip/usr/lib/racket/petite.boot"
+  #define CZIP_SCHEME_BOOT "/zip/usr/lib/racket/scheme.boot"
+  #define CZIP_RACKET_BOOT "/zip/usr/lib/racket/racket.boot"
+
+  char use_central_zip_boot_image = (getenv("COSMOPOLITAN_DISABLE_ZIPOS") == NULL &&
+				     access(CZIP_PETITE_BOOT, R_OK) == 0 &&
+    				     access(CZIP_SCHEME_BOOT, R_OK) == 0 &&
+    				     access(CZIP_RACKET_BOOT, R_OK) == 0);
+#endif
 
   if (argc) {
     argc--;
@@ -207,6 +217,9 @@ static int bytes_main(int argc, char **argv,
   else
     boot_offset = 0;
 #else
+  #ifdef __COSMOPOLITAN__
+  if (!use_central_zip_boot_image)
+  #endif
   boot_offset = find_boot_section(boot_exe,
                                   /* If the first offset is 0 and the second is not,
                                      then the intent must be for those offsets to
@@ -230,6 +243,15 @@ static int bytes_main(int argc, char **argv,
       boot3_path = path_append_2(fw_path, "racket.boot");
       boot1_offset = boot2_offset = boot3_offset = boot_end_offset = 0;
     }
+  }
+#endif
+
+#ifdef __COSMOPOLITAN__
+  if (use_central_zip_boot_image) {
+    boot1_path = CZIP_PETITE_BOOT;
+    boot2_path = CZIP_SCHEME_BOOT;
+    boot3_path = CZIP_RACKET_BOOT;
+    boot1_offset = boot2_offset = boot3_offset = boot_end_offset = 0;
   }
 #endif
 

--- a/racket/src/rktio/rktio_dll.c
+++ b/racket/src/rktio/rktio_dll.c
@@ -18,6 +18,30 @@ static void free_dll(rktio_dll_t *dll);
 #ifdef RKTIO_SYSTEM_UNIX
 #include <dlfcn.h>
 typedef void *dll_handle_t;
+
+/* NOTE: dlopen support is experimental [1] in cosmopolitan libc
+
+   libffi does wrap function call convention ABI details, which may
+   need to be considered when using the foreign package [2][3] on non-posix
+   operating systems.
+
+   As a lot of the racket distribution outside of minimal racket
+   relies on foreign, dlopen is enabled when building with
+   cosmopolitan. Correct usage on non-posix will require further
+   patching, but building the main distribution does work on
+   linux-amd64.
+
+   [1] https://github.com/jart/cosmopolitan/blob/3.3.10/libc/dlopen/dlopen.c#L864
+   [2] https://docs.racket-lang.org/foreign/foreign_c-only.html#%28def._%28%28quote._~23~25foreign%29._ffi-call%29%29
+   [3] https://docs.racket-lang.org/foreign/foreign_procedures.html#%28form._%28%28lib._ffi%2Funsafe..rkt%29.__fun%29%29
+ */
+#ifdef __COSMOPOLITAN__
+  #define dlopen cosmo_dlopen
+  #define dlerror cosmo_dlerror
+  #define dlsym cosmo_dlsym
+  #define dlclose cosmo_dlclose
+#endif
+
 #endif
 
 #ifdef RKTIO_SYSTEM_WINDOWS

--- a/racket/src/rktio/rktio_network.c
+++ b/racket/src/rktio/rktio_network.c
@@ -1970,7 +1970,7 @@ int rktio_udp_set_receive_buffer_size(rktio_t *rktio, rktio_fd_t *rfd, int size)
 int rktio_udp_get_multicast_loopback(rktio_t *rktio, rktio_fd_t *rfd)
 {
   rktio_socket_t s = rktio_fd_socket(rktio, rfd);
-  u_char loop;
+  uint8_t loop;
   rktio_sockopt_len_t loop_len = sizeof(loop);
   int status;
   
@@ -1986,7 +1986,7 @@ int rktio_udp_get_multicast_loopback(rktio_t *rktio, rktio_fd_t *rfd)
 int rktio_udp_set_multicast_loopback(rktio_t *rktio, rktio_fd_t *rfd, int on)
 {
   rktio_socket_t s = rktio_fd_socket(rktio, rfd);
-  u_char loop = (on ? 1 : 0);
+  uint8_t loop = (on ? 1 : 0);
   rktio_sockopt_len_t loop_len = sizeof(loop);
   int status;
   
@@ -2034,7 +2034,7 @@ int rktio_udp_set_ttl(rktio_t *rktio, rktio_fd_t *rfd, int ttl_val)
 int rktio_udp_get_multicast_ttl(rktio_t *rktio, rktio_fd_t *rfd)
 {
   rktio_socket_t s = rktio_fd_socket(rktio, rfd);
-  u_char ttl;
+  uint8_t ttl;
   rktio_sockopt_len_t ttl_len = sizeof(ttl);
   int status;
   
@@ -2050,7 +2050,7 @@ int rktio_udp_get_multicast_ttl(rktio_t *rktio, rktio_fd_t *rfd)
 int rktio_udp_set_multicast_ttl(rktio_t *rktio, rktio_fd_t *rfd, int ttl_val)
 {
   rktio_socket_t s = rktio_fd_socket(rktio, rfd);
-  u_char ttl = ttl_val;
+  uint8_t ttl = ttl_val;
   rktio_sockopt_len_t ttl_len = sizeof(ttl);
   int status;
   


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] Feature
- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->

This patch adds some minimal scaffolding to allow building and running Chez and the Racket main distribution with cosmopolitan libc, affording access to 6 operating systems with a single binary https://github.com/jart/cosmopolitan

The main contents of this patch are a couple of platform checks, and an addition to Racket's bootup procedure such that it can load the start image and packages from an embedded ZIP object store provided by the platform. I know this isn't exactly new in terms of what `raco exe` can do, but it does collapse the amount of binary images needed to ship to different platforms, while taking away ABI variability/build churn.

The shell script included in the commit message demonstrates shipping the main distribution as a single binary file, which runs on amd64 Linux, Windows 10, MacOS, NetBSD, OpenBSD, and FreeBSD. These are all covered by the static minimal racket binary built with the cosmopolitan toolchain. aarch64 should also work, though I still need to try it out.

Of course, this isn't all sunshine and rainbows. Cosmo does ship its own implementation of a POSIX ABI to cover most OS interfacing, but Racket assumes a lot about the underlying system from build time (such as it pertains to the foreign interface for instance, getting the gui package to work might be a challenge). I don't want to make outlandish claims of what's possible or worth doing, but I thought this was interesting and useful enough to share with the maintainers. Also where I might not be expert in the details of the platform, @jart or @ahgamut should be able to provide some clarification. I'd be happy to make any changes the authors would prefer of course. I'll also add an accompanying PR to the Chez repo https://github.com/cisco/ChezScheme/pull/837