### PR TITLE
Make deprecated alias definitions more flexible

### DIFF
--- a/racket/collects/racket/deprecation.rkt
+++ b/racket/collects/racket/deprecation.rkt
@@ -9,17 +9,25 @@
 
 
 (define-syntax (define-deprecated-alias stx)
-  (syntax-case stx
-    ()
+  (syntax-case stx ()
     [(_ id target-id)
      (let ()
        (unless (identifier? #'id)
-         (raise-syntax-error #f "expected an alias identifier" stx #'id))
+         (raise-syntax-error #false "expected an alias identifier" stx #'id (list stx)))
        (unless (identifier? #'target-id)
-         (raise-syntax-error #f "expected a target identifier" stx #'target-id))
-       (unless (identifier-binding #'target-id (syntax-local-phase-level) #true)
-         (raise-syntax-error #f "target identifier not bound" stx #'target-id
-                             #:exn exn:fail:syntax:unbound))
-       (syntax-property #'(define-syntax id (deprecated-alias #'target-id))
-                        'disappeared-use
-                        (list (syntax-local-introduce #'target-id))))]))
+         (raise-syntax-error #false "expected a target identifier" stx #'target-id (list stx)))
+       (syntax-property
+        #`(define-syntax id (make-and-check-deprecated-alias #'target-id #:context #'#,stx))
+        'disappeared-use
+        (list (syntax-local-introduce #'target-id))))]))
+
+
+(define-for-syntax (make-and-check-deprecated-alias target-id #:context context-stx)
+  (unless (identifier-binding target-id (syntax-local-phase-level) #true)
+    (raise-syntax-error #false
+                        "target identifier not bound"
+                        context-stx
+                        target-id
+                        (list context-stx)
+                        #:exn exn:fail:syntax:unbound))
+  (deprecated-alias target-id))


### PR DESCRIPTION
This is a work-in-progress attempt to make `define-deprecated-alias` more user-friendly, specifically by allowing it to be defined either before or after the definition of the alias's target while still raising an error if the target is unbound.