### PR TITLE
configure: set strip_needs_dash_s on FreeBSD builds

### DIFF
--- a/racket/src/bc/configure.ac
+++ b/racket/src/bc/configure.ac
@@ -536,6 +536,7 @@ case "$host_os" in
     LIBS="$LIBS -rdynamic"
     DYN_CFLAGS="-fPIC"
     enable_pthread_by_default=yes
+    strip_needs_dash_s=yes
     ;;
   openbsd*)
     LIBS="$LIBS -Wl,--export-dynamic"

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -253,6 +253,7 @@ case "$host_os" in
     LIBS="${LIBS} -lm -lpthread"
     LINK_DYNAMIC="-rdynamic"
     add_iconv_lib="-liconv"
+    strip_needs_dash_s=yes
     ;;
   openbsd*)
     MACH_OS=ob


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change
This fixes an issue found on FreeBSD while building 8.16 using llvm-strip. The
issue is that upon stripping with default args, the final `racket` executable
reported this upon running:

```
/wrkdirs/usr/ports/lang/racket/work/stage/usr/local/bin/racket -X ../collects -G ../etc -O info'@'compiler/cm -l- setup --boot setup-go.rkt cs/c/compiled ignored cs/c/ignored.d ../collects/setup/unixstyle-install.rkt make-install-copytree .. /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/bin /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/share/racket/collects /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/share/racket/pkgs /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/share/doc/racket /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/lib /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/include/racket /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/lib/racket /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/share/racket /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/etc/racket /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/share/applications /wrkdirs/usr/ports/lang/racket/work/stage/usr/local/share/man no
/wrkdirs/usr/ports/lang/racket/work/stage/usr/local/bin/racket: ELF section ".rackboot" is missing
failed
 in build-one
 in loop
 in module->hash
gmake: *** [Makefile:25: install] Error 1
```

This is due to the switch to LLVM binutils by default in this FreeBSD commit:
https://github.com/freebsd/freebsd-src/commit/1cae7121c667d9caf205832cf45fd02af3157e6f

## Notes
I see that there is a comment from 2018 saying that not all implementations of strip implement the `-S` flag. Which ones in particular are those, and is that comment still relevant today in April 2025? I found that `-S` is supported on both GNU and LLVM strip, as well as a strip executable found on my macos system by default.