### PR TITLE
Fix typo in help messages

### DIFF
--- a/racket/src/bc/cmdline.inc
+++ b/racket/src/bc/cmdline.inc
@@ -1487,7 +1487,7 @@ static int run_from_cmd_line(int argc, char *_argv[],
   "  -l <path>, --lib <path>\n"
   "     Like -e '(require (lib \"<path>\"))' [*]\n"
   "  -p <package>\n"
-  "     Like -e '(require (planet \"<package>\")' [*]\n"
+  "     Like -e '(require (planet \"<package>\"))' [*]\n"
   "  -r <file>, --script <file>\n"
   "     Same as -f <file> -N <file> --\n"
   "  -u <file>, --require-script <file>\n"

--- a/racket/src/cs/main/help.ss
+++ b/racket/src/cs/main/help.ss
@@ -27,7 +27,7 @@
     "  -l <path>, --lib <path>\n"
     "     Like -e '(require (lib \"<path>\"))' [*]\n"
     "  -p <package>\n"
-    "     Like -e '(require (planet \"<package>\")' [*]\n"
+    "     Like -e '(require (planet \"<package>\"))' [*]\n"
     "  -r <file>, --script <file>\n"
     "     Same as -f <file> -N <file> --\n"
     "  -u <file>, --require-script <file>\n"


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->

In what `racket --help` prints, I noticed an unbalanced parenthesis in the label of `-p`. This fixes it.
I looked through command line reference to make sure there isn't the same mistake.
