### PR TITLE
net,url: remove URL fragment on http-conn-send

### DIFF
--- a/racket/collects/net/url.rkt
+++ b/racket/collects/net/url.rkt
@@ -214,7 +214,9 @@
                         (if (null? (url-path url))
                             (values #t (list (make-path/param "" '())))
                             (values (url-path-absolute? url) (url-path url)))])
-            (make-url #f #f #f #f abs? path (url-query url) (url-fragment url)))))))
+            ;; We don't send the URL fragment to the server, hence
+            ;; the last #f
+            (make-url #f #f #f #f abs? path (url-query url) #f))))))
 
   (hc:http-conn-send! hc access-string
                       #:method (if get? #"GET" #"POST")
@@ -459,11 +461,13 @@
            (url->string
             (if (and proxy (not (proxy-tunneled? url)))
                 url
+                ;; We don't send the URL fragment to the server, hence
+                ;; the last #f
                 (make-url #f #f #f #f
                           (url-path-absolute? url)
                           (url-path url)
                           (url-query url)
-                          (url-fragment url)))))])
+                          #f))))])
     (hc:http-conn-send! hc access-string
                         #:method method
                         #:headers strings


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [ ] Tests included
- [ ] Documentation

There were **no** regressions with this change, so I am not sure how exactly should I test this. Not sure if the documentation needs to be updated. Any pointers or directions for these would be a great help in closing this issue.

## Description of change
<!-- Please provide a description of the change here. -->
The `get-impure-port` function sends the URL fragment in the http connection request. The fragment part should not be sent to the server and should be handled at client side.

This commit removes the fragment part from the `get-impure-port` function call.

Closes #5221.