### PR TITLE
Index additional delimited sequences

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/printer.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/printer.scrbl
@@ -552,10 +552,10 @@ unreadably nevertheless counts as @tech{quotable}.
 @section[#:tag "print-compiled"]{Printing Compiled Code}
 
 Compiled code as produced by @racket[compile] prints using
-@litchar{#~}. Compiled code printed with @litchar{#~} is essentially
-assembly code for Racket, and reading such a form produces a compiled
-form when the @racket[read-accept-compiled] parameter is set to
-@racket[#t].
+@as-index{@litchar{#~}}. Compiled code printed with @litchar{#~} is
+essentially assembly code for Racket, and reading such a form produces
+a compiled form when the @racket[read-accept-compiled] parameter is
+set to @racket[#t].
 
 Compiled code parsed from @litchar{#~} is marked as non-runnable if
 the current code inspector (see @racket[current-code-inspector]) is

--- a/pkgs/racket-doc/scribblings/reference/reader.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/reader.scrbl
@@ -663,17 +663,18 @@ file.
 
 @section[#:tag "parse-vector"]{Reading Vectors}
 
-When the reader encounters a @litchar{#(}, @litchar{#[}, or
-@litchar["#{"], it starts parsing a @tech{vector}; see @secref["vectors"] for
-information on vectors. A @litchar{#fl} in place of @litchar{#}
-starts an @tech{flvector}, but is not allowed in @racket[read-syntax] mode; 
-see @secref["flvectors"] for information on flvectors.
-A @litchar{#fx} in place of @litchar{#}
-starts an @tech{fxvector}, but is not allowed in @racket[read-syntax] mode; 
-see @secref["fxvectors"] for information on fxvectors.
-The @litchar{#[}, @litchar["#{"], @litchar{#fl[}, @litchar["#fl{"], 
-@litchar{#fx[}, and @litchar["#fx{"] forms can be disabled through 
-the @racket[read-square-bracket-as-paren] and
+When the reader encounters a @as-index{@litchar{#(}},
+@as-index{@litchar{#[}}, or @as-index{@litchar["#{"]}, it starts
+parsing a @tech{vector}; see @secref["vectors"] for information on
+vectors. A @as-index{@litchar{#fl}} in place of @litchar{#} starts an
+@tech{flvector}, but is not allowed in @racket[read-syntax] mode; see
+@secref["flvectors"] for information on flvectors.  A
+@as-index{@litchar{#fx}} in place of @litchar{#} starts an
+@tech{fxvector}, but is not allowed in @racket[read-syntax] mode; see
+@secref["fxvectors"] for information on fxvectors.  The @litchar{#[},
+@litchar["#{"], @litchar{#fl[}, @litchar["#fl{"], @litchar{#fx[}, and
+@litchar["#fx{"] forms can be disabled through the
+@racket[read-square-bracket-as-paren] and
 @racket[read-curly-brace-as-paren] @tech{parameters}.
 
 The elements of the vector are recursively read until a matching
@@ -707,11 +708,12 @@ immutable.
 
 @section[#:tag "parse-structure"]{Reading Structures}
 
-When the reader encounters a @litchar{#s(}, @litchar{#s[}, or
-@litchar["#s{"], it starts parsing an instance of a @tech{prefab}
-@tech{structure type}; see @secref["structures"] for information on
-@tech{structure types}.  The @litchar{#s[} and @litchar["#s{"] forms
-can be disabled through the @racket[read-square-bracket-as-paren] and
+When the reader encounters a @as-index{@litchar{#s(}},
+@as-index{@litchar{#s[}}, or @as-index{@litchar["#s{"]}, it starts
+parsing an instance of a @tech{prefab} @tech{structure type}; see
+@secref["structures"] for information on @tech{structure types}.  The
+@litchar{#s[} and @litchar["#s{"] forms can be disabled through the
+@racket[read-square-bracket-as-paren] and
 @racket[read-curly-brace-as-paren] @tech{parameters}.
 
 The elements of the structure are recursively read until a matching


### PR DESCRIPTION
## Checklist

- [x] documentation

## Description of change

This PR is an attempt to address #5207.

Modifications to some scribble files for "The Racket Reference" were made in order to index the following currently unindexed delimited sequences [1]:

* `printer.scrbl` - `#~`
* `reader.scrbl` - `#(`, `#[`, `#{`, `#fl`, `#fx`, `#s(`, `#s[`, `#s{`

---

[1] I hope "delimited sequence" is an appropriate term -- it's a guess based on the text:

> \# has a special meaning as an initial character in a delimited sequence; its meaning depends on the characters that follow; see below.

in [this section](https://docs.racket-lang.org/reference/reader.html#(part._default-readtable-dispatch)).