### PR TITLE
doc: fix incorrect references in `racket/signature`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/units.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/units.scrbl
@@ -878,10 +878,10 @@ The body must match the following @racket[_module-body] grammar:
 
 @racketgrammar*[
 #:literals (require)
-[module-body (code:line (require require-spec ...) ... sig-spec ...)]
+[module-body (code:line (require require-spec ...) ... sig-elem ...)]
 ]
 
-See @secref["creatingunits"] for the grammar of @racket[_sig-spec].
+See @racket[define-signature] for the grammar of @racket[_sig-elem].
 Unlike the body of a @racketmodname[racket/unit] module, a
 @racket[require] in a @racketmodname[racket/signature] module must be
 a literal use of @racket[require].
@@ -894,7 +894,7 @@ without the directory and file suffix). If the module name ends in
 name before @racketidfont{-sig}. Otherwise, the module name serves as
 @racket[_base].
 
-A @racket[struct] form as a @racket[_sig-spec] is consistent with the
+A @racket[struct] form as a @racket[_sig-elem] is consistent with the
 definitions introduced by @racket[define-struct], as opposed to
 definitions introduced by @racket[struct]. (That behavior was originally
 a bug, but it is preserved for compatibility.)


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->
- Replaced incorrect reference to `sig-spec` with the correct `sig-elem`.
- Updated the link from `@secref["creatingunits"]` to `@racket[define-signature]` to reflect the correct grammar reference.
