### PR TITLE
Fix typo in docs

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/make.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/make.scrbl
@@ -674,7 +674,7 @@ Racket processes. The callback, @racket[handler], is called with the symbol
 @racket['done] as the @racket[_handler-type] argument for each successfully compiled file, 
 @racket['output] when a
 successful compilation produces stdout/stderr output, @racket['error] when a
-compilation error has occurred, or @racket['fatal-error] when a unrecoverable
+compilation error has occurred, or @racket['fatal-error] when an unrecoverable
 error occurs. The other arguments give more information for each status update.
 The return value is @racket[(void)] if it was successful, or @racket[#f] if there was an error.
  

--- a/pkgs/racket-doc/scribblings/reference/symbols.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/symbols.scrbl
@@ -21,7 +21,7 @@ other symbol, although they may print the same as other symbols.
 
 The procedure @racket[string->unreadable-symbol] returns an
 @deftech{unreadable symbol} that is partially interned.  The default
-reader (see @secref["parse-symbol"]) never produces a unreadable
+reader (see @secref["parse-symbol"]) never produces an unreadable
 symbol, but two calls to @racket[string->unreadable-symbol] with
 @racket[equal?] strings produce @racket[eq?] results. An unreadable
 symbol can print the same as an interned or uninterned


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->
Use "an" before words beginning with a vowel sound. Namely "unrecoverable" and "unreadable".
