### PR TITLE
search: ranking results based on package status

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.14.0.4")
+(define version "8.14.0.5")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/info.rkt
+++ b/pkgs/racket-doc/info.rkt
@@ -6,7 +6,7 @@
                ["base" #:version "6.5.0.2"]
                "net-lib"
                "sandbox-lib"
-               ["scribble-lib" #:version "1.51"]
+               ["scribble-lib" #:version "1.52"]
                "racket-index"))
 (define build-deps '("rackunit-doc"
                      "errortrace-doc"

--- a/pkgs/racket-doc/scribblings/raco/config.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/config.scrbl
@@ -239,6 +239,23 @@ directory}:
        @history[#:changed "8.11.1.7" @elem{Added build stamp to
                                            @racket{banner}.}]
 
+ @item{@indexed-racket['base-documentation-packages] --- a list of
+       strings, each of which names a package. Any documentation
+       provided by the package and its dependencies is consider part
+       of the distribution's base language. This classification affects
+       the way that documentation search results are sorted and reported.
+       The default is @racket['("racket-doc")].
+
+       @history[#:added "8.14.0.5"]}
+
+ @item{@indexed-racket['distribution-documentation-packages] --- like
+       @racket['base-documentation-packages], but identifies a larger set of
+       documentation that is considered part of the distribution
+       beyond (but normally including) the base language. The default
+       is @racket['("main-distribution")].
+
+       @history[#:added "8.14.0.5"]}
+
  @item{@indexed-racket['absolute-installation?] --- a boolean that is
        @racket[#t] if the installation uses absolute path names,
        @racket[#f] otherwise.}

--- a/pkgs/racket-doc/scribblings/raco/setup.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/setup.scrbl
@@ -1795,7 +1795,27 @@ current-system paths while @racket[get-cross-lib-search-dirs] and
    that identifies an installation build, which can be used to augment
    the Racket version number to more specifically identify the
    build. An empty string is normally produced for a release build.
-   The result is @racket[#f] if no build stamp is available.}
+   The result is @racket[#f] if no build stamp is available.
+
+   @see-config[build-stamp]}
+
+@deftogether[(
+@defproc[(get-base-documentation-packages) (listof string?)]
+@defproc[(get-distribution-documentation-packages) (listof string?)]
+)]{
+
+   Returns a list of package names that represent a distribution's
+   base-language documentation and all of the documentation that is
+   part of the distribution, respectively. These lists are used to
+   classify and sort documentation search results. If a package is
+   part of the base documentation, that classification takes precedence
+   over distribution documentation.
+
+   See also @racket['base-documentation-packages] and
+   @racket['distribution-documentation-packages] in
+   @secref["config-file"].
+
+   @history[#:added "8.14.0.5"]}
 
 @defproc[(get-absolute-installation?) boolean?]{
   Returns @racket[#t] if this installation uses

--- a/pkgs/racket-index/scribblings/main/private/make-search.rkt
+++ b/pkgs/racket-index/scribblings/main/private/make-search.rkt
@@ -22,7 +22,8 @@
          (for-syntax racket/base)
          (for-syntax racket/runtime-path)
          (for-syntax compiler/cm-accomplice)
-         "index-scope.rkt")
+         "index-scope.rkt"
+         "pkg.rkt")
 
 (provide make-search)
 
@@ -39,9 +40,11 @@
 ;; ideally we could just inform scribble/raco that they need
 ;; installing, and they would just do that when appropriate.
 (begin-for-syntax
+  (define-runtime-path search-style "search.css")
   (define-runtime-path search-script "search.js")
   (define-runtime-path search-merge-script "search-merge.js")
   (define-runtime-path search-context-page "search-context.html")
+  (register-external-file search-style)
   (register-external-file search-script)
   (register-external-file search-merge-script)
   (register-external-file search-context-page))
@@ -119,8 +122,8 @@
                ;; don't index constructors (the class itself is already indexed)
                #:unless (constructor-index-desc? (list-ref i 3)))
       (set! idx (add1 idx))
-      ;; i is (list tag (text ...) (element ...) index-desc)
-      (define-values (tag texts elts desc) (apply values i))
+      ;; i is (list tag (text ...) (element ...) index-desc pkg)
+      (define-values (tag texts elts desc pre-pkg-name) (apply values i))
       (define text (string-downcase (string-join texts)))
       (define-values (href html)
         (let* ([e (add-between elts ", ")]
@@ -177,10 +180,11 @@
              [else
               "\"module\""])]
           [else "false"]))
+      (define pkg-name (if pre-pkg-name (quote-string pre-pkg-name) "false"))
       (and href
            (string-append "[" (quote-string text) ","
                           (quote-string href) ","
-                          html "," from-libs "]"))))
+                          html "," from-libs "," pkg-name "]"))))
   (define l (filter values l-all))
 
   (define user (if user-dir? "user_" ""))
@@ -223,7 +227,17 @@
                                  (string-append (quote-string (car x)) ": "
                                                 (number->string (cdr x))))
                                ms)])
-                 (add-between ms ",\n  "))};
+                 (add-between ms ",\n  "))
+          };
+          @||
+          // an array of (transitive) dependencies of base documentation
+          var plt_base_pkgs = [
+            @,@(add-between (map quote-string (get-base-pkgs)) ",\n  ")
+          ];
+          // an array of (transitive) dependencies of main-distribution
+          var plt_main_dist_pkgs = [
+            @,@(add-between (map quote-string (get-main-dist-pkgs)) ",\n  ")
+          ];
           @||})))
 
   (for ([src (append (list search-script search-context-page)

--- a/pkgs/racket-index/scribblings/main/private/pkg.rkt
+++ b/pkgs/racket-index/scribblings/main/private/pkg.rkt
@@ -1,0 +1,61 @@
+#lang racket/base
+
+(provide get-base-pkgs
+         get-main-dist-pkgs)
+
+(require racket/match
+         racket/set
+         pkg/lib
+         setup/getinfo
+         setup/dirs)
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; get-main-dist-pkgs
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(define base-pkgs #f)
+(define main-dist-pkgs #f)
+(define pkg-cache-for-pkg-directory (make-hash))
+
+(define (get-base-pkgs)
+  (unless base-pkgs
+    (set! base-pkgs (find-pkgs (get-base-documentation-packages))))
+  base-pkgs)
+
+(define (get-main-dist-pkgs)
+  (unless main-dist-pkgs
+    (set! main-dist-pkgs (find-pkgs (get-distribution-documentation-packages)
+                                    #:exclude (list->set (get-base-pkgs)))))
+  main-dist-pkgs)
+
+(define (find-pkgs root-pkg-names #:exclude [excludes (set)])
+  (define result '())
+  (define seen (set-copy excludes))
+  (for ([root-pkg-name (in-list root-pkg-names)])
+    (match (pkg-directory
+            root-pkg-name
+            #:cache pkg-cache-for-pkg-directory)
+      [#f '()]
+      [_
+       (let loop ([pkg root-pkg-name])
+         (unless (set-member? seen pkg)
+           (set-add! seen pkg)
+           (match (pkg-directory pkg #:cache pkg-cache-for-pkg-directory)
+             [#f
+              ;; these are platform dependent packages (like racket-win32-i386-3)
+              ;; they have no deps, and if they are platform dependent,
+              ;; they are not that useful (for documentation search) anyway
+              (set! result (cons pkg result))]
+             [dir
+              (set! result (cons pkg result))
+              (define get-info (get-info/full dir))
+              (define direct-deps
+                (for/list ([dep (extract-pkg-dependencies get-info #:build-deps? #f)])
+                  (match dep
+                    [(? string?) dep]
+                    [(cons dep _) dep])))
+              ;; we need to recur. For example, 2dtabular is in 2d-lib,
+              ;; which is not a direct dep of main-distribution
+              (for ([dep direct-deps])
+                (loop dep))])))]))
+  result)

--- a/pkgs/racket-index/scribblings/main/private/search.css
+++ b/pkgs/racket-index/scribblings/main/private/search.css
@@ -1,0 +1,25 @@
+.search-result-wrapper {
+    display: none;
+    box-sizing: border-box;
+    cursor: help;
+}
+
+/* The following pair of colors are picked to account for color blindness
+ * See https://davidmathlogic.com/colorblind/
+ */
+
+.search-result-wrapper-pkg-base {
+    background-color: #005AB5;
+    padding-right: 5px;
+}
+
+.search-result-wrapper-pkg-main-dist {
+    background-color: #A0CAC5;
+    padding-right: 5px;
+}
+
+.search-result-row {
+    margin: 0.1em 0em;
+    padding: 0.25em 1em;
+    cursor: default;
+}

--- a/pkgs/racket-index/scribblings/main/private/search.js
+++ b/pkgs/racket-index/scribblings/main/private/search.js
@@ -244,9 +244,7 @@ function InitializeSearch() {
 
 function makeProtoSearchResult() {
   var proto_search_result = document.createElement('div');
-  proto_search_result.style.display = 'none';
-  proto_search_result.style.margin = '0.1em 0em';
-  proto_search_result.style.padding = '0.25em 1em';
+  proto_search_result.classList.add('search-result-wrapper');
   return proto_search_result;
 }
 
@@ -552,6 +550,22 @@ function MakeShowProgress() {
   };
 }
 
+function packageCompare(a, b) {
+  var a_is_base = plt_base_pkgs.indexOf(a[4]) >= 0;
+  var b_is_base = plt_base_pkgs.indexOf(b[4]) >= 0;
+  if (a_is_base && b_is_base) return 0;
+  if (a_is_base) return -1;
+  if (b_is_base) return 1;
+
+  var a_in_main = plt_main_dist_pkgs.indexOf(a[4]) >= 0;
+  var b_in_main = plt_main_dist_pkgs.indexOf(b[4]) >= 0;
+  if (a_in_main && b_in_main) return 0;
+  if (a_in_main) return -1;
+  if (b_in_main) return 1;
+
+  return 0;
+}
+
 function Search(data, term, is_pre, K) {
   // `K' is a continuation if this run is supposed to happen in a "thread"
   // false otherwise
@@ -589,6 +603,11 @@ function Search(data, term, is_pre, K) {
     }
     if (i<data.length) t = setTimeout(DoChunk,5);
     else {
+      i = 0;
+      for (i = 0; i < matches.length; i++) {
+        matches[i].sort(packageCompare);
+      }
+
       r = [matches[0].length, [].concat.apply([],matches)];
       if (K) K(r); else return r;
     }
@@ -758,11 +777,28 @@ function UpdateResults() {
         else
           href = href + link_args;
       }
+
       result_links[i].innerHTML =
-        '<a href="' + href + '" class="indexlink" tabIndex="2">'
-        + UncompactHtml(res[2]) + '</a>' + (note || "");
-      result_links[i].style.backgroundColor =
+        '<div title="" class="search-result-row"><a href="' + href
+        + '" class="indexlink" tabIndex="2">'
+        + UncompactHtml(res[2]) + '</a>' + (note || "") + '</div>';
+      result_links[i].classList.remove(
+        'search-result-wrapper-pkg-base',
+        'search-result-wrapper-pkg-main-dist'
+      );
+      if (plt_base_pkgs.indexOf(res[4]) >= 0) {
+        result_links[i].classList.add('search-result-wrapper-pkg-base');
+        result_links[i].title = "from from base language's official documentation";
+      } else if (plt_main_dist_pkgs.indexOf(res[4]) >= 0) {
+        result_links[i].classList.add('search-result-wrapper-pkg-main-dist');
+        result_links[i].title = "from from distribution's official documentation";
+      } else {
+        result_links[i].title = '';
+      }
+
+      result_links[i].firstChild.style.backgroundColor =
         (n < exact_results_num) ? highlight_color : background_color;
+
       result_links[i].style.display = "block";
     } else {
       result_links[i].style.display = "none";

--- a/pkgs/racket-index/scribblings/main/private/utils.rkt
+++ b/pkgs/racket-index/scribblings/main/private/utils.rkt
@@ -42,7 +42,8 @@
 ;; it's missing, then it's a page with a single version
 (define (main-page id [installation-specific? '?]
                    #:force-racket-css? [force-racket-css? #f]
-                   #:show-root-info? [show-root-info? #f])
+                   #:show-root-info? [show-root-info? #f]
+                   #:extra-additions [extra-additions '()])
   (define info (page-info id))
   (define title-string (car info))
   (define root (cadr info))
@@ -65,7 +66,8 @@
                                         null
                                         (list
                                          (make-css-addition (collection-file-path "root-info.css" "scribblings/main/private"))
-                                         (make-js-addition (collection-file-path "root-info.js" "scribblings/main/private")))))))
+                                         (make-js-addition (collection-file-path "root-info.js" "scribblings/main/private"))))
+                                    extra-additions)))
            title-string
            #;
            ;; the "(installation)" part shouldn't be visible on the web, but

--- a/pkgs/racket-index/scribblings/main/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/search.scrbl
@@ -7,7 +7,12 @@
           "private/notice.rkt"
           "config.rkt")
 
-@main-page['search #t]
+@main-page['search #t
+           #:extra-additions
+           (list (make-css-addition
+                  (collection-file-path
+                   "search.css"
+                   "scribblings/main/private")))]
 
 @global-notice
 @local-notice

--- a/pkgs/racket-index/scribblings/main/user/search.scrbl
+++ b/pkgs/racket-index/scribblings/main/user/search.scrbl
@@ -1,11 +1,17 @@
 #lang scribble/doc
-@(require "../private/utils.rkt"
+@(require scribble/html-properties
+          "../private/utils.rkt"
           "../private/make-search.rkt"
           "../private/notice.rkt")
 
 @main-page['search #f
-                   ;; "racket.css" needs to be installed for search results:
-                   #:force-racket-css? #t]
+           ;; "racket.css" needs to be installed for search results:
+           #:force-racket-css? #t
+           #:extra-additions
+           (list (make-css-addition
+                  (collection-file-path
+                   "search.css"
+                   "scribblings/main/private")))]
 
 @local-notice
 

--- a/pkgs/racket-index/setup/scribble.rkt
+++ b/pkgs/racket-index/setup/scribble.rkt
@@ -341,12 +341,14 @@
                     (loop)))))))
 
   (log-setup-info "getting document information")
+  (define pkg-cache (make-hash))
   (define (make-sequential-get-info only-fast?)
     (get-doc-info only-dirs latex-dest
                   avoid-main? auto-main? auto-user? main-doc-exists?
                   with-record-error setup-printf #f 
                   only-fast? force-out-of-date?
-                  no-lock (if gc-after-each-sequential? gc-point void)))
+                  no-lock (if gc-after-each-sequential? gc-point void)
+                  pkg-cache))
   (define num-sequential (let loop ([docs docs])
                            (cond
                             [(null? docs) 0]
@@ -410,11 +412,12 @@
                                           ((error-display-handler) (exn-message exn) exn)
                                           (raise exn))])
                          (go)))
+                     (define pkg-cache (make-hash))
                      (s-exp->fasl (serialize 
                                    ((get-doc-info only-dirs latex-dest
                                                   avoid-main? auto-main? auto-user? main-doc-exists?
                                                   with-record-error setup-printf workerid
-                                                  #f force-out-of-date? lock void)
+                                                  #f force-out-of-date? lock void pkg-cache)
                                     (deserialize (fasl->s-exp doc))))))
                    
                    (verbose verbosev)
@@ -664,7 +667,7 @@
       (for ([info (in-list infos)])
         (when (and (info-need-in-write? info)
                    (not (info-need-run? info)))
-          (write-in/info latex-dest info no-lock main-doc-exists?)
+          (write-in/info latex-dest info no-lock main-doc-exists? pkg-cache)
           (set-info-need-in-write?! info #f)))
       ;; Iterate, if any need to run:
       (when (and (ormap info-need-run? infos) (iter . < . 30) (not only-fast?))
@@ -710,7 +713,7 @@
                 (prep-info! i)
                 (update-info! i (build-again! latex-dest i with-record-error
                                               no-lock (if gc-after-each-sequential? gc-point void)
-                                              main-doc-exists?)))
+                                              main-doc-exists? pkg-cache)))
               (parallel-do
                #:use-places? use-places?
                (min worker-count (length need-rerun))
@@ -748,6 +751,7 @@
                                       (raise x))])
                      (go)))
                  (verbose verbosev)
+                 (define pkg-cache (make-hash))
                  (match-message-loop
                   [info 
                    (send/success 
@@ -755,7 +759,8 @@
                                                           (deserialize (fasl->s-exp info))
                                                           with-record-error
                                                           (lock-via-channel lock-ch) void
-                                                          main-doc-exists?))))])))))
+                                                          main-doc-exists?
+                                                          pkg-cache))))])))))
         ;; If we only build 1, then it reaches it own fixpoint
         ;; even if the info doesn't seem to converge immediately.
         ;; This is a useful shortcut when re-building a single
@@ -774,7 +779,7 @@
     (make-loop #t 0)
     ;; cache info to disk
     (for ([i infos] #:when (info-need-in-write? i))
-      (write-in/info latex-dest i no-lock main-doc-exists?))))
+      (write-in/info latex-dest i no-lock main-doc-exists? pkg-cache))))
 
 (define shared-style-files
   (list "scribble.css"
@@ -790,7 +795,7 @@
 (define shared-empty-script-files
   (list "doc-site.js"))
 
-(define (make-renderer latex-dest doc main-doc-exists?)
+(define (make-renderer latex-dest doc main-doc-exists? pkg-cache)
   (if latex-dest
       (new (latex:render-mixin render%)
            [dest-dir latex-dest]
@@ -812,7 +817,8 @@
               (if multi?
                   contract:override-render-mixin-multi 
                   contract:override-render-mixin-single)]
-             [allow-indirect? (and (doc-pkg? doc)
+             [pkg-cache (doc-pkg doc pkg-cache)]
+             [allow-indirect? (and pkg-cache
                                    ;; (not main?)
                                    (not (memq 'no-depend-on (doc-flags doc))))]
              [local-redirect-file (build-path (if main-doc-exists?
@@ -1042,7 +1048,8 @@
 (define ((get-doc-info only-dirs latex-dest
                        avoid-main? auto-main? auto-user? main-doc-exists?
                        with-record-error setup-printf workerid 
-                       only-fast? force-out-of-date? lock gc-point)
+                       only-fast? force-out-of-date? lock gc-point
+                       pkg-cache)
          doc)
 
   ;; First, move pre-rendered documentation, if any, into place
@@ -1055,7 +1062,7 @@
                    force-out-of-date?
                    (not (file-exists? (build-path (doc-dest-dir doc) "synced.rktd")))))
       (move-documentation-into-place doc rendered-dir setup-printf workerid lock
-                                     main-doc-exists?)))
+                                     main-doc-exists? pkg-cache)))
 
   (let* ([info-out-files (for/list ([i (add1 (doc-out-count doc))])
                            (sxref-path latex-dest doc (format "out~a.sxref" i)))]
@@ -1072,7 +1079,7 @@
                            ;; need to render, so complain if no source is available:
                            path)))]
          [src-sha1 (and src-zo (get-compiled-file-sha1 src-zo))]
-         [renderer (make-renderer latex-dest doc main-doc-exists?)]
+         [renderer (make-renderer latex-dest doc main-doc-exists? pkg-cache)]
          [can-run? (can-build? only-dirs avoid-main? doc)]
          [stamp-data (with-handlers ([exn:fail:filesystem? (lambda (exn) (list "" "" ""))])
                        (let ([v (call-with-input-file* stamp-file read)])
@@ -1172,7 +1179,8 @@
                                       ((get-doc-info only-dirs latex-dest
                                                      avoid-main? auto-main? auto-user? main-doc-exists?
                                                      with-record-error setup-printf workerid 
-                                                     #f #f lock gc-point)
+                                                     #f #f lock gc-point
+                                                     pkg-cache)
                                        doc))])
            (let ([v-in  (load-sxref info-in-file)])
              (unless (equal? (car v-in) (list vers (doc-flags doc)))
@@ -1187,7 +1195,7 @@
                ;; across installations.
                (move-documentation-into-place doc #f
                                               setup-printf workerid lock
-                                              main-doc-exists?))
+                                              main-doc-exists? pkg-cache))
              (define out-hash (get-info-out-hash doc latex-dest))
              (make-info
               doc
@@ -1270,13 +1278,13 @@
                                      #f
                                      #f)])
                      (when need-out-write
-                       (render-time "xref-out" (write-out/info latex-dest info scis defss db-file lock))
+                       (render-time "xref-out" (write-out/info latex-dest info scis defss db-file lock pkg-cache))
                        (set-info-out-hash! info (get-info-out-hash doc latex-dest))
                        (set-info-need-out-write?! info #f)
                        (set-info-done-time! info (current-inexact-milliseconds)))
 
                      (when (info-need-in-write? info)
-                       (render-time "xref-in" (write-in/info latex-dest info lock main-doc-exists?))
+                       (render-time "xref-in" (write-in/info latex-dest info lock main-doc-exists? pkg-cache))
                        (set-info-need-in-write?! info #f))
 
                      (let ([data stamp-sha1s])
@@ -1331,7 +1339,7 @@
     (hash-set! done dir #t)))
 
 (define (move-documentation-into-place doc src-dir setup-printf workerid lock
-                                       main-doc-exists?)
+                                       main-doc-exists? pkg-cache)
   (with-handlers ([exn:fail? (lambda (exn)
                                ;; On any failure, log the error and give up.
                                ;; Maybe further actions are appropriate, but
@@ -1366,15 +1374,16 @@
                            provides-path
                            (lambda (in) (fasl->s-exp in))))
         (define db-file (find-db-file doc #f main-doc-exists?))
+        (define pkg (doc-pkg doc pkg-cache))
         (for ([provides (in-list providess)]
               [n (in-naturals)])
           (define filename (sxref-path #f doc (format "out~a.sxref" n)))
           (call-with-lock
            lock
            (lambda ()
-             (doc-db-clear-provides db-file filename)
-             (doc-db-add-provides db-file provides filename)
-             (doc-db-set-provides-timestamp db-file filename 
+             (doc-db-clear-provides db-file filename #:pkg pkg)
+             (doc-db-add-provides db-file provides filename #:pkg pkg)
+             (doc-db-set-provides-timestamp db-file filename #:pkg pkg
                                             (file-or-directory-modify-seconds filename)))))))
     ;; For each ".html" file, check for a reference to "local-redirect.js",
     ;; and fix up the path if there is a reference:
@@ -1470,7 +1479,7 @@
 
 (define (build-again! latex-dest info-or-list with-record-error
                       lock gc-point
-                      main-doc-exists?)
+                      main-doc-exists? pkg-cache)
   ;; If `info-or-list' is a list, then we're in a parallel build, and
   ;; it provides just enough of `info' from the main place to re-build
   ;; in this place along with the content of "in.sxref".
@@ -1490,7 +1499,7 @@
                 (load-sxref (sxref-path latex-dest doc (format "out~a.sxref" i))))))
   (define info (and (info? info-or-list) info-or-list))
   (define doc (if info (info-doc info) (car info-or-list)))
-  (define renderer (make-renderer latex-dest doc main-doc-exists?))
+  (define renderer (make-renderer latex-dest doc main-doc-exists? pkg-cache))
   (with-record-error
    (doc-src-file doc)
    (lambda ()
@@ -1533,9 +1542,9 @@
          (when (or in-delta?
                    (and info (info-need-in-write? info))
                    (and (not info) (caddr info-or-list)))
-           (render-time "xref-in" (write-in latex-dest vers doc undef ff-deps-rel searches db-file lock)))
+           (render-time "xref-in" (write-in latex-dest vers doc undef ff-deps-rel searches db-file lock pkg-cache)))
          (when out-delta?
-           (render-time "xref-out" (write-out latex-dest vers doc scis defss db-file lock)))
+           (render-time "xref-out" (write-out latex-dest vers doc scis defss db-file lock pkg-cache)))
 
          (cleanup-dest-dir doc)
          (render-time
@@ -1612,11 +1621,12 @@
                       out))))
     (final! filename)))
 
-(define (write-out latex-dest vers doc scis providess db-file lock)
+(define (write-out latex-dest vers doc scis providess db-file lock pkg-cache)
   ;; A "provides.sxref" file is used when a package is converted to binary
   ;; form, in which case cross-reference information needs to be loaded
   ;; into the database at install time:
-  (when (and (doc-pkg? doc)
+  (define pkg (doc-pkg doc pkg-cache))
+  (when (and pkg
              (not (doc-under-main? doc))
              (not latex-dest))
     (make-directory* (doc-dest-dir doc))
@@ -1635,35 +1645,36 @@
               (call-with-lock
                lock
                (lambda ()
-                 (doc-db-clear-provides db-file filename)
-                 (doc-db-add-provides db-file provides filename))))
+                 (doc-db-clear-provides db-file filename #:pkg pkg)
+                 (doc-db-add-provides db-file provides filename #:pkg pkg))))
             (lambda (filename)
               (call-with-lock
                lock
                (lambda ()
                  (doc-db-set-provides-timestamp
-                  db-file filename 
+                  db-file filename #:pkg pkg
                   (file-or-directory-modify-seconds filename))))))))
 
-(define (write-out/info latex-dest info scis providess db-file lock)
-  (write-out latex-dest (info-vers info) (info-doc info) scis providess db-file lock))
+(define (write-out/info latex-dest info scis providess db-file lock pkg-cache)
+  (write-out latex-dest (info-vers info) (info-doc info) scis providess db-file lock pkg-cache))
 
-(define (write-in latex-dest vers doc undef rels searches db-file lock)
+(define (write-in latex-dest vers doc undef rels searches db-file lock pkg-cache)
   (write- latex-dest vers doc "in.sxref" 
           (list (list rels)
                 (list (serialize (list undef
                                        searches))))
           (lambda (filename)
+            (define pkg (doc-pkg doc pkg-cache))
             (call-with-lock
              lock
              (lambda ()
-               (doc-db-clear-dependencies db-file filename)
-               (doc-db-clear-searches db-file filename)
-               (doc-db-add-dependencies db-file undef filename)
-               (doc-db-add-searches db-file searches filename))))
+               (doc-db-clear-dependencies db-file filename #:pkg pkg)
+               (doc-db-clear-searches db-file filename #:pkg pkg)
+               (doc-db-add-dependencies db-file undef filename #:pkg pkg)
+               (doc-db-add-searches db-file searches filename #:pkg pkg))))
           void))
 
-(define (write-in/info latex-dest info lock main-doc-exists?)
+(define (write-in/info latex-dest info lock main-doc-exists? pkg-cache)
   (when (eq? 'delayed (info-undef info))
     (read-delayed-in! info latex-dest))
   (write-in latex-dest
@@ -1673,7 +1684,8 @@
             (info-deps->rel-doc-src-file info)
             (info-searches info)
             (find-db-file (info-doc info) latex-dest main-doc-exists?)
-            lock))
+            lock
+            pkg-cache))
 
 (define (rel->path r)
   (if (bytes? r)
@@ -1719,8 +1731,5 @@
    [else
     (reroot-path base root)]))
 
-
-(define path-pkg-cache (make-hash))
-
-(define (doc-pkg? doc)
-  (and (path->pkg (doc-src-file doc) #:cache path-pkg-cache) #t))
+(define (doc-pkg doc path-pkg-cache)
+  (path->pkg (doc-src-file doc) #:cache path-pkg-cache))

--- a/racket/collects/setup/private/dirs.rkt
+++ b/racket/collects/setup/private/dirs.rkt
@@ -91,6 +91,8 @@
 (define-config config:doc-open-url 'doc-open-url values)
 (define-config config:installation-name 'installation-name values)
 (define-config config:build-stamp 'build-stamp values)
+(define-config config:base-documentation-packages 'base-documentation-packages values)
+(define-config config:distribution-documentation-packages 'distribution-documentation-packages values)
 
 (provide get-absolute-installation?
          get-cgc-suffix
@@ -99,7 +101,9 @@
          get-doc-search-url
          get-doc-open-url
          get-installation-name
-         get-build-stamp)
+         get-build-stamp
+         get-base-documentation-packages
+         get-distribution-documentation-packages)
 
 (define (get-absolute-installation?) (force config:absolute-installation?))
 (define (get-cgc-suffix) (force config:cgc-suffix))
@@ -114,6 +118,13 @@
     [() (force installation-name)]
     [(config) (utils:get-installation-name config)]))
 (define (get-build-stamp) (force config:build-stamp))
+
+(define (get-base-documentation-packages)
+  (or (force config:base-documentation-packages)
+      (list "racket-doc")))
+(define (get-distribution-documentation-packages)
+  (or (force config:distribution-documentation-packages)
+      (list "main-distribution")))
 
 ;; ----------------------------------------
 ;;  "collects"

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 14
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 4
+#define MZSCHEME_VERSION_W 5
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
This is an updated version of #4510. The main difference is that it doesn't try to infer a package from a tag. A package is determined as the package that contains the document, not the defined identifier, which locks things down a little more among documents. It also makes the notion of "base" and "main distribution" configurable via "config.rktd".

Within a group of search results of the same score, search results associated with the base packages will come first, followed by those in main-distribution packages, and then everything else.

Search results also have an additional indicator on the right border, which can be hovered to read the description. This commit changes the indicator colors compared to the original PR, using bright blue and faded blue to reflect an ordering of base -> distro -> other.

Tracking the package that contains a document requires some plumbing in the index-loading machinery, and it triggers a schema change in "docindex.sqlite". If you try this comment and then rewind, discard generated "docindex.sqlite" files.
