### PR TITLE
ci: extract run-racket-tests.sh and run more tests on PR and push

### DIFF
--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+HERE="$(dirname "$0")"
+BIN="$HERE/../../racket/bin"
+RACKET="$BIN/racket"
+RACO="$BIN/raco"
+CPUS="$("$RACKET" -e '(processor-count)')"
+
+"$RACO" pkg install --auto --skip-installed db-test racket-test
+
+do_test() {
+    "$RACO" test --timeout 300 -j "$CPUS" "$@"
+}
+
+
+# What Gets Tested
+# ~~~~~~~~~~~~~~~~
+# These tests run in GitHub Actions, where the environment isn't suited
+# to run all the tests. This script tries to run most of the tests that
+# can easily run in that environment. The rest of the tests are run by
+# DrDr[1] whenever changes are made to the master branch.
+#
+# [1]: http://drdr.racket-lang.org/
+
+
+# Collection Tests
+# ~~~~~~~~~~~~~~~~
+# Tests where `raco test` can discover and run all the tests.
+
+COLLECTIONS_TO_TEST=$(cat <<EOF
+tests/file
+tests/future
+tests/generic
+tests/json
+tests/match
+tests/net
+tests/setup
+tests/stxparse
+tests/syntax
+tests/units
+tests/utils
+tests/xml
+EOF
+                   )
+
+for collection in $COLLECTIONS_TO_TEST; do
+    echo " == Testing collection '$collection'"
+    do_test -c "$collection"
+done
+
+
+# Module Tests
+# ~~~~~~~~~~~~
+# Tests where a central module controls what gets tested.
+
+MODULES_TO_TEST=$(cat <<EOF
+tests/db/all-tests
+tests/openssl/basic
+tests/openssl/https
+tests/zo-path
+EOF
+               )
+
+for mpath in $MODULES_TO_TEST; do
+    echo " == Testing module path '$mpath'"
+    do_test -l "$mpath"
+done
+
+
+# Special Cases
+# ~~~~~~~~~~~~~
+# Tests that don't fit in the previous two buckets.
+
+"$RACKET" -l tests/racket/contract/all

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -17,28 +17,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: make CPUS=$(nproc) PKGS="racket-test db-test unstable-flonum-lib net-test"
+      run: make CPUS="$(nproc)" PKGS=""
     - name: Test
-      run: |
-        export PATH=$PATH:`pwd`/racket/bin
-        raco test -l tests/racket/test
-        racket -l tests/racket/contract/all
-        raco test -l tests/json/json
-        raco test -l tests/file/main
-        raco test -l tests/net/head
-        raco test -l tests/net/uri-codec
-        raco test -l tests/net/url
-        raco test -l tests/net/url-port
-        raco test -l tests/net/encoders
-        raco test -l tests/openssl/basic
-        raco test -l tests/openssl/https
-        raco test -l tests/match/main
-        raco test -l tests/zo-path
-        raco test -c tests/xml
-        raco test --timeout 300 -c tests/future
-        raco test -l tests/db/all-tests
-        raco test -c tests/stxparse
-        raco test -c tests/syntax
+      run: bash .github/scripts/run-racket-tests.sh
 
   buildtest-macos:
 
@@ -47,28 +28,9 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Build
-      run: make CPUS=$(sysctl -n hw.physicalcpu) PKGS="racket-test db-test unstable-flonum-lib net-test"
+      run: make CPUS="$(sysctl -n hw.physicalcpu)" PKGS=""
     - name: Test
