### PR TITLE
db: Improve `prepare` to properly handle virtual statements

### DIFF
--- a/racket/collects/db/private/generic/functions.rkt
+++ b/racket/collects/db/private/generic/functions.rkt
@@ -159,8 +159,9 @@
 ;; == Prepare
 
 (define (prepare c stmt)
-  ;; FIXME: handle non-string statements
-  (prepare1 'prepare c stmt #f))
+  (if (virtual-statement? stmt)
+      ((prop:statement-ref stmt) stmt c)
+      (prepare1 'prepare c stmt #f)))
 
 (define (prepare1 fsym c stmt close-on-exec?)
   ;; stmt is string


### PR DESCRIPTION
The `prepare` function is documented and contracted as accepting virtual statements, but the implementation did not handle them, resulting in an internal error. Fortunately, handling them is an easy fix.

Docs and tests for this change are in `db-doc` and `db-test` and are therefore in a separate racket/db#33 pull request.