### PR TITLE
Add `∘[₁]` as aliases for `compose[1]`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/procedures.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/procedures.scrbl
@@ -33,7 +33,9 @@ arguments; otherwise, the @exnraise[exn:fail:contract]. The given
 ]}
 
 @deftogether[(@defproc[(compose  [proc procedure?] ...) procedure?]
-              @defproc[(compose1 [proc procedure?] ...) procedure?])]{
+              @defproc[(compose1 [proc procedure?] ...) procedure?]
+              @defproc[(∘  [proc procedure?] ...) procedure?]
+              @defproc[(∘₁ [proc procedure?] ...) procedure?])]{
 
 Returns a procedure that composes the given functions, applying the last
 @racket[proc] first and the first @racket[proc] last.  The @racket[compose] function
@@ -44,6 +46,9 @@ a single value.  In both cases, the input arity of the last function and
 the output arity of the first are unrestricted, and they become the
 corresponding arity of the resulting composition (including keyword
 arguments for the input side).
+
+@racket[∘] and @racket[∘₁] are aliases for @racket[compose] and @racket[compose1]
+respectively.
 
 When no @racket[proc] arguments are given, the result is
 @racket[values].  When exactly one is given, it is returned.

--- a/racket/collects/racket/private/list.rkt
+++ b/racket/collects/racket/private/list.rkt
@@ -32,8 +32,8 @@
 
            reverse
 
-           compose
-           compose1)
+           compose  (rename-out [compose ∘])
+           compose1 (rename-out [compose ∘₁]))
 
   (#%require (rename "sort.rkt" raw-sort sort)
              (for-syntax "stxcase-scheme.rkt")


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

##### Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [ ] tests included
- [x] documentation

### Description of change
<!-- Please provide a description of the change here. -->
When implementing mathematical functions in Racket, I often define the alias manually: `(define ∘ compose)`, to represent composed functions like `g∘f` as `(∘ g f)`. This repetitive task occurs so frequently that I believe it makes sense for Racket to natively support `∘`.