### PR TITLE
unixstyle-install.rkt: unbreak for powerpc

### DIFF
--- a/racket/collects/setup/unixstyle-install.rkt
+++ b/racket/collects/setup/unixstyle-install.rkt
@@ -258,8 +258,11 @@
                                                            #""
                                                            r))))])
     (cond [(or (regexp-match #rx#"^\177ELF" magic)
+               ;; Mach-O magic numbers for LE/BE, 32/64-bit
                (regexp-match #rx#"^\316\372\355\376" magic)
-               (regexp-match #rx#"^\317\372\355\376" magic))
+               (regexp-match #rx#"^\317\372\355\376" magic)
+               (regexp-match #rx#"^\376\355\372\316" magic)
+               (regexp-match #rx#"^\376\355\372\317" magic))
            (let ([temp (format "~a-temp-for-install"
                                (regexp-replace* #rx"/" file "_"))])
              (with-handlers ([exn? (lambda (e) (rm temp) (raise e))])


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

### Description of change

Fixes the build on Darwin PowerPC, which is currently broken due to misspecified Mach-O magic numbers.
