### PR TITLE
Update concurrency.scrbl

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/concurrency.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/concurrency.scrbl
@@ -579,7 +579,7 @@ to wait until at least a certain number of items have been produced.
            (code:comment "we check to see if there has been enough")
            (code:comment "production")
            (cond
-             [(>= (car waiter) total-items-seen)
+             [(<= (car waiter) total-items-seen)
               (code:comment "if so, we send a message back on the channel")
               (code:comment "and continue the loop without that item")
               (handle-evt


### PR DESCRIPTION
some mistake in section 18.7's code. there should be "<=" instead of ">="

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

### Description of change
<!-- Please provide a description of the change here. -->
according to the requirement " wait until at least a certain number of items have been produced.",  the condition should be "(<= (car waiter) total-items-seen)"