-      run: |
-        export PATH=$PATH:`pwd`/racket/bin
-        raco test -l tests/racket/test
-        racket -l tests/racket/contract/all
-        raco test -l tests/json/json
-        raco test -l tests/file/main
-        raco test -l tests/net/head
-        raco test -l tests/net/uri-codec
-        raco test -l tests/net/url
-        raco test -l tests/net/url-port
-        raco test -l tests/net/encoders
-        raco test -l tests/openssl/basic
-        raco test -l tests/openssl/https
-        raco test -l tests/match/main
-        raco test -l tests/zo-path
-        raco test -c tests/xml
-        raco test --timeout 300 -c tests/future
-        raco test -l tests/db/all-tests
-        raco test -c tests/stxparse
-        raco test -c tests/syntax
+      run: bash .github/scripts/run-racket-tests.sh
     - name: Tarball
       run: tar -cvjf racketcs-macos-aarch64_git${{ github.sha }}.tar.bz2 racket
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/ci-push-x86_linux.yml
+++ b/.github/workflows/ci-push-x86_linux.yml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         cify: [nocify]
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -66,9 +66,9 @@ jobs:
     runs-on: ubuntu-22.04
     container:
       image: racket/racket-ci:latest
-                
+
     needs: build-racketcgc
-      
+
     strategy:
       fail-fast: false
       matrix:
@@ -85,7 +85,7 @@ jobs:
             cify: nocify
             efp: efp
             cc: gcc # clang has a problem with future tests timing out
-  
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -155,7 +155,7 @@ jobs:
       image: racket/racket-ci:latest
 
     needs: build-racketcgc
-    
+
     strategy:
       fail-fast: false
       matrix:
@@ -202,10 +202,8 @@ jobs:
         path: /tmp/racketcs-debian10-x64-${{ matrix.cc }}_git${{ github.sha }}.tar.bz2
 
   # Tests
-  # Unfortunately Actions does not support atm yaml anchors
-  # otherwise all the following jobs could be simplified
-  # Note: the reason we cannot transform this into a matrix
-  # build is because we cannot use variables in the needs keyword.
+  # Note: the reason we cannot transform this into a matrix build is
+  # because we cannot use variables in the needs keyword.
   test-cgc:
     runs-on: ubuntu-22.04
     container:
@@ -238,44 +236,10 @@ jobs:
           raco pkg config --set catalogs $PWD/rktcat/ https://pkgs.racket-lang.org https://planet-compats.racket-lang.org
       - name: Install racket-test dependency
         run: raco pkg install --auto racket-test
-      - name: Run tests/racket/test
-        run: raco test -l tests/racket/test
-      - name: Run tests/racket/contract/all
-        run: racket -l tests/racket/contract/all
-      - name: Run tests/json/json
-        run: raco test -l tests/json/json
-      - name: Run tests/file/main
-        run: raco test -l tests/file/main
-      - name: Run tests/net/head
-        run: raco test -l tests/net/head
-      - name: Run tests/net/uri-codec
-        run: raco test -l tests/net/uri-codec
-      - name: Run tests/net/url
-        run: raco test -l tests/net/url
-      - name: Run tests/net/url-port
-        run: raco test -l tests/net/url-port
-      - name: Run tests/net/encoders
-        run: raco test -l tests/net/encoders
-      - name: Run tests/openssl/basic
-        run: raco test -l tests/openssl/basic
-      - name: Run tests/openssl/https
-        run: raco test -l tests/openssl/https
-      - name: Run tests/match/main
-        run: raco test -l tests/match/main
-      - name: Run tests/zo-path
-        run: raco test -l tests/zo-path
-      - name: Run tests/xml
-        run: raco test -c tests/xml
-      - name: Run tests/future
-        run: raco test --timeout 300 -c tests/future
-      - name: Run tests/stxparse
-        run: raco test -c tests/stxparse
       - name: Install db tests dependency
         run: raco pkg install --auto db-test
-      - name: Run db tests
-        run: raco test -l tests/db/all-tests
-      - name: Run syntax tests
-        run: raco test -c tests/syntax
+      - name: Test
+        run: bash .github/scripts/run-racket-tests.sh
 
   test-3m:
     runs-on: ubuntu-22.04
