### PR TITLE
racket/class: add support interface method default implementations

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/class.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/class.scrbl
@@ -125,13 +125,14 @@ The class system allows a program to define a new class (a
 ]
 
 An @deftech{interface} is a collection of method names to be
-implemented by a class, combined with a derivation requirement. A
+implemented by a class, potentially with default implementations
+some methods, combined with a derivation requirement. A
 class @deftech{implements} an interface when it
 
 @itemize[
 
- @item{declares (or inherits) a public method for each variable in the
- interface;}
+ @item{declares (or inherits) a public method for each method in the
+ interface (that does not have a default implementation);}
 
  @item{is derived from the class required by the interface, if any; and}
 
@@ -145,6 +146,9 @@ implements. Each class also implements an implicitly-defined interface
 that is associated with the class. The implicitly-defined interface
 contains all of the class's public method names, and it requires that
 all other implementations of the interface are derived from the class.
+When a class implements an interface but does not explicitly
+declare an implementation of a method that has a default implementation
+in the interface, then the default implementation is used for the class.
 
 A new interface can @deftech{extend} one or more interfaces with
 additional method names; each class that implements the extended
@@ -168,7 +172,9 @@ interface is not an object (i.e., there are no ``meta-classes'' or
 @defform/subs[(interface (super-interface-expr ...) name-clause ...)
               ([name-clause
                 id
-                (id contract-expr)])]{
+                (id contract-expr)
+                (id #:default default-expr)
+                (id contract-expr #:default default-expr)])]{
 
 Produces an interface. The @racket[id]s must be mutually distinct.
 
@@ -183,11 +189,19 @@ superinterfaces.
 
 The result of an @racket[interface] expression is an interface that
 includes all of the specified @racket[id]s, plus all identifiers from
-the superinterfaces. Duplicate identifier names among the
-superinterfaces are ignored, but if a superinterface contains one of
-the @racket[id]s in the @racket[interface] expression, the
-@exnraise[exn:fail:object]. A given @racket[id] may be paired with
-a corresponding @racket[contract-expr].
+the superinterfaces. A given @racket[id] may be paired with
+a corresponding @racket[contract-expr], and it may have a @racket[default-expr],
+which supplies a default implementation of @racket[id] when it is not
+present in an implementing class. Each @racket[default-expr] must
+be a @racket[_method-procedure]; see @secref["clmethoddefs"].
+Duplicate identifier names among the
+superinterfaces are ignored, as long a no more than one of them provides
+a default implementation for each identifier that originated in a
+different interface. If a superinterface contains one of
+the @racket[id]s in the @racket[interface] expression, then if it has
+a @racket[default-expr], the new default implementation replaces the
+inherited one; if the @racket[id] does not have a @racket[default-expr],
+the @exnraise[exn:fail:object].
 
 If no @racket[super-interface-expr]s are provided, then the derivation
 requirement of the resulting interface is trivial: any class that
@@ -206,14 +220,19 @@ superinterfaces specify inconsistent derivation requirements, the
   (interface (file-interface<%>)
     [file-list (->m (listof (is-a?/c file-interface<%>)))]
     parent-directory))
-]}
+]
+
+@history[#:changed "8.17.0.4" @elem{Added support for @racket[#:default] method
+                                    implementations.}]}
 
 @defform/subs[(interface* (super-interface-expr ...)
                           ([property-expr val-expr] ...)
                 name-clause ...)
               ([name-clause
                 id
-                (id contract-expr)])]{
+                (id contract-expr)
+                (id #:default default-expr)
+                (id contract-expr #:default default-expr)])]{
 
 Like @racket[interface], but also associates to the interface the
 structure-type properties produced by the @racket[property-expr]s with
@@ -234,7 +253,10 @@ structure type property's guard, if any).
 (define i<%> (interface* () ([prop:custom-write
                               (lambda (obj port mode) (void))])
                method1 method2 method3))
-]}
+]
+
+@history[#:changed "8.17.0.4" @elem{Added support for @racket[#:default] method
+                                    implementations.}]}
 
 @; ------------------------------------------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/object.rktl
