### PR TITLE
nested-thread.rkt: change a mostly irrelevant thing

### DIFF
--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -12413,84 +12413,85 @@
                     (let ((result_0 #f))
                       (let ((result-kind_0 #f))
                         (let ((ready-sema_0 (1/make-semaphore)))
-                          (let ((t_0 unsafe-undefined))
-                            (set! t_0
-                              (with-continuation-mark*
-                               push-authentic
-                               break-enabled-key
-                               (make-thread-cell #f)
-                               (let ((temp5_0
-                                      (lambda ()
-                                        (begin
-                                          (1/semaphore-wait ready-sema_0)
-                                          (let ((with-handlers-predicate7_0
-                                                 (|#%name|
-                                                  with-handlers-predicate7
-                                                  (lambda (x_0) #t))))
-                                            (let ((with-handlers-handler8_0
-                                                   (|#%name|
-                                                    with-handlers-handler8
-                                                    (lambda (x_0)
-                                                      (begin
-                                                        (set! result-kind_0
-                                                          'exn)
-                                                        (set! result_0
-                                                          x_0))))))
-                                              (let ((bpz_0
-                                                     (continuation-mark-set-first
-                                                      #f
-                                                      break-enabled-key)))
-                                                (call-handled-body
-                                                 bpz_0
-                                                 (lambda (e_0)
-                                                   (select-handler/no-breaks
-                                                    e_0
+                          (let ((t_0
+                                 (with-continuation-mark*
+                                  push-authentic
+                                  break-enabled-key
+                                  (make-thread-cell #f)
+                                  (let ((temp5_0
+                                         (lambda ()
+                                           (begin
+                                             (1/semaphore-wait ready-sema_0)
+                                             (let ((with-handlers-predicate7_0
+                                                    (|#%name|
+                                                     with-handlers-predicate7
+                                                     (lambda (x_0) #t))))
+                                               (let ((with-handlers-handler8_0
+                                                      (|#%name|
+                                                       with-handlers-handler8
+                                                       (lambda (x_0)
+                                                         (begin
+                                                           (set! result-kind_0
+                                                             'exn)
+                                                           (set! result_0
+                                                             x_0))))))
+                                                 (let ((bpz_0
+                                                        (continuation-mark-set-first
+                                                         #f
+                                                         break-enabled-key)))
+                                                   (call-handled-body
                                                     bpz_0
-                                                    (list
-                                                     (cons
-                                                      with-handlers-predicate7_0
-                                                      with-handlers-handler8_0))))
-                                                 (lambda ()
-                                                   (with-continuation-mark*
-                                                    authentic
-                                                    break-enabled-key
-                                                    init-break-cell_0
-                                                    (begin
-                                                      (set! result_0
-                                                        (call-with-continuation-barrier
-                                                         (lambda ()
-                                                           (call-with-values
+                                                    (lambda (e_0)
+                                                      (select-handler/no-breaks
+                                                       e_0
+                                                       bpz_0
+                                                       (list
+                                                        (cons
+                                                         with-handlers-predicate7_0
+                                                         with-handlers-handler8_0))))
+                                                    (lambda ()
+                                                      (with-continuation-mark*
+                                                       authentic
+                                                       break-enabled-key
+                                                       init-break-cell_0
+                                                       (begin
+                                                         (set! result_0
+                                                           (call-with-continuation-barrier
                                                             (lambda ()
-                                                              (call-with-continuation-prompt
-                                                               thunk2_0
-                                                               (default-continuation-prompt-tag)
-                                                               (lambda (thunk_0)
-                                                                 (abort-current-continuation
+                                                              (call-with-values
+                                                               (lambda ()
+                                                                 (call-with-continuation-prompt
+                                                                  thunk2_0
                                                                   (default-continuation-prompt-tag)
-                                                                  thunk_0))))
-                                                            list))))
-                                                      (begin
-                                                        (start-atomic)
-                                                        (begin0
-                                                          (begin
-                                                            (set! result-kind_0
-                                                              'value)
-                                                            (thread-dead! t_0))
-                                                          (end-atomic)))
-                                                      (engine-block))))))))))))
-                                 (do-make-thread.1
-                                  #f
-                                  cust_0
-                                  #f
-                                  #f
-                                  'call-in-nested-thread
-                                  temp5_0))))
+                                                                  (lambda (thunk_0)
+                                                                    (abort-current-continuation
+                                                                     (default-continuation-prompt-tag)
+                                                                     thunk_0))))
+                                                               list))))
+                                                         (begin
+                                                           (start-atomic)
+                                                           (begin0
+                                                             (begin
+                                                               (set! result-kind_0
+                                                                 'value)
+                                                               (thread-dead!
+                                                                (current-thread/in-atomic)))
+                                                             (end-atomic)))
+                                                         (engine-block))))))))))))
+                                    (do-make-thread.1
+                                     #f
+                                     cust_0
+                                     #f
+                                     #f
+                                     'call-in-nested-thread
+                                     temp5_0)))))
                             (begin
                               (start-atomic)
                               (begin
                                 (begin0
-                                  (let ((app_0 (current-thread/in-atomic)))
-                                    (set-thread-forward-break-to! app_0 t_0))
+                                  (set-thread-forward-break-to!
+                                   (current-thread/in-atomic)
+                                   t_0)
                                   (end-atomic))
                                 (begin
                                   (1/semaphore-post ready-sema_0)

--- a/racket/src/thread/nested-thread.rkt
+++ b/racket/src/thread/nested-thread.rkt
@@ -55,7 +55,7 @@
              ;; that the thread completed with a value
              (atomically
               (set! result-kind 'value)
-              (thread-dead! t))
+              (thread-dead! (current-thread/in-atomic)))
              (engine-block)))))
       #:custodian cust)))
   (atomically


### PR DESCRIPTION
Right now, there's a bit of code which does:

    (define t
      (make-thread
        (lambda ()
          (wait-for-event)
          ...
          (do-stuff t))))
    (trigger-the-event)

This results in a knot getting tied with a letrec, analogously to:

    (letrec ([t undefined])
      (set! t (make-thread ...))
      ...)

This is fine from a correctness perspective, but the algorithms in the extractor aren't nearly powerful enough to reason about threading primitives (see PR #5272) and we'd like to be able to add a warning for cases where the expander can't prove safety. In this case, we can tweak the code *very* slightly: change a place where the thread refers to itself by using `(current-thread/in-atomic)` instead of `t`.
