### PR TITLE
Zuo: remove unused private `modulo` binding

### DIFF
--- a/racket/src/zuo/lib/zuo/private/base-common/lib.zuo
+++ b/racket/src/zuo/lib/zuo/private/base-common/lib.zuo
@@ -41,13 +41,3 @@
 
 (define (gensym sym)
   (string->uninterned-symbol (symbol->string sym)))
-
-(define (modulo n m)
-  (let ([r (remainder n m)])
-    (if (>= m 0)
-        (if (>= n 0)
-            r
-            (- r))
-        (if (< n 0)
-            r
-            (+ r n)))))


### PR DESCRIPTION
## Description of change
This is a remnant of the change that removed `modulo` from `zuo/kernel`, but actually `modulo` isn't used anywhere in private modules.  Moreover, the implementation actually has a bug: `(+ r n)` should be `(+ r m)`.  I think it's best to just remove it since it's unused.