### PR TITLE
Fix use of empty-tag-shorthand in write-xexpr

### DIFF
--- a/pkgs/racket-test/tests/xml/test-xexpr.rkt
+++ b/pkgs/racket-test/tests/xml/test-xexpr.rkt
@@ -1,0 +1,20 @@
+#lang racket/base
+
+(module+ test
+
+  (require rackunit
+           xml
+           racket/port)
+
+  (define xe
+    '(doc
+      (short)
+      (alsoShort)))
+
+  (parameterize ([empty-tag-shorthand '(short alsoShort)])
+    (check-equal?
+     (call-with-output-string
+      (lambda (out)
+        (write-xexpr xe out)))
+     "<doc><short/><alsoShort/></doc>")))
+    

--- a/pkgs/racket-test/tests/xml/test-xexpr.rkt
+++ b/pkgs/racket-test/tests/xml/test-xexpr.rkt
@@ -16,5 +16,41 @@
      (call-with-output-string
       (lambda (out)
         (write-xexpr xe out)))
-     "<doc><short/><alsoShort/></doc>")))
+     "<doc><short/><alsoShort/></doc>"))
+
+  (parameterize ([empty-tag-shorthand '(short)])
+    (check-equal?
+     (call-with-output-string
+      (lambda (out)
+        (write-xexpr xe out)))
+     "<doc><short/><alsoShort></alsoShort></doc>"))
+
+  (parameterize ([empty-tag-shorthand '(alsoShort)])
+    (check-equal?
+     (call-with-output-string
+      (lambda (out)
+        (write-xexpr xe out)))
+     "<doc><short></short><alsoShort/></doc>"))
+
+  (parameterize ([empty-tag-shorthand '()])
+    (check-equal?
+     (call-with-output-string
+      (lambda (out)
+        (write-xexpr xe out)))
+     "<doc><short></short><alsoShort></alsoShort></doc>"))
+
+  (parameterize ([empty-tag-shorthand 'always])
+    (check-equal?
+     (call-with-output-string
+      (lambda (out)
+        (write-xexpr xe out)))
+     "<doc><short/><alsoShort/></doc>"))
+
+  (parameterize ([empty-tag-shorthand 'never])
+    (check-equal?
+     (call-with-output-string
+      (lambda (out)
+        (write-xexpr xe out)))
+     "<doc><short></short><alsoShort></alsoShort></doc>")))
+
     

--- a/racket/collects/xml/private/xexpr.rkt
+++ b/racket/collects/xml/private/xexpr.rkt
@@ -110,9 +110,10 @@
 (define (write-xexpr x [out (current-output-port)]
                      #:insert-newlines? [insert-newlines? #f])
   (define short
-    (map
-     lowercase-symbol
-     (empty-tag-shorthand)))
+    (let ([s (empty-tag-shorthand)])
+      (if (list? s)
+          (map lowercase-symbol s)
+          s)))
   (define unescaped (current-unescaped-tags))
   (let loop ([x x] [escape? #t])
     (cond

--- a/racket/collects/xml/private/xexpr.rkt
+++ b/racket/collects/xml/private/xexpr.rkt
@@ -109,7 +109,10 @@
 
 (define (write-xexpr x [out (current-output-port)]
                      #:insert-newlines? [insert-newlines? #f])
-  (define short (empty-tag-shorthand))
+  (define short
+    (map
+     lowercase-symbol
+     (empty-tag-shorthand)))
   (define unescaped (current-unescaped-tags))
   (let loop ([x x] [escape? #t])
     (cond


### PR DESCRIPTION
##### Checklist

- [x] Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation

### Description of Change

See also: Issue #5119 

In `xml`, the function `write-xexpr` uses the parameter `empty-tag-shorthand` to determine which elements to shorthand. However, all tags with uppercase letters are ignored.

This pull request allows tags with uppercase letters to be shorthanded. Generally the test for shorthanding is case-insensitive now.
