### PR TITLE
use sin and cos from msvcrt on mingw

### DIFF
--- a/racket/src/worksp/mingw-ms.zuo
+++ b/racket/src/worksp/mingw-ms.zuo
@@ -5,26 +5,28 @@
 (define (make-mingw-to-ms-link-libraries m dir config)
   (cond
     [(member m '("ta6nt" "ti3nt"))
-     ;; Synthesize a library that links `pow` to msvcrt,
+     ;; Synthesize a library that links `sin`, `cos` and `pow` to msvcrt,
      ;; instead of using MinGW's implementation
      (define dlltool (find-cc-like-tool config 'DLLTOOL "dlltool"))
 
-     (define mspow-def (build-path dir "mspow.def"))
-     (define out (fd-open-output mspow-def :truncate))
+     (define msfuns-def (build-path dir "msfuns.def"))
+     (define out (fd-open-output msfuns-def :truncate))
      (fd-write out (~a "LIBRARY msvcrt\n"
                        "EXPORTS\n"
+                       "  sin\n"
+                       "  cos\n"
                        "  pow\n"))
      (fd-close out)
 
-     (define mspow-a (path-replace-extension mspow-def ".a"))
+     (define msfuns-a (path-replace-extension msfuns-def ".a"))
 
      (define proc (hash-ref
-                   (shell dlltool "-d" mspow-def "-l" mspow-a)
+                   (shell dlltool "-d" msfuns-def "-l" msfuns-a)
                    'process))
 
      (process-wait proc)
      (or (and (equal? 0 (process-status proc))
-              (list mspow-a))
+              (list msfuns-a))
          '())]
     [else '()]))
 


### PR DESCRIPTION
## Checklist
- [x] Bugfix
- [ ] tests included

## Description of change
windows-versions of racket `bc` and `cs` build with mingw give different results for `sin` and `cos` for arguments > 1e16. Comparing with linux-build and `mpfr` the difference can be 1e16 `flulp`s.
While `cs` has a special case for larger arguments (> 1e9) this does not seem to help over the complete range. [Chez - 5.c - line1474](https://github.com/cisco/ChezScheme/blob/fb0303678391a222c70b440773d4da8a69103056/c/prim5.c#L1474)
`tan` does produce the same results as linux and `mpfr` leading to the case that `(/ (sin x) (cos x))` != `(tan x)` (for large x)

I tried crossbuilding this commit, but Ifailed (due to problems with ffi that I don't know how to solve. same problem without the commit...), the linking of this definition did seem to work.

Another problem that I found is that in `bc`, if  'debugging and  profiling' is turned off (DrRacket), `sin` and `cos` produce even more different values:
```
#lang racket/base

(require racket/flonum math/bigfloat)

(define-namespace-anchor ns)

(define α 1.8384e31)
;(define α -1.797693134862315e+308)
(bf-precision 256)
(define A (bf α))

(list 'sin (flsin α)
      'cos (flcos α)
      'tan (fltan α)
      's/c (fl/ (flsin α) (flcos α)))
(eval '(list 'sin (flsin α)
             'cos (flcos α)
             'tan (fltan α)
             's/c (/ (flsin α) (flcos α)))
      (namespace-anchor->namespace ns))
(list 'sin (bigfloat->flonum (bfsin A))
      'cos (bigfloat->flonum (bfcos A))
      'tan (bigfloat->flonum (bftan A))
      's/c (bigfloat->flonum (bf/ (bfsin A) (bfcos A))))
(banner)

;; '(sin -0.17495269434000016 cos  0.9845768404462775   tan -0.771419604681833 s/c  -0.17769328624538808)
;; '(sin  0.9992436819643825  cos -0.038885267830682066 tan -0.771419604681833 s/c -25.697230280510976)
;; '(sin  0.6107990033181792  cos -0.7917856891517546   tan -0.771419604681833 s/c  -0.771419604681833)
;; "Welcome to Racket v8.16.0.2-2025-02-11-2b670506f9 [bc].\n"
```

