### PR TITLE
Bring back tests/racket/test in CI

### DIFF
--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -27,6 +27,12 @@ do_test() {
 #
 # [1]: http://drdr.racket-lang.org/
 
+# Core Tests.
+# ~~~~~~~~~~~~~~~~
+# The core test suite of Racket itself.
+
+do_test -l "tests/racket/test"
+
 
 # Collection Tests
 # ~~~~~~~~~~~~~~~~
@@ -48,7 +54,7 @@ COLLECTIONS_TO_TEST=(
 )
 
 for collection in "${COLLECTIONS_TO_TEST[@]}"; do
-    echo " == Testing collection '$collection'"
+    echo "\n\n == Testing collection '$collection' ==\n"
     do_test -c "$collection"
 done
 
@@ -65,7 +71,7 @@ MODULES_TO_TEST=(
 )
 
 for mpath in "${MODULES_TO_TEST[@]}"; do
-    echo " == Testing module path '$mpath'"
+    echo "\n\n == Testing module path '$mpath' ==\n"
     do_test -l "$mpath"
 done
 
@@ -73,5 +79,7 @@ done
 # Special Cases
 # ~~~~~~~~~~~~~
 # Tests that don't fit in the previous two buckets.
+
+echo "\n\n == Testing tests/racket/contract/all ==\n"
 
 "$RACKET" -l tests/racket/contract/all

--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -31,7 +31,7 @@ do_test() {
 # ~~~~~~~~~~~~~~~~
 # The core test suite of Racket itself.
 
-printf "\n\n == Testing collection 'tests/racket/test' ==\n"
+printf "\n\n\n\n == Testing collection 'tests/racket/test' ==\n"
 do_test -l "tests/racket/test"
 
 
@@ -55,7 +55,7 @@ COLLECTIONS_TO_TEST=(
 )
 
 for collection in "${COLLECTIONS_TO_TEST[@]}"; do
-    printf "\n\n == Testing collection '' ==\n" "$collection"
+    printf "\n\n\n\n == Testing collection '%s' ==\n" "$collection"
     do_test -c "$collection"
 done
 
@@ -72,7 +72,7 @@ MODULES_TO_TEST=(
 )
 
 for mpath in "${MODULES_TO_TEST[@]}"; do
-    printf "\n\n == Testing module path '%s' ==\n" "$mpath"
+    printf "\n\n\n\n == Testing module path '%s' ==\n" "$mpath"
     do_test -l "$mpath"
 done
 

--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -31,6 +31,7 @@ do_test() {
 # ~~~~~~~~~~~~~~~~
 # The core test suite of Racket itself.
 
+printf "\n\n == Testing collection 'tests/racket/test' ==\n"
 do_test -l "tests/racket/test"
 
 
@@ -54,7 +55,7 @@ COLLECTIONS_TO_TEST=(
 )
 
 for collection in "${COLLECTIONS_TO_TEST[@]}"; do
-    echo "\n\n == Testing collection '$collection' ==\n"
+    printf "\n\n == Testing collection '' ==\n" "$collection"
     do_test -c "$collection"
 done
 
@@ -71,7 +72,7 @@ MODULES_TO_TEST=(
 )
 
 for mpath in "${MODULES_TO_TEST[@]}"; do
-    echo "\n\n == Testing module path '$mpath' ==\n"
+    printf "\n\n == Testing module path '%s' ==\n" "$mpath"
     do_test -l "$mpath"
 done
 
@@ -80,6 +81,6 @@ done
 # ~~~~~~~~~~~~~
 # Tests that don't fit in the previous two buckets.
 
-echo "\n\n == Testing tests/racket/contract/all ==\n"
+printf "\n\n == Testing tests/racket/contract/all ==\n"
 
 "$RACKET" -l tests/racket/contract/all

--- a/.github/scripts/run-racket-tests.sh
+++ b/.github/scripts/run-racket-tests.sh
@@ -31,7 +31,7 @@ do_test() {
 # ~~~~~~~~~~~~~~~~
 # The core test suite of Racket itself.
 
-printf "\n\n\n\n == Testing collection 'tests/racket/test' ==\n"
+printf '\n\n\n\n%s\n\n' "== Testing core tests, 'tests/racket/test' =="
 do_test -l "tests/racket/test"
 
 
@@ -55,7 +55,7 @@ COLLECTIONS_TO_TEST=(
 )
 
 for collection in "${COLLECTIONS_TO_TEST[@]}"; do
-    printf "\n\n\n\n == Testing collection '%s' ==\n" "$collection"
+    printf '\n\n\n\n%s\n\n' "== Testing collection '$collection' =="
     do_test -c "$collection"
 done
 
@@ -72,7 +72,7 @@ MODULES_TO_TEST=(
 )
 
 for mpath in "${MODULES_TO_TEST[@]}"; do
-    printf "\n\n\n\n == Testing module path '%s' ==\n" "$mpath"
+    printf '\n\n\n\n%s\n\n' "== Testing module path '$mpath' =="
     do_test -l "$mpath"
 done
 
@@ -81,6 +81,6 @@ done
 # ~~~~~~~~~~~~~
 # Tests that don't fit in the previous two buckets.
 
-printf "\n\n == Testing tests/racket/contract/all ==\n"
+printf '\n\n\n\n%s\n\n' "== Testing 'tests/racket/contract/all' =="
 
 "$RACKET" -l tests/racket/contract/all


### PR DESCRIPTION
This commit brings back `tests/racket/test` in CI. It was lost at some point.

Although `tests/racket/test` fits the module tests case, we want to run it first because it is testing the core Racket functionalities.