### PR TITLE
[doc]: Corrected return type for `mutable-treelist`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -556,7 +556,7 @@ noted.
 Returns @racket[#t] if @racket[v] is a @tech{mutable treelist},
 @racket[#f] otherwise.}
 
-@defproc[(mutable-treelist [v any/c] ...) treelist?]{
+@defproc[(mutable-treelist [v any/c] ...) mutable-treelist?]{
 
 Returns a @tech{mutable treelist} with @racket[v]s as its elements in order.
 

--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -336,13 +336,14 @@ operation takes @math{O(N)} time.
 @defproc[(treelist-find [tl treelist?] [pred (any/c . -> . any/c)]) any/c]{
 
 Checks each element of @racket[tl] with @racket[pred] until the result
-is a true value, and then returns that element. If no such element is
+is a non-false value, and then returns that element. If no such element is
 found, the result is @racket[#f]. For a constant-time
 @racket[pred], this operation takes @math{O(N)} time.
 
 @examples[
 #:eval the-eval
 (define items (treelist 1 "a" 'apple))
+(treelist-find items number->string)
 (treelist-find items string?)
 (treelist-find items symbol?)
 ]}

--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -336,16 +336,16 @@ operation takes @math{O(N)} time.
 @defproc[(treelist-find [tl treelist?] [pred (any/c . -> . any/c)]) any/c]{
 
 Checks each element of @racket[tl] with @racket[pred] until the result
-is a non-false value, and then returns that element. If no such element is
+is a true value, and then returns that element. If no such element is
 found, the result is @racket[#f]. For a constant-time
 @racket[pred], this operation takes @math{O(N)} time.
 
 @examples[
 #:eval the-eval
 (define items (treelist 1 "a" 'apple))
-(treelist-find items number->string)
 (treelist-find items string?)
 (treelist-find items symbol?)
+(treelist-find items number->string)
 ]}
 
 @defproc[(treelist-sort [tl treelist?]


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->
This PR addresses a minor error in the mutable-treelist documentation:
`(mutable-treelist v ...) → treelist?` -> `(mutable-treelist v ...) → mutable-treelist?`

I noticed that in the `mutable-treelist-append!` documentation, both `treelist`
and `mutable-treelist` are valid for `other-tl`. However, the contract of
`append-proc` in `chaperone-mutable-treelist` and `impersonate-mutable-treelist`
is `(mutable-treelist? treelist? . -> . treelist?)`. I don't know much about these
two procedures, so I'm not sure if there is a problem here.
