### PR TITLE
for: fix splicing clauses in `for/and`, `for/or`, and `for/first`

### DIFF
--- a/pkgs/racket-test-core/tests/racket/for.rktl
+++ b/pkgs/racket-test-core/tests/racket/for.rktl
@@ -1401,6 +1401,71 @@
       'final-if-7
       (for/list ([i (in-range 10)] #:splice (final-if-7 i)) i))
 
+;; splicing clauses in `for/and`, `for/or`, and `for/first`
+;; These expand differently than in non-splicing cases
+
+(test #f
+      'parallel3/and
+      (for/and (#:splice (parallel3 n m))
+        (and (not (= n m))
+             (list n m))))
+(test #f
+      'parallel3/and
+      (for*/and (#:splice (parallel3 n m))
+        (and (not (= n m))
+             (list n m))))
+
+(test #f
+      'cross3/and
+      (for/and (#:splice (cross3 n m))
+        (and (not (= n m))
+             (list n m))))
+(test #f
+      'cross3/and
+      (for*/and (#:splice (cross3 n m))
+        (and (not (= n m))
+             (list n m))))
+
+(test #f
+      'parallel3/or
+      (for/or (#:splice (parallel3 n m))
+        (and (not (= n m))
+             (list n m))))
+(test #f
+      'parallel3/or
+      (for*/or (#:splice (parallel3 n m))
+        (and (not (= n m))
+             (list n m))))
+
+(test '(0 1)
+      'cross3/or
+      (for/or (#:splice (cross3 n m))
+        (and (not (= n m))
+             (list n m))))
+(test '(0 1)
+      'cross3/or
+      (for*/or (#:splice (cross3 n m))
+        (and (not (= n m))
+             (list n m))))
+
+(test '(0 0)
+      'parallel3/first
+      (for/first (#:splice (parallel3 n m))
+        (list n m)))
+(test '(0 0)
+      'parallel3/first
+      (for*/first (#:splice (parallel3 n m))
+        (list n m)))
+
+(test '(0 0)
+      'cross3/first
+      (for/first (#:splice (cross3 n m))
+        (list n m)))
+(test '(0 0)
+      'cross3/first
+      (for*/first (#:splice (cross3 n m))
+        (list n m)))
+
 ;; ----------------------------------------
 ;; defining sequence syntax
 

--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -3,7 +3,6 @@
   (#%require "misc.rkt"
              "define.rkt"
              "letstx-scheme.rkt"
-             "member.rkt"
              "reverse.rkt"
              "sort.rkt"
              "performance-hint.rkt"
@@ -15,7 +14,6 @@
                          "qqstx.rkt"
                          "define.rkt"
                          "fixnum.rkt"
-                         "member.rkt"
                          "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
                          "stxcase-scheme.rkt"
                          "more-scheme.rkt"))
@@ -1983,7 +1981,7 @@
                                       ;; handle it, and no need to wrap any more:
                                       bs])))]
                             [(not (free-identifier=? derived-id-stx nonnested-id-stx))
-                             ;; add `#:when? #t` after each binding clause to trigger nesting
+                             ;; add `#:when #t` after each binding clause to trigger nesting
                              (let loop ([bs bs])
                                (if (null? bs)
                                    null
@@ -2193,7 +2191,7 @@
     (lambda (rhs) #`(stop-after #,rhs (lambda x (not result))))
     (lambda (x) x)
     (lambda (x) #`((define result #,x)
-                   #:final? (not result)
+                   #:final (not result)
                    result)))
 
   (define-for-variants (for/or for*/or)
@@ -2202,7 +2200,7 @@
     (lambda (rhs) #`(stop-after #,rhs (lambda x result)))
     (lambda (x) x)
     (lambda (x) #`((define result #,x)
-                   #:final? result
+                   #:final result
                    result)))
 
   (define-for-variants (for/first for*/first)
@@ -2210,8 +2208,8 @@
     (lambda (x) #`(let-values ([(val _) #,x]) val))
     (lambda (rhs) #`(stop-after #,rhs (lambda x stop?)))
     (lambda (x) #`(values #,x #t))
-    (lambda (x) #`(#:final? #t
-                   (values x #t))))
+    (lambda (x) #`(#:final #t
+                   (values #,x #t))))
 
   (define-for-variants (for/last for*/last)
     ([result #f])


### PR DESCRIPTION
##### Checklist
- [x] Bugfix
- [x] tests included

### Description of change
These expand differently than in non-splicing cases, namely wrapping the body as opposed to `for` clauses, but the `#:final` keyword is wrong.