### PR TITLE
bc complex exp and log

### DIFF
--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -2461,6 +2461,10 @@
 (test -272+1084.i z-round (* 1000 (tan -1+i)))
 
 (test 693.+3142.i z-round (* 1000 (log -2)))
+(test 710073.+785.i z-round (* 1000 (log 1.7e308+1.7e308i)))
+(test 735435.+464.i z-round (* 1000 (log (make-rectangular (string->number (build-string 320 (lambda (x) #\2)))
+                                                           (string->number (build-string 320 (lambda (x) #\1)))))))
+(test 710000.+2300.i z-round (* 1000 (log (exp 710+2.3i))))
 (test 1571.-1317.i z-round (* 1000 (asin 2)))
 (test -1571.+1317.i z-round (* 1000 (asin -2)))
 (test 0.0+3688.i z-round (* 1000 (acos 20)))

--- a/racket/src/bc/src/number.c
+++ b/racket/src/bc/src/number.c
@@ -2961,7 +2961,8 @@ static Scheme_Object *complex_log(Scheme_Object *c)
   }
   else {
     m = magnitude(1, &c);
-    return log_e_prim(1, &m);
+    return scheme_bin_plus(log_e_prim(1, &m),
+                           scheme_bin_mult(scheme_plus_i, theta));
   }
 }
 

--- a/racket/src/bc/src/number.c
+++ b/racket/src/bc/src/number.c
@@ -2899,7 +2899,7 @@ static Scheme_Object *complex_exp(Scheme_Object *c)
   }
   cos_a = cos_prim(1, &i);
   sin_a = sin_prim(1, &i);
-  /* is this the best way to check this? or is math/flonums +max.0 and (log +max.0) defined */
+  /* is this the best way to check this? or is math/flonum's +max.0 and (log +max.0) defined */
   if (scheme_real_to_double(r) <= 709.782712893384) {
     r = exp_prim(1, &r);
     return scheme_bin_mult(r, scheme_bin_plus(cos_a, scheme_bin_mult(sin_a, scheme_plus_i)));
@@ -2935,7 +2935,6 @@ static Scheme_Object *complex_log(Scheme_Object *c)
     /* impossible: is not complex
     if (SAME_OBJ(r, scheme_exact_zero) && SAME_OBJ(i, scheme_exact_zero)) { return log_e_prim(1, &r); } */
     m = scheme_bin_minus(r, i);
-    /* is there a max or compare function available? */
     if (MZ_IS_NAN(scheme_real_to_double(m))) return scheme_make_complex(m, theta);
     if   (scheme_is_negative(m)) { m = i; }
     else                         { m = r; r = i; }
@@ -2945,7 +2944,6 @@ static Scheme_Object *complex_log(Scheme_Object *c)
       if (MZ_IS_NAN(x)) { x = 0.0; }
     }
     m = log_e_prim(1, &m);
-    /* is log1p available everywhere? It is in math.h of gcc and mingw */
     x = 0.5 * log1p( x * x );
     m = scheme_bin_plus( m, scheme_make_double(x));
     return scheme_make_complex(m, theta);
@@ -4103,6 +4101,7 @@ static Scheme_Object *angle(int argc, Scheme_Object *argv[])
   if (SCHEME_COMPLEXP(o)) {
     Scheme_Object *r = (Scheme_Object *)_scheme_complex_real_part(o);
     Scheme_Object *i = (Scheme_Object *)_scheme_complex_imaginary_part(o);
+    Scheme_Object *m, *n;
     double rd, id, v;
 #ifdef MZ_USE_SINGLE_FLOATS
 # ifdef USE_SINGLE_FLOATS_AS_DEFAULT
@@ -4111,6 +4110,13 @@ static Scheme_Object *angle(int argc, Scheme_Object *argv[])
     int was_single = (SCHEME_FLTP(r) || SCHEME_FLTP(i));
 # endif
 #endif
+    if (scheme_is_exact(r)) {
+      m = scheme_abs(1, &r);
+      n = scheme_abs(1, &i);
+      if (scheme_bin_lt(m, n)) { m = n; }
+      r = scheme_bin_div(r, m);
+      i = scheme_bin_div(i, m);
+    }
 
     id = TO_DOUBLE_VAL(i);
     rd = TO_DOUBLE_VAL(r);

--- a/racket/src/bc/src/number.c
+++ b/racket/src/bc/src/number.c
@@ -2900,7 +2900,12 @@ static Scheme_Object *complex_exp(Scheme_Object *c)
   cos_a = cos_prim(1, &i);
   sin_a = sin_prim(1, &i);
   /* is this the best way to check this? or is math/flonum's +max.0 and (log +max.0) defined */
-  if (scheme_real_to_double(r) <= 709.782712893384) {
+#ifdef MZ_USE_SINGLE_FLOATS
+  if (SCHEME_FLTP(r) ? (SCHEME_FLOAT_VAL(r) <= 88.72284f) : (scheme_real_to_double(r) <= 709.782712893384e0))
+#else
+  if (scheme_real_to_double(r) <= 709.782712893384e0)
+#endif
+  {
     r = exp_prim(1, &r);
     return scheme_bin_mult(r, scheme_bin_plus(cos_a, scheme_bin_mult(sin_a, scheme_plus_i)));
   }
@@ -2945,6 +2950,12 @@ static Scheme_Object *complex_log(Scheme_Object *c)
     }
     m = log_e_prim(1, &m);
     x = 0.5 * log1p( x * x );
+#ifdef MZ_USE_SINGLE_FLOATS
+    if (SCHEME_FLTP(m)) {
+      m = scheme_bin_plus( m, scheme_make_float((float)x));
+      return scheme_make_complex(m, theta);
+    }
+#endif
     m = scheme_bin_plus( m, scheme_make_double(x));
     return scheme_make_complex(m, theta);
   }


### PR DESCRIPTION
## Checklist
- [x] Bugfix
- [x] tests included

## Description of change
This brings the bc implementation in line with the cs implementation at [cfllog](https://github.com/racket/racket/blob/d0aa9b87c6f4e780c790a25c4e3cde80def79568/racket/src/ChezScheme/s/5_3.ss#L548) and [cflexp](https://github.com/racket/racket/blob/d0aa9b87c6f4e780c790a25c4e3cde80def79568/racket/src/ChezScheme/s/5_3.ss#L606)

allowing bc to calculate
* `(log z)` when `(magnitude z)` > `max.0` and without underflow near 1.
* `(exp z)` when `(magnitude (exp z))` > `max.0` and overflow can be avoided
* `(angle z)` more accurately if over/underflow can be avoided

```
#lang racket/base

(banner)
(define big1 (string->number (build-string 400 (λ (_) #\1))))
(define big2 (string->number (build-string 250 (λ (_) #\1))))
(log (make-rectangular big1 1/2))
(log (make-rectangular big1 big2))
(log (make-rectangular +nan.0 1))
(log (make-rectangular 1 +nan.0))
(log 1.+1e-150i)
(log 1.7e308+1.7e308i)
(exp 710+2.3i)
(exp 710+0.7i)
(exp (make-rectangular +nan.0 1))
(exp (make-rectangular 1 +nan.0))
(when (single-flonum-available?)
  (parameterize ([read-single-flonum #t])
    (values
     (log (string->number "3.4f38+3.4f38i"))
     (exp (string->number "89f0+0.78f0i")))))
```

currently on bc this gives:
```
"Welcome to Racket v8.16.0.2-2025-02-19-1f49402c4f [bc].\n"
+inf.0+0.0i
+inf.0+0.0i
+nan.0+nan.0i
+nan.0+nan.0i
0.0+1e-150i
+inf.0+0.7853981633974483i
-inf.0+inf.0i
+inf.0+inf.0i
+nan.0+nan.0i
+nan.0+nan.0i
+inf.f+0.7853982f0i
+inf.f+inf.fi
```

and on cs the result is:
```
"Welcome to Racket v8.16.0.2-2025-02-19-1f49402c4f [cs].\n"
918.836812620282+0.0i
918.836812620282+1e-150i
+nan.0+nan.0i
+nan.0+nan.0i
0.0+1e-150i
710.0734104835082+0.7853981633974483i
-1.4884571443582287e+308+1.6659015411022147e+308i
1.7086534433331492e+308+1.4391789415577674e+308i
+nan.0+nan.0i
+nan.0+nan.0i
```

after change this produces
```
"Welcome to Racket v8.16.0.2 [bc].\n"
918.8368126202821+0.0i
918.8368126202821+1e-150i
+nan.0+nan.0i
+nan.0+nan.0i
5e-301+1e-150i
710.0734104835082+0.7853981633974483i
-1.4884571443582287e+308+1.6659015411022147e+308i
1.7086534433331492e+308+1.4391789415577674e+308i
+nan.0+nan.0i
+nan.0+nan.0i
89.06858f0+0.7853982f0i
3.191735f+38+3.1574637f+38i
```
note that 
* this hardcodes the `(log +max.0/f)` value. ~~(will this be ok for single floats?)~~ [edit: it was not - extra examples for single floats added]
* this uses `log1p` which is defined in `math.h` for gcc and mingw, but not sure if this ok everywhere
* on cs [fllog1+](https://github.com/racket/racket/blob/d0aa9b87c6f4e780c790a25c4e3cde80def79568/racket/src/ChezScheme/s/5_3.ss#L412) used in [cfllog](https://github.com/racket/racket/blob/d0aa9b87c6f4e780c790a25c4e3cde80def79568/racket/src/ChezScheme/s/5_3.ss#L548) doesn't seem to use the log1p from the `math.h` library
* maybe related to [racket/typed-racket#969](https://github.com/racket/typed-racket/issues/969)
* ~~not sure where to add tests~~ [edit: done, I think]