### PR TITLE
docs: SHA1 is mandatory for package checksums

### DIFF
--- a/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
+++ b/pkgs/racket-doc/pkg/scribblings/pkg.scrbl
@@ -64,8 +64,8 @@ Each @tech{package} has associated @deftech{package metadata}:
  @item{a @deftech{package name} --- a string made of the characters @|package-name-chars|.}
  @item{a @deftech{checksum} --- a string that identifies different releases of a package. A
                                 package can be updated when its @tech{checksum} changes,
-                                whether or not its @tech{version} changes. The checksum normally
-                                can be computed as the SHA1 (see @racketmodname[openssl/sha1])
+                                whether or not its @tech{version} changes. The checksum must
+                                be computed as the SHA1 (see @racketmodname[openssl/sha1])
                                 of the package's content.}
  @item{a @deftech{version} --- a string of the form @nonterm{maj}@litchar{.}@nonterm{min},
                      @nonterm{maj}@litchar{.}@nonterm{min}@litchar{.}@nonterm{sub}, or


### PR DESCRIPTION
For background: https://joeldueck.com/code/pluto

The old wording seems to indicate a package’s checksum can be *any* unique string — i.e. it doesn’t actually _have_ to be computed using SHA1.

However, when using [manual deployment][md], `raco pkg` will actually compute the SHA1 hash of `pkg.zip` and bail if the contents of `pkg.zip.CHECKSUM` don’t match (including if `pkg.zip.CHECKSUM` is not provided).

I think there is a case to be made that the old wording should be kept, and that `raco pkg` should stop verifying the contents of `pkg.zip`.[^1] But for now the docs should be updated to match current behavior.

[^1]: Verifying the checksum doesn’t provide real protection against anything, since anyone who can fiddle with or intercept `pkg.zip` can also do so with the provided checksum.

[md]: https://docs.racket-lang.org/pkg/getting-started.html#%28part._manual-deploy%29