### PR TITLE
fix(ci): use Bash arrays to simplify test loops

### DIFF
--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -28,23 +28,22 @@ do_test() {
 # ~~~~~~~~~~~~~~~~
 # Tests where `raco test` can discover and run all the tests.
 
-COLLECTIONS_TO_TEST=$(cat <<EOF
-tests/file
-tests/future
-tests/generic
-tests/json
-tests/match
-tests/net
-tests/setup
-tests/stxparse
-tests/syntax
-tests/units
-tests/utils
-tests/xml
-EOF
-                   )
+COLLECTIONS_TO_TEST=(
+  tests/file
+  tests/future
+  tests/generic
+  tests/json
+  tests/match
+  tests/net
+  tests/setup
+  tests/stxparse
+  tests/syntax
+  tests/units
+  tests/utils
+  tests/xml
+)
 
-for collection in $COLLECTIONS_TO_TEST; do
+for collection in "${COLLECTIONS_TO_TEST[@]}"; do
     echo " == Testing collection '$collection'"
     do_test -c "$collection"
 done
@@ -54,15 +53,14 @@ done
 # ~~~~~~~~~~~~
 # Tests where a central module controls what gets tested.
 
-MODULES_TO_TEST=$(cat <<EOF
-tests/db/all-tests
-tests/openssl/basic
-tests/openssl/https
-tests/zo-path
-EOF
-               )
+MODULES_TO_TEST=(
+  tests/db/all-tests
+  tests/openssl/basic
+  tests/openssl/https
+  tests/zo-path
+)
 
-for mpath in $MODULES_TO_TEST; do
+for mpath in "${MODULES_TO_TEST[@]}"; do
     echo " == Testing module path '$mpath'"
     do_test -l "$mpath"
 done


### PR DESCRIPTION
This is a small follow-on to https://github.com/racket/racket/pull/5184#discussion_r1931549848. AFAIK, Bash has always had arrays, so this should not depend on which version we get in the action runner.

Commit 00f205b039 (ci: extract run-racket-tests.sh and run more tests on PR and push, 2025-01-19) improved the way we run tests in CI, but it uses a looping and variable data pattern that depend on a clean IFS [1], [2]. Instead use arrays, which loop cleanly (and require fewer UUOC [3] as a bonus).

[1]: https://unix.stackexchange.com/q/171346/301073, noting that in this
     case we control the data so it's "safe" but potentially confusing.
[2]: https://mywiki.wooledge.org/IFS
[3]: https://porkmail.org/era/unix/award