### PR TITLE
Correct 'return' to 'returned' in linklet.scrbl

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/linklet.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/linklet.scrbl
@@ -539,7 +539,7 @@ variable. If a variable for @racket[name] exists as constant, the
           void?]{
 
 Registers information about @racket[name] in @racket[instance] that
-may be useful for compiling linklets where the instance is return via
+may be useful for compiling linklets where the instance is returned via
 the @racket[_get-import] callback to @racket[compile-linklet]. The
 @racket[desc-v] description can be any value; the recognized
 descriptions depend on virtual machine, but may include the following:


### PR DESCRIPTION
Fix typo in documentation regarding instance return.

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change
<!-- Please provide a description of the change here. -->
