### PR TITLE
Fix analysis categories for the scanbuild workflow

### DIFF
--- a/.github/workflows/scanbuild_static-analysis.yml
+++ b/.github/workflows/scanbuild_static-analysis.yml
@@ -219,4 +219,4 @@ jobs:
       if: ${{ steps.chunk_presence.outputs.presence == '1' }}
       with:
         sarif_file: workspace
-        category: scanbuild-${{ matrix.variants }}-${{ matrix.chunks }}-${{ github.sha }}
+        category: scanbuild-${{ matrix.variants }}-${{ matrix.chunks }}


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change

Hello from GitHub Code Scanning! 😄👋

We noticed your repo had an unusually large number of active categories, which I think was unintended.

By including the commit SHA in the category name, each scan will create a new category.
This means you won't be able to track alert changes between two different runs of the same tool.
Similarly, if an alert is fixed in recent runs, it will continue to appear as open because it's still present in all the other scan categories.

You can see this manifested on the alert page, where there are multiple versions of the same alert created for each new scan:
<img width="1280" alt="image" src="https://github.com/user-attachments/assets/4a6c6e90-2a43-487a-988f-dc3126c9dde2" />

This change should ensure Code Scanning works as expected and allows the correct management of alerts.

Unfortunately, you'll still be stuck with all the old categories unless you manually delete them via the API.
If it makes things easier, we can clean them up for you.

