### PR TITLE
Make xexprs serializable via read and write

### DIFF
--- a/pkgs/racket-test/tests/xml/test.rkt
+++ b/pkgs/racket-test/tests/xml/test.rkt
@@ -392,7 +392,7 @@ END
      
      (test-read-xml/element/exn
       "<!-- comment --><br />"
-      "read-xml: parse-error: expected root element - received (comment ")
+      "read-xml: parse-error: expected root element - received '#s(comment \" comment \"")
      
      (test-read-xml/element
       "<title><![CDATA[hello world[mp3]]]></title>"
@@ -520,7 +520,7 @@ END
      
      (test-syntax:read-xml/element/exn
       "<!-- comment --><br />"
-      "read-xml: parse-error: expected root element - received (comment ")
+      "read-xml: parse-error: expected root element - received '#s(comment \" comment \"")
 
      (check-equal?
       (syntax-source

--- a/racket/collects/xml/private/core.rkt
+++ b/racket/collects/xml/private/core.rkt
@@ -9,20 +9,20 @@
 (define permissive-xexprs (make-parameter #f))
 
 ; Source = (make-source Location Location)
-(define-struct source (start stop) #:transparent)
+(define-struct source (start stop) #:prefab)
 
 ; Comment = (make-comment String)
-(define-struct comment (text) #:transparent)
+(define-struct comment (text) #:prefab)
 
 ; Processing-instruction = (make-p-i Location Location String String)
 ; also represents XMLDecl
-(define-struct (p-i source) (target-name instruction) #:transparent)
+(define-struct (p-i source) (target-name instruction) #:prefab)
 
 ; Pcdata = (make-pcdata Location Location String)
-(define-struct (pcdata source) (string) #:transparent)
+(define-struct (pcdata source) (string) #:prefab)
 
 ; Cdata = (make-cdata Location Location String)
-(define-struct (cdata source) (string) #:transparent)
+(define-struct (cdata source) (string) #:prefab)
 
 ; Section 2.2 of XML 1.1
 ; (XML 1.0 is slightly different and more restrictive)


### PR DESCRIPTION
To enable this Scribble pull request: https://github.com/racket/scribble/pull/498
make xexprs serializable via read and write by converting some structs to pre-fab structs.

The intent is to enable blogging systems like Greg Hendershott's "Tadpole", but using Scribble markup rather than Markdown. Greg gets away with serializing `xexpr`s because he doesn't insert comments, CDATA, or PCDATA in his Markdown source.

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [ ] tests included
- [ ] documentation

## Description of change

Convert the comment, CDATA, and PCDATA structs to pre-fab structs.

I should add a test for serializing those structs, and amend the xexpr docs to mention that they are serializable.
