### PR TITLE
test,generic: disable racket/generic benchmarks on CGC

### DIFF
--- a/pkgs/racket-test/tests/generic/benchmark.rkt
+++ b/pkgs/racket-test/tests/generic/benchmark.rkt
@@ -79,7 +79,11 @@
 (define factor 137)
 
 (define-syntax-rule (timing e)
-  (get-timing 'e (lambda () e)))
+  ;; Disable these tests on CGC because they end up being too slow and
+  ;; cause CI to fail.
+  (if (eq? 'cgc (system-type 'gc))
+      (printf "skipped ~s~n" 'e)
+      (get-timing 'e (lambda () e))))
 
 (define (get-timing expr proc)
   (collect-garbage)


### PR DESCRIPTION
Closes #5199, based on [a suggestion](https://discord.com/channels/571040468092321801/893314076346826852/1336690083474047036) from Matthew.