### PR TITLE
Fix undeclared __clear_cache.

### DIFF
--- a/racket/src/ChezScheme/c/clearcache.c
+++ b/racket/src/ChezScheme/c/clearcache.c
@@ -45,6 +45,7 @@ void S_doflush(uptr start, uptr end) {
 #ifdef S_TARGET_OS_IPHONE
   sys_icache_invalidate((void *)start, (char *)end-(char *)start);
 #else
+  extern void __clear_cache(void*, void*);
   __clear_cache((char *)start, (char *)end);
 # if defined(__clang__) && defined(__aarch64__) && !defined(__APPLE__)
   /* Seem to need an extra combination of barriers here to make up for


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change
<!-- Please provide a description of the change here. -->
When I was compiling Rackert for Riscv and Loongarch, I encountered an issue

```
[  361s] ChezScheme/c/clearcache.c:48:3: error: call to undeclared function '__clear_cache';  ISO C99 and later do not support implicit function declarations [-Wimplicit-function-declaration]
[  361s]    48 |   __clear_cache((char *)start, (char *)end);
[  361s]       |   ^
[  361s] 1 error generated.
This issue is due to the fact that implicit function declarations are not allowed after ISO C99, so I fixed it.
```

