### PR TITLE
Add a simple check for method defns to struct

### DIFF
--- a/pkgs/racket-test/tests/generic/errors.rkt
+++ b/pkgs/racket-test/tests/generic/errors.rkt
@@ -136,4 +136,13 @@
                            (define-generics AA [meth AA . a])
                            (meth 1 2))))
              "rest args present")
+
+  ;; https://github.com/racket/racket/issues/1711
+
+  (check-exn #rx"struct: .* not a parenthesized sequence of method definitions"
+             (lambda () (convert-compile-time-error
+                         (let ()
+                           (define-generics foo (do-foo foo))
+                           (struct inst () #:methods gen:foo "not methods")
+                           'ignore))))
   )

--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -349,6 +349,11 @@
                  (car p)
                  " is not a name for a generic interface"
                  (cadr p)))
+          (unless (list? (syntax-e gen-defs))
+            (bad "the second argument to the"
+                 (car p)
+                 " is not a parenthesized sequence of method definitions"
+                 gen-defs))
           (loop (list* #'#:property
                        (quasisyntax/loc gen-id
                          (generic-property #,gen-id))


### PR DESCRIPTION
## Checklist
- [x] Bugfix
- [x] tests included

## Description of change
Adds an outer level check to `struct` for `#:methods` sub-forms to ensure the methods definitions are a nested list form.

resolves #1711
