### PR TITLE
Link to `raco demod` in `raco exe`

### DIFF
--- a/pkgs/racket-doc/scribblings/raco/exe.scrbl
+++ b/pkgs/racket-doc/scribblings/raco/exe.scrbl
@@ -15,7 +15,8 @@
 @exec{raco exe}, use a smaller base language---such as
 @racketmodfont{#lang} @racketmodname[racket/base] instead of
 @racketmodfont{#lang} @racketmodname[racket]. Also, ensure that
-bytecode files are compiled by using @seclink["make"]{@exec{raco make}}.}
+bytecode files are compiled by using @seclink["make"]{@exec{raco make}}.
+For further improvements, try using @seclink["demod"]{@exec{raco demod}}.}
 
 Compiled code produced by @exec{raco make} relies on Racket
 executables to provide run-time support to the compiled code. However,
@@ -275,4 +276,3 @@ The @exec{raco exe} command accepts the following command-line flags:
 @include-section["exe-api.scrbl"]
 @include-section["launcher.scrbl"]
 @include-section["exe-dylib-path.scrbl"]
-


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->
`demod` has better runtime performance than `make`, and is closer to the semantics that people coming from compiled languages will expect.

![image](https://github.com/user-attachments/assets/656eeb75-219f-4a37-9750-50d4f55eb318)
