### PR TITLE
HISTORY.txt: Copyediting on the 8.18 notes

### DIFF
--- a/racket/collects/racket/HISTORY.txt
+++ b/racket/collects/racket/HISTORY.txt
@@ -7,7 +7,7 @@ Use Unicode 16.0 for character and string operations
 Change `struct` to support `#:properties prop-alist-expr`
 Improve `expt` on a flonum to a large exact power
 xml: Change structs to serializable
-ffi/unsafe: Add `{star,end}-uninterruptible`
+ffi/unsafe: Add `start-uninterruptible`, `end-uninterruptible`
 net/imap: Add `imap-move`
 
 Version 8.17, April 2025


### PR DESCRIPTION
Change "`{star,end}-uninterruptible`"
to "`start-uninterruptible`, `end-uninterruptible`.

This fixes the typo, and makes the function names searchable.
