### PR TITLE
net,http-client: handle RST during body read

### DIFF
--- a/pkgs/net-lib/info.rkt
+++ b/pkgs/net-lib/info.rkt
@@ -11,4 +11,4 @@
 (define license
   '(Apache-2.0 OR MIT))
 
-(define version "1.3")
+(define version "1.3.1")

--- a/pkgs/net-test/tests/net/http-client/.gitignore
+++ b/pkgs/net-test/tests/net/http-client/.gitignore
@@ -1,1 +1,0 @@
-rst-server-constants

--- a/pkgs/net-test/tests/net/http-client/.gitignore
+++ b/pkgs/net-test/tests/net/http-client/.gitignore
@@ -1,0 +1,1 @@
+rst-server-constants

--- a/pkgs/net-test/tests/net/http-client/rst-server-constants.c
+++ b/pkgs/net-test/tests/net/http-client/rst-server-constants.c
@@ -1,0 +1,7 @@
+#include <stdio.h>
+#include <sys/socket.h>
+
+int main(void) {
+  printf("%d %d\n", SOL_SOCKET, SO_LINGER);
+  return 0;
+}

--- a/pkgs/net-test/tests/net/http-client/rst-server.rkt
+++ b/pkgs/net-test/tests/net/http-client/rst-server.rkt
@@ -1,0 +1,92 @@
+#lang racket/base
+
+;; Spawns a one-shot HTTP server that sends a RST packet in the middle
+;; of sending its response content. Relies on the availability of a C
+;; compiler in order to determine the values of some C socket constants.
+
+(require ffi/unsafe
+         ffi/unsafe/port
+         racket/runtime-path
+         racket/system
+         racket/tcp)
+
+(define cc (find-executable-path "cc"))
+(define-runtime-path rst-server-constants
+  "rst-server-constants")
+(define-runtime-path rst-server-constants.c
+  "rst-server-constants.c")
+
+;; Returns the values of SOL_SOCKET and SO_LINGER for the current
+;; platform (POSIX only).
+(define (get-constants)
+  (parameterize ([current-subprocess-custodian-mode 'kill]
+                 [subprocess-group-enabled #t])
+    (unless (zero? (system*/exit-code cc "-o" rst-server-constants rst-server-constants.c))
+      (error 'get-constants "failed to compile"))
+    (define out (open-output-string))
+    (parameterize ([current-output-port out])
+      (unless (zero? (system*/exit-code rst-server-constants))
+        (error 'get-constants "failed to get constants")))
+    (parameterize ([current-input-port (open-input-string (get-output-string out))])
+      (values (read) (read)))))
+
+(define-cstruct _linger
+  ([l_onoff _int]
+   [l_linger _int]))
+
+(define setsockopt
+  (get-ffi-obj "setsockopt" #f (_fun _int _int _int _linger-pointer _size -> _int)))
+
+(define (serve mode)
+  (define-values (SOL_SOCKET SO_LINGER)
+    (get-constants))
+  (define listener (tcp-listen 0 512 #t))
+  (define-values (_local-host local-port _remote-host _remote-port)
+    (tcp-addresses listener #t))
+  (define accept-thd
+    (thread
+     (lambda ()
+       (define-values (in out)
+         (tcp-accept listener))
+       (for ([line (in-lines in)])
+         #:break (equal? line "")
+         (void))
+       (close-input-port in)
+       (fprintf out "HTTP/1.1 200 OK\r\n")
+       (case mode
+         [(chunked)
+          (fprintf out "Transfer-Encoding: chunked\r\n")
+          (fprintf out "\r\n")
+          (fprintf out "2\r\n")
+          (fprintf out "hi\r\n")
+          (fprintf out "50\r\n")]
+         [(full)
+          (fprintf out "Content-Length: 50\r\n")
+          (fprintf out "\r\n")
+          (fprintf out "hello")])
+       (define sock (unsafe-port->socket out))
+       (define opt (make-linger 1 0))
+       (setsockopt sock SOL_SOCKET SO_LINGER opt (ctype-sizeof _linger))
+       (close-output-port out))))
+  (values
+   local-port
+   (thread-dead-evt accept-thd)
+   (λ () (tcp-close listener))))
+
+(module+ main
+  (require racket/cmdline)
+  (define mode
+    (command-line
+     #:args [MODE]
+     (case MODE
+       [("chunked") 'chunked]
+       [("full") 'full]
+       [else (error "MODE must be either 'chunked' or 'full'")])))
+  (file-stream-buffer-mode (current-output-port) 'line)
+  (file-stream-buffer-mode (current-error-port) 'line)
+  (define-values (port done?-evt stop)
+    (serve mode))
+  (printf "PORT: ~a~n" port)
+  (with-handlers ([exn:break? void])
+    (void (sync/enable-break done?-evt)))
+  (stop))

--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -225,57 +225,126 @@
 (define (http-conn-response-port/rest! hc)
   (http-conn-response-port/length! hc +inf.0 #:close? #t))
 
-(define (http-conn-response-port/length! hc count #:close? [close? #f])
-  (define-values (in out) (make-pipe PIPE-SIZE))
-  (thread
-   (λ ()
-     (copy-bytes (http-conn-from hc) out count)
-     (when close?
-       (http-conn-close! hc))
-     (close-output-port out)))
-  in)
+(define (http-conn-response-port/length! hc n #:close? [close? #f])
+  (make-conn-response-port
+   hc close?
+   (lambda (in out)
+     (copy-bytes in out n))))
 
 (define (http-conn-response-port/chunked! hc #:close? [close? #f])
-  (define (http-pipe-chunk ip op)
-    (define (done) (void))
-    (define crlf-bytes (make-bytes 2))
-    (let loop ([last-bytes #f])
-      (define in-v (read-line ip eol-type))
-      (cond
-        [(eof-object? in-v)
-         (done)]
-        [else
-         (define size-str (string-trim in-v))
-         (define chunk-size (string->number size-str 16))
-         (unless chunk-size
-           (error 'http-conn-response/chunked
-                  "Could not parse ~S as hexadecimal number"
-                  size-str))
-         (define use-last-bytes?
-           (and last-bytes (<= chunk-size (bytes-length last-bytes))))
-         (if (zero? chunk-size)
-             (done)
-             (let* ([bs (if use-last-bytes?
-                            (begin
-                              (read-bytes! last-bytes ip 0 chunk-size)
-                              last-bytes)
-                            (read-bytes chunk-size ip))]
-                    [crlf (read-bytes! crlf-bytes ip 0 2)])
-               (write-bytes bs op 0 chunk-size)
-               (loop bs)))])))
+  (make-conn-response-port
+   hc close?
+   (lambda (in out)
+     (http-pipe-chunk in out))))
 
-  (define-values (in out) (make-pipe PIPE-SIZE))
-  (define chunk-t
-    (thread
-     (λ ()
-       (http-pipe-chunk (http-conn-from hc) out))))
+(define (http-pipe-chunk ip op)
+  (define crlf-bytes
+    (make-bytes 2))
+  (let loop ([last-bytes #f])
+    (define in-v (read-line ip eol-type))
+    (cond
+      [(eof-object? in-v)
+       (void)]
+      [else
+       (define size-str
+         (string-trim in-v))
+       (define chunk-size
+         (string->number size-str 16))
+       (unless chunk-size
+         (error 'http-pipe-chunk
+                "Could not parse ~S as hexadecimal number"
+                size-str))
+       (define use-last-bytes?
+         (and last-bytes (<= chunk-size (bytes-length last-bytes))))
+       (cond
+         [(zero? chunk-size)
+          (void)]
+         [else
+          (define bs
+            (cond
+              [use-last-bytes?
+               (read-bytes! last-bytes ip 0 chunk-size)
+               last-bytes]
+              [else
+               (read-bytes chunk-size ip)]))
+          (read-bytes! crlf-bytes ip 0 2)
+          (write-bytes bs op 0 chunk-size)
+          (loop bs)])])))
+
+;; The other end can hang up while we're reading the response, so we
+;; have to ensure that reading from the port doesn't deadlock and that
+;; the thread reading the port we return is notified of the exn.
+(define (make-conn-response-port hc close? copy)
+  (define-values (in out set-err!)
+    (make-pipe/err PIPE-SIZE))
   (thread
-   (λ ()
-     (thread-wait chunk-t)
-     (when close?
-       (http-conn-close! hc))
-     (close-output-port out)))
+   (lambda ()
+     (with-handlers ([exn:fail?
+                      (lambda (e)
+                        (set-err! e)
+                        (http-conn-close! hc)
+                        (close-output-port out))])
+       (copy (http-conn-from hc) out)
+       (when close? (http-conn-close! hc))
+       (close-output-port out))))
   in)
+
+;; Like make-pipe, but returns 3 values: the input port, the output port
+;; and a procedure to signal that an error has ocurred while piping
+;; data. When an error a signaled, in-progress and subsequent reads from
+;; the input port raise that error.
+(define (make-pipe/err size)
+  (define-values (in out)
+    (make-pipe size))
+  (define err #f)
+  (define (make-ready-or-err-evt)
+    ;; When an error has already been signaled, raise immediately.
+    (when err
+      (raise err))
+    ;; Otherwise wait for the port to make progress or be closed.
+    ;; Assumes the user of make-pipe/err will close the output port
+    ;; after signaling an error.
+    (wrap-evt
+     in
+     (lambda (ip)
+       (when err
+         (raise err))
+       ip)))
+  (define (set-err! e)
+    (set! err e))
+  (define custom-in
+    (make-input-port
+     #;name
+     'http-conn-response-port
+     #;read-in
+     (lambda (bs)
+       (wrap-evt
+        (make-ready-or-err-evt)
+        (lambda (ip)
+          (read-bytes-avail! bs ip))))
+     #;peek
+     (lambda (bs s progress)
+       (wrap-evt
+        (make-ready-or-err-evt)
+        (lambda (ip)
+          (peek-bytes-avail! bs s progress ip))))
+     #;close
+     (lambda ()
+       (close-input-port in))
+     #;get-progress-evt
+     (lambda ()
+       (port-progress-evt in))
+     #;commit
+     (lambda (amt progress evt)
+       (port-commit-peeked amt progress evt in))
+     #;get-location
+     (lambda ()
+       (port-next-location in))
+     #;count-lines!
+     (lambda ()
+       (port-count-lines! in))
+     #;init-position 1))
+  (values custom-in out set-err!))
 
 ;; Derived
 

--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -267,6 +267,8 @@
                last-bytes]
               [else
                (read-bytes chunk-size ip)]))
+          (when (eof-object? bs)
+            (error 'http-pipe-chunk "Unexpected EOF while reading chunk"))
           (read-bytes! crlf-bytes ip 0 2)
           (write-bytes bs op 0 chunk-size)
           (loop bs)])])))


### PR DESCRIPTION
An RST packet received while reading a response with a Content-Length header would cause a thread reading from the body output port to block indefinitely as the piping thread would crash without closing the output side of the pipe. The same situation for a chunked transfer would lead to a slightly better outcome, namely that the output side of the pipe would get closed, so the reader wouldn't block indefinitely, but it would end up receiving partial data with no notice that something went wrong in the process.

This change wraps the input side of these pipes into a custom input port that propagates any errors from the piping thread to the thread reading the input port.

Unfortunately, it's not possible to trigger an RST using portable Racket code, so the added test only works on POSIX-compatible platforms and relies on the test machine having at least a C compiler.

EDIT: Looks like the test server doesn't cause an RST packet to be sent on Linux, so I'll have to look into that later.
