### PR TITLE
xml,reader: improve performance

### DIFF
--- a/racket/collects/xml/private/reader.rkt
+++ b/racket/collects/xml/private/reader.rkt
@@ -1,7 +1,8 @@
 #lang racket/base
 (require racket/contract/base
          racket/list
-         "structures.rkt")
+         (only-in "structures.rkt" make-document make-prolog)
+         (except-in (submod "structures.rkt" unsafe) make-document make-prolog))
 
 (provide/contract
  [read-xml (() (input-port?) . ->* . document?)]

--- a/racket/collects/xml/private/structures.rkt
+++ b/racket/collects/xml/private/structures.rkt
@@ -28,7 +28,7 @@
 ; Attribute = (make-attribute Location Location Symbol String)
 (define-struct (attribute source) (name value) #:transparent)
 
-; Content = Pcdata  
+; Content = Pcdata
 ;         |  Element
 ;         |  Entity
 ;         |  Misc
@@ -64,6 +64,7 @@
 (define location/c
   (or/c location? symbol? false/c))
 (provide/contract
+ #:unprotected-submodule unsafe
  (struct location ([line (or/c false/c exact-nonnegative-integer?)]
                    [char (or/c false/c exact-nonnegative-integer?)]
                    [offset exact-nonnegative-integer?]))
@@ -81,12 +82,12 @@
  (struct (p-i source) ([start location/c]
                        [stop location/c]
                        [target-name symbol?]
-                       [instruction string?])) 
+                       [instruction string?]))
  [misc/c contract?]
  (struct prolog ([misc (listof misc/c)]
                  [dtd (or/c document-type? false/c)]
                  [misc2 (listof misc/c)]))
- (struct document ([prolog prolog?] 
+ (struct document ([prolog prolog?]
                    [element element?]
                    [misc (listof misc/c)]))
  (struct (element source) ([start location/c]
@@ -100,13 +101,13 @@
                              [value (or/c string? permissive/c)]))
  [permissive-xexprs (parameter/c boolean?)]
  [permissive/c contract?]
- [content/c contract?] 
+ [content/c contract?]
  (struct (pcdata source) ([start location/c]
                           [stop location/c]
                           [string string?]))
  (struct (cdata source) ([start location/c]
                          [stop location/c]
-                         [string string?])) 
+                         [string string?]))
  [valid-char? (any/c . -> . boolean?)]
  (struct (entity source) ([start location/c]
                           [stop location/c]


### PR DESCRIPTION
The KMP implementation turns out to be about 2-3x slower on inputs with long CDATA than this implementation. On short CDATA, this implementation is about 10% better.

Testing on the attached file, the following program:

```racket
#lang racket/base

(require racket/port
         xml)

(define data
  (call-with-input-file "test.xml"
    port->bytes))

(time
 (for ([_ (in-range 100)])
   (call-with-input-bytes data
     read-xml/document)))
```

returns:

```
cpu time: 4160 real time: 4317 gc time: 189
```

on HEAD

and 

```
cpu time: 1482 real time: 1549 gc time: 81
```

on this branch.

[test.xml.zip](https://github.com/user-attachments/files/17270588/test.xml.zip)