@@ -321,44 +285,10 @@ jobs:
           raco pkg config --set catalogs $PWD/rktcat/ https://pkgs.racket-lang.org https://planet-compats.racket-lang.org
       - name: Install racket-test dependency
         run: raco pkg install --auto racket-test
-      - name: Run tests/racket/test
-        run: raco test -l tests/racket/test
-      - name: Run tests/racket/contract/all
-        run: racket -l tests/racket/contract/all
-      - name: Run tests/json/json
-        run: raco test -l tests/json/json
-      - name: Run tests/file/main
-        run: raco test -l tests/file/main
-      - name: Run tests/net/head
-        run: raco test -l tests/net/head
-      - name: Run tests/net/uri-codec
-        run: raco test -l tests/net/uri-codec
-      - name: Run tests/net/url
-        run: raco test -l tests/net/url
-      - name: Run tests/net/url-port
-        run: raco test -l tests/net/url-port
-      - name: Run tests/net/encoders
-        run: raco test -l tests/net/encoders
-      - name: Run tests/openssl/basic
-        run: raco test -l tests/openssl/basic
-      - name: Run tests/openssl/https
-        run: raco test -l tests/openssl/https
-      - name: Run tests/match/main
-        run: raco test -l tests/match/main
-      - name: Run tests/zo-path
-        run: raco test -l tests/zo-path
-      - name: Run tests/xml
-        run: raco test -c tests/xml
-      - name: Run tests/future
-        run: raco test --timeout 300 -c tests/future
-      - name: Run tests/stxparse
-        run: raco test -c tests/stxparse
       - name: Install db tests dependency
         run: raco pkg install --auto db-test
-      - name: Run db tests
-        run: raco test -l tests/db/all-tests
-      - name: Run syntax tests
-        run: raco test -c tests/syntax
+      - name: Test
+        run: bash .github/scripts/run-racket-tests.sh
 
   test-cs:
     runs-on: ubuntu-22.04
@@ -390,51 +320,15 @@ jobs:
         run: |
           racket -l- pkg/dirs-catalog --immediate $PWD/rktcat $PWD/pkgs/
           raco pkg config --set catalogs $PWD/rktcat/ https://pkgs.racket-lang.org https://planet-compats.racket-lang.org
-      - name: Install racket-test dependency
-        run: raco pkg install --auto racket-test
-      - name: Run tests/racket/test
-        run: raco test -l tests/racket/test
-      - name: Run tests/racket/contract/all
-        run: racket -l tests/racket/contract/all
-      - name: Run tests/json/json
-        run: raco test -l tests/json/json
-      - name: Run tests/file/main
-        run: raco test -l tests/file/main
-      - name: Run tests/net/head
-        run: raco test -l tests/net/head
-      - name: Run tests/net/uri-codec
-        run: raco test -l tests/net/uri-codec
-      - name: Run tests/net/url
-        run: raco test -l tests/net/url
-      - name: Run tests/net/url-port
-        run: raco test -l tests/net/url-port
-      - name: Run tests/net/encoders
-        run: raco test -l tests/net/encoders
-      - name: Run tests/openssl/basic
-        run: raco test -l tests/openssl/basic
-      - name: Run tests/openssl/https
-        run: raco test -l tests/openssl/https
-      - name: Run tests/match/main
-        run: raco test -l tests/match/main
-      - name: Run tests/zo-path
-        run: raco test -l tests/zo-path
-      - name: Run tests/xml
-        run: raco test -c tests/xml
-      - name: Run tests/future
-        run: raco test --timeout 300 -c tests/future
-      - name: Run tests/stxparse
-        run: raco test -c tests/stxparse
-      - name: Install db tests dependency
-        run: raco pkg install --auto db-test
-      - name: Run db tests
-        run: raco test -l tests/db/all-tests
-      - name: Run syntax tests
-        run: raco test -c tests/syntax
+      - name: Test
+        run: bash .github/scripts/run-racket-tests.sh
+
+  # XXX: Do we still need/want this?
   slack:
     runs-on: ubuntu-latest
     needs: [test-cgc, test-3m, test-cs]
 
