### PR TITLE
Fixes syntax in init-decl example

### DIFF
--- a/pkgs/racket-doc/syntax/scribblings/parse/ex-uniform.scrbl
+++ b/pkgs/racket-doc/syntax/scribblings/parse/ex-uniform.scrbl
@@ -93,7 +93,7 @@ of the definition of @racket[init-decl]:
 (define-syntax-class init-decl
   #:attributes (internal external default)
   (pattern internal:id
-           #:with external #:internal
+           #:with external #'internal
            #:with default ???)
   (pattern (mr:maybe-renamed)
            #:with internal #'mr.internal
@@ -123,7 +123,7 @@ respectively. More precisely:
 (define-syntax-class init-decl
   #:attributes (internal external default)
   (pattern internal:id
-           #:with external #:internal
+           #:with external #'internal
            #:with default #'())
   (pattern (mr:maybe-renamed)
            #:with internal #'mr.internal


### PR DESCRIPTION
It seems like syntax ```#'internal``` is intended rather than keyword ```#:internal```.
