### PR TITLE
io: fix fallback for (find-system-path 'host-addon-dir)

### DIFF
--- a/racket/src/cs/schemified/io.scm
+++ b/racket/src/cs/schemified/io.scm
@@ -29319,7 +29319,7 @@
                      (1/path->directory-path p_0))
                    (if (unsafe-fx< index_0 8)
                      (if (eq? host-addon-dir 'inherit)
-                       (1/find-system-path addon-dir)
+                       (1/find-system-path 'addon-dir)
                        (let ((or-part_0 host-addon-dir))
                          (if or-part_0
                            or-part_0

--- a/racket/src/io/path/system.rkt
+++ b/racket/src/io/path/system.rkt
@@ -42,7 +42,7 @@
                                        collects-dir
                                        (string->path "../collects")))]
       [(host-addon-dir) (if (eq? host-addon-dir 'inherit)
-                            (find-system-path addon-dir)
+                            (find-system-path 'addon-dir)
                             (or host-addon-dir
                                 (rktio-system-path who RKTIO_PATH_ADDON_DIR)))]
       [(orig-dir) (as-dir orig-dir)]
@@ -67,7 +67,7 @@
                                    "      'host-collects-dir 'host-config-dir 'host-addon-dir)")
                                   key)])
     (security-guard-check-file who #f '(exists))))
-                                 
+
 (define exec-file #f)
 (define (set-exec-file! p) (set! exec-file p))
 


### PR DESCRIPTION
Without this change, a call to `(find-system-path 'host-addon-dir)` would end up in a call to `(find-system-path #f)`, because the `addon-dir` variable is initialized to `#f`.
