### PR TITLE
guide: Add Gentoo geiser port

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/other-editors.scrbl
@@ -52,7 +52,8 @@ popular among Racketeers as well.
        @hyperlink["http://www.nongnu.org/geiser/"]{Geiser manual}.
 
        Debian and Ubuntu packages for Geiser are available under the
-       name @tt{geiser}.}
+       name @tt{geiser}. A Gentoo port is also available (under the
+       name @tt{app-emacs/geiser}).}
 
  @item{Emacs ships with a major mode for Scheme, @tt{scheme-mode},
        that while not as featureful as the above options, works


### PR DESCRIPTION
This makes the section more consistent with Quack's section which mentions the existence of the `app-emacs/quack` package.
Signed-off-by: Tomas Fabrizio Orsi <torsi@fi.uba.ar>

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [X] documentation

### Description of change
<!-- Please provide a description of the change here. -->
Small addition that mentions the existence of Gentoo's geiser port (package can be seen [here](https://github.com/gentoo/gentoo/blob/master/app-emacs/geiser/geiser-0.31.ebuild)). This is done simply to match Quack's section which mentions the existence of a Gentoo package for said program.   