### PR TITLE
Optimize `for/mutable-treelist` and `treelist-reverse` performance

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -464,6 +464,8 @@ Like @racket[for/vector] and @racket[for*/vector], but generating
 
 @examples[
 #:eval the-eval
+(for/treelist ([i (in-range 10)]) i)
+(for/treelist #:length 15 ([i (in-range 10)]) i)
 (for/treelist #:length 15 #:fill 'a ([i (in-range 10)]) i)
 ]}
 
@@ -959,6 +961,8 @@ Like @racket[for/vector] and @racket[for*/vector], but generating
 
 @examples[
 #:eval the-eval
+(for/mutable-treelist ([i (in-range 10)]) i)
+(for/mutable-treelist #:length 15 ([i (in-range 10)]) i)
 (for/mutable-treelist #:length 15 #:fill 'a ([i (in-range 10)]) i)
 ]}
 

--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -455,17 +455,16 @@ If @racket[s] is infinite, this function does not terminate.
 @history[#:added "8.15.0.6"]}
 
 @deftogether[(
-@defform[(for/treelist (for-clause ...) body-or-break ... body)]
-@defform[(for*/treelist (for-clause ...) body-or-break ... body)]
+@defform[(for/treelist maybe-length (for-clause ...) body-or-break ... body)]
+@defform[(for*/treelist maybe-length (for-clause ...) body-or-break ... body)]
 )]{
 
-Like @racket[for/list] and @racket[for*/list], but generating
+Like @racket[for/vector] and @racket[for*/vector], but generating
 @tech{treelists}.
 
 @examples[
 #:eval the-eval
-(for/treelist ([i (in-range 10)])
-  i)
+(for/treelist #:length 15 #:fill 'a ([i (in-range 10)]) i)
 ]}
 
 @defproc[(chaperone-treelist [tl treelist?]
@@ -951,17 +950,16 @@ Returns a @tech{sequence} equivalent to @racket[tl].
 ]}
 
 @deftogether[(
-@defform[(for/mutable-treelist (for-clause ...) body-or-break ... body)]
-@defform[(for*/mutable-treelist (for-clause ...) body-or-break ... body)]
+@defform[(for/mutable-treelist maybe-length (for-clause ...) body-or-break ... body)]
+@defform[(for*/mutable-treelist maybe-length (for-clause ...) body-or-break ... body)]
 )]{
 
-Like @racket[for/list] and @racket[for*/list], but generating
+Like @racket[for/vector] and @racket[for*/vector], but generating
 @tech{mutable treelists}.
 
 @examples[
 #:eval the-eval
-(for/mutable-treelist ([i (in-range 10)])
-  i)
+(for/mutable-treelist #:length 15 #:fill 'a ([i (in-range 10)]) i)
 ]}
 
 @defproc[(chaperone-mutable-treelist [tl mutable-treelist?]

--- a/pkgs/racket-doc/scribblings/reference/treelists.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/treelists.scrbl
@@ -455,18 +455,17 @@ If @racket[s] is infinite, this function does not terminate.
 @history[#:added "8.15.0.6"]}
 
 @deftogether[(
-@defform[(for/treelist maybe-length (for-clause ...) body-or-break ... body)]
-@defform[(for*/treelist maybe-length (for-clause ...) body-or-break ... body)]
+@defform[(for/treelist (for-clause ...) body-or-break ... body)]
+@defform[(for*/treelist (for-clause ...) body-or-break ... body)]
 )]{
 
-Like @racket[for/vector] and @racket[for*/vector], but generating
+Like @racket[for/list] and @racket[for*/list], but generating
 @tech{treelists}.
 
 @examples[
 #:eval the-eval
-(for/treelist ([i (in-range 10)]) i)
-(for/treelist #:length 15 ([i (in-range 10)]) i)
-(for/treelist #:length 15 #:fill 'a ([i (in-range 10)]) i)
+(for/treelist ([i (in-range 10)])
+  i)
 ]}
 
 @defproc[(chaperone-treelist [tl treelist?]

--- a/pkgs/racket-test-core/tests/racket/treelist.rktl
+++ b/pkgs/racket-test-core/tests/racket/treelist.rktl
@@ -37,16 +37,6 @@
       (for*/treelist ([i (in-range 1 4)]
                       [m '(1 -1)])
         (* i m)))
-(test (treelist 1 -1 2 -2 3 -3 0 0) 'for*
-      (for*/treelist #:length 8
-                     ([i (in-range 1 4)]
-                      [m '(1 -1)])
-        (* i m)))
-(test (treelist 1 -1 2 -2 3 -3 'x 'x) 'for*
-      (for*/treelist #:length 8 #:fill 'x
-                     ([i (in-range 1 4)]
-                      [m '(1 -1)])
-        (* i m)))
 
 (test (make-treelist 0 567) "make-treelist 0" (treelist))
 (test (eq? (make-treelist 0 567) (treelist)) "eq make-treelist" #t)
@@ -276,6 +266,21 @@
 (test small-treelist mutable-treelist-snapshot small-mutable-treelist)
 
 (test #t mutable-treelist-empty? (make-mutable-treelist 0))
+
+(test (mutable-treelist 1 -1 2 -2 3 -3) 'for*
+      (for*/mutable-treelist ([i (in-range 1 4)]
+                              [m '(1 -1)])
+        (* i m)))
+(test (mutable-treelist 1 -1 2 -2 3 -3 0 0) 'for*
+      (for*/mutable-treelist #:length 8
+                             ([i (in-range 1 4)]
+                              [m '(1 -1)])
+        (* i m)))
+(test (mutable-treelist 1 -1 2 -2 3 -3 'x 'x) 'for*
+      (for*/mutable-treelist #:length 8 #:fill 'x
+                             ([i (in-range 1 4)]
+                              [m '(1 -1)])
+        (* i m)))
 
 (define (mutable-treelist-tests small-treelist wrap)
   (define test!

--- a/pkgs/racket-test-core/tests/racket/treelist.rktl
+++ b/pkgs/racket-test-core/tests/racket/treelist.rktl
@@ -37,6 +37,16 @@
       (for*/treelist ([i (in-range 1 4)]
                       [m '(1 -1)])
         (* i m)))
+(test (treelist 1 -1 2 -2 3 -3 0 0) 'for*
+      (for*/treelist #:length 8
+                     ([i (in-range 1 4)]
+                      [m '(1 -1)])
+        (* i m)))
+(test (treelist 1 -1 2 -2 3 -3 'x 'x) 'for*
+      (for*/treelist #:length 8 #:fill 'x
+                     ([i (in-range 1 4)]
+                      [m '(1 -1)])
+        (* i m)))
 
 (test (make-treelist 0 567) "make-treelist 0" (treelist))
 (test (eq? (make-treelist 0 567) (treelist)) "eq make-treelist" #t)

--- a/racket/collects/racket/mutable-treelist.rkt
+++ b/racket/collects/racket/mutable-treelist.rkt
@@ -319,9 +319,9 @@
   (in-treelist (mutable-treelist-tl mtl)))
 
 (define-syntax for/mutable-treelist
-  (make-for/treelist #'for/fold/derived #'treelist-copy))
+  (make-for/treelist #'for/vector #'vector->mutable-treelist))
 (define-syntax for*/mutable-treelist
-  (make-for/treelist #'for*/fold/derived #'treelist-copy))
+  (make-for/treelist #'for*/vector #'vector->mutable-treelist))
 
 (define (check-chaperone-arguments who
                                    ref-proc

--- a/racket/collects/racket/mutable-treelist.rkt
+++ b/racket/collects/racket/mutable-treelist.rkt
@@ -242,16 +242,7 @@
 (define (mutable-treelist-reverse! mtl)
   (check-mutable-treelist 'mutable-treelist-reverse! mtl)
   (define tl (mutable-treelist-tl mtl))
-  (cond
-    [(impersonator? mtl)
-     (set-mutable-treelist-tl! mtl (treelist-reverse tl))]
-    [else
-     (define len (treelist-length tl))
-     (define vec (make-vector len))
-     (for ([el (in-treelist tl)]
-           [i (in-range (sub1 len) -1 -1)])
-       (vector-set! vec i el))
-     (set-mutable-treelist-tl! mtl (vector->treelist vec))]))
+  (set-mutable-treelist-tl! mtl (treelist-reverse tl)))
 
 (define (mutable-treelist->vector mtl)
   (check-mutable-treelist 'mutable-treelist->vector mtl)

--- a/racket/collects/racket/treelist.rkt
+++ b/racket/collects/racket/treelist.rkt
@@ -276,16 +276,18 @@
            ((fx+ pos 1) next-node next-node-pos))]]
       [_ #f])))
 
-(define-for-syntax (make-for/treelist for/fold/derived-id)
+(define-for-syntax (make-for/treelist for/fold/derived-id wrap-result-id)
   (lambda (stx)
     (syntax-case stx ()
       [(_ binds body0 body ...)
        (with-syntax ([((pre-body ...) (post-body ...)) (split-for-body stx #'(body0 body ...))]
-                     [for/fold/derived for/fold/derived-id])
+                     [for/fold/derived for/fold/derived-id]
+                     [wrap-result wrap-result-id])
          #`(for/fold/derived #,stx ([root empty-node] [size 0] [height 0]
-                                                      #:result (if (fx= size 0)
-                                                                   empty-treelist
-                                                                   (treelist root size height)))
+                                                      #:result (wrap-result
+                                                                (if (fx= size 0)
+                                                                    empty-treelist
+                                                                    (treelist root size height))))
                              binds
              pre-body ...
              (unsafe-root-add root size height
@@ -293,9 +295,9 @@
                                 post-body ...))))])))
 
 (define-syntax for/treelist
-  (make-for/treelist #'for/fold/derived))
+  (make-for/treelist #'for/fold/derived #'values))
 (define-syntax for*/treelist
-  (make-for/treelist #'for*/fold/derived))
+  (make-for/treelist #'for*/fold/derived #'values))
 
 (define in-treelist/proc
   ;; Slower strategy than the inline version, but the

--- a/racket/collects/racket/treelist.rkt
+++ b/racket/collects/racket/treelist.rkt
@@ -1525,7 +1525,7 @@ minimum required storage. |#
 (define (treelist-reverse/slow tl)
   (define who 'treelist-reverse)
   (check-treelist who tl)
-  (define len (treelist-length tl))
+  (define len (treelist-size tl))
   (for/fold ([new-tl (treelist-take tl 0)]) ([i (in-range len)])
     (treelist-add new-tl (treelist-ref tl (fx- len i 1)))))
 

--- a/racket/collects/racket/treelist.rkt
+++ b/racket/collects/racket/treelist.rkt
@@ -834,10 +834,16 @@ minimum required storage. |#
     [else (treelist-take (treelist-drop tl pos) len)]))
 
 (define (treelist-reverse tl)
-  (check-treelist 'treelist-reverse tl)
-  (define len (treelist-length tl))
-  (for/fold ([new-tl (treelist-take tl 0)]) ([i (in-range len)])
-    (treelist-add new-tl (treelist-ref tl (fx- len i 1)))))
+  (cond
+    [(impersonator? tl) (treelist-reverse/slow tl)]
+    [else
+     (check-treelist 'treelist-reverse tl)
+     (define len (treelist-size tl))
+     (define vec (make-vector len))
+     (for ([el (in-treelist tl)]
+           [i (in-range (sub1 len) -1 -1)])
+       (vector-set! vec i el))
+     (vector->treelist vec)]))
 
 (define (treelist-rest tl)
   (cond
@@ -1517,6 +1523,13 @@ minimum required storage. |#
      (raise-arguments-error* who 'racket/primitive "treelist is empty")]
     [else
      (treelist-ref/slow tl (fx- (treelist-size tl) 1))]))
+
+(define (treelist-reverse/slow tl)
+  (define who 'treelist-reverse)
+  (check-treelist who tl)
+  (define len (treelist-size tl))
+  (for/fold ([new-tl (treelist-take/slow tl 0)]) ([i (in-range len)])
+    (treelist-add/slow new-tl (treelist-ref/slow tl (fx- len i 1)))))
 
 (define (treelist-rest/slow tl)
   (define who 'treelist-rest)

--- a/racket/collects/racket/treelist.rkt
+++ b/racket/collects/racket/treelist.rkt
@@ -1526,8 +1526,8 @@ minimum required storage. |#
   (define who 'treelist-reverse)
   (check-treelist who tl)
   (define len (treelist-size tl))
-  (for/fold ([new-tl (treelist-take tl 0)]) ([i (in-range len)])
-    (treelist-add new-tl (treelist-ref tl (fx- len i 1)))))
+  (for/fold ([new-tl (treelist-take/slow tl 0)]) ([i (in-range len)])
+    (treelist-add/slow new-tl (treelist-ref/slow tl (fx- len i 1)))))
 
 (define (treelist-rest/slow tl)
   (define who 'treelist-rest)

--- a/racket/collects/racket/treelist.rkt
+++ b/racket/collects/racket/treelist.rkt
@@ -832,13 +832,16 @@ minimum required storage. |#
     [else (treelist-take (treelist-drop tl pos) len)]))
 
 (define (treelist-reverse tl)
-  (check-treelist 'treelist-reverse tl)
-  (define len (treelist-size tl))
-  (define vec (make-vector len))
-  (for ([el (in-treelist tl)]
-        [i (in-range (sub1 len) -1 -1)])
-    (vector-set! vec i el))
-  (vector->treelist vec))
+  (cond
+    [(impersonator? tl) (treelist-reverse/slow tl)]
+    [else
+     (check-treelist 'treelist-reverse tl)
+     (define len (treelist-size tl))
+     (define vec (make-vector len))
+     (for ([el (in-treelist tl)]
+           [i (in-range (sub1 len) -1 -1)])
+       (vector-set! vec i el))
+     (vector->treelist vec)]))
 
 (define (treelist-rest tl)
   (cond
@@ -1518,6 +1521,13 @@ minimum required storage. |#
      (raise-arguments-error* who 'racket/primitive "treelist is empty")]
     [else
      (treelist-ref/slow tl (fx- (treelist-size tl) 1))]))
+
+(define (treelist-reverse/slow tl)
+  (define who 'treelist-reverse)
+  (check-treelist who tl)
+  (define len (treelist-length tl))
+  (for/fold ([new-tl (treelist-take tl 0)]) ([i (in-range len)])
+    (treelist-add new-tl (treelist-ref tl (fx- len i 1)))))
 
 (define (treelist-rest/slow tl)
   (define who 'treelist-rest)


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [x] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->
This PR optimizes the performance of `for/treelist` and `treelist-reverse` by introducing new implementations that leverage `for/vector` and `vector->treelist`. See also https://racket.discourse.group/t/for-treelist-vs-vector-treelist/3441/5 .

Example:
```racket
#lang racket

(require racket/treelist)

(define (my/treelist-reverse tl)
  (define len (treelist-length tl))
  (define vec (make-vector len))
  (for ([el (in-treelist tl)]
        [i (in-range (sub1 len) -1 -1)])
    (vector-set! vec i el))
  (vector->treelist vec))

(define tl (make-treelist 10000000 'pear))
(void
 (time (my/treelist-reverse tl))
 (time (treelist-reverse tl))
 (newline))


(define-for-syntax (make-for/treelist for/vector-id vector->treelist-id)
  (lambda (stx)
    (syntax-case stx ()
      [(_ binds body0 body ...)
       (quasisyntax/loc stx
         (#,vector->treelist-id
          (#,for/vector-id binds body0 body ...)))]
      [(_ #:length length-expr #:fill fill-expr binds body0 body ...)
       (quasisyntax/loc stx
         (#,vector->treelist-id
          (#,for/vector-id #:length length-expr #:fill fill-expr binds body0 body ...)))]
      [(_ #:length length-expr binds body0 body ...)
       (quasisyntax/loc stx
         (#,vector->treelist-id
          (#,for/vector-id #:length length-expr binds body0 body ...)))])))

(define-syntax my/for/treelist
  (make-for/treelist #'for/vector #'vector->treelist))
(define-syntax my/for*/treelist
  (make-for/treelist #'for*/vector #'vector->treelist))

(void
 (time (my/for/treelist #:length 10000000 ([i 10000000]) i))
 (time (my/for/treelist ([i 10000000]) i))
 (time (for/treelist ([i 10000000]) i))
 (newline))
```

Output:
```
cpu time: 427 real time: 428 gc time: 256
cpu time: 1842 real time: 1849 gc time: 288

cpu time: 220 real time: 221 gc time: 146
cpu time: 558 real time: 560 gc time: 353
cpu time: 1396 real time: 1400 gc time: 179

```