### PR TITLE
disallow the empty string to be a key in plist-dict

### DIFF
--- a/pkgs/racket-test/tests/xml/plist.rkt
+++ b/pkgs/racket-test/tests/xml/plist.rkt
@@ -1,0 +1,40 @@
+#lang racket/base
+
+(module+ test
+  (require
+   (only-in rackunit
+            test-case
+            check-pred
+            check-false
+            check-equal?)
+   (only-in racket/port
+            with-output-to-string
+            call-with-input-string)
+   (only-in xml/plist
+            plist-value?
+            write-plist
+            read-plist))
+
+  (define (plist->string pl)
+    (with-output-to-string
+      (lambda ()
+        (write-plist pl (current-output-port)))))
+
+  (define (string->plist s)
+    (call-with-input-string
+     s
+     (lambda (port)
+       (read-plist port))))
+
+  (define (check-inverse v0)
+    (check-pred plist-value? v0)
+    (define s
+      (plist->string v0))
+    (define v1
+      (string->plist s))
+    (check-equal? v1 v0))
+
+  (check-false (plist-value? '(dict (assoc-pair "" (array)))))
+  (check-inverse "blub")
+  (check-inverse '(dict (assoc-pair "a" (array)))))
+

--- a/pkgs/racket-test/tests/xml/plist.rkt
+++ b/pkgs/racket-test/tests/xml/plist.rkt
@@ -35,6 +35,9 @@
     (check-equal? v1 v0))
 
   (check-false (plist-value? '(dict (assoc-pair "" (array)))))
+
   (check-inverse "blub")
-  (check-inverse '(dict (assoc-pair "a" (array)))))
+  (check-inverse '(dict))
+  (check-inverse '(dict (assoc-pair "a" (array))))
+  (check-inverse '(dict (assoc-pair "a" "bla") (assoc-pair "b" "blub"))))
 

--- a/pkgs/racket-test/tests/xml/plist.rkt
+++ b/pkgs/racket-test/tests/xml/plist.rkt
@@ -37,6 +37,8 @@
   (check-false (plist-value? '(dict (assoc-pair "" (array)))))
 
   (check-inverse "blub")
+  (check-inverse '(true))
+  (check-inverse '(false))
   (check-inverse '(dict))
   (check-inverse '(dict (assoc-pair "a" (array))))
   (check-inverse '(dict (assoc-pair "a" "bla") (assoc-pair "b" "blub"))))

--- a/racket/collects/xml/plist.rkt
+++ b/racket/collects/xml/plist.rkt
@@ -1,6 +1,7 @@
 #lang racket/base
 (require racket/list
          racket/contract
+         racket/string
          xml)
 
 (define (plist-dict? v)
@@ -11,7 +12,7 @@
                  (and (list? v)
                       (= 3 (length v))
                       (eq? (car v) 'assoc-pair)
-                      (string? (cadr v))
+                      (non-empty-string? (cadr v))
                       (plist-value? (caddr v))))
                (cdr v))))
 


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation

## Description of change

### Observation

It is possible to define and encode plist-dicts with the empty string as a key:

    #lang racket/base

    (require
     xml/plist
     racket/port)

    (define v0 '(dict (assoc-pair "" (array))))

    (define s
      (with-output-to-string
        (lambda ()
          (write-plist v0 (current-output-port)))))

    (displayln s)

The XML document output looks like this:

    <?xml version="1.0" encoding="UTF-8"?>
    <!DOCTYPE plist SYSTEM "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
    <plist version="0.9"><dict><key></key><array></array></dict></plist>


Hovever, when trying to read such a dict back using `read-plist`, Racket raises an obscure error.

    (call-with-input-string
     s
     (lambda (port)
       (read-plist port)))

The error message being

    cadr: contract violation
      expected: (cons/c any/c pair?)
      given: '(key)

### Approach

This pr makes `plist-value?` require dicts to have non-empty keys.