-    # this is required, otherwise it gets skipped if any needed jobs fail. 
+    # this is required, otherwise it gets skipped if any needed jobs fail.
     # https://help.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idneeds
     if: always()
 

--- a/.github/workflows/ci-push_macos.yml
+++ b/.github/workflows/ci-push_macos.yml
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  
+
 # Build jobs
 # These jobs build each Racket component separately and tests on the component start as soon as each
 # component finishes building.
@@ -19,11 +19,11 @@ jobs:
       fail-fast: false
       matrix:
         cify: [nocify]
-          
+
     runs-on: macos-14
     env:
       RACKET_EXTRA_CONFIGURE_ARGS: ""
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -37,18 +37,18 @@ jobs:
     - name: Configuring Racket CGC
       working-directory: ./racket/src
       run: >
-        ./configure 
+        ./configure
         --prefix=$GITHUB_WORKSPACE/racketcgc
-        $RACKET_EXTRA_CONFIGURE_ARGS 
-        --enable-cgcdefault 
-        --enable-jit 
+        $RACKET_EXTRA_CONFIGURE_ARGS
+        --enable-cgcdefault
+        --enable-jit
         --enable-foreign
         --enable-macprefix
-        --enable-places 
+        --enable-places
         --enable-float
         $CIFY_OPTION
         --enable-pthread
-        --disable-docs 
+        --disable-docs
     - name: Building
       working-directory: ./racket/src
       run: |
@@ -70,14 +70,14 @@ jobs:
       fail-fast: false
       matrix:
         cify: [nocify]
-            
+
     runs-on: macos-14
-    
+
     needs: build-racketcgc
-    
+
     env:
       RACKET_EXTRA_CONFIGURE_ARGS: ""
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -101,17 +101,17 @@ jobs:
         CC: clang
       run: >
         ./configure
-        --prefix=$GITHUB_WORKSPACE/racket3m 
-        $RACKET_EXTRA_CONFIGURE_ARGS 
-        --enable-racket=$GITHUB_WORKSPACE/racketcgc/bin/racket 
-        --enable-bcdefault 
-        --enable-jit 
+        --prefix=$GITHUB_WORKSPACE/racket3m
+        $RACKET_EXTRA_CONFIGURE_ARGS
+        --enable-racket=$GITHUB_WORKSPACE/racketcgc/bin/racket
+        --enable-bcdefault
+        --enable-jit
         --enable-foreign
         --enable-macprefix
-        --enable-places 
-        --enable-float 
-        --disable-docs 
-        $CIFY_OPTION 
+        --enable-places
+        --enable-float
+        --disable-docs
+        $CIFY_OPTION
         --enable-pthread
     - name: Building
       working-directory: ./racket/src
@@ -132,7 +132,7 @@ jobs:
   build-racketcs:
     runs-on: macos-14
     needs: build-racketcgc
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -149,14 +149,14 @@ jobs:
       env:
         CC: ${{ matrix.cc }}
       run: >
-        ./configure 
+        ./configure
         --prefix=$GITHUB_WORKSPACE/racketcs
         --enable-racket=$GITHUB_WORKSPACE/racketcgc/bin/racket
         --enable-macprefix
-        --enable-compress 
-        --disable-docs 
-        --enable-pthread 
-        --enable-csdefault 
+        --enable-compress
+        --disable-docs
+        --enable-pthread
+        --enable-csdefault
         --enable-csonly
     - name: Building
       working-directory: ./racket/src
@@ -203,10 +203,8 @@ jobs:
           make install
 
   # Tests
-  # Unfortunately Actions does not support atm yaml anchors
-  # otherwise all the following jobs could be simplified
-  # Note: the reason we cannot transform this into a matrix
-  # build is because we cannot use variables in the needs keyword.
+  # Note: the reason we cannot transform this into a matrix build is
+  # because we cannot use variables in the needs keyword.
   test-cgc:
     strategy:
       fail-fast: false
