### PR TITLE
pairs/lists: Introduce 4 additional algorithms

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/pairs.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/pairs.scrbl
@@ -449,6 +449,42 @@ each call to @racket[proc]).
   (foldr (lambda (v l) (cons (add1 v) l)) '() '(1 2 3 4))]}
 
 
+@defproc[(running-foldl [proc procedure?] [init any/c] [lst list?] ...+)
+         list?]{
+
+Like @racket[foldl], but produces a list containing all the results of applying 
+@racket[proc] as well as the initial accumulator.
+
+@mz-examples[
+  (running-foldl + 0 '(1 2 3))
+  (running-foldl + 0 '())
+  (running-foldl (lambda (a b acc) 
+                   (* acc (+ a b))) 
+                 1 
+                 '(1 2)
+                 '(3 4))]
+@history[#:added "8.16"]{}
+}
+
+
+@defproc[(running-foldr [proc procedure?] [init any/c] [lst list?] ...+)
+         list?]{
+
+Like @racket[running-foldl], but produces the intermediate results from the right
+like @racket[foldr].
+
+@mz-examples[
+  (running-foldr + 0 '(1 2 3))
+  (running-foldr + 0 '())
+  (running-foldr (lambda (a b acc) 
+                   (* acc (+ a b))) 
+                 1 
+                 '(1 2)
+                 '(3 4))]
+@history[#:added "8.16"]{}
+}
+
+
 @; ----------------------------------------
 @section{List Filtering}
 
@@ -1657,6 +1693,35 @@ produces a true value.
 @history[#:added "6.3"]{}
 }
 
+
+@defproc[(windows [size exact-positive-integer?] [step exact-positive-integer?] [lst list?]) 
+         (listof list?)]{
+
+Returns a list of sliding windows such that each window contains @racket[size] elements with the window
+sliding @racket[step] positions on each iteration. If the number of remaining elements is less than 
+@racket[size], then those elements are dropped.
+
+@mz-examples[#:eval list-eval
+  (windows 3 1 '(1 2 3 4))
+  (windows 2 3 '(1 2 3))
+  (windows 1 2 '(1 2 3 4))]
+@history[#:added "8.16"]{}
+}
+
+
+@defproc[(slice-by [proc (-> any/c any/c any/c)] [lst list?])
+         (listof list?)]{
+
+Returns a list such that each element is a sublist (slice) that is 
+constructed from comparing each pair of adjacent elements. All pairs of 
+elements that satisfy @racket[proc] will be grouped together into a slice, otherwise 
+the element will start a new slice.
+
+@mz-examples[#:eval list-eval
+  (slice-by eq? '(1 1 2 1 3))
+  (slice-by < '(1 2 3 3 4))]
+@history[#:added "8.16"]{}
+}
 
 @close-eval[list-eval]
 

--- a/pkgs/racket-test-core/tests/racket/list.rktl
+++ b/pkgs/racket-test-core/tests/racket/list.rktl
@@ -772,4 +772,50 @@
 (test '(1 3) indexes-where '(1 2 3 4 5) even?)
 (test '(0 2 4) indexes-where '(1 2 3 4 5) odd?)
 
+;; ---------- running-foldl / running-foldr ----------
+(test '(0) running-foldl + 0 '())
+(test '(0 1 3 6) running-foldl + 0 '(1 2 3))
+(err/rt-test (running-foldl 1 0 0))
+(err/rt-test (running-foldl + 0 0))
+(test '(1 2 6 0 0) running-foldl * 1 '(2 3 0 4))
+(test '(1 2 2 2) running-foldl (lambda (val _) val) 1 '(2 2 2))
+;; variadic tests
+(test '(0) running-foldl + 0 '() '())
+(err/rt-test (running-foldl + 0 '(1) '()))
+(err/rt-test (running-foldl + 0 '() (1)))
+(test '(1 3 7 13) running-foldl + 1 '(1 2 3) '(1 2 3))
+(test '(1 2 24 0 0) running-foldl * 1 '(2 3 0 4) '(1 4 4 5))
+
+(test '(0) running-foldr + 0 '())
+(test '(6 5 3 0) running-foldr + 0 '(1 2 3))
+(err/rt-test (running-foldr 1 0 0))
+(err/rt-test (running-foldr + 0 0))
+(test '(0 0 0 4 1) running-foldr * 1 '(2 3 0 4))
+(test '(2 2 2 1) running-foldr (lambda (val _) val) 1 '(2 2 2))
+;; variadic tests
+(test '(0) running-foldr + 0 '() '())
+(err/rt-test (running-foldr + 0 '(1) '()))
+(err/rt-test (running-foldr + 0 '() (1)))
+(test '(13 11 7 1) running-foldr + 1 '(1 2 3) '(1 2 3))
+(test '(0 0 0 20 1) running-foldr * 1 '(2 3 0 4) '(1 4 4 5))
+
+;; ---------- windows ----------
+(test '((1 1 1) (2 2 2) (3 3 3)) windows 3 3 '(1 1 1 2 2 2 3 3 3))
+(test '((1 2 3) (2 3 4) (3 4 5)) windows 3 1 '(1 2 3 4 5))
+(err/rt-test (windows 0 1 '(1)))
+(err/rt-test (windows 1 0 '(1)))
+(err/rt-test (windows 1 1 (void)))
+(test '((1 1 1)) windows 3 3 '(1 1 1 2 2))
+(test '((1 1 1)) windows 3 7 '(1 1 1 2 2))
+(test '((1) (2) (3)) windows 1 1 '(1 2 3))
+(test '((1) (3)) windows 1 2 '(1 2 3 4))
+
+;; ---------- slice-by ----------
+(test '() slice-by eq? '())
+(test '((1 1) (2 2) (3 3)) slice-by eq? '(1 1 2 2 3 3))
+(test '((1) (1 2) (2)) slice-by < '(1 1 2 2))
+(err/rt-test (slice-by positive? '()))
+(err/rt-test (slice-by equal? (void)))
+(test '((1 2 3) (-1 -2 -3) (4)) slice-by (lambda (e1 e2) (eq? (positive? e1) (positive? e2))) '(1 2 3 -1 -2 -3 4))
+
 (report-errs)

--- a/racket/collects/racket/private/list.rkt
+++ b/racket/collects/racket/private/list.rkt
@@ -3,6 +3,8 @@
 
   (provide foldl
            foldr
+           running-foldl
+           running-foldr
 
            remv
            remq
@@ -271,6 +273,41 @@
          (if (pair? (car ls)) ; `check-fold' ensures all lists have equal length
              (apply f (mapadd car ls (loop (map cdr ls))))
              init))]))
+  
+  (define running-foldl
+    (case-lambda
+      [(f init l)
+       (check-fold 'running-foldl f init l null)
+       (let loop ([l l] [acc init] [result null])
+         (if (null? l)
+             (reverse (cons acc result))
+             (loop (cdr l) (f (car l) acc) (cons acc result))))]
+      [(f init l . ls)
+       (check-fold 'running-foldl f init l ls)
+       (let loop ([ls (cons l ls)] [acc init] [result null])
+         (if (null? (car ls)) ; `check-fold' ensures all lists have equal length
+             (reverse (cons acc result))
+             (loop (map cdr ls) 
+                   (apply f (mapadd car ls acc))
+                   (cons acc result))))]))
+
+  (define running-foldr
+    (case-lambda
+      [(f init l)
+       (check-fold 'running-foldr f init l null)
+       (let loop ([l l])
+         (if (null? l)
+             (list init)
+             (let ([accs (loop (cdr l))])
+               (cons (f (car l) (car accs)) accs))))]
+      [(f init l . ls)
+       (check-fold 'running-foldr f init l ls)
+       (let loop ([ls (cons l ls)])
+         (if (null? (car ls)) ; `check-fold' ensures all lists have equal length
+             (list init)
+             (let ([accs (loop (map cdr ls))])
+               (cons (apply f (mapadd car ls (car accs))) 
+                     accs))))]))
 
   (define (filter f list)
     (unless (and (procedure? f)


### PR DESCRIPTION
## Description
Adds some more algorithms that are commonly found in other functional programming languages.
* slice-by
* windows
* running-foldl
* running-foldr

The fold variants are variadic to keep with the conventions of the current fold algorithms. Furthermore, I chose to make it so that windows does not accept partial windows since this is how the algorithm is normally implemented.

Issue: https://github.com/racket/racket/issues/5210#issue-2852668731

## Checklist
- [x] Feature
- [x] tests included
- [x] documentation

## Testing details
* ran unit tests
* tested the code out in the REPL and in a source file. I also measured the performance of these algorithms against the equivalent ones found in the `algorithms` collection. Some of the ones here performed orders of magnitude better (windows and running-foldl) and the rest performed about the same but with proper error handling and more functionality. 
* checked the doc changes with `raco docs`