### PR TITLE
cs,iOS: add iOS-specific machine type and make OpenSSL work

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -101,3 +101,53 @@ jobs:
           --enable-scheme=${{ github.workspace }}/host-racket/src/build/cs/c
         make
         make install
+
+  build-pb-ios:
+    runs-on: macos-14
+    steps:
+    - uses: actions/checkout@v4
+    - name: Build LibFFI
+      run: |
+        set -euxo pipefail
+        brew install automake libtool
+        git clone https://github.com/libffi/libffi
+        cd libffi
+        git checkout v3.4.6
+        ./autogen.sh
+        python generate-darwin-source-and-headers.py --only-ios
+        xcodebuild \
+          -configuration release \
+          -target libffi-iOS \
+          -scheme libffi-iOS \
+          -sdk "$(xcode-select -p)/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS.sdk" \
+          -derivedDataPath dist \
+          IPHONEOS_DEPLOYMENT_TARGET=12
+    - name: Build PB iOS Racket
+      run: |
+        set -euxo pipefail
+        make fetch-pb
+        mkdir -p racket/src/build
+        cd racket/src/build
+        cat >libffi.pc <<EOF
+          prefix=${GITHUB_WORKSPACE}/libffi/dist/Build/Products/Release-iphoneos
+          exec_prefix=\${prefix}
+          libdir=\${exec_prefix}
+          toolexeclibdir=\${libdir}
+          includedir=\${prefix}/include/ffi
+
+          Name: libffi
+          Description: Library supporting Foreign Function Interfaces
+          Version: 3.4.6
+          Libs: -L\${toolexeclibdir} -lffi
+          Cflags: -I\${includedir}
+        EOF
+        cat libffi.pc
+        env PKG_CONFIG_PATH="$(pwd)" \
+          ../configure \
+            --host=aarch64-apple-darwin \
+            --enable-ios=iPhoneOS \
+            --enable-pb \
+            --enable-racket=auto \
+            --enable-libffi
+        make
+        make install

