### PR TITLE
add shape check to `struct-copy`

### DIFF
--- a/pkgs/racket-test-core/tests/racket/struct.rktl
+++ b/pkgs/racket-test-core/tests/racket/struct.rktl
@@ -1947,5 +1947,13 @@
                 (read (open-input-bytes (get-output-bytes o)))))))
 
 ;; ----------------------------------------
+;; Report malformed struct-copy correctly
+;; https://github.com/racket/racket/issues/5194
+
+(syntax-test #'struct-copy #px"struct-copy: bad syntax")
+(syntax-test #'(struct-copy) #px"struct-copy: bad syntax")
+(syntax-test #'(struct-copy (foo 1 2)) #px"struct-copy: bad syntax")
+
+;; ----------------------------------------
 
 (report-errs)

--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -1001,6 +1001,9 @@
                  (struct-field-info-list compile-time-info))))
 
   (define-for-syntax (struct-copy-core stx)
+    (syntax-case stx ()
+      [(_ _ _ . _) (void)]
+      [_ (raise-syntax-error #f "bad syntax" stx)])
     (with-syntax ([(form-name info struct-expr field+val ...) stx])
       (define ans (syntax->list #'(field+val ...)))
       ;; Check syntax:


### PR DESCRIPTION
## Checklist
- [x] Bugfix
- [x] tests included


## Description of change
Add a shape check and report errors in terms of `struct-copy`.

resolves #5194

