### PR TITLE
[doc]: Clarify `end` behavior in `vector-sort[!]` when set to `#f`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/vectors.scrbl
@@ -492,10 +492,13 @@ Like @racket[vector-member], but finds an element using @racket[eq?].
 (define v1 (vector 4 3 2 1))
 v1
 (vector-sort v1 <)
+v1
 (vector-sort v1 < 2 #f #:key #f)
+v1
 (define v2 (vector '(4) '(3) '(2) '(1)))
 v2
 (vector-sort v2 < 1 3 #:key car)
+v2
 ]
 
 @history[#:added "6.6.0.5"]{}

--- a/pkgs/racket-doc/scribblings/reference/vectors.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/vectors.scrbl
@@ -472,7 +472,7 @@ Like @racket[vector-member], but finds an element using @racket[eq?].
 @defproc[(vector-sort [vec vector?]
                       [less-than? (any/c any/c . -> . any/c)]
                       [start exact-nonnegative-integer? 0]
-                      [end exact-nonnegative-integer? (vector-length vec)]
+                      [end (or/c #f exact-nonnegative-integer?) #f]
                       [#:key key (or/c #f (any/c . -> . any/c)) #f]
                       [#:cache-keys? cache-keys? boolean? #f])
          vector?]{
@@ -485,13 +485,18 @@ Like @racket[vector-member], but finds an element using @racket[eq?].
  not modified). This sort is stable (i.e., the order of ``equal''
  elements is preserved).
 
+ If @racket[end] is @racket[#f], it is replaced with
+ @racket[(vector-length vec)].
+
 @mz-examples[#:eval vec-eval
 (define v1 (vector 4 3 2 1))
-(vector-sort v1 <)
 v1
+(vector-sort v1 <)
+(vector-sort v1 < 2 #f #:key #f)
 (define v2 (vector '(4) '(3) '(2) '(1)))
+v2
 (vector-sort v2 < 1 3 #:key car)
-v2]
+]
 
 @history[#:added "6.6.0.5"]{}
 }
@@ -499,8 +504,8 @@ v2]
 @defproc[(vector-sort! [vec (and/c vector? (not/c immutable?))]
                        [less-than? (any/c any/c . -> . any/c)]
                        [start exact-nonnegative-integer? 0]
-                       [end exact-nonnegative-integer? (vector-length vec)]
-                       [#:key key (any/c . -> . any/c) (λ (x) x)]
+                       [end (or/c #f exact-nonnegative-integer?) #f]
+                       [#:key key (or/c #f (any/c . -> . any/c)) #f]
                        [#:cache-keys? cache-keys? boolean? #f])
          void?]{
 
@@ -511,11 +516,18 @@ v2]
 
 @mz-examples[#:eval vec-eval
 (define v1 (vector 4 3 2 1))
+v1
 (vector-sort! v1 <)
 v1
-(define v2 (vector '(4) '(3) '(2) '(1)))
-(vector-sort! v2 < 1 3 #:key car)
-v2]
+(define v2 (vector 4 3 2 1))
+v2
+(vector-sort! v2 < 2 #f #:key #f)
+v2
+(define v3 (vector '(4) '(3) '(2) '(1)))
+v3
+(vector-sort! v3 < 1 3 #:key car)
+v3
+]
 
 @history[#:added "6.6.0.5"]{}
 }


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->
This PR updates the `vector-sort` and `vector-sort!` documentation to clarify the behavior of the `end` and `key`.