### PR TITLE
Using the racket executable from PATH

### DIFF
--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -2,11 +2,15 @@
 
 set -euo pipefail
 HERE="$(dirname "$0")"
-BIN="$HERE/../../racket/bin"
-RACKET="$BIN/racket"
-RACO="$BIN/raco"
+RACKET="racket"
+RACO="raco"
+
+echo Using `which "$RACKET"`
+"$RACKET" -v
+
 CPUS="$("$RACKET" -e '(processor-count)')"
 
+echo Installing dt-test and racket-test using `which "$RACO"`
 "$RACO" pkg install --auto --skip-installed db-test racket-test
 
 do_test() {

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -18,6 +18,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: make CPUS="$(nproc)" PKGS=""
+    - name: Extend PATH with Racket executable
+      run: echo "${GITHUB_WORKSPACE}/racket/bin" >> $GITHUB_PATH
     - name: Test
       run: bash .github/scripts/run-racket-tests.sh
 
@@ -29,6 +31,8 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build
       run: make CPUS="$(sysctl -n hw.physicalcpu)" PKGS=""
+    - name: Extend PATH with Racket executable
+      run: echo "${GITHUB_WORKSPACE}/racket/bin" >> $GITHUB_PATH
     - name: Test
       run: bash .github/scripts/run-racket-tests.sh
     - name: Tarball


### PR DESCRIPTION

## Description of change
<!-- Please provide a description of the change here. -->

The workflows share built binaries and install them in `/usr/local/SOMEWHERE/...`. Each workflow sets its own `PATH`.