### PR TITLE
More treelist utility functions

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -347,6 +347,107 @@ found, the result is @racket[#f]. For a constant-time
 (treelist-find items symbol?)
 ]}
 
+@defproc[(treelist-index-of [tl treelist?]
+                            [v any/c]
+                            [eql? (any/c any/c . -> . any/c) equal?])
+         (or/c exact-nonnegative-integer? #f)]{
+
+Returns the index of the first element in @racket[tl] that is
+@racket[eql?] to @racket[v].
+If no such element is found, the result is @racket[#f].
+
+@examples[
+#:eval the-eval
+(define items (treelist 1 "a" 'apple))
+(treelist-index-of items 1)
+(treelist-index-of items "a")
+(treelist-index-of items 'apple)
+(treelist-index-of items 'unicorn)
+]}
+
+@defproc[(treelist-index-where [tl treelist?] [pred (any/c . -> . any/c)])
+         (or/c exact-nonnegative-integer? #f)]{
+
+Returns the index of the first element in @racket[tl] where applying
+@racket[pred] to the element produces a true value.
+If no such element is found, the result is @racket[#f].
+
+@examples[
+#:eval the-eval
+(define items (treelist 1 "a" 'apple))
+(treelist-index-where items number?)
+(treelist-index-where items string?)
+(treelist-index-where items symbol?)
+(treelist-index-where items void?)
+]}
+
+@defproc[(treelist-splitf [tl treelist?] [pred (any/c . -> . any/c)])
+         (values treelist? treelist?)]{
+
+Splits @racket[tl] into 2 treelists returned as values.
+The first treelist contains elements taken successivly from @racket[tl]
+as long as they satisfy @racket[pred].
+The second treelist the rest of the elements of @racket[tl], from the
+first element not satisfying @racket[pred] and onward.
+
+@examples[
+#:eval the-eval
+(treelist-splitf (treelist 2 4 5 8) even?)
+(treelist-splitf (treelist 2 4 5 8) odd?)
+(treelist-splitf (treelist 2 4 6 8) even?)
+(treelist-splitf (treelist 2 4 6 8) odd?)
+]}
+
+@defproc[(treelist-keep-members [tl treelist?]
+                                [other-tl treelist?]
+                                [eql? (any/c any/c . -> . any/c) equal?])
+         treelist?]{
+
+Produces a treelist with only members of @racket[tl] that are also
+members of @racket[other-tl], according to @racket[eql?].
+
+@examples[
+#:eval the-eval
+(treelist-keep-members (treelist 1 2 3 2 4 5 2) (treelist 2 1))
+(treelist-keep-members (treelist 1 2 3 2 4 5 2) (treelist 4 3 5))
+]}
+
+@defproc[(treelist-skip-members [tl treelist?]
+                                [other-tl treelist?]
+                                [eql? (any/c any/c . -> . any/c) equal?])
+         treelist?]{
+
+Produces a treelist with only members of @racket[tl] that are not
+members of @racket[other-tl], according to @racket[eql?].
+
+@examples[
+#:eval the-eval
+(treelist-skip-members (treelist 1 2 3 2 4 5 2) (treelist 4 3 5))
+(treelist-skip-members (treelist 1 2 3 2 4 5 2) (treelist 2 1))
+]}
+
+@defproc[(treelist-flatten [v any/c]) treelist?]{
+
+Flattens a tree of nested treelists into a single treelist.
+
+@examples[
+#:eval the-eval
+(treelist-flatten
+ (treelist (treelist "a") "b" (treelist "c" (treelist "d") "e") (treelist)))
+(treelist-flatten "a")
+]}
+
+@defproc[(treelist-flatten-once [tlotl (treelist/c treelist?)]) treelist?]{
+
+Flattens a treelist of treelists one level down into a treelist,
+leaving any further nested treelists alone.
+
+@examples[
+#:eval the-eval
+(treelist-flatten-once
+ (treelist (treelist "a" "b") (treelist "c" (treelist "d") "e") (treelist)))
+]}
+
 @defproc[(treelist-sort [tl treelist?]
                         [less-than? (any/c any/c . -> . any/c)]
                         [#:key key (or/c #f (any/c . -> . any/c)) #f]

--- a/pkgs/racket-test-core/tests/racket/treelist.rktl
+++ b/pkgs/racket-test-core/tests/racket/treelist.rktl
@@ -56,6 +56,9 @@
                                                                       (regexp-quote (symbol->string 'op))
                                                                       ":"))))
 
+(define-syntax-rule (test-values expected actual)
+  (test (call-with-values (λ () expected) list) call-with-values (λ () actual) list))
+
 (define small-treelist (treelist 0 "a" 'b '#:c))
 (define (treelist-tests small-treelist)
   (test #f treelist-empty? small-treelist)
@@ -102,6 +105,56 @@
   (test "a" treelist-find small-treelist string?)
   (test '#:c treelist-find small-treelist keyword?)
   (test #f treelist-find small-treelist list?)
+
+  (test 0 treelist-index-of small-treelist 0)
+  (test 1 treelist-index-of small-treelist "a")
+  (test 2 treelist-index-of small-treelist 'b)
+  (test 3 treelist-index-of small-treelist '#:c)
+  (test #f treelist-index-of small-treelist 'x)
+  (test 0 treelist-index-where small-treelist number?)
+  (test 1 treelist-index-where small-treelist string?)
+  (test 2 treelist-index-where small-treelist symbol?)
+  (test 3 treelist-index-where small-treelist keyword?)
+  (test #f treelist-index-where small-treelist void?)
+
+  (test-values (values (treelist 0) (treelist "a" 'b '#:c))
+               (treelist-splitf small-treelist number?))
+  (test-values (values empty-treelist small-treelist)
+               (treelist-splitf small-treelist string?))
+  (test-values (values (treelist 2 4) (treelist 5 8))
+               (treelist-splitf (treelist 2 4 5 8) even?))
+  (test-values (values empty-treelist (treelist 2 4 5 8))
+               (treelist-splitf (treelist 2 4 5 8) odd?))
+  (test-values (values (treelist 2 4 6 8) empty-treelist)
+               (treelist-splitf (treelist 2 4 6 8) even?))
+  (test-values (values empty-treelist (treelist 2 4 6 8))
+               (treelist-splitf (treelist 2 4 6 8) odd?))
+
+  (test (treelist 1 2 2 2)
+        treelist-keep-members
+        (treelist 1 2 3 2 4 5 2)
+        (treelist 2 1))
+  (test (treelist 3 4 5)
+        treelist-keep-members
+        (treelist 1 2 3 2 4 5 2)
+        (treelist 4 3 5))
+  (test (treelist 1 2 2 2)
+        treelist-skip-members
+        (treelist 1 2 3 2 4 5 2)
+        (treelist 4 3 5))
+  (test (treelist 3 4 5)
+        treelist-skip-members
+        (treelist 1 2 3 2 4 5 2)
+        (treelist 2 1))
+
+  (test (treelist "a" "b" "c" "d" "e")
+        treelist-flatten
+        (treelist (treelist "a") "b" (treelist "c" (treelist "d") "e") (treelist)))
+  (test (treelist "a") treelist-flatten "a")
+  (test (treelist "a" "b" "c" (treelist "d") "e")
+        treelist-flatten-once
+        (treelist (treelist "a" "b") (treelist "c" (treelist "d") "e") (treelist)))
+
   (test (treelist 1 2 3 5) treelist-sort (treelist 5 3 1 2) <)
   (test (treelist 5 3 2 1) treelist-sort (treelist 5 3 1 2) < #:key -)
   (test (treelist 5 3 2 1) treelist-sort (treelist 5 3 1 2) < #:key - #:cache-keys? #t)


### PR DESCRIPTION
##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [x] tests included
- [x] documentation

### Description of change

Adds 7 new treelist functions:
- `treelist-index-of`: like list `index-of`
- `treelist-index-where`: like list `index-where`
- `treelist-splitf`: like list `splitf-at`
- `treelist-keep-members`: like set intersect, but with configurable equality instead of arbitrary arity
- `treelist-skip-members`: list set subtract, but with configurable equality instead of arbitrary arity, also like list `remove*` but with opposite argument order
- `treelist-flatten`: like list `flatten`
- `treelist-flatten-once`: like list `append*` on one argument

