### PR TITLE
cs: re-run `make derived` after `exn-classify-errno` addition

### DIFF
--- a/racket/src/cs/schemified/io.scm
+++ b/racket/src/cs/schemified/io.scm
@@ -80,7 +80,7 @@
                 (1/error-print-source-location error-print-source-location)
                 (error-value->string error-value->string)
                 (1/executable-yield-handler executable-yield-handler)
-                (exn-classify-errno exn-classify-errno)
+                (1/exn-classify-errno exn-classify-errno)
                 (1/expand-user-path expand-user-path)
                 (1/explode-path explode-path)
                 (ffi-get-lib ffi-get-lib)
@@ -32642,29 +32642,31 @@
         (begin
           (do-write 'default-error-value->string-handler v_0 o_0 len_0)
           (1/get-output-string o_0))))))
-(define exn-classify-errno
-  (lambda (errno_0)
-    (begin
-      (if (if (pair? errno_0)
-            (if (exact-integer? (car errno_0))
-              (memq (cdr errno_0) '(posix windows gai))
-              #f)
-            #f)
-        (void)
-        (raise-argument-error
-         'exn-classify-errno
-         "(cons/c exact-integer? (or/c 'posix 'windows 'gai))"
-         errno_0))
-      (if (fixnum? (car errno_0))
-        (let ((bstr_0
-               (let ((app_0
-                      (let ((tmp_0 (cdr errno_0)))
-                        (if (eq? tmp_0 'posix)
-                          0
-                          (if (eq? tmp_0 'windows) 1 2)))))
-                 (|#%app| rktio_classify_error app_0 (car errno_0)))))
-          (if bstr_0 (string->symbol (1/bytes->string/latin-1 bstr_0)) #f))
-        #f))))
+(define 1/exn-classify-errno
+  (|#%name|
+   exn-classify-errno
+   (lambda (errno_0)
+     (begin
+       (if (if (pair? errno_0)
+             (if (exact-integer? (car errno_0))
+               (memq (cdr errno_0) '(posix windows gai))
+               #f)
+             #f)
+         (void)
+         (raise-argument-error
+          'exn-classify-errno
+          "(cons/c exact-integer? (or/c 'posix 'windows 'gai))"
+          errno_0))
+       (if (fixnum? (car errno_0))
+         (let ((bstr_0
+                (let ((app_0
+                       (let ((tmp_0 (cdr errno_0)))
+                         (if (eq? tmp_0 'posix)
+                           0
+                           (if (eq? tmp_0 'windows) 1 2)))))
+                  (|#%app| rktio_classify_error app_0 (car errno_0)))))
+           (if bstr_0 (string->symbol (1/bytes->string/latin-1 bstr_0)) #f))
+         #f)))))
 (define install-error-value->string-handler!
   (lambda ()
     (begin


### PR DESCRIPTION
Summary:

The primitive `exn-classify-errno` was added in
01bd403766b46e52ed646a82d09441f4c83c70fc, but (per @mflatt)

> The make derived target doesn't know how to find a fixed point: it was
> generated using a Racket that did not yet have exn-classify-errno as a
> primitive (naturally), and I didn't run it again afterward, although I
> probably should have. Confusing, and it makes history messier than it should
> be, but harmless otherwise.

So, re-run `make derived`.

Closes #5392.

Test Plan:

`make derived` is a fixpoint now

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change
<!-- Please provide a description of the change here. -->
