### PR TITLE
json: add `#:replace-malformed-surrogate?` argument

### DIFF
--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -161,6 +161,13 @@
         ;; Invalid UTF-8 input.
         (bytes->jsexpr #"\"\377\377\377\"") =error> exn:fail?
 
+        ;; high surrogate only
+        (string->jsexpr "\"\\uDEAD\"") =error> exn:fail?
+        (string->jsexpr "\"\\uDEAD\"" #:replace-malformed-surrogate? #t) => "\uFFFD"
+        (string->jsexpr "\"\\uDEADZ\""  #:replace-malformed-surrogate? #t) => "\uFFFDZ"
+        (string->jsexpr "\"\\uDEAD\\u007a\"" #:replace-malformed-surrogate? #t) => "\uFFFDz"
+        (string->jsexpr "\"\\udead\\ud83d\\ude00\""  #:replace-malformed-surrogate? #t) => "\uFFFD\U1F600"
+
         ;; whitespace should be only the four allowed charactes
         (string->jsexpr (string-append
                          "{ \"x\" :"

--- a/pkgs/racket-test/tests/json/json.rkt
+++ b/pkgs/racket-test/tests/json/json.rkt
@@ -162,11 +162,24 @@
         (bytes->jsexpr #"\"\377\377\377\"") =error> exn:fail?
 
         ;; high surrogate only
-        (string->jsexpr "\"\\uDEAD\"") =error> exn:fail?
-        (string->jsexpr "\"\\uDEAD\"" #:replace-malformed-surrogate? #t) => "\uFFFD"
-        (string->jsexpr "\"\\uDEADZ\""  #:replace-malformed-surrogate? #t) => "\uFFFDZ"
-        (string->jsexpr "\"\\uDEAD\\u007a\"" #:replace-malformed-surrogate? #t) => "\uFFFDz"
-        (string->jsexpr "\"\\udead\\ud83d\\ude00\""  #:replace-malformed-surrogate? #t) => "\uFFFD\U1F600"
+        (string->jsexpr "\"\\uDBFF\"") =error> exn:fail?
+        (string->jsexpr "\"\\uDBFF\"" #:replace-malformed-surrogate? #t) => "\uFFFD"
+        (string->jsexpr "\"\\uDBFFZ\""  #:replace-malformed-surrogate? #t) => "\uFFFDZ"
+        (string->jsexpr "\"\\uDBFF\\u007A\"" #:replace-malformed-surrogate? #t) => "\uFFFDz"
+
+        ;; high surrogate followed by valid pair
+        (string->jsexpr "\"\\ud83d\\ud83d\\ude00\""  #:replace-malformed-surrogate? #t) => "\uFFFD\U1F600"
+
+        ;; low without high surrogate
+        (string->jsexpr "\"\\ude00Z\""  #:replace-malformed-surrogate? #t) => "\uFFFDZ"
+        (string->jsexpr "\"\\ude00\\u007A\"" #:replace-malformed-surrogate? #t) => "\uFFFDz"
+        (string->jsexpr "\"\\ude00\\ud83d\\ude00\""  #:replace-malformed-surrogate? #t) => "\uFFFD\U1F600"
+
+        ;; reversed surrogates
+        (string->jsexpr "\"\\ude00\\ud83d\""  #:replace-malformed-surrogate? #t) => "\uFFFD\UFFFD"
+
+        ;; two low surrogates
+        (string->jsexpr "\"\\ude00\\ude00\""  #:replace-malformed-surrogate? #t) => "\uFFFD\UFFFD"
 
         ;; whitespace should be only the four allowed charactes
         (string->jsexpr (string-append

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -370,7 +370,7 @@
          (define-values (e* new-result new-pos)
            (let resync ([e e] [result result] [pos pos])
              (cond
-               [(<= #xD800 e #xDFFF)
+               [(<= #xD800 e #xDBFF)
                 (cond
                   [(equal? (peek-bytes 2 0 i) #"\\u")
                    (read-bytes 2 i)
@@ -388,6 +388,10 @@
                    (values #xFFFD result pos)]
                   [else
                    (err "bad string \\u escape, missing second half of a UTF-16 pair")])]
+               [(<= #xDC00 e #xDFFF)
+                (if replace-malformed-surrogate?
+                    (values #xFFFD result pos)
+                    (err "bad string \\u escape, missing first half of a UTF-16 pair"))]
                [else (values e result pos)])))
          (keep-char (integer->char e*) new-result new-pos converter)]
         [else (err "bad string escape: \"~a\"" esc)]))

--- a/racket/collects/json/main.rkt
+++ b/racket/collects/json/main.rkt
@@ -41,7 +41,9 @@
         any)] ;; void?
   [read-json
    (->* ()
-        (input-port? #:null any/c) ;; (json-null)
+        (input-port?
+         #:replace-malformed-surrogate? any/c
+         #:null any/c) ;; (json-null)
         any)] ;; jsexpr?
   [jsexpr->string
    (->* (any/c) ;; jsexpr? but dependent on #:null arg
@@ -57,11 +59,13 @@
         any)] ;; bytes?
   [string->jsexpr
    (->* (string?)
-        (#:null any/c) ;; (json-null)
+        (#:replace-malformed-surrogate? any/c
+         #:null any/c) ;; (json-null)
         any)] ;; jsexpr?
   [bytes->jsexpr
    (->* (bytes?)
-        (#:null any/c) ;; (json-null)
+        (#:replace-malformed-surrogate? any/c
+         #:null any/c) ;; (json-null)
         any)] ;; jsexpr?
   ))
 
@@ -234,8 +238,11 @@
 ;; -----------------------------------------------------------------------------
 ;; PARSING (from JSON to Racket)
 
-(define (read-json [i (current-input-port)] #:null [jsnull (json-null)])
+(define (read-json [i (current-input-port)]
+                   #:null [jsnull (json-null)]
+                   #:replace-malformed-surrogate? [replace-malformed-surrogate? #f])
   (read-json* 'read-json i
+              #:replace-malformed-surrogate? replace-malformed-surrogate?
               #:null jsnull
               #:make-object make-immutable-hasheq
               #:make-list values
@@ -243,6 +250,7 @@
               #:make-string values))
 
 (define (read-json* who i
+                    #:replace-malformed-surrogate? replace-malformed-surrogate?
                     #:null jsnull
                     #:make-object make-object-rep
                     #:make-list make-list-rep
@@ -281,7 +289,7 @@
     ;; Using a string output port would make sense here, but managing
     ;; a string buffer directly is even faster
     (define result (make-string 16))
-    (define (keep-char c old-result pos converter)
+    (define (save-char c old-result pos)
       (define result
         (cond
           [(= pos (string-length old-result))
@@ -290,7 +298,10 @@
            new]
           [else old-result]))
       (string-set! result pos c)
-      (loop result (add1 pos) converter))
+      (values result (add1 pos)))
+    (define (keep-char c old-result old-pos converter)
+      (define-values (result pos) (save-char c old-result old-pos))
+      (loop result pos converter))
     (define (loop result pos converter)
       (define c (read-byte i))
       (cond
@@ -356,21 +367,29 @@
               (arithmetic-shift (hex-convert c3) 4)
               (hex-convert c4)))
          (define e (get-hex))
-         (define e*
-           (cond
-             [(<= #xD800 e #xDFFF)
-              (define (err-missing)
-                (err "bad string \\u escape, missing second half of a UTF-16 pair"))
-              (unless (eqv? (read-byte i) (char->integer #\\)) (err-missing))
-              (unless (eqv? (read-byte i) (char->integer #\u)) (err-missing))
-              (define e2 (get-hex))
-              (cond
-                [(<= #xDC00 e2 #xDFFF)
-                 (+ (arithmetic-shift (- e #xD800) 10) (- e2 #xDC00) #x10000)]
-                [else
-                 (err "bad string \\u escape, bad second half of a UTF-16 pair")])]
-             [else e]))
-         (keep-char (integer->char e*) result pos converter)]
+         (define-values (e* new-result new-pos)
+           (let resync ([e e] [result result] [pos pos])
+             (cond
+               [(<= #xD800 e #xDFFF)
+                (cond
+                  [(equal? (peek-bytes 2 0 i) #"\\u")
+                   (read-bytes 2 i)
+                   (define e2 (get-hex))
+                   (cond
+                     [(<= #xDC00 e2 #xDFFF)
+                      (define cp (+ (arithmetic-shift (- e #xD800) 10) (- e2 #xDC00) #x10000))
+                      (values cp result pos)]
+                     [replace-malformed-surrogate?
+                      (define-values (new-result new-pos) (save-char (integer->char #xFFFD) result pos))
+                      (resync e2 new-result new-pos)]
+                     [else
+                      (err "bad string \\u escape, bad second half of a UTF-16 pair")])]
+                  [replace-malformed-surrogate?
+                   (values #xFFFD result pos)]
+                  [else
+                   (err "bad string \\u escape, missing second half of a UTF-16 pair")])]
+               [else (values e result pos)])))
+         (keep-char (integer->char e*) new-result new-pos converter)]
         [else (err "bad string escape: \"~a\"" esc)]))
     (loop result 0 #f))
   ;;
@@ -626,18 +645,24 @@
                #:string-rep->string values)
   (get-output-bytes o))
 
-(define (string->jsexpr str #:null [jsnull (json-null)])
+(define (string->jsexpr str
+                        #:replace-malformed-surrogate? [replace-malformed-surrogate? #f]
+                        #:null [jsnull (json-null)])
   ;; str is protected by contract
   (read-json* 'string->jsexpr (open-input-string str)
+              #:replace-malformed-surrogate? replace-malformed-surrogate?
               #:null jsnull
               #:make-object make-immutable-hasheq
               #:make-list values
               #:make-key string->symbol
               #:make-string values))
 
-(define (bytes->jsexpr bs #:null [jsnull (json-null)])
+(define (bytes->jsexpr bs
+                       #:replace-malformed-surrogate? [replace-malformed-surrogate? #f]
+                       #:null [jsnull (json-null)])
   ;; bs is protected by contract
   (read-json* 'bytes->jsexpr (open-input-bytes bs)
+              #:replace-malformed-surrogate? replace-malformed-surrogate?
               #:null jsnull
               #:make-object make-immutable-hasheq
               #:make-list values


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Feature
- [x] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->
As specified in the the JSON grammar 16 bit unicode escapes are allowed with `\uHHHH`.  To write a 32 bit code point the specification requires the escapes to be written with surrogate pairs ala UTF-16.  When these surrogate pairs are malformed the previous implementation would raise an exception.  This patch changes the behavior to raise an error or replace the malformed bytes with the unicode replacement character. The replacement behavior implemented here is consistent with other JSON processing tools.
