### PR TITLE
pkg: forward alias arguments including keywords

### DIFF
--- a/racket/collects/pkg/commands.rkt
+++ b/racket/collects/pkg/commands.rkt
@@ -172,8 +172,7 @@
                   (args-app arg.arg-ids (name og.call ... ...)))
                 arg.help-strs])]
     [pattern (#:alias alias:id redirect-to:id)
-             #:attr function #'(define (alias . args)
-                                 (apply redirect-to args))
+             #:attr function #'(define alias (procedure-rename redirect-to 'alias))
              #:attr name #'alias
              #:attr variables #'(begin)
              #:attr command-line


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [ ] tests included

PS would you like a test case for this change?

## Description of change

The previous strategy omitted keywords; a variant using make-keyword-procedure and keyword-apply works but doesn't report useful information from procedure-keywords. Instead, rename the target procedure. This does mean that the definition of alias is not delayed and depends on coming after the target.

Close https://github.com/racket/racket/issues/5140