### PR TITLE
add #:properties option for struct

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/define-struct.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/define-struct.scrbl
@@ -23,6 +23,7 @@
                               (code:line #:auto-value auto-expr)
                               (code:line #:guard guard-expr)
                               (code:line #:property prop-expr val-expr)
+                              (code:line #:properties prop-list-expr)
                               (code:line #:transparent)
                               (code:line #:prefab)
                               (code:line #:sealed)
@@ -133,9 +134,10 @@ procedure, respectively. See @racket[make-struct-type] for more
 information on these attributes of a structure type.  The
 @racket[#:property] option, which can be supplied
 multiple times, attaches a property value to the structure type; see
-@secref["structprops"] for more information on properties. The
-@racket[#:transparent] option is a shorthand for @racket[#:inspector
-#f].
+@secref["structprops"] for more information on properties.
+The @racket[#:properties] option, which can be supplied multiple times,
+accepts multiple properties and their values as an association list.
+The @racket[#:transparent] option is a shorthand for @racket[#:inspector #f].
 
 @examples[#:eval posn-eval
   (struct point (x y) #:inspector #f)
@@ -307,7 +309,8 @@ cp
 For serialization, see @racket[define-serializable-struct].
 
 @history[#:changed "6.9.0.4" @elem{Added @racket[#:authentic].}
-         #:changed "8.0.0.7" @elem{Added @racket[#:sealed].}]}
+         #:changed "8.0.0.7" @elem{Added @racket[#:sealed].}
+         #:changed "8.17.0.4" @elem{Added @racket[#:properties].}]}
 
 
 @defform[(struct-field-index field-id)]{

--- a/pkgs/racket-test-core/tests/racket/struct.rktl
+++ b/pkgs/racket-test-core/tests/racket/struct.rktl
@@ -1252,7 +1252,16 @@
   (test "abc" a-ref (s 1 2))
   (test "xyz" b-ref (s 1 2))
   (test 'here c-ref (s 1 2))
-  (test 123 (s 1 2) 123))
+  (test 123 (s 1 2) 123)
+
+  ;; Allow #:properties with #:prefab, dynamic error if non-empty
+  (struct ps1 (x y) #:prefab #:properties null)
+  (struct ps2 (x [y #:mutable]) #:properties null #:prefab)
+  (err/rt-test (let ()
+                 (struct pbad (x y)
+                   #:prefab
+                   #:properties (list (cons prop:procedure void)))
+                 (void))))
 
 ;; ----------------------------------------
 

--- a/pkgs/racket-test-core/tests/racket/struct.rktl
+++ b/pkgs/racket-test-core/tests/racket/struct.rktl
@@ -1240,6 +1240,22 @@
 
 ;; ----------------------------------------
 
+(let ()
+  (define-values (prop:a a? a-ref) (make-struct-type-property 'a))
+  (define-values (prop:b b? b-ref) (make-struct-type-property 'b))
+  (define-values (prop:c c? c-ref) (make-struct-type-property 'c))
+  (struct s (x y)
+    #:properties (list (cons prop:a "abc") (cons prop:b "xyz"))
+    #:property prop:procedure (lambda (self arg) arg)
+    #:properties (list (cons prop:c 'here)))
+
+  (test "abc" a-ref (s 1 2))
+  (test "xyz" b-ref (s 1 2))
+  (test 'here c-ref (s 1 2))
+  (test 123 (s 1 2) 123))
+
+;; ----------------------------------------
+
 (require (for-syntax racket/struct-info))
 
 (let ()


### PR DESCRIPTION
## Checklist

- [x] Feature
- [x] tests included
- [x] documentation

## Description of change

Add a `#:properties` option to `struct` that takes an association list (same type as `make-struct-type`).

This makes `struct` a better target for macros, since the calculation of properties can be separated from the rest of the struct declaration. Multiple property values can be calculated in a single expression position, making it easier for property values to share intermediate calculations and syntax bindings.

This PR does not change the expansion of existing `struct` definitions, if any tools rely on that.

Unlike `#:property`, `#:properties` does not signal an error if used with `#:prefab`. The property list might be empty, in which case there is no conflict, and `make-struct-type` will catch the error otherwise.