### PR TITLE
Fix #3167

### DIFF
--- a/pkgs/racket-test-core/tests/racket/logger.rktl
+++ b/pkgs/racket-test-core/tests/racket/logger.rktl
@@ -280,6 +280,35 @@
     warning-counter))
 (test 2 test-intercepted-logging2)
 
+;; From issue #3167
+(define (test-intercepted-logging3)
+  (define-logger bar)
+  (define ok? #t)
+  (with-intercepted-logging
+    (λ (l) (set! ok? #f))
+    (λ () (log-warning "hello"))
+    #:logger bar-logger
+    'warning)
+  ok?)
+(test #t test-intercepted-logging3)
+
+(define (test-intercepted-logging4)
+  (define msg #f)
+  (define kont #f)
+  (call-with-continuation-prompt
+   (λ ()
+     (with-intercepted-logging
+       (λ (l) (set! msg l))
+       (λ ()
+         (when (call-with-composable-continuation
+                (λ (k)
+                  (set! kont k) #f))
+           (log-warning "hello")))
+       'warning)))
+  (kont #t)
+  (and msg #t))
+(test #t test-intercepted-logging4)
+
 ; --------------------
 ;; Check that a blocked log receiver is not GCed if
 ;; if might receiver something


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [x] tests included

## Description of change

This PR fixes the behavior described in #3167 to match both intuitive expectations and the documentation. I did not end up going with the solution that I originally proposed in the issue because it turns out that the strategy the code currently uses is fundamentally broken. If `proc` captures a continuation and restores it later, it can cause `channel-put` to execute after the thread has terminated, resulting in hanging. The solution I ended up going with, which resolves both this issue and my original one, is to use `dynamic-wind` to launch and teardown the receiver thread when execution enters and exits the dynamic extent of `proc`. 

I have two tests. The first confirms that #3167 is fixed. The second confirms that logs are intercepted when a continuation is invoked that re-enters `proc`.