### PR TITLE
[json] Add `#:mhash?` to `read-json`

### DIFF
--- a/pkgs/racket-doc/json/json.scrbl
+++ b/pkgs/racket-doc/json/json.scrbl
@@ -129,7 +129,8 @@ the @rfc for more information about JSON.
 @section{Parsing JSON Text into JS-Expressions}
 
 @defproc[(read-json [in input-port? (current-input-port)]
-                    [#:null jsnull any/c (json-null)])
+                    [#:null jsnull any/c (json-null)]
+                    [#:mhash? jsmhash? boolean? #f])
          (or/c jsexpr? eof-object?)]{
   Reads a @tech{jsexpr} from a single JSON-encoded input port @racket[in] as a
   Racket (immutable) value, or produces @racket[eof] if only whitespace
@@ -137,14 +138,28 @@ the @rfc for more information about JSON.
   characters in the port so that a second call can retrieve the
   remaining JSON input(s). If the JSON inputs aren't delimited per se
   (true, false, null), they must be separated by whitespace from the
-  following JSON input. Raises @racket[exn:fail:read] if @racket[in] is not
-  at EOF and starts with malformed JSON (that is, no initial sequence of bytes
-  in @racket[in] can be parsed as JSON); see below for examples.
+  following JSON input.
+
+  @racket[jsmhash?] determines whether the generated hash table is mutable.
+
+  Raises @racket[exn:fail:read] if @racket[in] is not at EOF and starts with
+  malformed JSON (that is, no initial sequence of bytes in @racket[in] can be
+  parsed as JSON); see below for examples.
 
 @examples[#:eval ev
   (with-input-from-string
     "{\"arr\" : [1, 2, 3, 4]}"
     (λ () (read-json)))
+
+  (immutable?
+   (with-input-from-string
+     "{\"arr\" : [1, 2, 3, 4]}"
+     (λ () (read-json))))
+
+  (immutable?
+   (with-input-from-string
+     "{\"arr\" : [1, 2, 3, 4]}"
+     (λ () (read-json #:mhash? #t))))
 
   (with-input-from-string
     "\"sandwich\""
@@ -190,11 +205,14 @@ the @rfc for more information about JSON.
            @racket[#\space], @racket[#\tab], @racket[#\newline], or @racket[#\return].}]
 }
 
-@defproc[(string->jsexpr [str string?] [#:null jsnull any/c (json-null)])
+@defproc[(string->jsexpr [str string?]
+                         [#:null jsnull any/c (json-null)]
+                         [#:mhash? jsmhash? boolean? #f])
          jsexpr?]{
   Parses a recognizable prefix of the string @racket[str] as an immutable @tech{jsexpr}.
   If the prefix isn't delimited per se (true, false, null), it
   must be separated by whitespace from the remaining characters.
+
   Raises @racket[exn:fail:read] if the string is malformed JSON.
 
 
@@ -203,12 +221,15 @@ the @rfc for more information about JSON.
 ]
 }
 
-@defproc[(bytes->jsexpr [str bytes?] [#:null jsnull any/c (json-null)])
+@defproc[(bytes->jsexpr [str bytes?]
+                        [#:null jsnull any/c (json-null)]
+                        [#:mhash? jsmhash? boolean? #f])
          jsexpr?]{
   Parses a recognizable prefix of the string @racket[str] as an immutable @tech{jsexpr}.
   If the prefix isn't delimited per se (true, false, null), it
-  must be separated by whitespace from the remaining bytes. Raises
-  @racket[exn:fail:read] if the byte string is malformed JSON.
+  must be separated by whitespace from the remaining bytes.
+
+  Raises @racket[exn:fail:read] if the byte string is malformed JSON.
 
 
 @examples[#:eval ev

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -41,7 +41,9 @@
         any)] ;; void?
   [read-json
    (->* ()
-        (input-port? #:null any/c) ;; (json-null)
+        (input-port?
+         #:null any/c ;; (json-null)
+         #:mhash? boolean?) ;; #f
         any)] ;; jsexpr?
   [jsexpr->string
    (->* (any/c) ;; jsexpr? but dependent on #:null arg
@@ -57,11 +59,13 @@
         any)] ;; bytes?
   [string->jsexpr
    (->* (string?)
-        (#:null any/c) ;; (json-null)
+        (#:null any/c ;; (json-null)
+         #:mhash? boolean?) ;; #f
         any)] ;; jsexpr?
   [bytes->jsexpr
    (->* (bytes?)
-        (#:null any/c) ;; (json-null)
+        (#:null any/c ;; (json-null)
+         #:mhash? boolean?) ;; #f
         any)] ;; jsexpr?
   ))
 
@@ -234,10 +238,12 @@
 ;; -----------------------------------------------------------------------------
 ;; PARSING (from JSON to Racket)
 
-(define (read-json [i (current-input-port)] #:null [jsnull (json-null)])
+(define (read-json [i (current-input-port)]
+                   #:null [jsnull (json-null)]
+                   #:mhash? [jsmhash? #f])
   (read-json* 'read-json i
               #:null jsnull
-              #:make-object make-immutable-hasheq
+              #:make-object (if jsmhash? make-hasheq make-immutable-hasheq)
               #:make-list values
               #:make-key string->symbol
               #:make-string values))
@@ -626,20 +632,24 @@
                #:string-rep->string values)
   (get-output-bytes o))
 
-(define (string->jsexpr str #:null [jsnull (json-null)])
+(define (string->jsexpr str
+                        #:null [jsnull (json-null)]
+                        #:mhash? [jsmhash? #f])
   ;; str is protected by contract
   (read-json* 'string->jsexpr (open-input-string str)
               #:null jsnull
-              #:make-object make-immutable-hasheq
+              #:make-object (if jsmhash? make-hasheq make-immutable-hasheq)
               #:make-list values
               #:make-key string->symbol
               #:make-string values))
 
-(define (bytes->jsexpr bs #:null [jsnull (json-null)])
+(define (bytes->jsexpr bs
+                       #:null [jsnull (json-null)]
+                       #:mhash? [jsmhash? #f])
   ;; bs is protected by contract
   (read-json* 'bytes->jsexpr (open-input-bytes bs)
               #:null jsnull
-              #:make-object make-immutable-hasheq
+              #:make-object (if jsmhash? make-hasheq make-immutable-hasheq)
               #:make-list values
               #:make-key string->symbol
               #:make-string values))


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [x] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->

This PR adds an optional `#:mhash?` keyword to the `read-json` function.

The current `read-json` implementation creates immutable hashtables for JSON
objects, making it very difficult to modify the content of a `.json` file
(e.g., adding, deleting, or updating keys).

Furthermore, `jsexpr?` already treats mutable hashtables as valid JSON objects,
making this change a natural and consistent extension.