--- a/racket/collects/openssl/libcrypto.rkt
+++ b/racket/collects/openssl/libcrypto.rkt
@@ -86,7 +86,26 @@
     [else '(so "libcrypto")]))
 
 (define libcrypto
-  (with-handlers ([exn:fail? (lambda (x)
-                               (set! libcrypto-load-fail-reason (exn-message x))
-                               #f)])
-    (ffi-lib libcrypto-so openssl-lib-versions)))
+  (cond
+    ;; On iOS, linking to regular shared objects (except those provided
+    ;; by Apple) is not supported. Instead, the library must be linked
+    ;; via an XCFramework containing a position-independent library such
+    ;; as the one provided by [1]. Here, we assume the library has been
+    ;; loaded if we can get the OpenSSL_version_num function.
+    ;;
+    ;; [1]: https://github.com/krzyzanowskim/OpenSSL-Package
+    [(eq? (system-type 'os*) 'ios)
+     (define the-lib (ffi-lib #f))
+     (define openssl-version
+       ((get-ffi-obj
+         "OpenSSL_version_num" the-lib
+         (_fun -> _ulong)
+         (lambda ()
+           (lambda ()
+             0)))))
+     (and (> openssl-version 0) the-lib)]
+    [else
+     (with-handlers ([exn:fail? (lambda (x)
+                                  (set! libcrypto-load-fail-reason (exn-message x))
+                                  #f)])
+       (ffi-lib libcrypto-so openssl-lib-versions))]))

--- a/racket/collects/openssl/libssl.rkt
+++ b/racket/collects/openssl/libssl.rkt
@@ -24,8 +24,13 @@
 
 (define libssl
   (and libcrypto
-       (with-handlers ([exn:fail?
-                        (lambda (x)
-                          (set! libssl-load-fail-reason (exn-message x))
-                          #f)])
-         (ffi-lib libssl-so openssl-lib-versions))))
+       (if (eq? (system-type 'os*) 'ios)
+           ;; If libcrypto has been loaded and we're on iOS, assume
+           ;; that libssl has also been loaded. See the comment in
+           ;; libcrypto.rkt for details.
+           (ffi-lib #f)
+           (with-handlers ([exn:fail?
+                            (lambda (x)
+                              (set! libssl-load-fail-reason (exn-message x))
+                              #f)])
+             (ffi-lib libssl-so openssl-lib-versions)))))

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -278,7 +278,7 @@ TO DO:
         '((macosx-keychain #f))]
        [(ios)
         ;; On iOS, the function SecTrustCopyAnchorCertificates is not
-        ;; available in the Security framework, so applications must
+        ;; provided by the Security framework, so applications must
         ;; bundle and provide their own certificates. Log an error here
         ;; if the sources have not been changed.
         (log-openssl-error "ssl-default-verify-sources must be set on iOS")

--- a/racket/collects/openssl/mzssl.rkt
+++ b/racket/collects/openssl/mzssl.rkt
@@ -276,6 +276,13 @@ TO DO:
         '((win32-store "ROOT"))]
        [(macosx darwin)
         '((macosx-keychain #f))]
+       [(ios)
+        ;; On iOS, the function SecTrustCopyAnchorCertificates is not
+        ;; available in the Security framework, so applications must
+        ;; bundle and provide their own certificates. Log an error here
+        ;; if the sources have not been changed.
+        (log-openssl-error "ssl-default-verify-sources must be set on iOS")
+        null]
        [else
         (x509-root-sources)]))))
 

--- a/racket/src/ac/sdk_ios.m4
+++ b/racket/src/ac/sdk_ios.m4
@@ -9,14 +9,25 @@ if test "${enable_ios}" != "" ; then
   esac
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
-     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
-     echo "=== Using inferred iOS SDK path ${ios_sdk}"
+     IOS_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     echo "=== Using inferred iOS SDK path ${IOS_SDK}"
      ;;
     *)
-     ios_sdk="${enable_ios}"
+     IOS_SDK="${enable_ios}"
      ;;
   esac
   IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+  IOS_SDK_FLAGS="-miphoneos-version-min=${IOS_PHONE_VERS}"
+  case "${IOS_SDK}" in
+      # When -arch is arm64-apple-darwin and -sdk is iPhoneSimulator,
+      # passing -miphoneos-version-min makes clang think it's targeting
+      # iPhoneOS instead of iPhoneSimulator, which causes the configure
+      # script to fail. There is no -miphonesimulator-version-min flag.
+      # The -mtargetos flag exhibits the same behavior.
+      *iPhoneSimulator.sdk)
+          IOS_SDK_FLAGS=""
+          ;;
+  esac
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${IOS_SDK} ${IOS_SDK_FLAGS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${IOS_SDK} ${IOS_SDK_FLAGS} -liconv"
 fi

--- a/racket/src/bc/configure
+++ b/racket/src/bc/configure
@@ -3722,16 +3722,27 @@ if test "${enable_ios}" != "" ; then
   esac
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
-     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
-     echo "=== Using inferred iOS SDK path ${ios_sdk}"
+     IOS_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     echo "=== Using inferred iOS SDK path ${IOS_SDK}"
      ;;
     *)
-     ios_sdk="${enable_ios}"
+     IOS_SDK="${enable_ios}"
      ;;
   esac
   IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+  IOS_SDK_FLAGS="-miphoneos-version-min=${IOS_PHONE_VERS}"
+  case "${IOS_SDK}" in
+      # When -arch is arm64-apple-darwin and -sdk is iPhoneSimulator,
+      # passing -miphoneos-version-min makes clang think it's targeting
+      # iPhoneOS instead of iPhoneSimulator, which causes the configure
+      # script to fail. There is no -miphonesimulator-version-min flag.
+      # The -mtargetos flag exhibits the same behavior.
+      *iPhoneSimulator.sdk)
+          IOS_SDK_FLAGS=""
+          ;;
+  esac
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${IOS_SDK} ${IOS_SDK_FLAGS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${IOS_SDK} ${IOS_SDK_FLAGS} -liconv"
 fi
 
 if test "${enable_ios}" != "" ; then

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -4589,6 +4589,9 @@ case "$host_os" in
   darwin*)
     PREFLAGS="$PREFLAGS -DOS_X"
     MACH_OS=osx
+    if test "${enable_ios}" != "" ; then
+      MACH_OS=ios
+    fi
     LIBS="${LIBS} -framework CoreFoundation"
     LDFLAGS="${LDFLAGS} -Wl,-headerpad_max_install_names"
     SIGNED_EXE="t"

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -3386,16 +3386,27 @@ if test "${enable_ios}" != "" ; then
   esac
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
-     ios_sdk=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
-     echo "=== Using inferred iOS SDK path ${ios_sdk}"
+     IOS_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     echo "=== Using inferred iOS SDK path ${IOS_SDK}"
      ;;
     *)
-     ios_sdk="${enable_ios}"
+     IOS_SDK="${enable_ios}"
      ;;
   esac
   IOS_PHONE_VERS="6.0"
-  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS}"
-  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${ios_sdk} -miphoneos-version-min=${IOS_PHONE_VERS} -liconv"
+  IOS_SDK_FLAGS="-miphoneos-version-min=${IOS_PHONE_VERS}"
+  case "${IOS_SDK}" in
+      # When -arch is arm64-apple-darwin and -sdk is iPhoneSimulator,
+      # passing -miphoneos-version-min makes clang think it's targeting
+      # iPhoneOS instead of iPhoneSimulator, which causes the configure
+      # script to fail. There is no -miphonesimulator-version-min flag.
+      # The -mtargetos flag exhibits the same behavior.
+      *iPhoneSimulator.sdk)
+          IOS_SDK_FLAGS=""
+          ;;
+  esac
+  PREFLAGS="$PREFLAGS -DTARGET_OS_IPHONE=1 -arch ${IOS_ARCH} -isysroot ${IOS_SDK} ${IOS_SDK_FLAGS}"
+  LDFLAGS="$LDFLAGS -arch ${IOS_ARCH} -isysroot ${IOS_SDK} ${IOS_SDK_FLAGS} -liconv"
 fi
 
 

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -325,6 +325,9 @@ case "$host_os" in
   darwin*)
     PREFLAGS="$PREFLAGS -DOS_X"
     MACH_OS=osx
+    if test "${enable_ios}" != "" ; then
+      MACH_OS=ios
+    fi
     LIBS="${LIBS} -framework CoreFoundation"
     LDFLAGS="${LDFLAGS} -Wl,-headerpad_max_install_names"
     SIGNED_EXE="t"

--- a/racket/src/cs/rumble/system.ss
+++ b/racket/src/cs/rumble/system.ss
@@ -36,6 +36,7 @@
 
 (define os*-symbol
   (case (reflect-machine-type)
+    [(a6ios ta6ios arm64ios tarm64ios) 'ios]
     [(a6osx ta6osx
             i3osx ti3osx
             arm64osx tarm64osx
@@ -74,6 +75,10 @@
 
 (define arch-symbol
   (case (reflect-machine-type)
+    [(a6ios ta6ios)
+     'x86_64]
+    [(arm64ios tarm64ios)
+     'aarch64]
     [(a6osx ta6osx
             a6nt ta6nt
             a6le ta6le
@@ -122,6 +127,8 @@
 
 (define link-symbol
   (case (reflect-machine-type)
+    [(a6ios ta6ios arm64ios tarm64ios)
+     'framework]
     [(a6osx ta6osx i3osx ti3osx arm64osx tarm64osx)
      (if unix-style-macos?
          'static
@@ -133,6 +140,7 @@
 
 (define so-suffix-bytes
   (case (reflect-machine-type)
+    [(a6ios ta6ios arm64ios tarm64ios) (string->utf8 ".dylib")]
     [(a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx) (string->utf8 ".dylib")]
     [(a6nt ta6nt i3nt ti3nt arm64nt tarm64nt) (string->utf8 ".dll")]
     [else (string->utf8 ".so")]))

--- a/racket/src/cs/rumble/system.ss
+++ b/racket/src/cs/rumble/system.ss
@@ -29,14 +29,17 @@
 
 (define os-symbol
   (case (reflect-machine-type)
-    [(a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx)
+    [(a6ios ta6ios arm64ios tarm64ios a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx)
      (if unix-style-macos? 'unix 'macosx)]
     [(a6nt ta6nt i3nt ti3nt arm64nt tarm64nt) 'windows]
     [else 'unix]))
 
 (define os*-symbol
   (case (reflect-machine-type)
-    [(a6ios ta6ios arm64ios tarm64ios) 'ios]
+    [(a6ios ta6ios arm64ios tarm64ios)
+     (if unix-style-macos?
+         'unix
+         'ios)]
     [(a6osx ta6osx
             i3osx ti3osx
             arm64osx tarm64osx

--- a/racket/src/cs/rumble/system.ss
+++ b/racket/src/cs/rumble/system.ss
@@ -29,7 +29,8 @@
 
 (define os-symbol
   (case (reflect-machine-type)
-    [(a6ios ta6ios arm64ios tarm64ios a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx)
+    [(a6ios ta6ios arm64ios tarm64ios
+            a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx)
      (if unix-style-macos? 'unix 'macosx)]
     [(a6nt ta6nt i3nt ti3nt arm64nt tarm64nt) 'windows]
     [else 'unix]))
@@ -37,9 +38,7 @@
 (define os*-symbol
   (case (reflect-machine-type)
     [(a6ios ta6ios arm64ios tarm64ios)
-     (if unix-style-macos?
-         'unix
-         'ios)]
+     'ios]
     [(a6osx ta6osx
             i3osx ti3osx
             arm64osx tarm64osx
@@ -78,11 +77,8 @@
 
 (define arch-symbol
   (case (reflect-machine-type)
-    [(a6ios ta6ios)
-     'x86_64]
-    [(arm64ios tarm64ios)
-     'aarch64]
     [(a6osx ta6osx
+            a6ios ta6ios
             a6nt ta6nt
             a6le ta6le
             a6ob ta6ob
@@ -107,6 +103,7 @@
      'arm]
     [(arm64le tarm64le
               arm64osx tarm64osx
+              arm64ios tarm64ios
               arm64fb tarm64fb
               arm64ob tarm64ob
               arm64nb tarm64nb
@@ -130,9 +127,8 @@
 
 (define link-symbol
   (case (reflect-machine-type)
-    [(a6ios ta6ios arm64ios tarm64ios)
-     'framework]
-    [(a6osx ta6osx i3osx ti3osx arm64osx tarm64osx)
+    [(a6ios ta6ios arm64ios tarm64ios
+            a6osx ta6osx i3osx ti3osx arm64osx tarm64osx)
      (if unix-style-macos?
          'static
          'framework)]
@@ -143,10 +139,13 @@
 
 (define so-suffix-bytes
   (case (reflect-machine-type)
-    [(a6ios ta6ios arm64ios tarm64ios) (string->utf8 ".dylib")]
-    [(a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx) (string->utf8 ".dylib")]
-    [(a6nt ta6nt i3nt ti3nt arm64nt tarm64nt) (string->utf8 ".dll")]
-    [else (string->utf8 ".so")]))
+    [(a6ios ta6ios arm64ios tarm64ios
+            a6osx ta6osx i3osx ti3osx arm64osx tarm64osx ppc32osx tppc32osx)
+     (string->utf8 ".dylib")]
+    [(a6nt ta6nt i3nt ti3nt arm64nt tarm64nt)
+     (string->utf8 ".dll")]
+    [else
+     (string->utf8 ".so")]))
 
 (define so-mode
   (case (reflect-machine-type)


### PR DESCRIPTION
With this change, PB iOS builds report `(system-type)` as `unix` and `(system-type 'os*)` as `ios`. The former could be made to report `macosx` instead, but then more code would have to change and I'm not sure pretending to be macOS is a good idea in the long term.