### PR TITLE
Make syntax->string work on boxes.

### DIFF
--- a/pkgs/racket-test/tests/syntax/to-string.rkt
+++ b/pkgs/racket-test/tests/syntax/to-string.rkt
@@ -12,6 +12,9 @@
 ; we can't find where . is, default to earliest position
 (check-equal? (syntax->string #'((  a  b  .  c))) "(  a  b .   c)")
 
+(check-equal? (syntax->string #'(#&1)) "#&1")
+(check-equal? (syntax->string #'(#&(1 .    2))) "#&(1 .    2)")
+
 ;; quote tests
 (check-equal? (syntax->string #'('a)) "'a")
 (check-equal? (syntax->string #'('  a)) "'  a")

--- a/racket/collects/syntax/to-string.rkt
+++ b/racket/collects/syntax/to-string.rkt
@@ -103,6 +103,11 @@
                (map (loop init-line!) (vector->list (syntax-e c)))
                (printf ")")
                (set! col (+ col 1))]
+              [(box? (syntax-e c))
+               (advance c init-line!)
+               (printf "#&")
+               (set! col (+ col 2))
+               ((loop init-line!) (unbox (syntax-e c)))]
               [else
                (advance c init-line!)
                (let ([s (format "~s" (syntax-e c))])


### PR DESCRIPTION
## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [x] tests included

## Description of change

The `syntax->string` function from `syntax/to-string` does not currently work for literal boxes and instead prints the string representation of the inner syntax object (e.g. `(syntax->string #'(#&1))` produces `"#&#<syntax:17-unsaved-editor:3:21 1>"`).  This commit adds functionality to traverse the inner syntax object appropriately.  A couple simple tests are included.

The same problem exists for literal hash tables, but is more complicated to solve since (a) there are several different kinds of literal hash tables, and (b) the keys of the hash table are not syntax objects and so it's unclear how `syntax->string` should  print the result.