### PR TITLE
docs: add a note that filtered-in &co. require (for-syntax racket/base)

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/fixnums.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/fixnums.scrbl
@@ -24,6 +24,8 @@ The expected use of the @racketmodname[racket/fixnum] library is for
 code where the @racket[require] of @racketmodname[racket/fixnum] is
 replaced with
 
+@margin-note{See the documentation of @racket[filtered-in] for use with @racket[@#,(hash-lang) @#,racketmodname[racket/base]].}
+
 @racketblock[(require (filtered-in
                        (λ (name)
                          (and (regexp-match #rx"^unsafe-fx" name)

--- a/pkgs/racket-doc/scribblings/reference/syntax.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/syntax.scrbl
@@ -1580,6 +1580,16 @@ aliens
   procedure must return either a string for the import's new name or
   @racket[#f] to exclude the import.
 
+  @margin-note{
+    The second part of @racket[filtered-in] is expand-time code evaluated in the
+    scope of the enclosing module. Accordingly, most uses need
+    @racket[(require (for-syntax racket/base))] if @racketmodname[racket/base]
+    is not already imported @racket[for-syntax]. For example,
+    @racket[@#,(hash-lang) @#,racketmodname[racket]] establishes this import
+    automatically, while @racket[@#,(hash-lang) @#,racketmodname[racket/base]]
+    does not.
+  }
+
   For example,
   @racketblock[
     (require (filtered-in
@@ -1687,6 +1697,8 @@ Examples:
 
  Analogous to @racket[filtered-in], but for filtering and renaming
  exports.
+
+  @margin-note{See the documentation of @racket[filtered-in] for use with @racket[@#,(hash-lang) @#,racketmodname[racket/base]].}
 
   For example,
   @racketblock[


### PR DESCRIPTION
## Checklist

- [x] documentation

## Description of change

Otherwise the fixnum sample doesn't work in #lang racket/base, for example.

It seems to me this should happen automatically, but I'm probably missing the key ingredient that prevents that from making sense.
