### PR TITLE
doc: explain lookahead behavior in `sequence-generate`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -926,10 +926,12 @@ each element in the sequence.
 @defproc[(sequence-generate [seq sequence?])
          (values (-> boolean?) (-> any))]{
   @tech{Initiates} a sequence and returns two thunks to extract
-  elements from the sequence.  The first returns @racket[#t] if more
-  values are available for the sequence.  The second returns the next
-  element (which may be multiple values) from the sequence; if no more
-  elements are available, the @exnraise[exn:fail:contract].
+  elements from the sequence.  The first checks if more elements are
+  available by reading and caching the next element (which may be multiple
+  values) if none is currently cached, returning @racket[#t] if successful.
+  The second retrieves the cached element if available; otherwise it reads
+  the next element from the sequence directly; if no more elements are
+  available, the @exnraise[exn:fail:contract].
 
   Note that a @elemref["sequence-state"]{sequence itself can have
   state}, so multiple calls to @racket[sequence-generate] on the same
@@ -937,14 +939,26 @@ each element in the sequence.
 
   @examples[
   #:eval sequence-evaluator
-  (define inport (open-input-bytes (bytes 1 2 3 4 5)))
+  (define inport (open-input-bytes (bytes 1 2 3 4 5 6 7 8 9 10)))
   (define-values (more? get) (sequence-generate inport))
   (more?)
   (get)
+  (more?)
+  (sequence-ref inport 0)
+  (get)
+  (more?)
+  (for/first ([i inport]) i)
   (get)
 
   (define-values (more2? get2) (sequence-generate inport))
-  (list (get2) (get2) (get2))
+  (more?)
+  (list (get2) (get))
+  (more2?)
+  (more2?)
+  (list (get) (get2))
+  (more?)
+  (more2?)
+  (more?)
   (more2?)
  ]}
 


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers.

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->

### Problem

The current documentation for `sequence-generate` doesn't explain that the `more?` function may consume elements from the underlying sequence to determine if more elements are available, caching them for subsequent `get` calls. This can cause unexpected behavior when mixing `sequence-generate` usage with direct sequence access.

### Example

```racket
Welcome to Racket v8.17 [cs].
> (define inport (open-input-bytes (bytes 1 2 3 4 5 6 7 8 9 10)))
> (define-values (more? get) (sequence-generate inport))
> (more?)
#t
> (get)
1
> (more?)
#t
> (sequence-ref inport 0)
3
> (get)
2
> (more?)
#t
> (for/first ([i inport]) i)
5
> (get)
4
> (define-values (more2? get2) (sequence-generate inport))
> (more?)
#t
> (list (get2) (get))
'(7 6)
> (more2?)
#t
> (more2?)
#t
> (list (get) (get2))
'(9 8)
> (more?)
#t
> (more2?)
#f
> (more?)
#t
> (more2?)
#f
```
