### PR TITLE
unixstyle-install: only clean `'config` in non-`origtree` configuration

### DIFF
--- a/racket/collects/setup/unixstyle-install.rkt
+++ b/racket/collects/setup/unixstyle-install.rkt
@@ -604,7 +604,13 @@
   (skip-dot-files!)
   (with-handlers ([exn? (lambda (e) (undo-changes) (raise e))])
     (set! yes-to-all? #t) ; non-interactive
-    (for-each cleantree (list 'collects 'pkgs 'sharerkt 'doc 'config))
+    (for-each cleantree (list 'collects 'pkgs 'sharerkt 'doc))
+    ;; Only deletes 'config (which is etc/ in some cases) when origtree? is not set.
+    ;; This particularly affects Unix-style builds on Mac with a custom --prefix where
+    ;; origtree? would be true in this case. Consequently, there is not a separate
+    ;; write-config step later in this function.
+    ;; Therefore, 'config should not be deleted in the first place.
+    (unless origtree? (cleantree 'config))
     (copytree "collects" 'collects)
     (copytree (make-path "share" "pkgs") 'pkgs #:missing 'skip)
     (parameterize ([current-skip-filter (add-pkgs-skip (current-skip-filter))])


### PR DESCRIPTION
Would close #5196 and #5197. See #5196 for the relevant error messages and commits.

Only deletes `'config` when `origtree?` is not set. This particularly affects
Unix-style builds on Mac with a custom `--prefix`.

In this case, `origtree?` would be true, so there is not a separate `write-config` step
later in `make-install-copytree`. Therefore, `'config` should not be deleted
in the first place.