### PR TITLE
build,ac: use xcode-select to infer SDK paths

### DIFF
--- a/racket/src/ac/sdk_ios.m4
+++ b/racket/src/ac/sdk_ios.m4
@@ -9,7 +9,7 @@ if test "${enable_ios}" != "" ; then
   esac
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
-     IOS_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     IOS_SDK="$(xcode-select -p)/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk"
      echo "=== Using inferred iOS SDK path ${IOS_SDK}"
      ;;
     *)

--- a/racket/src/bc/configure
+++ b/racket/src/bc/configure
@@ -3722,7 +3722,7 @@ if test "${enable_ios}" != "" ; then
   esac
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
-     IOS_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     IOS_SDK="$(xcode-select -p)/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk"
      echo "=== Using inferred iOS SDK path ${IOS_SDK}"
      ;;
     *)

--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -3386,7 +3386,7 @@ if test "${enable_ios}" != "" ; then
   esac
   case "${enable_ios}" in
     iPhoneOS|iPhoneSimulator)
-     IOS_SDK=/Applications/Xcode.app/Contents/Developer/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk
+     IOS_SDK="$(xcode-select -p)/Platforms/${enable_ios}.platform/Developer/SDKs/${enable_ios}.sdk"
      echo "=== Using inferred iOS SDK path ${IOS_SDK}"
      ;;
     *)


### PR DESCRIPTION
This makes it slightly easier to infer SDKs when working with multiple Xcode installs.

I considered adding a check for `xcode-select` itself, and falling back to the hardcoded path, but it seems unlikely that someone would be using this particular bit of functionality on a non macOS system in the first place (or that the hardcoded path would work in that case).