### PR TITLE
Fix `sequence-ref` to avoid unnecessary lookahead consumption

### DIFF
--- a/pkgs/racket-test-core/tests/racket/sequence.rktl
+++ b/pkgs/racket-test-core/tests/racket/sequence.rktl
@@ -174,8 +174,8 @@
   (define s
     (make-do-sequence
      (λ ()
-       (define (pos->element _) v)
-       (define (continue-with-pos? _) (set! v (add1 v)) (< v 100))
+       (define (pos->element _) (set! v (add1 v)) v)
+       (define (continue-with-pos? _) (< v 100))
        (values pos->element void (void) continue-with-pos? #f #f))))
   (define-values (more? get) (sequence-generate s))
   (test 1 'sequence-ref (get))

--- a/pkgs/racket-test-core/tests/racket/sequence.rktl
+++ b/pkgs/racket-test-core/tests/racket/sequence.rktl
@@ -184,7 +184,7 @@
   (test 5 'sequence-ref (sequence-ref s 1))
   (test 7 'sequence-ref (sequence-ref s 1))
   (test 8 'sequence-ref (get))
-  (test 91 'sequence-length (sequence-length s)))
+  (test 92 'sequence-length (sequence-length s)))
 
 (test-values '(2 3) (lambda () (sequence-ref (in-parallel '(2) '(3)) 0)))
 (test-values '(8 12) (lambda () (sequence-ref (in-parallel '(2 5 8 -1) '(3 9 12 0)) 2)))

--- a/pkgs/racket-test-core/tests/racket/sequence.rktl
+++ b/pkgs/racket-test-core/tests/racket/sequence.rktl
@@ -170,6 +170,21 @@
                         stream-count)
 
 (test 3 'sequence-length (sequence-length #hasheq((1 . 'a) (2 . 'b) (3 . 'c))))
+(let ([v 0])
+  (define s
+    (make-do-sequence
+     (λ ()
+       (define (pos->element _) v)
+       (define (continue-with-pos? _) (set! v (add1 v)) (< v 100))
+       (values pos->element void (void) continue-with-pos? #f #f))))
+  (define-values (more? get) (sequence-generate s))
+  (test 1 'sequence-ref (get))
+  (test 2 'sequence-ref (sequence-ref s 0))
+  (test 3 'sequence-ref (sequence-ref s 0))
+  (test 5 'sequence-ref (sequence-ref s 1))
+  (test 7 'sequence-ref (sequence-ref s 1))
+  (test 8 'sequence-ref (get))
+  (test 91 'sequence-length (sequence-length s)))
 
 (test-values '(2 3) (lambda () (sequence-ref (in-parallel '(2) '(3)) 0)))
 (test-values '(8 12) (lambda () (sequence-ref (in-parallel '(2 5 8 -1) '(3 9 12 0)) 2)))

--- a/racket/collects/racket/sequence.rkt
+++ b/racket/collects/racket/sequence.rkt
@@ -73,14 +73,14 @@
                        #:unless (j . < . i))
              (or v '(#f)))])
     (cond
-      [(not v)
-       (raise-arguments-error
-        'sequence-ref
-        "sequence ended before index"
-        "index" i
-        "sequence" s)]
-      [(list? v) (apply values v)]
-      [else v])))
+     [(not v)
+      (raise-arguments-error
+       'sequence-ref
+       "sequence ended before index"
+       "index" i
+       "sequence" s)]
+     [(list? v) (apply values v)]
+     [else v])))
 
 (define (sequence-tail seq i)
   (unless (sequence? seq) (raise-argument-error 'sequence-tail "sequence?" seq))

--- a/racket/collects/racket/sequence.rkt
+++ b/racket/collects/racket/sequence.rkt
@@ -70,7 +70,7 @@
     (raise-argument-error 'sequence-ref "exact-nonnegative-integer?" i))
   (let ([v (for/fold ([c #f]) ([v (in-values*-sequence s)]
                                [j (in-range (add1 i))]
-                               #:unless (j . < . i))
+                               #:final (j . >= . i))
              (or v '(#f)))])
     (cond
      [(not v)

--- a/racket/collects/racket/sequence.rkt
+++ b/racket/collects/racket/sequence.rkt
@@ -69,7 +69,7 @@
   (unless (exact-nonnegative-integer? i)
     (raise-argument-error 'sequence-ref "exact-nonnegative-integer?" i))
   (define-values (more? get) (sequence-generate s))
-  (for ([_ (in-range i)]) (when (more?) (get)))
+  (for (#:when (more?) [_ (in-range i)]) (get))
   (unless (more?)
     (raise-arguments-error
      'sequence-ref

--- a/racket/collects/racket/sequence.rkt
+++ b/racket/collects/racket/sequence.rkt
@@ -68,15 +68,19 @@
   (unless (sequence? s) (raise-argument-error 'sequence-ref "sequence?" s))
   (unless (exact-nonnegative-integer? i)
     (raise-argument-error 'sequence-ref "exact-nonnegative-integer?" i))
-  (define-values (more? get) (sequence-generate s))
-  (for ([_ (in-range i)] #:when (more?)) (get))
-  (unless (more?)
-    (raise-arguments-error
-     'sequence-ref
-     "sequence ended before index"
-     "index" i
-     "sequence" s))
-  (get))
+  (let ([v (for/first ([v (in-values*-sequence s)]
+                       [j (in-range (add1 i))]
+                       #:unless (j . < . i))
+             (or v '(#f)))])
+    (cond
+      [(not v)
+       (raise-arguments-error
+        'sequence-ref
+        "sequence ended before index"
+        "index" i
+        "sequence" s)]
+      [(list? v) (apply values v)]
+      [else v])))
 
 (define (sequence-tail seq i)
   (unless (sequence? seq) (raise-argument-error 'sequence-tail "sequence?" seq))

--- a/racket/collects/racket/sequence.rkt
+++ b/racket/collects/racket/sequence.rkt
@@ -68,19 +68,15 @@
   (unless (sequence? s) (raise-argument-error 'sequence-ref "sequence?" s))
   (unless (exact-nonnegative-integer? i)
     (raise-argument-error 'sequence-ref "exact-nonnegative-integer?" i))
-  (let ([v (for/fold ([c #f]) ([v (in-values*-sequence s)]
-                               [j (in-range (add1 i))]
-                               #:final (j . >= . i))
-             (or v '(#f)))])
-    (cond
-     [(not v)
-      (raise-arguments-error
-       'sequence-ref
-       "sequence ended before index"
-       "index" i
-       "sequence" s)]
-     [(list? v) (apply values v)]
-     [else v])))
+  (define-values (more? get) (sequence-generate s))
+  (for ([_ (in-range i)]) (when (more?) (get)))
+  (unless (more?)
+    (raise-arguments-error
+     'sequence-ref
+     "sequence ended before index"
+     "index" i
+     "sequence" s))
+  (get))
 
 (define (sequence-tail seq i)
   (unless (sequence? seq) (raise-argument-error 'sequence-tail "sequence?" seq))

--- a/racket/collects/racket/sequence.rkt
+++ b/racket/collects/racket/sequence.rkt
@@ -69,7 +69,7 @@
   (unless (exact-nonnegative-integer? i)
     (raise-argument-error 'sequence-ref "exact-nonnegative-integer?" i))
   (define-values (more? get) (sequence-generate s))
-  (for (#:when (more?) [_ (in-range i)]) (get))
+  (for ([_ (in-range i)] #:when (more?)) (get))
   (unless (more?)
     (raise-arguments-error
      'sequence-ref


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers.

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation

## Description of change

Fix `sequence-ref` to stop consuming extra elements from stateful sequences.

### Problem

The current implementation of `sequence-ref` uses `#:unless (j . < . i)` which causes the loop to continue after reaching the target index, leading to unnecessary consumption of an additional element from the sequence. See also #5338.

### Example

```racket
> (define v 0)
> (define s
    (make-do-sequence
     (λ ()
       (define (pos->element _) v)
       (define (continue-with-pos? _) (set! v (add1 v)) (< v 100))
       (values pos->element void (void) continue-with-pos? #f #f))))
> (define-values (more? get) (sequence-generate s))
> (displayln (get))
1
> (displayln (sequence-ref s 0))
2
> (displayln (sequence-ref s 0))
4
> (displayln (sequence-ref s 1))
7
> (displayln (sequence-ref s 1))
10
> (displayln (get))
12
> (displayln (sequence-length s))
87
```
