### PR TITLE
[Doc]: Fixes pattern head in mycond*

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/ex-kw-args.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/ex-kw-args.scrbl
@@ -36,11 +36,11 @@ Here's one way to do it:
 
 (define-syntax mycond*
   (syntax-rules ()
-    [(mycond error? who [question answer] . clauses)
+    [(mycond* error? who [question answer] . clauses)
      (if question answer (mycond* error? who . clauses))]
-    [(mycond #t who)
+    [(mycond* #t who)
      (error who "no clauses matched")]
-    [(mycond #f _)
+    [(mycond* #f _)
      (void)]))
 ]
 


### PR DESCRIPTION

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x ] documentation

## Description of change
The pattern head in ```mycond*``` should probably be ```_``` or ```mycond*```.
