### PR TITLE
ci: bump Ubuntu runners to 22.04

### DIFF
--- a/.github/workflows/chez-build.yml
+++ b/.github/workflows/chez-build.yml
@@ -15,18 +15,18 @@ on:
       - ".github/scripts/**"
       - ".github/workflows/chez-build.yml"
       - "Makefile"
-      
+
 permissions:
   contents: read
 
 jobs:
   build-linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false
       matrix:
-        mach: ['i3le', 'ti3le', 'a6le', 'ta6le'] 
+        mach: ['i3le', 'ti3le', 'a6le', 'ta6le']
 
     env:
       MACH: ${{ matrix.mach }}

--- a/.github/workflows/scanbuild_static-analysis.yml
+++ b/.github/workflows/scanbuild_static-analysis.yml
@@ -15,7 +15,7 @@ jobs:
 #
   scanbuild-racketcgc:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: pmatos/scan-build:12.0.1
 
     steps:
@@ -66,7 +66,7 @@ jobs:
 
   scanbuild-racket3m:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: pmatos/scan-build:12.0.1
 
     steps:
@@ -128,7 +128,7 @@ jobs:
 
   scanbuild-racketcs:
 
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     container: pmatos/scan-build:12.0.1
 
     steps:
@@ -185,7 +185,7 @@ jobs:
         path: sarif-files/
 
   upload:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs: [scanbuild-racketcgc, scanbuild-racket3m, scanbuild-racketcs]
 
     strategy:


### PR DESCRIPTION
The Ubuntu 20.04 runners have been [decommissioned as of 2025-04-15][1].

[1]: https://github.com/actions/runner-images/issues/11101