### PR TITLE
Switch some file operations to be statically-bound kw functions.

### DIFF
--- a/racket/collects/racket/private/collect.rkt
+++ b/racket/collects/racket/private/collect.rkt
@@ -1,33 +1,32 @@
 (module collect '#%kernel
   (#%require "qq-and-or.rkt"
              "path.rkt"
-             "kw.rkt")
+             "kw.rkt"
+	     (prefix k: '#%kernel))
+  
+  (#%provide (rename collection-path new:collection-path)
+	     [rename collection-file-path new:collection-file-path])
+  
+  (new-define collection-path
+	      (new-lambda (collection 
+			   #:fail [fail (lambda (s)
+					  (raise
+					   (exn:fail:filesystem
+					    (string-append "collection-path: " s)
+					    (current-continuation-marks))))]
+			   . collections)
+			  (k:collection-path fail collection collections)))
 
-  (#%provide new:collection-path
-             new:collection-file-path)
-
-  (define-values (new:collection-path)
-    (let ([collection-path (new-lambda (collection 
-                                        #:fail [fail (lambda (s)
-                                                       (raise
-                                                        (exn:fail:filesystem
-                                                         (string-append "collection-path: " s)
-                                                         (current-continuation-marks))))]
-                                        . collections)
-                             (collection-path fail collection collections))])
-      collection-path))
-
-  (define-values (new:collection-file-path)
-    (let ([collection-file-path (new-lambda (file-name 
-                                             collection
-                                             #:check-compiled? [check-compiled?
-                                                                (and (path-string? file-name)
-                                                                     (regexp-match? #rx".[.]rkt$" file-name))]
-                                             #:fail [fail (lambda (s)
-                                                            (raise
-                                                             (exn:fail:filesystem
-                                                              (string-append "collection-file-path: " s)
-                                                              (current-continuation-marks))))]
-                                             . collections)
-                                  (collection-file-path fail check-compiled? file-name collection collections))])
-      collection-file-path)))
+  (new-define collection-file-path
+	      (new-lambda (file-name 
+			   collection
+			   #:check-compiled? [check-compiled?
+					      (and (path-string? file-name)
+						   (regexp-match? #rx".[.]rkt$" file-name))]
+			   #:fail [fail (lambda (s)
+					  (raise
+					   (exn:fail:filesystem
+					    (string-append "collection-file-path: " s)
+					    (current-continuation-marks))))]
+			   . collections)
+			  (k:collection-file-path fail check-compiled? file-name collection collections))))

--- a/racket/collects/racket/private/kw-file.rkt
+++ b/racket/collects/racket/private/kw-file.rkt
@@ -158,9 +158,7 @@
             (lambda () (proc p))
             (lambda () (close-output-port p)))))
 
-  ;; Using `define-values' to avoid the inlining expansion for keyword
-  ;; arguments, because that expansion confuses Typed Racket:
-  (define-values (directory-list)
+  (define directory-list
     (lambda ([dir (current-directory)] #:build? [build? #f])
       (unless (path-string? dir)
         (raise-argument-error 'directory-list "path-string?" dir))
@@ -170,24 +168,23 @@
             (map (lambda (i) (build-path dir i)) content)
             content))))
 
-  (define-values (copy-file)
-    (let ([not-supplied exists-syms])
-      (lambda (src dest [exists-ok? not-supplied]
-                   #:exists-ok? [exists-ok?/kw not-supplied]
-                   #:permissions [perms #f]
-                   #:replace-permissions? [replace-permissions? #t])
-        (unless (or (eq? exists-ok? not-supplied)
-                    (eq? exists-ok?/kw not-supplied))
-          (raise-arguments-error 'copy-file "cannot supply both non-keyword and keyword `exists-ok?` argument"
-                                 "by-position argument" exists-ok?
-                                 "keyword argument" exists-ok?/kw))
-        (k:copy-file src dest
-                     (if (eq? exists-ok? not-supplied)
-                         (if (eq? exists-ok?/kw not-supplied)
-                             #f
-                             exists-ok?/kw)
-                         exists-ok?)
-                     perms replace-permissions?))))
+  (define copy-file
+    (lambda (src dest [exists-ok? exists-syms]
+		 #:exists-ok? [exists-ok?/kw exists-syms]
+		 #:permissions [perms #f]
+		 #:replace-permissions? [replace-permissions? #t])
+      (unless (or (eq? exists-ok? exists-syms)
+		  (eq? exists-ok?/kw exists-syms))
+	(raise-arguments-error 'copy-file "cannot supply both non-keyword and keyword `exists-ok?` argument"
+			       "by-position argument" exists-ok?
+			       "keyword argument" exists-ok?/kw))
+      (k:copy-file src dest
+		   (if (eq? exists-ok? exists-syms)
+		       (if (eq? exists-ok?/kw exists-syms)
+			   #f
+			   exists-ok?/kw)
+		       exists-ok?)
+		   perms replace-permissions?)))
 
   (define (raise-syntax-error given-name message
                               [expr #f] [sub-expr #f]


### PR DESCRIPTION
This is designed to make these functions work better with demodularization.

Includes support for helping `typed/racket` with `make-temporary-file`, including
and ugly hack only needed to support TR testing, which hopefully someone has a 
better idea for.