### PR TITLE
fix various bugs in syntax/flatten-begin

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/flatten-begin.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/flatten-begin.scrbl
@@ -12,8 +12,8 @@
 
 @defproc[(flatten-begin [stx syntax?]) (listof syntax?)]{
 
-Extracts the sub-expressions from a @racket[begin]-like form,
-reporting an error if @racket[stx] does not have the right shape
+Extracts the sub-expressions from @racket[stx], assuming that it is a @racket[begin] form.
+Reports an error if @racket[stx] does not have the right shape
 (i.e., a syntax list). The resulting syntax objects have annotations
 transferred from @racket[stx] using @racket[syntax-track-origin].
 

--- a/pkgs/racket-test/tests/syntax/flatten-begin.rkt
+++ b/pkgs/racket-test/tests/syntax/flatten-begin.rkt
@@ -11,10 +11,30 @@
   (check-equal? (map syntax->datum actual)
                 (map syntax->datum expected)))
 
+(define-test-suite flatten-begin-tests
+  (check-exn exn:fail:syntax? (λ () (flatten-begin #'())))
+  (check-exn exn:fail:syntax? (λ () (flatten-begin #'(1))))
+  (check-exn exn:fail:syntax? (λ () (flatten-begin #'(1 2))))
+  (check-exn exn:fail:syntax? (λ () (flatten-begin #'(1 . 2))))
+  (check-equal-datum? (flatten-begin #'(begin))
+                      (list))
+  (check-equal-datum? (flatten-begin #'(begin 1 2 3))
+                      (list #'1 #'2 #'3))
+  (check-equal-datum? (flatten-begin #'(+ 1 2 3))
+                      (list #'1 #'2 #'3))
+  (check-equal-datum? (flatten-begin #'(begin (begin 1 2) 3))
+                      (list #'(begin 1 2) #'3)))
+
 (define-test-suite flatten-all-begins-tests
+  (check-exn exn:fail:syntax? (λ () (flatten-all-begins #'())))
+  (check-exn exn:fail:syntax? (λ () (flatten-all-begins #'(1))))
+  (check-exn exn:fail:syntax? (λ () (flatten-all-begins #'(1 . 2))))
   (check-exn exn:fail:syntax? (λ () (flatten-all-begins #'(1 2 3))))
+  (check-exn exn:fail:syntax? (λ () (flatten-all-begins #'(begin . 1))))
   (check-equal-datum? (flatten-all-begins #'(begin 1 2 3))
                       (list #'1 #'2 #'3))
+  (check-equal-datum? (flatten-all-begins #'(begin (1 2) 2 3))
+                      (list #'(1 2) #'2 #'3))
   (check-equal-datum? (flatten-all-begins (syntax-shift-phase-level #'(begin 1 2 3) 2))
                       (list #'1 #'2 #'3))
   (check-equal-datum? (flatten-all-begins #'(begin (begin 1 2) 3))
@@ -26,4 +46,5 @@
   (check-equal-datum? (flatten-all-begins #'(begin (begin 1 2) (begin 3) 4))
                       (list #'1 #'2 #'3 #'4)))
 
+(run-tests flatten-begin-tests)
 (run-tests flatten-all-begins-tests)


### PR DESCRIPTION
- Raise a syntax error (instead of a contract error) for (flatten-begin #'())
- Make (flatten-begin #'(1 2)) a bad syntax error instead of an internal error on syntax-track-origin
- For consistency with #'(1 2), make (flatten-begin #'(1)) a syntax error instead of producing an empty list
- Make (flatten-all-begins #'(begin . 1)) a syntax error, instead of producing (list #'(begin . 1))
- Make (flatten-all-begins #'(begin (1))) produce (list #'(1)), instead a syntax error