### PR TITLE
feat(main.zuo): add support for $JOBS environment variable

### DIFF
--- a/main.zuo
+++ b/main.zuo
@@ -52,7 +52,11 @@
     (define cpus (let ([s (lookup 'CPUS)])
                    (and (not (equal? s ""))
                         s)))
-    (define simple-jobs (or cpus
+
+    (define env-jobs-pair (assoc "JOBS" (hash-ref (runtime-env) 'env)))
+    (define env-jobs (and env-jobs-pair (cdr env-jobs-pair)))
+
+    (define simple-jobs (or env-jobs cpus
                             (let ([s (lookup 'JOBS)])
                               (and (not (equal? s ""))
                                    s))))
@@ -65,8 +69,12 @@
     (when (and jobs
                (or (not n-jobs)
                    (< n-jobs 1)))
-      (error (~a (if cpus "CPUS" (if simple-jobs "JOBS" "JOB_OPTIONS argument"))
-                 "is not a positive integer"
+      (error (~a (cond 
+                   [env-jobs "$JOBS environment variable"]
+                   [simple-jobs "JOBS"]
+                   [cpus "CPUS"]
+                   [else "JOB_OPTIONS argument"])
+                 " is not a positive integer: "
                  jobs)))
     (or n-jobs
         (infer-gnu-make-jobs)))


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

(Not sure what to put here - this is just a convenient build system change)

### Description of change
<!-- Please provide a description of the change here. -->

Currently, if you want to change the number of threads used during a top-level Racket build, you must edit the Makefile. This isn't particularly conducive to automated building (it requires a Makefile diff), which bit me trying to build on a particularly slow device. This adds support for a `$JOBS` environment variable to conveniently change the number of threads for the build.