@@ -235,44 +233,8 @@ jobs:
         run: |
           racket -l- pkg/dirs-catalog --immediate $PWD/rktcat $PWD/pkgs/
           raco pkg config --set catalogs $PWD/rktcat/ https://pkgs.racket-lang.org https://planet-compats.racket-lang.org
-      - name: Install racket-test dependency
-        run: raco pkg install --auto racket-test
-      - name: Run tests/racket/test
-        run: raco test -l tests/racket/test
-      - name: Run tests/racket/contract/all
-        run: racket -l tests/racket/contract/all
-      - name: Run tests/json/json
-        run: raco test -l tests/json/json
-      - name: Run tests/file/main
-        run: raco test -l tests/file/main
-      - name: Run tests/net/head
-        run: raco test -l tests/net/head
-      - name: Run tests/net/uri-codec
-        run: raco test -l tests/net/uri-codec
-      - name: Run tests/net/url
-        run: raco test -l tests/net/url
-      - name: Run tests/net/url-port
-        run: raco test -l tests/net/url-port
-      - name: Run tests/net/encoders
-        run: raco test -l tests/net/encoders
-      - name: Run tests/openssl/basic
-        run: raco test -l tests/openssl/basic
-      - name: Run tests/openssl/https
-        run: raco test -l tests/openssl/https
-      - name: Run tests/match/main
-        run: raco test -l tests/match/main
-      - name: Run tests/zo-path
-        run: raco test -l tests/zo-path
-      - name: Run tests/xml
-        run: raco test -c tests/xml
-      - name: Run tests/stxparse
-        run: raco test -c tests/stxparse
-      - name: Install db tests dependency
-        run: raco pkg install --auto db-test
-      - name: Run db tests
-        run: raco test -l tests/db/all-tests
-      - name: Run syntax tests
-        run: raco test -c tests/syntax
+      - name: Test
+        run: bash .github/scripts/run-racket-tests.sh
 
   test-3m:
     strategy:
@@ -302,45 +264,9 @@ jobs:
         run: |
           racket -l- pkg/dirs-catalog --immediate $PWD/rktcat $PWD/pkgs/
           raco pkg config --set catalogs $PWD/rktcat/ https://pkgs.racket-lang.org https://planet-compats.racket-lang.org
-      - name: Install racket-test dependency
-        run: raco pkg install --auto racket-test
-      - name: Run tests/racket/test
-        run: raco test -l tests/racket/test
-      - name: Run tests/racket/contract/all
-        run: racket -l tests/racket/contract/all
-      - name: Run tests/json/json
-        run: raco test -l tests/json/json
-      - name: Run tests/file/main
-        run: raco test -l tests/file/main
-      - name: Run tests/net/head
-        run: raco test -l tests/net/head
-      - name: Run tests/net/uri-codec
-        run: raco test -l tests/net/uri-codec
-      - name: Run tests/net/url
-        run: raco test -l tests/net/url
-      - name: Run tests/net/url-port
-        run: raco test -l tests/net/url-port
-      - name: Run tests/net/encoders
-        run: raco test -l tests/net/encoders
-      - name: Run tests/openssl/basic
-        run: raco test -l tests/openssl/basic
-      - name: Run tests/openssl/https
-        run: raco test -l tests/openssl/https
-      - name: Run tests/match/main
-        run: raco test -l tests/match/main
-      - name: Run tests/zo-path
-        run: raco test -l tests/zo-path
-      - name: Run tests/xml
-        run: raco test -c tests/xml
-      - name: Run tests/stxparse
-        run: raco test -c tests/stxparse
-      - name: Install db tests dependency
-        run: raco pkg install --auto db-test
-      - name: Run db tests
-        run: raco test -l tests/db/all-tests
-      - name: Run syntax tests
-        run: raco test -c tests/syntax
-          
+      - name: Test
+        run: bash .github/scripts/run-racket-tests.sh
+
   test-cs:
     runs-on: macos-14
 
