### PR TITLE
Refactor vector-count and add an optional argument to vector-member

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/vectors.scrbl
@@ -443,8 +443,10 @@ Locates the first element of @racket[vec] that is equal to @racket[v] according
 @mz-examples[#:eval vec-eval
 (vector-member 2 (vector 1 2 3 4))
 (vector-member 9 (vector 1 2 3 4))
-(vector-member 1 (vector 1 2 3 4) =)
-]}
+(vector-member 1.0 (vector 1 2 3 4) =)
+]
+
+@history[#:changed "8.15.0.1" @elem{Added the @racket[is-equal?] argument.}]}
 
 
 @defproc[(vector-memv [v any/c] [vec vector?])

--- a/pkgs/racket-doc/scribblings/reference/vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/vectors.scrbl
@@ -436,13 +436,14 @@ the result of @racket[proc].
 @defproc[(vector-member [v any/c] [vec vector?])
          (or/c natural-number/c #f)]{
 
-Locates the first element of @racket[vec] that is @racket[equal?] to
- @racket[v]. If such an element exists, the index of that element in
+Locates the first element of @racket[vec] that is equal to @racket[v] according
+ to @racket[is-equal?]. If such an element exists, the index of that element in
  @racket[vec] is returned. Otherwise, the result is @racket[#f].
 
 @mz-examples[#:eval vec-eval
 (vector-member 2 (vector 1 2 3 4))
 (vector-member 9 (vector 1 2 3 4))
+(vector-member 1 (vector 1 2 3 4) =)
 ]}
 
 

--- a/pkgs/racket-doc/scribblings/reference/vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/vectors.scrbl
@@ -433,7 +433,7 @@ the result of @racket[proc].
 }
 
 
-@defproc[(vector-member [v any/c] [vec vector?])
+@defproc[(vector-member [v any/c] [vec vector?] [is-equal? (-> any/c any/c any/c) equal?])
          (or/c natural-number/c #f)]{
 
 Locates the first element of @racket[vec] that is equal to @racket[v] according

--- a/pkgs/racket-test-core/tests/racket/vector.rktl
+++ b/pkgs/racket-test-core/tests/racket/vector.rktl
@@ -290,7 +290,7 @@
 ;; vector-mem{ber,v,q}
 
   (test 0 vector-member 1 #(1 2 3 4) =)
-  (err/rt-test (vector-member 1 #(1 2 3 4) (lambda (a) a)) (check-regs #rx"vector-member" #rx"(-> any/c any/c any/c)"))
+  (err/rt-test (vector-member 1 #(1 2 3 4) (lambda (a) a)) exn:fail:contract? #rx"(-> any/c any/c any/c)")
   (test 0 vector-member 7 #(7 1 2))
   (test #f vector-member 7 #(0 1 2))
   (test 1 vector-memq 'x #(7 x 2))

--- a/pkgs/racket-test-core/tests/racket/vector.rktl
+++ b/pkgs/racket-test-core/tests/racket/vector.rktl
@@ -290,7 +290,7 @@
 ;; vector-mem{ber,v,q}
 
   (test 0 vector-member 1 #(1 2 3 4) =)
-  (err/rt-test (vector-member 1 #(1 2 3 4) (lambda (a) a)) exn:fail:contract? #rx"(-> any/c any/c any/c)")
+  (err/rt-test (vector-member 1 #(1 2 3 4) (lambda (a) a)) exn:fail:contract? #rx"(procedure-arity-includes/c 2)")
   (test 0 vector-member 7 #(7 1 2))
   (test #f vector-member 7 #(0 1 2))
   (test 1 vector-memq 'x #(7 x 2))

--- a/pkgs/racket-test-core/tests/racket/vector.rktl
+++ b/pkgs/racket-test-core/tests/racket/vector.rktl
@@ -289,6 +289,8 @@
 
 ;; vector-mem{ber,v,q}
 
+  (test 0 vector-member 1 #(1 2 3 4) =)
+  (err/rt-test (vector-member 1 #(1 2 3 4) (lambda (a) a)) (check-regs #rx"vector-member" #rx"(-> any/c any/c any/c)"))
   (test 0 vector-member 7 #(7 1 2))
   (test #f vector-member 7 #(0 1 2))
   (test 1 vector-memq 'x #(7 x 2))

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -15,7 +15,7 @@
                   vector-copy vector-append vector-set/copy
                   vector*-copy vector*-append vector*-set/copy
 		  vector-extend vector*-extend)
-         (for-syntax racket/base racket/list)
+         (for-syntax racket/base)
          (rename-in (except-in "private/sort.rkt" sort)
                     [vector-sort! raw-vector-sort!]
                     [vector-sort raw-vector-sort]))
@@ -185,7 +185,8 @@
 (define-syntax (vm-mk stx)
   (syntax-case stx ()
     ((_ name cmp (opt-arg default check contract) ...)
-     (with-syntax (((index ...) (range 2 (+ 2 (length (syntax->datum #'(opt-arg ...)))))))
+     (with-syntax (((index ...) (build-list (length (syntax->datum #'(opt-arg ...)))
+                                            (lambda (n) (+ 2 n)))))
        #'(define (name val vec (opt-arg default) ...)
            (unless (vector? vec)
              (raise-argument-error 'name "vector?" 1 val vec opt-arg ...))

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -107,15 +107,15 @@
   (list->vector (for/list ([i (in-vector v)] #:unless (f i)) i)))
 
 (define (vector-count f v . vs)
+  (define len (varargs-check f v vs 'vector-count #f))
   (if (pair? vs)
-      (let ([len (varargs-check f v vs 'vector-count #f)])
-        (for/fold ([c 0])
-                  ([i (in-range len)]
-                   #:when
-                   (apply f
-                          (unsafe-vector-ref v i)
-                          (map (lambda (v) (unsafe-vector-ref v i)) vs)))
-          (add1 c)))
+      (for/fold ([c 0])
+                ([i (in-range len)]
+                 #:when
+                 (apply f
+                        (unsafe-vector-ref v i)
+                        (map (lambda (v) (unsafe-vector-ref v i)) vs)))
+        (add1 c))
       (for/fold ([cnt 0]) ([i (in-vector v)] #:when (f i))
         (add1 cnt))))
 

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -204,7 +204,7 @@
 (vm-mk vector-member is-equal?
        (is-equal? equal?
         (and (procedure? is-equal?) (procedure-arity-includes? is-equal? 2))
-        "(-> any/c any/c any/c)"))
+        "(procedure-arity-includes/c 2)"))
 (vm-mk vector-memq eq?)
 (vm-mk vector-memv eqv?)
 

--- a/racket/collects/racket/vector.rkt
+++ b/racket/collects/racket/vector.rkt
@@ -15,7 +15,7 @@
                   vector-copy vector-append vector-set/copy
                   vector*-copy vector*-append vector*-set/copy
 		  vector-extend vector*-extend)
-         (for-syntax racket/base)
+         (for-syntax racket/base racket/list)
          (rename-in (except-in "private/sort.rkt" sort)
                     [vector-sort! raw-vector-sort!]
                     [vector-sort raw-vector-sort]))
@@ -107,29 +107,17 @@
   (list->vector (for/list ([i (in-vector v)] #:unless (f i)) i)))
 
 (define (vector-count f v . vs)
-  (unless (procedure? f)
-    (raise-argument-error 'vector-count "procedure?" f))
-  (unless (procedure-arity-includes? f (add1 (length vs)))
-    (raise-arguments-error 'vector-count "mismatch between procedure arity and argument count"
-                           "procedure" f
-                           "expected arity" (add1 (length vs))))
-  (unless (and (vector? v) (andmap vector? vs))
-    (raise-argument-error
-     'vector-count "vector?"
-     (ormap (lambda (x) (and (not (list? x)) x)) (cons v vs))))
   (if (pair? vs)
-    (let ([len (vector-length v)])
-      (if (andmap (lambda (v) (= len (vector-length v))) vs)
+      (let ([len (varargs-check f v vs 'vector-count #f)])
         (for/fold ([c 0])
-            ([i (in-range len)]
-             #:when
-             (apply f
-                    (unsafe-vector-ref v i)
-                    (map (lambda (v) (unsafe-vector-ref v i)) vs)))
-          (add1 c))
-        (raise-arguments-error 'vector-count "all vectors must have same size")))
-    (for/fold ([cnt 0]) ([i (in-vector v)] #:when (f i))
-      (add1 cnt))))
+                  ([i (in-range len)]
+                   #:when
+                   (apply f
+                          (unsafe-vector-ref v i)
+                          (map (lambda (v) (unsafe-vector-ref v i)) vs)))
+          (add1 c)))
+      (for/fold ([cnt 0]) ([i (in-vector v)] #:when (f i))
+        (add1 cnt))))
 
 (define (check-vector/index v n name)
   (unless (vector? v)
@@ -194,19 +182,28 @@
 (define (vector-argmin f xs) (mk-min < 'vector-argmin f xs))
 (define (vector-argmax f xs) (mk-min > 'vector-argmax f xs))
 
-(define-syntax-rule (vm-mk name cmp)
-  (define (name val vec)
-    (unless (vector? vec)
-      (raise-argument-error 'name "vector?" 1 val vec))
-    (let ([sz (unsafe-vector-length vec)])
-      (let loop ([k 0])
-        (cond [(= k sz) #f]
-              [(cmp val
-                    (unsafe-vector-ref vec k))
-               k]
-              [else (loop (unsafe-fx+ 1 k))])))))
+(define-syntax (vm-mk stx)
+  (syntax-case stx ()
+    ((_ name cmp (opt-arg default check contract) ...)
+     (with-syntax (((index ...) (range 2 (+ 2 (length (syntax->datum #'(opt-arg ...)))))))
+       #'(define (name val vec (opt-arg default) ...)
+           (unless (vector? vec)
+             (raise-argument-error 'name "vector?" 1 val vec opt-arg ...))
+           (unless check
+             (raise-argument-error 'name contract index val vec opt-arg ...))
+           ...
+           (let ([sz (unsafe-vector-length vec)])
+             (let loop ([k 0])
+               (cond [(= k sz) #f]
+                     [(cmp val
+                           (unsafe-vector-ref vec k))
+                      k]
+                     [else (loop (unsafe-fx+ 1 k))]))))))))
 
-(vm-mk vector-member equal?)
+(vm-mk vector-member is-equal?
+       (is-equal? equal?
+        (and (procedure? is-equal?) (procedure-arity-includes? is-equal? 2))
+        "(-> any/c any/c any/c)"))
 (vm-mk vector-memq eq?)
 (vm-mk vector-memv eqv?)
 


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Feature
- [x] tests included
- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->

- The `member` function accepts an optional `is-equal?` argument but the `vector-member` function doesn't. So I hope to add this argument to the latter.
- Use the existing `varargs-check` function to check the arguments of `vector-count`.