### PR TITLE
fix thread-receive in parallel thread

### DIFF
--- a/pkgs/racket-test-core/tests/racket/parallel.rktl
+++ b/pkgs/racket-test-core/tests/racket/parallel.rktl
@@ -1621,6 +1621,17 @@
   (test (void) break-thread t)
   (test #t thread-dead? t))
 
+;; --------------------
+;; Check blocking `thread-receive` on a thread/parallel
+
+(let ()
+  (define sema (make-semaphore 0))
+  (define t (thread/parallel (lambda () (thread-receive) (semaphore-post sema))))
+  (sync (system-idle-evt))  ;; wait until t blocks
+  (thread-send t 'ok)
+  (sync t)
+  (test #t semaphore-try-wait? sema))
+
 ; --------------------
 
 (report-errs)

--- a/racket/src/cs/schemified/thread.scm
+++ b/racket/src/cs/schemified/thread.scm
@@ -8471,7 +8471,8 @@
         (begin0
           (let ((t_0 (current-thread/in-racket)))
             (if (is-mail? t_0)
-              (let ((v_0 (dequeue-mail! t_0))) (lambda () v_0))
+              (let ((v_0 (dequeue-mail! t_0)))
+                (lambda () (begin (future-barrier-exit) v_0)))
               (begin
                 (set-thread-mailbox-wakeup!
                  t_0
@@ -8483,7 +8484,7 @@
                          (thread-deschedule!.1 void t_0 #f temp96_0)))
                     (lambda ()
                       (begin (|#%app| do-yield_0) (1/thread-receive))))))))
-          (end-atomic)))))))
+          (end-atomic/no-barrier-exit)))))))
 (define 1/thread-try-receive
   (|#%name|
    thread-try-receive

--- a/racket/src/thread/thread.rkt
+++ b/racket/src/thread/thread.rkt
@@ -1214,12 +1214,14 @@
        (lambda () #f)]))))
 
 (define (thread-receive)
-  ((atomically
+  ((atomically/no-barrier-exit
     (define t (current-thread/in-racket))
     (cond
       [(is-mail? t)
        (define v (dequeue-mail! t))
-       (lambda () v)]
+       (lambda ()
+         (future-barrier-exit)
+         v)]
       [else
        ;; The current wakeup callback must be `void`, since this thread
        ;; can't be in the middle of a `sync` (unless interrupted by a break)
@@ -1237,7 +1239,7 @@
        (lambda ()
          (do-yield)
          (thread-receive))]))))
- 
+
 (define (thread-try-receive)
   (atomically
    (define t (current-thread/in-racket))


### PR DESCRIPTION
See #5364. I'm not completely sure this is the right fix, but it seems to follow the comments in src/thread/atomic.rkt and the implementation pattern of unsafe-semaphore-wait.

## Checklist

- [x] Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation
