### PR TITLE
extracter: status output: make parameterizable

### DIFF
--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -12413,84 +12413,85 @@
                     (let ((result_0 #f))
                       (let ((result-kind_0 #f))
                         (let ((ready-sema_0 (1/make-semaphore)))
-                          (let ((t_0 unsafe-undefined))
-                            (set! t_0
-                              (with-continuation-mark*
-                               push-authentic
-                               break-enabled-key
-                               (make-thread-cell #f)
-                               (let ((temp5_0
-                                      (lambda ()
-                                        (begin
-                                          (1/semaphore-wait ready-sema_0)
-                                          (let ((with-handlers-predicate7_0
-                                                 (|#%name|
-                                                  with-handlers-predicate7
-                                                  (lambda (x_0) #t))))
-                                            (let ((with-handlers-handler8_0
-                                                   (|#%name|
-                                                    with-handlers-handler8
-                                                    (lambda (x_0)
-                                                      (begin
-                                                        (set! result-kind_0
-                                                          'exn)
-                                                        (set! result_0
-                                                          x_0))))))
-                                              (let ((bpz_0
-                                                     (continuation-mark-set-first
-                                                      #f
-                                                      break-enabled-key)))
-                                                (call-handled-body
-                                                 bpz_0
-                                                 (lambda (e_0)
-                                                   (select-handler/no-breaks
-                                                    e_0
+                          (let ((t_0
+                                 (with-continuation-mark*
+                                  push-authentic
+                                  break-enabled-key
+                                  (make-thread-cell #f)
+                                  (let ((temp5_0
+                                         (lambda ()
+                                           (begin
+                                             (1/semaphore-wait ready-sema_0)
+                                             (let ((with-handlers-predicate7_0
+                                                    (|#%name|
+                                                     with-handlers-predicate7
+                                                     (lambda (x_0) #t))))
+                                               (let ((with-handlers-handler8_0
+                                                      (|#%name|
+                                                       with-handlers-handler8
+                                                       (lambda (x_0)
+                                                         (begin
+                                                           (set! result-kind_0
+                                                             'exn)
+                                                           (set! result_0
+                                                             x_0))))))
+                                                 (let ((bpz_0
+                                                        (continuation-mark-set-first
+                                                         #f
+                                                         break-enabled-key)))
+                                                   (call-handled-body
                                                     bpz_0
-                                                    (list
-                                                     (cons
-                                                      with-handlers-predicate7_0
-                                                      with-handlers-handler8_0))))
-                                                 (lambda ()
-                                                   (with-continuation-mark*
-                                                    authentic
-                                                    break-enabled-key
-                                                    init-break-cell_0
-                                                    (begin
-                                                      (set! result_0
-                                                        (call-with-continuation-barrier
-                                                         (lambda ()
-                                                           (call-with-values
+                                                    (lambda (e_0)
+                                                      (select-handler/no-breaks
+                                                       e_0
+                                                       bpz_0
+                                                       (list
+                                                        (cons
+                                                         with-handlers-predicate7_0
+                                                         with-handlers-handler8_0))))
+                                                    (lambda ()
+                                                      (with-continuation-mark*
+                                                       authentic
+                                                       break-enabled-key
+                                                       init-break-cell_0
+                                                       (begin
+                                                         (set! result_0
+                                                           (call-with-continuation-barrier
                                                             (lambda ()
-                                                              (call-with-continuation-prompt
-                                                               thunk2_0
-                                                               (default-continuation-prompt-tag)
-                                                               (lambda (thunk_0)
-                                                                 (abort-current-continuation
+                                                              (call-with-values
+                                                               (lambda ()
+                                                                 (call-with-continuation-prompt
+                                                                  thunk2_0
                                                                   (default-continuation-prompt-tag)
-                                                                  thunk_0))))
-                                                            list))))
-                                                      (begin
-                                                        (start-atomic)
-                                                        (begin0
-                                                          (begin
-                                                            (set! result-kind_0
-                                                              'value)
-                                                            (thread-dead! t_0))
-                                                          (end-atomic)))
-                                                      (engine-block))))))))))))
-                                 (do-make-thread.1
-                                  #f
-                                  cust_0
-                                  #f
-                                  #f
-                                  'call-in-nested-thread
-                                  temp5_0))))
+                                                                  (lambda (thunk_0)
+                                                                    (abort-current-continuation
+                                                                     (default-continuation-prompt-tag)
+                                                                     thunk_0))))
+                                                               list))))
+                                                         (begin
+                                                           (start-atomic)
+                                                           (begin0
+                                                             (begin
+                                                               (set! result-kind_0
+                                                                 'value)
+                                                               (thread-dead!
+                                                                (current-thread/in-atomic)))
+                                                             (end-atomic)))
+                                                         (engine-block))))))))))))
+                                    (do-make-thread.1
+                                     #f
+                                     cust_0
+                                     #f
+                                     #f
+                                     'call-in-nested-thread
+                                     temp5_0)))))
                             (begin
                               (start-atomic)
                               (begin
                                 (begin0
-                                  (let ((app_0 (current-thread/in-atomic)))
-                                    (set-thread-forward-break-to! app_0 t_0))
+                                  (set-thread-forward-break-to!
+                                   (current-thread/in-atomic)
+                                   t_0)
                                   (end-atomic))
                                 (begin
                                   (1/semaphore-post ready-sema_0)

--- a/racket/src/expander/run/status.rkt
+++ b/racket/src/expander/run/status.rkt
@@ -1,12 +1,18 @@
 #lang racket/base
 
 (provide log-status
-         lines)
+         lines
+         current-status-output-port)
 
 (define stdout (current-output-port))
 
+(define current-status-output-port
+  (make-parameter stdout
+                  (lambda (v) (if (output-port? v) v (raise-argument-error "output-port?" v)))
+                  'current-status-output-port))
+
 (define (log-status fmt . args)
-  (apply fprintf stdout (string-append fmt "\n") args))
+  (apply fprintf (current-status-output-port) (string-append fmt "\n") args))
 
 (define (lines prefix vals)
   (apply

--- a/racket/src/thread/nested-thread.rkt
+++ b/racket/src/thread/nested-thread.rkt
@@ -55,7 +55,7 @@
              ;; that the thread completed with a value
              (atomically
               (set! result-kind 'value)
-              (thread-dead! t))
+              (thread-dead! (current-thread/in-atomic)))
              (engine-block)))))
       #:custodian cust)))
   (atomically


### PR DESCRIPTION
Previously, the `(log-status ...)` in the expander's extractor unconditionally printed to stdout. Now, it uses a parameter `current-status-output-port` which defaults to stdout. This enables tests to capture and inspect the output.

Test plan: used in next PR