### PR TITLE
glob: clarify that only path values are returned

### DIFF
--- a/pkgs/racket-doc/file/scribblings/glob.scrbl
+++ b/pkgs/racket-doc/file/scribblings/glob.scrbl
@@ -64,7 +64,7 @@ has the same meaning as @racket['("foo.rkt" "bar.rkt")].
 }
 ]
 
-@defproc[(glob [pattern glob/c] [#:capture-dotfiles? capture-dotfiles? boolean? (glob-capture-dotfiles?)]) (listof path-string?)]{
+@defproc[(glob [pattern glob/c] [#:capture-dotfiles? capture-dotfiles? boolean? (glob-capture-dotfiles?)]) (listof path?)]{
   Builds a list of all paths on the current filesystem that match any glob
   in @racket[pattern]. The order of paths in the result is unspecified.
 
@@ -100,7 +100,7 @@ Examples:
 }
 }
 
-@defproc[(in-glob [pattern glob/c] [#:capture-dotfiles? capture-dotfiles? boolean? (glob-capture-dotfiles?)]) (sequence/c path-string?)]{
+@defproc[(in-glob [pattern glob/c] [#:capture-dotfiles? capture-dotfiles? boolean? (glob-capture-dotfiles?)]) (sequence/c path?)]{
   Returns a stream of all paths matching the glob @racket[pattern],
   instead of eagerly building a list.
 }

--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -595,7 +595,7 @@ each element in the sequence.
 @defproc[(in-directory [dir (or/c #f path-string?) #f]
                        [use-dir? ((and/c path? complete-path?) . -> . any/c)
                                  (lambda (dir-path) #t)])
-         sequence?]{
+         (sequence/c path?)]{
   Returns a sequence that produces all of the paths for files,
   directories, and links within @racket[dir], except for the
   contents of any directory for which @racket[use-dir?] returns

--- a/racket/collects/file/glob.rkt
+++ b/racket/collects/file/glob.rkt
@@ -8,8 +8,8 @@
 (provide
   glob/c
   (contract-out
-    [glob (->* [glob/c] [#:capture-dotfiles? boolean?] (listof path-string?))]
-    [in-glob (->* [glob/c] [#:capture-dotfiles? boolean?] (sequence/c path-string?))]
+    [glob (->* [glob/c] [#:capture-dotfiles? boolean?] (listof path?))]
+    [in-glob (->* [glob/c] [#:capture-dotfiles? boolean?] (sequence/c path?))]
     [glob-match? (->* [glob/c path-string?] [#:capture-dotfiles? boolean?] boolean?)]
     [glob-quote (->i ([ps path-string?]) [r (ps) (if (path? ps) path? string?)])]
     [glob-capture-dotfiles? (parameter/c boolean?)]))


### PR DESCRIPTION
## Description of change

Summarizing [1], experimental evidence suggested that `glob` and cousins
only returned values matching `path?` and never `string?`. Digging into
the source, glob depends on `in-directory` from
racket/collects/racket/private/for.rkt, which sorts the results
`directory-list` by `path<?`. So it certainly appears that `glob` only
returns path values. Correct both documentation and contract.

Also update `in-directory` documentation to note the kind of values
returned by its sequence (it has no corresponding source contract).

Also cleanup adjacent whitespace.

[1]: https://racket.discourse.group/t/does-glob-ever-return-strings-if-not-should-we-update-the-docs/3049/2

Best-viewed-with: --ignore-space-change

## Checklist

- [x] Bugfix (?)
- [x] documentation
