### PR TITLE
test: fix stderr check from localized output

### DIFF
--- a/pkgs/racket-test/tests/pkg/tests-clone.rkt
+++ b/pkgs/racket-test/tests/pkg/tests-clone.rkt
@@ -78,7 +78,7 @@
         $ (~a "cd " (build-path clone-dir "a") "; git add .; git commit -m local")
         $ "racket -l a" =stdout> "2\n"
         $ "racket -l a/alt" =stdout> "'one\n"
-        $ (~a "raco pkg update a") =exit> 1 =stderr> #rx"fast-forward"
+        $ "LC_ALL=C raco pkg update a" =exit> 1 =stderr> #rx"fast-forward"
         $ (~a "cd "  (build-path clone-dir "a") "; git pull --rebase")
         $ (~a "raco pkg update a")
         $ "racket -l a" =stdout> "3\n"


### PR DESCRIPTION

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] test fix

## Description of change
<!-- Please provide a description of the change here. -->

When running on a machine with non-English-like locale settings, a tests-clone check for text in an error message that is localized fails. Force the C locale to make the test pass.

