### PR TITLE
Change treelist/c to never be lazy by default

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -705,11 +705,7 @@ necessarily @racket[eq?] to the input.
 
 @defproc[(treelist/c [ctc contract?]
                      [#:flat? flat? any/c (flat-contract? ctc)]
-                     [#:lazy? lazy? any/c
-                      (cond
-                        [(flat-contract? ctc) #f]
-                        [(chaperone-contract? ctc) #t]
-                        [else #f])])
+                     [#:lazy? lazy? any/c #f])
          contract?]{
 
  Produces a contract for @tech{treelists} whose elements
@@ -722,11 +718,11 @@ necessarily @racket[eq?] to the input.
  If @racket[lazy?] is a true value, then @racket[ctc] must
  be a @tech{chaperone contract} and the resulting contract
  will be a chaperone contract. In that situation, the
- contracts on the elements of the tree list are not checked
+ contracts on the elements of the treelist are not checked
  until the values are accessed.
 
  If both @racket[flat?] and @racket[lazy?] are @racket[#f],
- then the contract will copy the tree list as part of the
+ then the contract will copy the treelist as part of the
  process of checking the contract and the result will be
  a @tech{chaperone contract} if @racket[ctc] is a
  chaperone contract.
@@ -744,7 +740,10 @@ necessarily @racket[eq?] to the input.
               (treelist/c natural?)
               (treelist -1 -2 -3)))]
 
-@history[#:added "8.12.0.7"]
+@history[#:added "8.12.0.7"
+         #:changed "8.15.0.2" @elem{Changed the default value of @racket[lazy?]
+           from @racket[(and (chaperone-contract? ctc) (not (flat-contract? ctc)))]
+           to @racket[#f].}]
 }
 
 @defproc[(mutable-treelist/c [ctc contract?])

--- a/racket/collects/racket/contract/private/treelist.rkt
+++ b/racket/collects/racket/contract/private/treelist.rkt
@@ -16,11 +16,7 @@
 (define/subexpression-pos-prop (treelist/c
                                 ctc
                                 #:flat? [flat? (flat-contract? ctc)]
-                                #:lazy? [lazy?
-                                         (cond
-                                           [(flat-contract? ctc) #f]
-                                           [(chaperone-contract? ctc) #t]
-                                           [else #f])])
+                                #:lazy? [lazy? #f])
   (when (and flat? lazy?)
     (raise-arguments-error
      'treelist/c


### PR DESCRIPTION
For the reasons described in https://github.com/racket/racket/issues/4922#issuecomment-2408449144, I believe the current default behavior of `treelist/c` when given a chaperone contract is a very bad idea. To summarize the points from that comment:

* The overhead of the bookkeeping used by lazy `treelist/c` to track which elements belong to the original treelist is substantial, and the effect compounds if the treelist repeatedly crosses a contract boundary.

* The overhead is surprising and challenging to reason about. There are no other contracts that work this way, and the costs are not documented.

* Making laziness the default exclusively for non-flat chaperone contracts feels extremely arbitrary. It also adds to the surprise, as I doubt most users of the contract system are consciously thinking about which contracts are flat and which ones are not, while even fewer are thinking about which contracts are chaperone contracts and which require impersonators.

This change does technically change behavior of existing programs. However, I doubt that many (if any?) users are intentionally relying on the current behavior. Moreover, if the behavior is to be changed, doing it sooner rather than later seems wise.