### PR TITLE
[doc]: Add indexed links for `info.rkt` fields

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/test.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/test.scrbl
@@ -236,15 +236,15 @@ identifiers:
 
 @itemlist[
 
- @item{@racket[timeout] --- a real number in seconds to override the default
+ @item{@indexed-racket[timeout] --- a real number in seconds to override the default
        timeout for the test, which applies only when timeouts are
        enabled.}
 
- @item{@racket[responsible] --- a string, symbol, or list of symbols
+ @item{@indexed-racket[responsible] --- a string, symbol, or list of symbols
        and strings identifying a responsible party that should be
        notified when the test fails. See @secref["test-responsible"].}
 
- @item{@racket[lock-name] --- a string that names a lock file that is
+ @item{@indexed-racket[lock-name] --- a string that names a lock file that is
        used to serialize tests (i.e., tests that have the same lock
        name do not run concurrently). The lock file's location is
        determined by the @envvar{PLTLOCKDIR} environment variable or
@@ -253,12 +253,12 @@ identifiers:
        @envvar{PLTLOCKTIME} environment variable or defaults to 4
        hours.}
 
- @item{@racket[ignore-stderr] --- a string, byte string, or
+ @item{@indexed-racket[ignore-stderr] --- a string, byte string, or
        @tech[#:doc reference-doc]{regexp value}, as a pattern that
        causes error output to not be treated as a failure if the
        output matches the pattern.}
 
- @item{@racket[random?] --- if true, indicates that the test's output
+ @item{@indexed-racket[random?] --- if true, indicates that the test's output
        is expected to vary. See @secref["test-responsible"].}
 
 ]
@@ -302,31 +302,31 @@ The following @filepath{info.rkt} fields are recognized:
 
 @itemlist[
 
- @item{@racket[test-omit-paths] --- a list of path strings (relative
+ @item{@indexed-racket[test-omit-paths] --- a list of path strings (relative
        to the enclosing directory) and regexp values (to omit all
        files within the enclosing directory matching the expression),
        or @racket['all] to omit all files within the enclosing directory.
        When a path string refers to a directory, all files within the
        directory are omitted.}
 
- @item{@racket[test-include-paths] --- a list of path strings (relative
+ @item{@indexed-racket[test-include-paths] --- a list of path strings (relative
        to the enclosing directory) and regexp values (to include all
        files within the enclosing directory matching the expression),
        or @racket['all] to include all files within the enclosing directory.
        When a path string refers to a directory, all files within the
        directory are included.}
       
- @item{@racket[test-command-line-arguments] --- a list of
+ @item{@indexed-racket[test-command-line-arguments] --- a list of
        @racket[(list _module-path-string (list _argument-path-string
        ...))], where @racket[current-command-line-arguments] is set to
        a vector that contains the @racket[_argument-path-string] when
        running @racket[_module-path-string].}
 
- @item{@racket[test-timeouts] --- a list of @racket[(list
+ @item{@indexed-racket[test-timeouts] --- a list of @racket[(list
        _module-path-string _real-number)] to override the default
        timeout in seconds for @racket[_module-path-string].}
 
- @item{@racket[test-responsibles] --- a list of @racket[(list
+ @item{@indexed-racket[test-responsibles] --- a list of @racket[(list
        _module-path-string _party)] or @racket[(list 'all _party)] to
        override the default responsible party for
        @racket[_module-path-string] or all files within the directory
@@ -334,12 +334,12 @@ The following @filepath{info.rkt} fields are recognized:
        string, symbol, or list of symbols and strings. See
        @secref["test-responsible"].}
 
- @item{@racket[test-lock-names] --- a list of @racket[(list
+ @item{@indexed-racket[test-lock-names] --- a list of @racket[(list
        _module-path-string _lock-string)] to declare a lock file name
        for @racket[_module-path-string]. See @racket[lock-name] in
        @secref["test-config"].}
 
- @item{@racket[test-ignore-stderrs] --- a list of @racket[(list
+ @item{@indexed-racket[test-ignore-stderrs] --- a list of @racket[(list
        _module-path-string _pattern)] or @racket[(list 'all _pattern)]
        to declare patterns of standard error output that are allowed a
        non-failures for @racket[_module-path-string] or all files
@@ -347,7 +347,7 @@ The following @filepath{info.rkt} fields are recognized:
        byte string, or @tech[#:doc reference-doc]{regexp value}. See
        @racket[ignore-stderr] in @secref["test-config"].}
 
- @item{@racket[test-randoms] --- a list of path strings (relative to
+ @item{@indexed-racket[test-randoms] --- a list of path strings (relative to
        the enclosing directory) for modules whose output varies.
        See @secref["test-responsible"].}
 


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation

### Description of change
<!-- Please describe the change here. -->

Update the `raco test` documentation to replace `@racket` with `@indexed-racket` for `info.rkt` fields. 
