### PR TITLE
racket/string: add `string-find`

### DIFF
--- a/pkgs/base/info.rkt
+++ b/pkgs/base/info.rkt
@@ -14,7 +14,7 @@
 
 ;; In the Racket source repo, this version should change exactly when
 ;; "racket_version.h" changes:
-(define version "8.15.0.6")
+(define version "8.15.0.7")
 
 (define deps `("racket-lib"
                ["racket" #:version ,version]))

--- a/pkgs/racket-doc/scribblings/reference/strings.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/strings.scrbl
@@ -644,20 +644,25 @@ returns @racket[#f] otherwise.
 }
 
 @deftogether[(
+@defproc[(string-find [s string?] [contained string?]) (or/c exact-nonnegative-integer? #f)]
 @defproc[(string-contains? [s string?] [contained string?]) boolean?]
 @defproc[(string-prefix? [s string?] [prefix string?]) boolean?]
 @defproc[(string-suffix? [s string?] [suffix string?]) boolean?])]{
-Checks whether @racket[s] includes at any location, start with, or ends with
-the second argument, respectively.
+Checks whether @racket[s] includes at any location, starts with, or ends with
+the second argument, respectively. The @racket[string-find] function returns the
+first position within @racket[s] where @racket[contained] is found, if any,
+while @racket[string-contains?] reports only whether it was found.
 
 @mz-examples[#:eval string-eval
   (string-prefix? "Racket" "R")
   (string-prefix? "Jacket" "R")
   (string-suffix? "Racket" "et")
+  (string-find "Racket" "ack")
   (string-contains? "Racket" "ack")
 ]
 
-@history[#:added "6.3"]{}
+@history[#:added "6.3"
+         #:changed "8.15.0.7" @elem{Added @racket[string-find].}]
 }
 
 

--- a/pkgs/racket-test-core/tests/racket/string.rktl
+++ b/pkgs/racket-test-core/tests/racket/string.rktl
@@ -611,6 +611,58 @@
   (test #(#f 0 0 0 #f 0 2 0) build-kmp-table "abcdabd")
   (test #(#f 0 #f 1 #f 0 #f 3 2 0) build-kmp-table "abacababc"))
 
+;; ---------- string-find ----------
+
+(let ()
+  (test 0 string-find "racket" "racket")
+  (test 2 string-find "racket" "cket")
+  (test 1 string-find "racket" "acke")
+  (test 5 string-find "racket" "t")
+  (test #f string-find "racket" "b")
+  (test #f string-find "racket" "R")
+  (test #f string-find "RACKET" "r")
+  (test #f string-find "racket" "kc")
+  (test #f string-find "racket" "racketr")
+  (test 0 string-find "racket" "")
+  (test 0 string-find "" "")
+  (test #f string-find "" "racket")
+  (test #f string-find "racket" "a..e")
+  (test 1 string-find "ra..et" "a..e")
+  ; string-find sometimes uses different code paths for short and long string,
+  ; so add some long test too.
+  (test 0 string-find "racket012345678901234567890123456789012345678901234567890123456789racket"
+        "racket012345678901234567890123456789012345678901234567890123456789racket")
+  (test 0 string-find "racket012345678901234567890123456789012345678901234567890123456789racket"
+        "racket01234567890123456789")
+  (test 46 string-find "racket012345678901234567890123456789012345678901234567890123456789racket"
+        "01234567890123456789racket")
+  (test 6 string-find "racket012345678901234567890123456789012345678901234567890123456789racket"
+        "012345678901234567890123456789")
+  (test #f string-find "racket012345678901234567890123456789012345678901234567890123456789racket"
+        "racket01234567890123456789racket")
+  (test 46 string-find "racket0123456789012345678901234567890123456789aaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaa")
+  (test 0 string-find "aaaaaaaaaaaaaaaaaaaaaaaaa0123456789012345678901234567890123456789racket"
+        "aaaaaaaaaaaaaaaaaaaaaaaaa")
+  (test #f string-find "aaaaaaaaaaaaaaaaaaaaaaaa_012345678901234567890_aaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaa")
+  (test 0 string-find "aaaaaaaaaaaaaaaaaaaaaaaaa012345678901234567890_aaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaa")
+  (test 46 string-find "aaaaaaaaaaaaaaaaaaaaaaaa_012345678901234567890aaaaaaaaaaaaaaaaaaaaaaaaa"
+        "aaaaaaaaaaaaaaaaaaaaaaaaa")
+  (test 50 string-find "1234567890aaaaa123456789012345678901234567890aaaaa1234567890123456789012345678901234567890"
+        "1234567890123456789012345678901234567890")
+  (test #f string-find "1234567890aaaaa123456789012345678901234567890aaaaa123456789012345678901234567890aaaa"
+        "1234567890123456789012345678901234567890")
+  (test #f string-find "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        "yyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyyy")
+  (test #f string-find "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        "xxxxxxxxxxxxxxxxxxxxxxxxy")
+  (test #f string-find "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        "yxxxxxxxxxxxxxxxxxxxxxxxx")
+  (test #f string-find "xxxxxxxxxxxxxxxxxxxxxxxxyxxxxxxxxxxxxxxxxxxxxxxxxyxxxxxxxxxxxxxxxxxxxxx"
+        "xxxxxxxxxxxxxxxxxxxxxxxxx"))
+
 ;; ---------- regexp-try-match ----------
 
 (define (check-try-match expect pattern in-bstr

--- a/racket/src/version/racket_version.h
+++ b/racket/src/version/racket_version.h
@@ -16,7 +16,7 @@
 #define MZSCHEME_VERSION_X 8
 #define MZSCHEME_VERSION_Y 15
 #define MZSCHEME_VERSION_Z 0
-#define MZSCHEME_VERSION_W 6
+#define MZSCHEME_VERSION_W 7
 
 /* A level of indirection makes `#` work as needed: */
 #define AS_a_STR_HELPER(x) #x


### PR DESCRIPTION
Add a variant of `string-contains?` that reports the location within the first string where the second string was found.

The `string-contains?` implementation already determines a starting position for the found string, so it seems a shame not to report it.

I worry that the name `string-find` is too obvious and could conflict with existing definitions, but I don't find the string `string-find` anywhere in currently registered package sources.