### PR TITLE
Correct link in Numbers doc

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -950,7 +950,7 @@ state space of practically 192 bits.
 When security is a concern, use @racket[crypto-random-bytes]
 instead of @racket[random].
 
-The @racketmodname[racket/math #:indirect] library provides @seclink[
+The @racketmodname[math/base #:indirect] library provides @seclink[
  #:indirect? #t #:doc '(lib "math/scribblings/math.scrbl") "Random_Number_Generation"]{
   additional functions for random number generation}
 without the limit of @racket[4294967087].


### PR DESCRIPTION
The docs say `racket/math` provide functions for generating random numbers without the limits of `random` and links to `racket/math`, however, `racket/math` doesn't provide these functions (nor it is mentioned in its docs).  The correct module to link to is `math/base`.

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->

Update docs of `random` to point to `math/base`.