### PR TITLE
better error message for incorrect usage of contract-in

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/contract-in.rkt
+++ b/pkgs/racket-test/tests/racket/contract/contract-in.rkt
@@ -5,6 +5,12 @@
 (parameterize ([current-contract-namespace
                 (make-basic-contract-namespace 'racket/contract 'racket/list)])
 
+  (contract-syntax-error-test
+   'contract-in-not-module-path
+   #'(require (contract-in (only-in racket add1)
+                           [add1 (-> number? number?)]))
+   #rx"expected a module-path")
+
   (test/spec-passed/result
    'contract-in1
    '(let ()


### PR DESCRIPTION
##### Checklist

- [x] Bugfix
- [x] tests included

### Description of change

Improve the syntax error of `contract-in`
