### PR TITLE
doc(openssl): fix the link to openssl-ciphers(1)

### DIFF
--- a/pkgs/racket-doc/openssl/openssl.scrbl
+++ b/pkgs/racket-doc/openssl/openssl.scrbl
@@ -609,7 +609,7 @@ loading certificate files in PEM format.
 Specifies the cipher suites that can be used in connections created
 with @racket[context]. The meaning of @racket[cipher-spec] is the same
 as for the
-@hyperlink["https://www.openssl.org/docs/manmaster/man1/ciphers.html"]{@tt{openssl
+@hyperlink["https://docs.openssl.org/master/man1/openssl-ciphers/"]{@tt{openssl
 ciphers} command}.
 }
 


### PR DESCRIPTION
The current link redirects to
https://docs.openssl.org/master/man1/openssl-cmds/, from which you need to scroll to "SEE ALSO" to get to
https://docs.openssl.org/master/man1/openssl-ciphers/, where we wanted to be in the first place.


## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation
