### PR TITLE
XML element tag should not be allowed to be empty

### DIFF
--- a/racket/collects/xml/private/xexpr-core.rkt
+++ b/racket/collects/xml/private/xexpr-core.rkt
@@ -3,6 +3,8 @@
          racket/contract/base
          racket/contract/combinator
          racket/pretty
+         (only-in racket/string
+                  non-empty-string?)
          "core.rkt")
 
 
@@ -75,6 +77,11 @@
       (true-k)))
 
 
+(define (non-empty-symbol? x)
+  (and
+   (symbol? x)
+   (non-empty-string? (symbol->string x))))
+
 ;; incorrect-xexpr?: any -> (or/c #f exn:invalid-xexpr)
 ;; Returns an exn:invalid-xexpr if the xexpr has incorrect structure.
 ;; Otherwise, returns #f.
@@ -94,7 +101,7 @@
              (current-continuation-marks)
              x)]
            [else
-            (if (symbol? (car x))
+            (if (non-empty-symbol? (car x))
                 (cond [(has-attribute-pairs? x)
                        (define maybe-exn (erroneous-attribute-pairs? (cadr x)))
                        (cond [maybe-exn maybe-exn]


### PR DESCRIPTION

| attribute        | value                                |
|------------------|--------------------------------------|
| Racket version   | 8.16.0.4-2025-04-03-14fc734705 [cs]  |
| #lang            | racket/base                          |
| collection       | xml/private/xexpr-core               |
| tags             | bug                                  |




### Observation

In the `xml` collection, an XML element's name is given as a symbol. E.g., the following code verifies and formats a simple element:

```racket
#lang racket/base

(require xml)

(define e '(myelement))

(values
 (xexpr? e)
 (xexpr->string e))

```

In Racket, symbols can be empty `'||`, just like strings `""`. However, XML element tags are not allowed to be empty. Nevertheless neither `xexpr?` produces `#f` nor does `xexpr->string` decline its input:

```racket
#lang racket/base

(require xml)

(define e '(||))

(values
 (xexpr? e)
 (xexpr->string e))

```

In my opinion, this case is relevant, because oftentimes users generate element tag names dynamically.

### Expectation

`(xexpr '(||))` should be `#f`. `(xexpr->string '(||))` should raise an error.

### Approach

In the definition of the function `incorrect-xexpr?` replace the call to `symbol?` with a call to `non-empty-symbol?`. We introduce `non-empty-symbol?` analogous to the function `non-empty-string?` in `racket/string`.