@@ -364,41 +290,5 @@ jobs:
         run: |
           racket -l- pkg/dirs-catalog --immediate $PWD/rktcat $PWD/pkgs/
           raco pkg config --set catalogs $PWD/rktcat/ https://pkgs.racket-lang.org https://planet-compats.racket-lang.org
-      - name: Install racket-test dependency
-        run: raco pkg install --auto racket-test
-      - name: Run tests/racket/test
-        run: raco test -l tests/racket/test
-      - name: Run tests/racket/contract/all
-        run: racket -l tests/racket/contract/all
-      - name: Run tests/json/json
-        run: raco test -l tests/json/json
-      - name: Run tests/file/main
-        run: raco test -l tests/file/main
-      - name: Run tests/net/head
-        run: raco test -l tests/net/head
-      - name: Run tests/net/uri-codec
-        run: raco test -l tests/net/uri-codec
-      - name: Run tests/net/url
-        run: raco test -l tests/net/url
-      - name: Run tests/net/url-port
-        run: raco test -l tests/net/url-port
-      - name: Run tests/net/encoders
-        run: raco test -l tests/net/encoders
-      - name: Run tests/openssl/basic
-        run: raco test -l tests/openssl/basic
-      - name: Run tests/openssl/https
-        run: raco test -l tests/openssl/https
-      - name: Run tests/match/main
-        run: raco test -l tests/match/main
-      - name: Run tests/zo-path
-        run: raco test -l tests/zo-path
-      - name: Run tests/xml
-        run: raco test -c tests/xml
-      - name: Run tests/stxparse
-        run: raco test -c tests/stxparse
-      - name: Install db tests dependency
-        run: raco pkg install --auto db-test
-      - name: Run db tests
-        run: raco test -l tests/db/all-tests
-      - name: Run syntax tests
-        run: raco test -c tests/syntax
+      - name: Test
+        run: bash .github/scripts/run-racket-tests.sh

--- a/pkgs/net-test/tests/net/git-checkout.rkt
+++ b/pkgs/net-test/tests/net/git-checkout.rkt
@@ -59,13 +59,13 @@
    [else
     (error 'compare "no such file: ~s" a)]))
 
-(when git-exe
+(when (and git-exe (not (getenv "GITHUB_ACTIONS")))
   (for ([link-mode '(rel up abs)])
     (define dir (make-temporary-file "~a-git-test" 'directory))
     (define http-custodian (make-custodian))
     (dynamic-wind
      void
-     (lambda () 
+     (lambda ()
        (parameterize ([current-custodian http-custodian])
          (thread
           (lambda ()
@@ -75,7 +75,7 @@
              #:extra-files-paths (list dir)
              #:servlet-regexp #rx"$." ; no servlets
              #:port 8950))))
-       
+
        (parameterize ([current-directory dir]
                       [current-environment-variables
                        (environment-variables-copy (current-environment-variables))])
@@ -103,7 +103,7 @@
            (git "add" ".")
            (git "commit" "-m" "initial commit")
            (git "update-server-info"))
-         
+
          (git-checkout "localhost" #:port 8950 #:transport 'http
                        "repo/.git"
                        #:dest-dir "also-repo")
@@ -125,10 +125,8 @@
              [(abs up) (unless (eq? 'windows (system-type))
                          (error "should not have worked"))])
            (compare "repo" "safe-repo"))
-         
+
          (void)))
      (lambda ()
        (custodian-shutdown-all http-custodian)
        (delete-directory/files dir)))))
-
-


### PR DESCRIPTION
Reduces some, but not all of the duplication in the workflows and runs more tests on PR and push. In particular, I didn't touch the asan and windows workflows since the former relies on skipping failing tests to produce a report and the latter can't run bash scripts.