### PR TITLE
Update strncpy in regexp.c (bc)

### DIFF
--- a/racket/src/bc/src/regexp.c
+++ b/racket/src/bc/src/regexp.c
@@ -4252,7 +4252,7 @@ regstrcspn(char *s1, char *e1, char *s2)
 }
 
 #ifndef strncpy
-  extern char *strncpy();
+  extern char *strncpy(char *, const char *, long unsigned int);
 #endif
 
 /*


### PR DESCRIPTION
#### Checklist
- [X] Bugfix

#### Description of change
In the last few months something changed on my machine that broke my build script for snapshot racket-bc on linux.
I think it has to do with how strict gcc is but anyway...
If `strncpy` is not defined a conflicting definition to what is used is given, this PR changes the signature to bring it in line.
But maybe this can be deleted all together since i don't see any use of `strncpy` in `regexp.c`.
(with this PR local build works again)
