### PR TITLE
doc: update url for “The WTF-8 Encoding” (Sapin 2018)

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/reference.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/reference.scrbl
@@ -241,7 +241,7 @@ In addition, it re-exports @racket[for-syntax] everything from
   (bib-entry #:key "Sapin18"
              #:author "Simon Sapin"
              #:title "The WTF-8 Encoding"
-             #:url "http://simonsapin.github.io/wtf-8/"
+             #:url "https://wtf-8.codeberg.page"
              #:date "2018")
 
   (bib-entry #:key "Shan04"


### PR DESCRIPTION
Moved to <https://wtf-8.codeberg.page>: see <https://github.com/SimonSapin/wtf-8/commit/e27dc7c6e0d25e9276274ad42eb25dc30aba8c1f>, specifically <https://github.com/SimonSapin/wtf-8/blob/e27dc7c6e0d25e9276274ad42eb25dc30aba8c1f/index.html#L4-L6>.