+++ b/pkgs/racket-test-core/tests/racket/object.rktl
@@ -4,7 +4,7 @@
 (require racket/class)
 
 (Section 'object)
-     
+
 ;; ------------------------------------------------------------
 ;; Test syntax errors
 
@@ -2453,6 +2453,109 @@
   (define sub-obj (new sub%))
   (test #t equal? (send sub-obj f 10) 10)
   (err/rt-test (send sub-obj f "hi") exn:fail:contract?))
+
+;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;; interface with default methods
+
+(let ()
+  (define i<%>
+    (interface ()
+      m1
+      [m2 #:default (lambda (arg)
+                      (define v (m1 arg))
+                      (test v (send this m1 arg))
+                      (list v arg))]))
+  (define cn%
+    (class* object% (i<%>)
+      (super-new)
+      (define/public (m1 arg) (+ arg 1))))
+  (define cy%
+    (class* object% (i<%>)
+      (super-new)
+      (define/public (m1 arg) (+ arg 1))
+      (define/public (m2 arg) (+ arg 2))))
+  (define pre-z%
+    (class object%
+      (super-new)
+      (define/public (m2 arg) (+ arg 2))))
+  (define cz%
+    (class* pre-z% (i<%>)
+      (super-new)
+      (define/public (m1 arg) (+ arg 1))))
+
+  (test 11 (send (new cn%) m1 10))
+  (test (list 11 10) (send (new cn%) m2 10))
+  (test 11 (send (new cy%) m1 10))
+  (test 12 (send (new cy%) m2 10))
+  (test 12 (send (new cz%) m2 10))
+
+  (err/rt-test (class* object% (i<%>)
+                 (super-new))
+               exn:fail?
+               #rx"missing interface-required method")
+  (err/rt-test (class* object% (i<%>)
+                 (super-new)
+                 (define/public (m2 arg) (+ arg 2)))
+               exn:fail?
+               #rx"missing interface-required method")
+
+  (define i2<%>
+    (interface (i<%>)
+      m3
+      [m4  (->m any/c list?) #:default (lambda (arg)
+                                         (and arg
+                                              (let ([v (m3 arg)])
+                                                (test v (send this m3 arg))
+                                                (list v arg))))]
+      [m5 #:default (lambda (arg) (m4 arg))]))
+  (define c2n%
+    (class* object% (i2<%>)
+      (super-new)
+      (define/public (m1 arg) (+ arg 1))
+      (define/public (m3 arg) (+ arg 3))))
+  (define c2y%
+    (class* object% (i2<%>)
+      (super-new)
+      (define/public (m1 arg) (+ arg 1))
+      (define/public (m2 arg) (+ arg 2))
+      (define/public (m3 arg) (+ arg 3))
+      (define/public (m4 arg) (and arg (list (+ arg 4))))))
+
+  (test 11 (send (new c2n%) m1 10))
+  (test (list 11 10) (send (new c2n%) m2 10))
+  (test 13 (send (new c2n%) m3 10))
+  (test (list 13 10) (send (new c2n%) m4 10))
+  (test 11 (send (new c2y%) m1 10))
+  (test 12 (send (new c2y%) m2 10))
+  (test 13 (send (new c2y%) m3 10))
+  (test (list 14) (send (new c2y%) m4 10))
+
+  (err/rt-test (send (new c2n%) m4 #f)
+               exn:fail:contract?
+               #rx"broke its own contract")
+  (err/rt-test (send (new c2y%) m4 #f)
+               exn:fail:contract?
+               #rx"broke its own contract")
+  (err/rt-test (send (new c2y%) m5 #f)
+               exn:fail:contract?
+               #rx"broke its own contract")
+
+  ;; ok to have default implementations from same original interface
+  (test #t interface? (interface (i<%> i2<%>)))
+  (test #t interface? (interface (i2<%> (interface (i<%>)))))
+
+  (err/rt-test (interface (i<%>
+                           (interface ()
+                             [m2 #:default (lambda (arg) "oops")])))
+               exn:fail:object?
+               #rx"conflicting default implementations")
+
+  (test #t interface? (interface (i<%>
+                                  (interface ()
+                                    [m2 #:default (lambda (arg) "oops")]))
+                        [m2 #:default (lambda (arg) "ok")]))
+
+  (void))
 
 ;; ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 

--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -459,226 +459,6 @@
     (define ((norm-init/field-iid/def-ctx def-ctx) norm) (syntax-local-identifier-as-binding (stx-car (stx-car norm)) def-ctx))
     (define ((norm-init/field-eid/def-ctx def-ctx) norm) (syntax-local-identifier-as-binding (stx-car (stx-cdr (stx-car norm))) def-ctx))
     
-    ;; expands an expression enough that we can check whether it has
-    ;; the right form for a method; must use local syntax definitions
-    (define (proc-shape name orig-stx xform? 
-                        the-obj the-finder
-                        bad class-name expand-stop-names
-                        def-ctx lookup-localize)
-      (define (expand expr locals)
-        (local-expand
-         expr
-         'expression
-         (append locals (list #'lambda) expand-stop-names)
-         def-ctx))
-      ;; Checks whether the vars sequence is well-formed
-      (define (vars-ok? vars)
-        (or (identifier? vars)
-            (stx-null? vars)
-            (and (stx-pair? vars)
-                 (identifier? (stx-car vars))
-                 (vars-ok? (stx-cdr vars)))))
-      (define (kw-vars-ok? vars)
-        (or (identifier? vars)
-            (stx-null? vars)
-            (and (stx-pair? vars)
-                 (let ([a (stx-car vars)]
-                       [opt-arg-ok?
-                        (lambda (a)
-                          (or (identifier? a)
-                              (and (stx-pair? a)
-                                   (identifier? (stx-car a))
-                                   (stx-pair? (stx-cdr a))
-                                   (stx-null? (stx-cdr (stx-cdr a))))))])
-                   (or (and (opt-arg-ok? a)
-                            (kw-vars-ok? (stx-cdr vars)))
-                       (and (keyword? (syntax-e a))
-                            (stx-pair? (stx-cdr vars))
-                            (opt-arg-ok? (stx-car (stx-cdr vars)))
-                            (kw-vars-ok? (stx-cdr (stx-cdr vars)))))))))
-      ;; mk-name: constructs a method name
-      ;; for error reporting, etc.
-      (define (mk-name name)
-        (datum->syntax 
-         #f 
-         (string->symbol (format "~a method~a~a" 
-                                 (syntax-e name)
-                                 (if class-name
-                                     " in "
-                                     "")
-                                 (or class-name 
-                                     ""))) 
-         #f))
-      ;; -- transform loop starts here --
-      (let loop ([stx orig-stx][can-expand? #t][name name][locals null])
-        (syntax-case (disarm stx) (#%plain-lambda lambda case-lambda letrec-values let-values)
-          [(lam vars body1 body ...)
-           (or (and (free-identifier=? #'lam #'#%plain-lambda)
-                    (vars-ok? (syntax vars)))
-               (and (free-identifier=? #'lam #'lambda)
-                    (kw-vars-ok? (syntax vars))))
-           (if xform?
-               (with-syntax ([the-obj the-obj]
-                             [the-finder the-finder]
-                             [name (mk-name name)])
-                 (with-syntax ([vars (if (free-identifier=? #'lam #'lambda)
-                                         (let loop ([vars #'vars])
-                                           (cond
-                                             [(identifier? vars) vars]
-                                             [(syntax? vars)
-                                              (datum->syntax vars
-                                                             (loop (syntax-e vars))
-                                                             vars
-                                                             vars)]
-                                             [(pair? vars)
-                                              (syntax-case (car vars) ()
-                                                [(id expr)
-                                                 (and (identifier? #'id) (not (immediate-default? #'expr)))
-                                                 ;; optional argument; need to wrap arg expression
-                                                 (cons
-                                                  (with-syntax ([expr (syntax/loc #'expr
-                                                                        (syntax-parameterize ([the-finder (quote-syntax the-obj)])
-                                                                          (#%expression expr)))])
-                                                    (syntax/loc (car vars)
-                                                      (id expr)))
-                                                  (loop (cdr vars)))]
-                                                [_ (cons (car vars) (loop (cdr vars)))])]
-                                             [else vars]))
-                                         #'vars)])
-                   (let ([l (syntax/loc stx 
-                              (lambda (the-obj . vars) 
-                                (syntax-parameterize ([the-finder (quote-syntax the-obj)])
-                                  body1 body ...)))])
-                     (syntax-track-origin
-                      (with-syntax ([l (rearm (add-method-property l) stx)])
-                        (syntax/loc stx 
-                          (let ([name l]) name)))                  
-                      stx
-                      (syntax-local-introduce #'lam)))))
-               stx)]
-          [(#%plain-lambda . _)
-           (bad "ill-formed lambda expression for method" stx)]
-          [(lambda . _)
-           (bad "ill-formed lambda expression for method" stx)]
-          [(case-lam [vars body1 body ...] ...)
-           (and (free-identifier=? #'case-lam #'case-lambda)
-                (andmap vars-ok? (syntax->list (syntax (vars ...)))))
-           (if xform?
-               (with-syntax ([the-obj the-obj]
-                             [the-finder the-finder]
-                             [name (mk-name name)])
-                 (let ([cl (syntax/loc stx
-                             (case-lambda [(the-obj . vars) 
-                                           (syntax-parameterize ([the-finder (quote-syntax the-obj)])
-                                             body1 body ...)] ...))])
-                   (syntax-track-origin 
-                    (with-syntax ([cl (rearm (add-method-property cl) stx)])
-                      (syntax/loc stx
-                        (let ([name cl]) name)))
-                    stx
-                    (syntax-local-introduce #'case-lam))))
-               stx)]
-          [(case-lambda . _)
-           (bad "ill-formed case-lambda expression for method" stx)]
-          [(let- ([(id) expr] ...) let-body)
-           (and (or (free-identifier=? (syntax let-) 
-                                       (quote-syntax let-values))
-                    (free-identifier=? (syntax let-) 
-                                       (quote-syntax letrec-values)))
-                (andmap identifier? (syntax->list (syntax (id ...)))))
-           (let* ([letrec? (free-identifier=? (syntax let-) 
-                                              (quote-syntax letrec-values))]
-                  [ids (syntax->list (syntax (id ...)))]
-                  [new-ids (if xform?
-                               (map
-                                (lambda (id)
-                                  (datum->syntax
-                                   #f
-                                   (gensym (syntax-e id))))
-                                ids)
-                               ids)]
-                  [body-locals (append ids locals)]
-                  [exprs (map (lambda (expr id)
-                                (loop expr #t id (if letrec?
-                                                     body-locals
-                                                     locals)))
-                              (syntax->list (syntax (expr ...)))
-                              ids)]
-                  [body (let ([body (syntax let-body)])
-                          (if (identifier? body)
-                              (ormap (lambda (id new-id)
-                                       (and (bound-identifier=? body id)
-                                            new-id))
-                                     ids new-ids)
-                              (loop body #t name body-locals)))])
-             (unless body
-               (bad "bad form for method definition" orig-stx))
-             (with-syntax ([(proc ...) exprs]
-                           [(new-id ...) new-ids]
-                           [mappings
-                            (if xform?
-                                (map
-                                 (lambda (old-id new-id)
-                                   (with-syntax ([old-id old-id]
-                                                 [old-id-localized (lookup-localize (localize old-id))]
-                                                 [new-id new-id]
-                                                 [the-obj the-obj]
-                                                 [the-finder the-finder])
-                                     (syntax (old-id (make-direct-method-map 
-                                                      (quote-syntax the-finder)
-                                                      (quote the-obj)
-                                                      (quote-syntax old-id)
-                                                      #f
-                                                      (quote-syntax old-id-localized)
-                                                      (quote new-id))))))
-                                 ids new-ids)
-                                null)]
-                           [body body])
-               (syntax-track-origin
-                (rearm
-                 (if xform?
-                     (if letrec?
-                         (syntax/loc stx (letrec-syntax mappings
-                                           (let- ([(new-id) proc] ...) 
-                                                 body)))
-                         (syntax/loc stx (let- ([(new-id) proc] ...) 
-                                               (letrec-syntax mappings
-                                                 body))))
-                     (syntax/loc stx (let- ([(new-id) proc] ...) 
-                                           body)))
-                 stx)
-                stx
-                (syntax-local-introduce #'let-))))]
-          [(-#%app -chaperone-procedure expr . rst)
-           (and (free-identifier=? (syntax -#%app)
-                                   (quote-syntax #%plain-app))
-                (free-identifier=? (syntax -chaperone-procedure)
-                                   (quote-syntax chaperone-procedure)))
-           (with-syntax ([expr (loop #'expr #t name locals)])
-             (syntax-track-origin
-              (rearm
-               (syntax/loc stx (-#%app -chaperone-procedure expr . rst))
-               stx)
-              stx
-              (syntax-local-introduce #'-#%app)))]
-          [_else 
-           (if can-expand?
-               (loop (expand stx locals) #f name locals)
-               (bad "bad form for method definition" orig-stx))])))
-    
-    (define (add-method-property l)
-      (syntax-property l 'method-arity-error #t))
-
-    ;; `class' wants to be priviledged with respect to
-    ;; syntax taints: save the declaration-time inspector and use it 
-    ;; to disarm syntax taints
-    (define method-insp (variable-reference->module-declaration-inspector
-                         (#%variable-reference)))
-    (define (disarm stx)
-      (syntax-disarm stx method-insp))
-    (define (rearm new old)
-      (syntax-rearm new old))
-    
     ;; --------------------------------------------------------------------------------
     ;; Start here:
     
@@ -1783,6 +1563,227 @@
                  (syntax->list #'(defn-or-expr ...)))]))
      )))
 
+(begin-for-syntax
+  ;; expands an expression enough that we can check whether it has
+  ;; the right form for a method; must use local syntax definitions
+  (define (proc-shape name orig-stx xform? 
+                      the-obj the-finder
+                      bad class-name expand-stop-names
+                      def-ctx lookup-localize)
+    (define (expand expr locals)
+      (local-expand
+       expr
+       'expression
+       (append locals (list #'lambda) expand-stop-names)
+       def-ctx))
+    ;; Checks whether the vars sequence is well-formed
+    (define (vars-ok? vars)
+      (or (identifier? vars)
+          (stx-null? vars)
+          (and (stx-pair? vars)
+               (identifier? (stx-car vars))
+               (vars-ok? (stx-cdr vars)))))
+    (define (kw-vars-ok? vars)
+      (or (identifier? vars)
+          (stx-null? vars)
+          (and (stx-pair? vars)
+               (let ([a (stx-car vars)]
+                     [opt-arg-ok?
+                      (lambda (a)
+                        (or (identifier? a)
+                            (and (stx-pair? a)
+                                 (identifier? (stx-car a))
+                                 (stx-pair? (stx-cdr a))
+                                 (stx-null? (stx-cdr (stx-cdr a))))))])
+                 (or (and (opt-arg-ok? a)
+                          (kw-vars-ok? (stx-cdr vars)))
+                     (and (keyword? (syntax-e a))
+                          (stx-pair? (stx-cdr vars))
+                          (opt-arg-ok? (stx-car (stx-cdr vars)))
+                          (kw-vars-ok? (stx-cdr (stx-cdr vars)))))))))
+    ;; mk-name: constructs a method name
+    ;; for error reporting, etc.
+    (define (mk-name name)
+      (datum->syntax 
+       #f 
+       (string->symbol (format "~a method~a~a" 
+                               (syntax-e name)
+                               (if class-name
+                                   " in "
+                                   "")
+                               (or class-name 
+                                   ""))) 
+       #f))
+    ;; -- transform loop starts here --
+    (let loop ([stx orig-stx][can-expand? #t][name name][locals null])
+      (syntax-case (disarm stx) (#%plain-lambda lambda case-lambda letrec-values let-values)
+        [(lam vars body1 body ...)
+         (or (and (free-identifier=? #'lam #'#%plain-lambda)
+                  (vars-ok? (syntax vars)))
+             (and (free-identifier=? #'lam #'lambda)
+                  (kw-vars-ok? (syntax vars))))
+         (if xform?
+             (with-syntax ([the-obj the-obj]
+                           [the-finder the-finder]
+                           [name (mk-name name)])
+               (with-syntax ([vars (if (free-identifier=? #'lam #'lambda)
+                                       (let loop ([vars #'vars])
+                                         (cond
+                                           [(identifier? vars) vars]
+                                           [(syntax? vars)
+                                            (datum->syntax vars
+                                                           (loop (syntax-e vars))
+                                                           vars
+                                                           vars)]
+                                           [(pair? vars)
+                                            (syntax-case (car vars) ()
+                                              [(id expr)
+                                               (and (identifier? #'id) (not (immediate-default? #'expr)))
+                                               ;; optional argument; need to wrap arg expression
+                                               (cons
+                                                (with-syntax ([expr (syntax/loc #'expr
+                                                                      (syntax-parameterize ([the-finder (quote-syntax the-obj)])
+                                                                        (#%expression expr)))])
+                                                  (syntax/loc (car vars)
+                                                    (id expr)))
+                                                (loop (cdr vars)))]
+                                              [_ (cons (car vars) (loop (cdr vars)))])]
+                                           [else vars]))
+                                       #'vars)])
+                 (let ([l (syntax/loc stx 
+                            (lambda (the-obj . vars) 
+                              (syntax-parameterize ([the-finder (quote-syntax the-obj)])
+                                body1 body ...)))])
+                   (syntax-track-origin
+                    (with-syntax ([l (rearm (add-method-property l) stx)])
+                      (syntax/loc stx 
+                        (let ([name l]) name)))                  
+                    stx
+                    (syntax-local-introduce #'lam)))))
+             stx)]
+        [(#%plain-lambda . _)
+         (bad "ill-formed lambda expression for method" stx)]
+        [(lambda . _)
+         (bad "ill-formed lambda expression for method" stx)]
+        [(case-lam [vars body1 body ...] ...)
+         (and (free-identifier=? #'case-lam #'case-lambda)
+              (andmap vars-ok? (syntax->list (syntax (vars ...)))))
+         (if xform?
+             (with-syntax ([the-obj the-obj]
+                           [the-finder the-finder]
+                           [name (mk-name name)])
+               (let ([cl (syntax/loc stx
+                           (case-lambda [(the-obj . vars) 
+                                         (syntax-parameterize ([the-finder (quote-syntax the-obj)])
+                                           body1 body ...)] ...))])
+                 (syntax-track-origin 
+                  (with-syntax ([cl (rearm (add-method-property cl) stx)])
+                    (syntax/loc stx
+                      (let ([name cl]) name)))
+                  stx
+                  (syntax-local-introduce #'case-lam))))
+             stx)]
+        [(case-lambda . _)
+         (bad "ill-formed case-lambda expression for method" stx)]
+        [(let- ([(id) expr] ...) let-body)
+         (and (or (free-identifier=? (syntax let-) 
+                                     (quote-syntax let-values))
+                  (free-identifier=? (syntax let-) 
+                                     (quote-syntax letrec-values)))
+              (andmap identifier? (syntax->list (syntax (id ...)))))
+         (let* ([letrec? (free-identifier=? (syntax let-) 
+                                            (quote-syntax letrec-values))]
+                [ids (syntax->list (syntax (id ...)))]
+                [new-ids (if xform?
+                             (map
+                              (lambda (id)
+                                (datum->syntax
+                                 #f
+                                 (gensym (syntax-e id))))
+                              ids)
+                             ids)]
+                [body-locals (append ids locals)]
+                [exprs (map (lambda (expr id)
+                              (loop expr #t id (if letrec?
+                                                   body-locals
+                                                   locals)))
+                            (syntax->list (syntax (expr ...)))
+                            ids)]
+                [body (let ([body (syntax let-body)])
+                        (if (identifier? body)
+                            (ormap (lambda (id new-id)
+                                     (and (bound-identifier=? body id)
+                                          new-id))
+                                   ids new-ids)
+                            (loop body #t name body-locals)))])
+           (unless body
+             (bad "bad form for method definition" orig-stx))
+           (with-syntax ([(proc ...) exprs]
+                         [(new-id ...) new-ids]
+                         [mappings
+                          (if xform?
+                              (map
+                               (lambda (old-id new-id)
+                                 (with-syntax ([old-id old-id]
+                                               [old-id-localized (lookup-localize (localize old-id))]
+                                               [new-id new-id]
+                                               [the-obj the-obj]
+                                               [the-finder the-finder])
+                                   (syntax (old-id (make-direct-method-map 
+                                                    (quote-syntax the-finder)
+                                                    (quote the-obj)
+                                                    (quote-syntax old-id)
+                                                    #f
+                                                    (quote-syntax old-id-localized)
+                                                    (quote new-id))))))
+                               ids new-ids)
+                              null)]
+                         [body body])
+             (syntax-track-origin
+              (rearm
+               (if xform?
+                   (if letrec?
+                       (syntax/loc stx (letrec-syntax mappings
+                                         (let- ([(new-id) proc] ...) 
+                                               body)))
+                       (syntax/loc stx (let- ([(new-id) proc] ...) 
+                                             (letrec-syntax mappings
+                                               body))))
+                   (syntax/loc stx (let- ([(new-id) proc] ...) 
+                                         body)))
+               stx)
+              stx
+              (syntax-local-introduce #'let-))))]
+        [(-#%app -chaperone-procedure expr . rst)
+         (and (free-identifier=? (syntax -#%app)
+                                 (quote-syntax #%plain-app))
+              (free-identifier=? (syntax -chaperone-procedure)
+                                 (quote-syntax chaperone-procedure)))
+         (with-syntax ([expr (loop #'expr #t name locals)])
+           (syntax-track-origin
+            (rearm
+             (syntax/loc stx (-#%app -chaperone-procedure expr . rst))
+             stx)
+            stx
+            (syntax-local-introduce #'-#%app)))]
+        [_else 
+         (if can-expand?
+             (loop (expand stx locals) #f name locals)
+             (bad "bad form for method definition" orig-stx))])))
+    
+    (define (add-method-property l)
+      (syntax-property l 'method-arity-error #t))
+
+    ;; `class' wants to be priviledged with respect to
+    ;; syntax taints: save the declaration-time inspector and use it 
+    ;; to disarm syntax taints
+    (define method-insp (variable-reference->module-declaration-inspector
+                         (#%variable-reference)))
+    (define (disarm stx)
+      (syntax-disarm stx method-insp))
+    (define (rearm new old)
+      (syntax-rearm new old)))
+
 (define-syntax (-define-serializable-class stx)
   (syntax-case stx ()
     [(_ orig-stx name super-expression (interface-expr ...)
@@ -2197,6 +2198,27 @@ last few projections.
                                 augment-names augment-final-names augride-normal-names
                                 abstract-names)
                         "method names"))
+
+  (define new-public-names (append pubment-names public-final-names public-normal-names abstract-names))
+
+  ;; method names added for default implementations
+  (define-values (default-method-names default-methods)
+    (for/fold ([names null] [methods null] [public-ht #f]
+                            #:result (values names methods))
+              ([intf (in-list interfaces)])
+      (for/fold ([names names] [methods null] [public-ht public-ht])
+                ([(var def) (in-hash (interface-defaults intf))])
+        (cond
+          [(and super (hash-ref (class-method-ht super) var #f))
+           (values names methods public-ht)]
+          [else
+           (let ([public-ht (or public-ht (for/hasheq ([name (in-list new-public-names)])
+                                            (values name #t)))])
+             (cond
+               [(hash-ref public-ht var #f)
+                (values names methods public-ht)]
+               [else
+                (values (cons var names) (cons def methods) public-ht)]))]))))
   
   ;; -- Run class-seal/unseal checkers --
   (when (has-seals? super)
@@ -2235,7 +2257,7 @@ last few projections.
                               (string->symbol (format "derived-from-~a" s))
                               s))))]
          ;; Combine method lists
-         [public-names (append pubment-names public-final-names public-normal-names abstract-names)]
+         [public-names (append new-public-names default-method-names)]
          [override-names (append overment-names override-final-names override-normal-names)]
          [augride-names (append augment-names augment-final-names augride-normal-names)]
          [final-names (append public-final-names override-final-names augment-final-names)]
@@ -2338,7 +2360,8 @@ last few projections.
               [new-augonly-indices (get-indices method-ht "pubment" pubment-names)]
               [new-final-indices (get-indices method-ht "public-final" public-final-names)]
               [new-normal-indices (get-indices method-ht "public" public-normal-names)]
-              [new-abstract-indices (get-indices method-ht "abstract" abstract-names)])
+              [new-abstract-indices (get-indices method-ht "abstract" abstract-names)]
+              [default-method-indices (get-indices method-ht "default" default-method-names)])
           
           ;; -- Check that all interfaces are satisfied --
           (for-each
@@ -2385,7 +2408,7 @@ last few projections.
                   (append abstract-names
                           (remq* override-names super-abstract-ids))]
                  [super-interfaces (cons (class-self-interface super) interfaces)]
-                 [i (interface-make name super-interfaces #f method-names (make-immutable-hash) #f null)]
+                 [i (interface-make name super-interfaces #f method-names (hash) (hash) #f null)]
                  [methods (if no-method-changes?
                               (class-methods super)
                               (make-vector method-width))]
@@ -2606,7 +2629,8 @@ last few projections.
                     (for-each (lambda (index)
                                 (vector-set! dynamic-idxs index 0))
                               (append new-augonly-indices new-final-indices
-                                      new-normal-indices new-abstract-indices)))
+                                      new-normal-indices new-abstract-indices
+                                      default-method-indices)))
                   
                   ;; -- Create method accessors --
                   (let ([method-accessors
@@ -2649,8 +2673,9 @@ last few projections.
                                   (vector-set! dynamic-idxs index 0)
                                   (vector-set! dynamic-projs index (vector values)))
                                 (append new-augonly-indices new-final-indices
-                                        new-abstract-indices new-normal-indices)
-                                new-methods)
+                                        new-abstract-indices new-normal-indices
+                                        default-method-indices)
+                                (append new-methods default-methods))
                       ;; Add only abstracts, making sure the super method just calls (void)
                       (let ([dummy (lambda args (void))])
                         (for-each (lambda (index)
@@ -3108,17 +3133,24 @@ An example
     (syntax-case m-stx ()
       [((interface-expr ...) ([prop prop-val] ...) var ...)
        (let ([name (syntax-local-infer-name stx)])
-         (define-values (vars ctcs)
-           (for/fold ([vars '()] [ctcs '()])
+         (define-values (vars ctcs defaults)
+           (for/fold ([vars '()] [ctcs '()] [defaults '()])
                      ([v (syntax->list #'(var ...))])
              (syntax-case v ()
                [id
                 (identifier? #'id)
-                (values (cons #'id vars) (cons #f ctcs))]
+                (values (cons #'id vars) (cons #f ctcs) (cons #f defaults))]
+               [(id #:default default-rhs)
+                (values (cons #'id vars) (cons #f ctcs) (cons #'default-rhs defaults))]
                [(id ctc)
                 (identifier? #'id)
-                (values (cons #'id vars) (cons #'ctc ctcs))]
-               [_ (raise-syntax-error #f "not an identifier or identifier-contract pair"
+                (values (cons #'id vars) (cons #'ctc ctcs) (cons #f defaults))]
+               [(id ctc #:default default-rhs)
+                (values (cons #'id vars) (cons #'ctc ctcs) (cons #'default-rhs defaults))]
+               [_ (raise-syntax-error #f
+                                      (string-append "bad syntax;\n"
+                                                     " not an identifier or parenthesized sequence of identifier,\n"
+                                                     " optional contract, and optional default implementation")
                                       stx v)])))
          (let ([dup (check-duplicate-identifier vars)])
            (when dup
@@ -3126,18 +3158,58 @@ An example
                                  "duplicate name"
                                  stx
                                  dup)))
-         (with-syntax ([name (datum->syntax #f name #f)]
-                       [(var ...) (map localize vars)]
-                       [((v c) ...) (filter (λ (p) (cadr p)) (map list vars ctcs))])
-           (class-syntax-protect
-            (syntax/loc stx
-              (compose-interface
-               'name
-               (list interface-expr ...)
-               `(var ...)
-               (make-immutable-hash (list (cons 'v c) ...))
-               (list prop ...)
-               (list prop-val ...))))))])))
+         (let ([the-obj (datum->syntax (quote-syntax here) (gensym 'self))]
+               [the-finder (datum->syntax #f (gensym 'find-self))])
+           (with-syntax ([name (datum->syntax #f name #f)]
+                         [(var ...) (map localize vars)]
+                         [((v c) ...) (filter (λ (p) (cadr p)) (map list vars ctcs))]
+                         [((v/def def) ...) (filter (λ (p) (cadr p)) (map list vars defaults))])
+             (with-syntax ([(def ...)
+                            (let ()
+                              (define (bad msg expr)
+                                (raise-syntax-error #f msg stx expr))
+                              (define expand-stop-names (append
+                                                         (syntax->list #'(var ...))
+                                                         (kernel-form-identifier-list)))
+                              (define def-ctx (syntax-local-make-definition-context))
+                              (define localized-map (make-bound-identifier-mapping))
+                              (define lookup-localize (lambda (id)
+                                                        (bound-identifier-mapping-get
+                                                         localized-map
+                                                         id
+                                                         (lambda () #f))))
+                              (for/list ([name (in-list (syntax->list #'(v/def ...)))]
+                                         [def (in-list (syntax->list #'(def ...)))])
+                                (proc-shape name def #t
+                                            the-obj the-finder
+                                            bad (syntax-e #'name) expand-stop-names
+                                            def-ctx lookup-localize)))])
+               (class-syntax-protect
+                (quasisyntax/loc stx
+                  (compose-interface
+                   'name
+                   (list interface-expr ...)
+                   `(var ...)
+                   (make-immutable-hash (list (cons 'v c) ...))
+                   #,(if (null? (syntax->list #'(def ...)))
+                         #'(hash)
+                         (with-syntax ([the-obj the-obj]
+                                       [the-finder the-finder])
+                           #'(let ()
+                               (define-syntax-parameter the-finder #f)
+                               (syntax-parameterize ([this-param (make-this-map (quote-syntax this-id)
+                                                                                (quote-syntax the-finder)
+                                                                                (quote the-obj))])
+                                 (let-syntax ([var (make-interface-method-map
+                                                    (quote-syntax set!)
+                                                    (quote-syntax the-finder)
+                                                    (quote the-obj)
+                                                    (quote-syntax find-method/who)
+                                                    (quote var))]
+                                              ...)
+                                   (make-immutable-hash (list (cons 'v/def def) ...)))))))
+                   (list prop ...)
+                   (list prop-val ...))))))))])))
 
 (define-syntax (_interface stx)
   (syntax-case stx ()
@@ -3170,12 +3242,13 @@ An example
     #:mutable]
    public-ids       ; (listof symbol) (in any order?!?)
    contracts        ; (hashof symbol? contract?)
+   defaults         ; (hashof symbol? procedure?)
    [class           ; (union #f class) -- means that anything implementing
        #:mutable]      ; this interface must be derived from this class
    properties)      ; (listof (vector gensym prop val))
   #:inspector insp)
 
-(define (compose-interface name supers vars ctcs props vals)
+(define (compose-interface name supers vars ctcs defaults props vals)
   (for-each
    (lambda (intf)
      (unless (interface? intf)
@@ -3203,9 +3276,11 @@ An example
        (for-each
         (lambda (var)
           (when (and (hash-ref ht var #f)
-                     (not (hash-ref ctcs var #f)))
-            (obj-error 'interface "variable already in superinterface" 
-                       "variable name" (as-write var)
+                     (not (hash-ref ctcs var #f))
+                     ;; ok to add/replace default implementation
+                     (not (hash-ref defaults var #f)))
+            (obj-error 'interface "method already in superinterface"
+                       "method name" (as-write var)
                        (and (interface-name super) "already in") (as-write (interface-name super))
                        #:intf-name name)))
         (interface-public-ids super)))
@@ -3237,11 +3312,28 @@ An example
             (lambda (var) (hash-set! ht var #t))
             (interface-public-ids super)))
          supers)
+        (define all-defaults
+          (for/fold ([all-defaults defaults]) ([super (in-list supers)])
+            (for/fold ([all-defaults all-defaults]) ([(var def) (in-hash (interface-defaults super))])
+              (cond
+                [(hash-ref defaults var #f)
+                 ;; method's default implementation is replaced
+                 all-defaults]
+                [else
+                 (define old-def (hash-ref all-defaults var #f))
+                 (when (and old-def
+                            ;; if the implementation is `eq?`, it must be from the
+                            ;; same superinterface
+                            (not (eq? old-def def)))
+                   (obj-error 'interface "method has conflicting default implementations in among superinterfaces"
+                              "method name" (as-write var)
+                              #:intf-name name))
+                 (hash-set all-defaults var def)]))))
         ;; Done
         (let* ([new-ctcs (for/hash ([(k v) (in-hash ctcs)])
                            (values k (coerce-contract 'interface v)))]
                [i (interface-make name supers #f (hash-map ht (lambda (k v) k))
-                                  new-ctcs class (hash-map prop-ht (lambda (k v) v)))])
+                                  new-ctcs all-defaults class (hash-map prop-ht (lambda (k v) v)))])
           (setup-all-implemented! i)
           i)))))
 
@@ -3325,7 +3417,7 @@ An example
 
 (define object<%> (let ([object<%>
 			 ((make-naming-constructor struct:interface 'interface:object% #f)
-			  'object% null #f null (make-immutable-hash) #f null)])
+			  'object% null #f null (hash) (hash) #f null)])
 		    (setup-all-implemented! object<%>)
 		    object<%>))
 (define object%


### PR DESCRIPTION
The change extends `interface` to allow a declared method to have a default implementation.

 * The syntax is `[<id> #:default <expr>]` or `[<id> <contract-expr> #:default <expr>]` in place of a plain `<id>` or `[<id> <contract-expr>]` within `interface`, where `<expr>` must have a method shape (i.e., `lambda` or similar)
 * A default method implementaiton can use `this` or call another declared method directly.
 * An interface can add or replace the default-method implementation of a superinterface. If multiple superinterfaces provide defaults for a method and no replacement is provided, then it's an error — unless the default from both superinterfaces comes from a shared ancestor interface.

Related to #5257 
