### PR TITLE
Fix bug in `hash/c` generation

### DIFF
--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -126,6 +126,10 @@
 (check-not-exn (λ ()
                  (test-contract-generation
                   (rename-contract (or/c integer? boolean?) 'b-or-i))))
+(check-not-exn (λ ()
+                 (test-contract-generation
+                  (letrec ([c (recursive-contract (hash/c any/c c #:flat? #t) #:flat)])
+                    c))))
 
 (define (check-empty-and-nonempty ctc val-empty? val-nonempty?)
   (define val-list

--- a/racket/collects/racket/contract/private/hash.rkt
+++ b/racket/collects/racket/contract/private/hash.rkt
@@ -197,7 +197,7 @@
   (define this-rng (base-hash/c-rng ctc))
   (define this-immutable (base-hash/c-immutable ctc))
   (λ (fuel)
-    (define rnd (random fuel)) ;; used to return empty hashes from time to time
+    (define rnd (if (zero? fuel) 0 (random fuel))) ;; used to return empty hashes from time to time
     (define gen-key (contract-random-generate/choose this-dom fuel))
     (define gen-val (contract-random-generate/choose this-rng fuel))
     (λ ()


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation

## Description of change

Generation for the following example

```rkt
(letrec ([c (recursive-contract (hash/c any/c c #:flat? #t) #:flat)])
   (contract-random-generate c))
```

yields this internal error:

```
  random: contract violation
    expected: (or/c (integer-in 1 4294967087) pseudo-random-generator?)
    given: 0
```

This PR fixes that. Thanks to @stites for finding this.
