### PR TITLE
Add `open-input-nowhere`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/port-lib.scrbl
@@ -79,7 +79,7 @@ lines like @racket[read-bytes-line].
 The input port is closed unless @racket[close?] is @racket[#f].
 
 @examples[#:eval port-eval
-(port->bytes-lines 
+(port->bytes-lines
  (open-input-string "line 1\nline 2\n  line 3\nline 4"))
 ]
 
@@ -179,9 +179,9 @@ input ports as it becomes available.
 @history[#:changed "6.90.0.19" @elem{Added the @racket[name] argument.}]}
 
 
-@defproc[(make-input-port/read-to-peek 
+@defproc[(make-input-port/read-to-peek
           [name any/c]
-          [read-in (bytes? 
+          [read-in (bytes?
                     . -> . (or/c exact-nonnegative-integer?
                                  eof-object?
                                  procedure?
@@ -200,7 +200,7 @@ input ports as it becomes available.
                                          evt?
                                          #f)))]
           [close (-> any)]
-          [get-location (or/c 
+          [get-location (or/c
                          (->
                           (values
                            (or/c exact-positive-integer? #f)
@@ -215,8 +215,8 @@ input ports as it becomes available.
                              #f)
                        #f]
           [buffering? any/c #f]
-          [on-consumed (or/c ((or/c exact-nonnegative-integer? eof-object? 
-                                    procedure? evt?) 
+          [on-consumed (or/c ((or/c exact-nonnegative-integer? eof-object?
+                                    procedure? evt?)
                               . -> . any)
                              #f)
                        #f])
@@ -279,7 +279,7 @@ contiguous parts of the original port's stream.}
 
 @defproc[(make-pipe-with-specials [limit exact-nonnegative-integer? #f]
                                   [in-name any/c 'pipe]
-                                  [out-name any/c 'pipe]) 
+                                  [out-name any/c 'pipe])
          (values input-port? output-port?)]{
 
 Returns two ports: an input port and an output port. The ports behave
@@ -346,11 +346,22 @@ instead of interleaving them.}
 @index*['("discard-output" "null-output" "null-output-port" "dev-null"
           "/dev/null")
 	'("Opening a null output port")]{
-	
+
 Creates} and returns an output port that discards all output sent to it
 (without blocking). The @racket[name] argument is used as the port's
 name. If the @racket[special-ok?]  argument is true, then the
 resulting port supports @racket[write-special], otherwise it does not.}
+
+
+@defproc[(open-input-nowhere [name any/c 'nowhere])
+         input-port?]{
+@index*['("null-input" "null-input-port" "dev-null"
+          "/dev/null")
+	'("Opening a null input port")]{
+
+Creates} and returns an input port that always returns @racket[eof]
+(without blocking). The @racket[name] argument is used as the port's
+name.}
 
 
 @defproc[(peeking-input-port [in input-port?]
@@ -420,7 +431,7 @@ a result of buffering bytes from @racket[an-original-port] earlier.
                               [close? any/c #f]
                               [name any/c (object-name in)]
                               [convert-newlines? any/c #f]
-                              [enc-error (string? input-port? . -> . any) 
+                              [enc-error (string? input-port? . -> . any)
                                          (lambda (msg port) (error ...))])
          input-port?]{
 
@@ -430,7 +441,7 @@ the byte stream using @racket[(bytes-open-converter encoding-str
 decoded sequences that correspond to UTF-8 encodings of @racket["\r\n"],
 @racket["\r\x85"], @racket["\r"], @racket["\x85"], and @racket["\u2028"]
 are all converted to the UTF-8 encoding of @racket["\n"].
- 
+
 If @racket[error-bytes] is provided and not @racket[#f], then the
 given byte sequence is used in place of bytes from @racket[in] that
 trigger conversion errors.  Otherwise, if a conversion is encountered,
@@ -454,7 +465,7 @@ incomplete encoding sequence.)}
                                [close? any/c #f]
                                [name any/c (object-name out)]
                                [newline-bytes (or/c #f bytes?) #f]
-                               [enc-error (string? output-port? . -> . any) 
+                               [enc-error (string? output-port? . -> . any)
                                           (lambda (msg port) (error ...))])
          output-port?]{
 
@@ -465,7 +476,7 @@ encoding-str)]. In addition, if @racket[newline-bytes] is not
 encoding of @racket["\n"] are first converted to
 @racket[newline-bytes] (before applying the convert from UTF-8 to
 @racket[encoding-str]).
- 
+
 If @racket[error-bytes] is provided and not @racket[#f], then the
 given byte sequence is used in place of bytes that have been sent to the output port
 and that trigger conversion errors. Otherwise, @racket[enc-error] is
@@ -566,7 +577,7 @@ Like @racket[relocate-input-port], but for output ports.}
 
 
 @defproc[(transplant-input-port [in input-port?]
-                                [get-location (or/c 
+                                [get-location (or/c
                                                (->
                                                 (values
                                                  (or/c exact-positive-integer? #f)
@@ -590,7 +601,7 @@ If @racket[count-lines!] is supplied, it is called when line counting
 is enabled for the resulting port. The default is @racket[void].}
 
 @defproc[(transplant-output-port [out output-port?]
-                                 [get-location (or/c 
+                                 [get-location (or/c
                                                 (->
                                                  (values
                                                   (or/c exact-positive-integer? #f)
@@ -631,7 +642,7 @@ Like @racket[transplant-input-port], but for output ports.}
          input-port?]{
 
 Creates a port that draws from @racket[in], but each result from the
-port's read and peek procedures (in the sense of @racket[make-input-port]) 
+port's read and peek procedures (in the sense of @racket[make-input-port])
 is filtered by @racket[read-wrap] and
 @racket[peek-wrap]. The filtering procedures each receive both the
 arguments and results of the read and peek procedures on @racket[in]
@@ -642,9 +653,9 @@ closes @racket[in].}
 
 
 @defproc[(special-filter-input-port [in input-port?]
-                                    [proc (procedure? bytes? . -> . (or/c exact-nonnegative-integer? 
+                                    [proc (procedure? bytes? . -> . (or/c exact-nonnegative-integer?
                                                                           eof-object?
-                                                                          procedure? 
+                                                                          procedure?
                                                                           evt?))]
                                     [close? any/c #t])
           input-port?]{
@@ -687,7 +698,7 @@ raises an exception first.
                                    background thread.}]}
 
 
-@defproc[(read-bytes-evt [k exact-nonnegative-integer?] [in input-port?]) 
+@defproc[(read-bytes-evt [k exact-nonnegative-integer?] [in input-port?])
          evt?]{
 
 Returns a @tech{synchronizable event} that is ready when @racket[k]
@@ -740,7 +751,7 @@ Exceptions attempting to read from @racket[in] are handled in the same
 way as by @racket[eof-evt].}
 
 
-@defproc[(read-bytes-avail!-evt [bstr (and/c bytes? (not/c immutable?))] [in input-port?]) 
+@defproc[(read-bytes-avail!-evt [bstr (and/c bytes? (not/c immutable?))] [in input-port?])
          evt?]{
 
 Like @racket[read-bytes!-evt], except that the event reads only as
@@ -748,7 +759,7 @@ many bytes as are immediately available, after at least one byte or
 one @racket[eof] becomes available.}
 
 
-@defproc[(read-string-evt [k exact-nonnegative-integer?] [in input-port?]) 
+@defproc[(read-string-evt [k exact-nonnegative-integer?] [in input-port?])
          evt?]{
 
 Like @racket[read-bytes-evt], but for character strings instead of
@@ -756,7 +767,7 @@ byte strings.}
 
 
 @defproc[(read-string!-evt [str (and/c string? (not/c immutable?))]
-                           [in input-port?]) 
+                           [in input-port?])
          evt?]{
 
 Like @racket[read-bytes!-evt], but for a character string instead of
@@ -784,7 +795,7 @@ way as by @racket[eof-evt].}
 @defproc[(read-bytes-line-evt [in input-port?]
                               [mode (or/c 'linefeed 'return 'return-linefeed 'any 'any-one) 'linefeed])
          evt?]{
- 
+
 Like @racket[read-line-evt], but returns a byte string instead of a
 string.}
 

--- a/pkgs/racket-test-core/tests/racket/port.rktl
+++ b/pkgs/racket-test-core/tests/racket/port.rktl
@@ -147,7 +147,7 @@
 ;; A port with no input...
 ;; Easy: \scheme{(open-input-bytes #"")}
 ;; Hard:
-(define /dev/null-in 
+(define /dev/null-in
   (make-input-port 'null
 		   (lambda (s) eof)
 		   (lambda (skip s progress-evt) eof)
@@ -190,18 +190,18 @@
   (test stubborn-infinite-ones sync/timeout 0 stubborn-infinite-ones))
 
 ;; A port that produces a stream of 1s:
-(define infinite-ones 
+(define infinite-ones
   (make-input-port
    'ones
-   (lambda (s) 
+   (lambda (s)
      (bytes-set! s 0 (char->integer #\1)) 1)
    #f
    void))
 (test "11111" read-string 5 infinite-ones)
 
 ;; An infinite stream of 1s with a specific peek procedure:
-(define infinite-ones 
-  (let ([one! (lambda (s) 
+(define infinite-ones
+  (let ([one! (lambda (s)
 	        (bytes-set! s 0 (char->integer #\1)) 1)])
     (make-input-port
      'ones
@@ -261,7 +261,7 @@
 	(cons (car l) (remq v (cdr l)))))
   ;; ----------------------------------------
   ;; The server has a list of outstanding commit requests,
-  ;;  and it also must service each port operation (read, 
+  ;;  and it also must service each port operation (read,
   ;;  progress-evt, etc.)
   (define (serve commit-reqs response-evts)
     (apply
@@ -291,11 +291,11 @@
 	;; Add an event to respond:
 	(serve commit-reqs
 	       (cons (choice-evt nack
-				 (channel-put-evt ch (if nothing? 
+				 (channel-put-evt ch (if nothing?
 							 #f
 							 (if closed? 0 1))))
 		     response-evts)))))
-  ;; Progress request: send a peek evt for the current 
+  ;; Progress request: send a peek evt for the current
   ;;  progress-sema
   (define ((handle-progress commit-reqs response-evts) r)
     (let ([ch (car r)]
@@ -327,7 +327,7 @@
       ;;  known, but we could send an exception in that case.
       (choice-evt
        (handle-evt progress-evt
-		   (lambda (x) 
+		   (lambda (x)
 		     (sync nack (channel-put-evt ch #f))
 		     (serve (remq r commit-reqs) response-evts)))
        ;; Only create an event to satisfy done-evt if progress-evt
@@ -418,13 +418,13 @@
 	[progress-evt (port-progress-evt mod3-cycle)])
     (test 1 peek-bytes-avail! s 0 progress-evt mod3-cycle)
     (test #"1" values s)
-    (test #t 
+    (test #t
 	  port-commit-peeked 1 progress-evt (make-semaphore 1)
 	  mod3-cycle)
     (test #t evt? (sync/timeout 0 progress-evt))
     (test 0 peek-bytes-avail! s 0 progress-evt mod3-cycle)
-    (test #f 
-	  port-commit-peeked 1 progress-evt (make-semaphore 1) 
+    (test #f
+	  port-commit-peeked 1 progress-evt (make-semaphore 1)
 	  mod3-cycle))
   (close-input-port mod3-cycle))
 
@@ -475,14 +475,14 @@
 (define should-be-breakable? #t)
 
 (define /dev/null-out
-  (make-output-port 
+  (make-output-port
    'null
    always-evt
    (lambda (s start end non-block? breakable?)
      (test should-be-breakable? 'breakable breakable?)
      (- end start))
    void
-   (lambda (special non-block? breakable?) 
+   (lambda (special non-block? breakable?)
      (test should-be-breakable? 'spec-breakable breakable?)
      #t)
    (lambda (s start end) (wrap-evt
@@ -522,7 +522,7 @@
 ;;  but not in a thread-safe way:
 (define accum-list null)
 (define accumulator/not-thread-safe
-  (make-output-port 
+  (make-output-port
    'accum/not-thread-safe
    always-evt
    (lambda (s start end non-block? breakable?)
@@ -537,7 +537,7 @@
 
 ;; Same as before, but with simple thread-safety:
 (define accum-list null)
-(define accumulator 
+(define accumulator
   (let* ([lock (make-semaphore 1)]
 	 [lock-peek-evt (semaphore-peek-evt lock)])
     (make-output-port
@@ -698,7 +698,7 @@
     (test-values '(2 0 2) (lambda () (port-next-location double)))
     (test-values '(#f #f #f) (lambda () (port-next-location none)))
     (err/rt-test (port-next-location bad) exn:fail:contract:arity?)
-    
+
     (test 'Hello read plain)
     (test 'Hello read double)
     (test 'Hello read none)
@@ -733,7 +733,7 @@
       (test #f syntax-column stx)
       (test #f syntax-position stx))
     (err/rt-test (read-syntax #f bad) exn:fail:contract:arity?)
-    
+
     (test-values '(3 6 14) (lambda () (port-next-location plain)))
     (test-values '(6 12 28) (lambda () (port-next-location double)))
     (test-values '(#f #f #f) (lambda () (port-next-location none)))
@@ -908,8 +908,8 @@
   (try peek-char)
   (try (lambda (x) (read-bytes-avail! (make-bytes 10) x)))
   (try (lambda (x) (read-bytes-avail!/enable-break (make-bytes 10) x)))
-  (parameterize-break 
-   #f 
+  (parameterize-break
+   #f
    (try (lambda (x) (read-bytes-avail!/enable-break (make-bytes 10) x)))))
 
 ;; Check nonblock? and break? interaction (again):
@@ -961,12 +961,12 @@
   (test i2 sync/timeout 0 i2)
   (test #"01234" read-bytes 5 i2)
   (test 0 read-bytes-avail!* (make-bytes 3) i2)
-  (thread (lambda () 
+  (thread (lambda ()
             (sync (system-idle-evt))
             (write-bytes #"5" o2)))
   (test #\5 read-char i2)
   (let ([s (make-bytes 6)])
-    (thread (lambda () 
+    (thread (lambda ()
               (sync (system-idle-evt))
               (test 5 write-bytes-avail #"6789ab" o2)))
     (test 5 read-bytes-avail! s i2)
@@ -984,7 +984,7 @@
                                    never-evt)
                                  void)]
             [t (current-thread)])
-        (thread (lambda () 
+        (thread (lambda ()
                   (sync (system-idle-evt))
                   (break-thread t)))
         (with-handlers ([exn:break? (lambda (exn) 'ok)])
@@ -1006,7 +1006,7 @@
            (port-commit-peeked 3 (port-progress-evt in) always-evt in)
            (test (+ d 3) file-position in)
            (let-values ([(l2 c2 p2) (port-next-location in)])
-             (test (list l (and c (+ c char-len)) (+ p (if c char-len 3))) 
+             (test (list l (and c (+ c char-len)) (+ p (if c char-len 3)))
                    list l2 c2 p2))
            (test #\4 read-char in)))])
   (define (check-all count-lines!)
@@ -1031,7 +1031,7 @@
     (let ()
       (call-in-temporary-directory
        (lambda ()
-         (with-output-to-file "tmp8" 
+         (with-output-to-file "tmp8"
            #:exists 'truncate/replace
            (lambda () (display "12345")))
          (define in (open-input-file "tmp8"))
@@ -1111,7 +1111,7 @@
     (test eof read-byte i)
     (test 1 file-position i))
   (check read-byte)
-  (check (lambda (i) 
+  (check (lambda (i)
            (define c (read-char i))
            (if (char? c)
                (char->integer c)
@@ -1167,7 +1167,7 @@
     (close-input-port ifile))
 
   (let* ([bs (call-with-input-file path
-	       #:mode 'text 
+	       #:mode 'text
 	       (lambda (p) (read-bytes (file-size path) p)))])
     ;; Check text-mode conversion at every boundary:
     (for ([i (in-range (add1 (bytes-length bs)))])
@@ -1219,7 +1219,7 @@
 ;; (because `read` may cheat internally with a private "unget")
 
 (let ()
-  (define p 
+  (define p
     (let ([in (open-input-string "(…)abcdef")])
       (make-input-port
        "unicode"
@@ -1308,6 +1308,18 @@
   (define str (make-string 10))
   (test 5 peek-string! str 0 in)
   (test "hello" substring str 0 5))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+
+(parameterize ([current-input-port (open-input-nowhere)])
+  (test eof read)
+  (test eof read-char)
+  (test eof read-byte)
+  (test eof read-line)
+  (test eof read-char-or-special))
+
+(test 'nowhere object-name (open-input-nowhere))
+(test 'apple   object-name (open-input-nowhere 'apple))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/racket/collects/racket/port.rkt
+++ b/racket/collects/racket/port.rkt
@@ -28,6 +28,7 @@
 
          ;; `mzlib/port` exports
          open-output-nowhere
+         open-input-nowhere
          make-pipe-with-specials
          make-input-port/read-to-peek
          peeking-input-port
@@ -732,7 +733,7 @@
      (let ([delta (- pos (or (file-position* p) pos))])
        (if (= delta 1)
            p
-           (lambda () 
+           (lambda ()
              (define v (file-position* p))
              (+ delta v))))
      (case-lambda
@@ -1143,13 +1144,13 @@
       (make-input-port
        (object-name port)
        (lambda (str)
-         (call-with-semaphore 
+         (call-with-semaphore
           lock-semaphore
           do-read
           try-again
           str))
        (lambda (str skip progress-evt)
-         (call-with-semaphore 
+         (call-with-semaphore
           lock-semaphore
           do-peek
           try-again
@@ -1160,7 +1161,7 @@
        (and (port-provides-progress-evts? port)
             (lambda () (port-progress-evt port)))
        (and (port-provides-progress-evts? port)
-            (lambda (n evt target-evt) 
+            (lambda (n evt target-evt)
               (let loop ()
                 (if (semaphore-try-wait? lock-semaphore)
                     (let ([ok? (port-commit-peeked n evt target-evt port)])
@@ -1245,11 +1246,11 @@
     ;; Beware that the input port might become closed at any time.
     ;; For the most part, progress evts should take care of that.
     (let try-again ([pos 0] [bstr orig-bstr] [progress-evt #f])
-      (let* ([progress-evt 
+      (let* ([progress-evt
               ;; if no progress event is given, get one to ensure that
               ;; consecutive bytes are read and can be committed:
               (or progress-evt prog-evt (port-progress-evt input-port))]
-             [v (and 
+             [v (and
                  ;; to implement weak support for reusing the buffer in `read-bytes!-evt',
                  ;; need to check nack after getting progress-evt:
                  (not (sync/timeout 0 nack))

--- a/racket/collects/racket/private/port.rkt
+++ b/racket/collects/racket/private/port.rkt
@@ -33,13 +33,7 @@
 
 (define open-input-nowhere
   (lambda ([name 'nowhere])
-    (make-input-port name
-                     (lambda (s) eof)
-                     (lambda (skip s progress-evt) eof)
-                     void
-                     (lambda () never-evt)
-                     (lambda (k progress-evt done-evt)
-                       (error "no successful peeks!")))))
+    (open-input-bytes #"" name)))
 
 (define (transplant-to-relocate transplant p line col pos close? name)
   (let-values ([(init-l init-c init-p) (port-next-location p)])

--- a/racket/collects/racket/private/port.rkt
+++ b/racket/collects/racket/private/port.rkt
@@ -9,6 +9,7 @@
 
 (provide copy-port
          open-output-nowhere
+         open-input-nowhere
          relocate-output-port
          transplant-output-port
          transplant-to-relocate)
@@ -29,6 +30,16 @@
      (and specials-ok?
           (lambda (special)
             (wrap-evt always-evt (lambda (x) #t)))))))
+
+(define open-input-nowhere
+  (lambda ([name 'nowhere])
+    (make-input-port name
+                     (lambda (s) eof)
+                     (lambda (skip s progress-evt) eof)
+                     void
+                     (lambda () never-evt)
+                     (lambda (k progress-evt done-evt)
+                       (error "no successful peeks!")))))
 
 (define (transplant-to-relocate transplant p line col pos close? name)
   (let-values ([(init-l init-c init-p) (port-next-location p)])


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Feature
- [x] tests included
- [x] documentation

### Description of change
Adds `open-input-nowhere`, an `input-port?` analogue of `open-output-nowhere` requested in issue #4730. Basic benchmarking informed the use of `(open-input-bytes #"")` for the implementation, but I'd appreciate help getting this up to mainline standards—I'm no expert.