### PR TITLE
Improve the error message of bytes-append* and fix bytes-join

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/bytes.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/bytes.scrbl
@@ -701,7 +701,7 @@ one between @racket[list] and @racket[list*].
 @defproc[(bytes-join [strs (listof bytes?)] [sep bytes?]) bytes?]{
 
 Appends the byte strings in @racket[strs], inserting @racket[sep] between
-each pair of bytes in @racket[strs].
+each pair of bytes in @racket[strs]. A new mutable byte string is returned.
 
 @mz-examples[#:eval string-eval
  (bytes-join '(#"one" #"two" #"three" #"four") #" potato ")

--- a/pkgs/racket-test-core/tests/racket/bytes.rktl
+++ b/pkgs/racket-test-core/tests/racket/bytes.rktl
@@ -5,13 +5,23 @@
 
 (require racket/bytes)
 
+;; ---------- bytes-append* ----------
+(err/rt-test (bytes-append* (vector)) exn:fail:contract? #rx"(listof bytes?)")
+(err/rt-test (bytes-append* (list "a")) exn:fail:contract? #rx"(listof bytes?)")
+(err/rt-test (bytes-append* "a" (list #"b")) exn:fail:contract? #rx"bytes?")
+(err/rt-test (bytes-append*) exn:fail:contract? #rx"arity mismatch")
+(test #"abc" bytes-append* #"a" #"b" (list #"c"))
+
 ;; ---------- bytes-join ----------
 (let ()
   (test #""    bytes-join '() #" ")
   (test #""    bytes-join '(#"") #" ")
   (test #" "   bytes-join '(#"" #"") #" ")
   (test #"x y" bytes-join '(#"x" #"y") #" ")
-  (test #"x"   bytes-join '(#"x") #" "))
+  (test #"x"   bytes-join '(#"x") #" ")
+  (let ((s #"abcd"))
+    (test #f eq? (bytes-join (list s) #" ") s)
+    (test #t bytes=? (bytes-join (list s) #" ") s)))
 
 
 (report-errs)


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [x] Feature
- [x] tests included
- [x] documentation

### Description of change

1. Check the arguments of `bytes-append*`.
2. It would be better if `bytes-join` always returns a newly allocated mutable byte string, just like `bytes-append`.