### PR TITLE
docs: provide example for the `call/cont` / `call/cc` comparison

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/control.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/control.scrbl
@@ -213,18 +213,18 @@ changing @racket[0] to grab the continuation before returning 0:
 @interaction[
 #:eval cc-eval
 (define saved-k #f)
-(define (save-it!)
+(define (save-comp!)
   (call-with-composable-continuation
    (lambda (k) (code:comment @#,t{@racket[k] is the captured continuation})
      (set! saved-k k)
      0)))
-(+ 1 (+ 1 (+ 1 (save-it!))))
+(+ 1 (+ 1 (+ 1 (save-comp!))))
 ]
 
 The @tech{continuation} saved in @racket[saved-k] encapsulates the
 program context @racket[(+ 1 (+ 1 (+ 1 _?)))], where @racket[_?]
 represents a place to plug in a result value---because that was the
-expression context when @racket[save-it!] was called. The
+expression context when @racket[save-comp!] was called. The
 @tech{continuation} is encapsulated so that it behaves like the
 function @racket[(lambda (v) (+ 1 (+ 1 (+ 1 v))))]:
 
@@ -243,7 +243,7 @@ not syntactically. For example, with
 #:eval cc-eval
 (define (sum n)
   (if (zero? n)
-      (save-it!)
+      (save-comp!)
       (+ n (sum (sub1 n)))))
 (sum 5)
 ]
@@ -262,15 +262,31 @@ A more traditional continuation operator in Racket (or Scheme) is
 @racket[call/cc]. It is like
 @racket[call-with-composable-continuation], but applying the captured
 continuation first @tech{aborts} (to the current @tech{prompt}) before
-restoring the saved continuation. In addition, Scheme systems
-traditionally support a single prompt at the program start, instead of
-allowing new prompts via
-@racket[call-with-continuation-prompt]. Continuations as in Racket
-are sometimes called @deftech{delimited continuations}, since a
-program can introduce new delimiting prompts, and continuations as
-captured by @racket[call-with-composable-continuation] are sometimes
-called @deftech{composable continuations}, because they do not have a
-built-in @tech{abort}.
+restoring the saved continuation.
+
+@interaction[
+#:eval cc-eval
+(+ 1 (+ 1 (+ 1 (save-comp!))))
+(+ 1 (saved-k 0))
+(define (save-cc!)
+  (call-with-current-continuation
+   (lambda (k) (code:comment @#,t{@racket[k] is the captured continuation})
+     (set! saved-k k)
+     0)))
+(+ 1 (+ 1 (+ 1 (save-cc!))))
+(+ 1 (saved-k 0))
+]
+
+Other Scheme systems traditionally support a single prompt at the program
+start, instead of allowing new prompts via
+@racket[call-with-continuation-prompt].
+
+Continuations as in Racket are sometimes called
+@deftech{delimited continuations}, since a program can introduce new
+delimiting prompts, and continuations as captured by
+@racket[call-with-composable-continuation] are sometimes called
+@deftech{composable continuations}, because they do not have a built-in
+@tech{abort}.
 
 For an example of how @tech{continuations} are useful, see
 @other-manual['(lib "scribblings/more/more.scrbl")]. For specific


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist

- [x] documentation

### Description of change

This adds a short example to the page in the Racket Guide on continuations, to showcase the difference between `call/comp` and `call/cc`. I didn't understand what the page meant at first glance, and understood better after trying this out in the REPL, so thought it might be helpful to have immediately on the page itself.

I didn't see anything about a formatter in `build.md` or `contributing.md`, so I formatted things to a best-effort.

(feel free to directly edit as desired)
