### PR TITLE
PR template: use appropriate header hierarchy

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@ For more information about how to contribute please see
 Bug fixes and new features should include tests.
 -->
 
-##### Checklist
+## Checklist
 <!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->
 
 - [ ] Bugfix
@@ -16,5 +16,5 @@ Bug fixes and new features should include tests.
 - [ ] tests included
 - [ ] documentation
 
-### Description of change
+## Description of change
 <!-- Please provide a description of the change here. -->


### PR DESCRIPTION
Use same-level h2s instead of h5 followed by h3: the latter has less semantic sense. If you take the PR title to be the h1 element (which is how GitHub marks it up), then direct child elements in the body should first be h2, then nested h3, etc.

This should also improve the screen-reader experience, which often have trouble making sense of heading levels that jump through the hierarchy.

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist

- [x] (Contributor) documentation

## Description of change

Change some heading levels in the PR template. (Bet you didn't notice that I did it manually in this PR description and in that of #5124 ?)
