### PR TITLE
Include 'system in keyword list

### DIFF
--- a/racket/src/schemify/aim.rkt
+++ b/racket/src/schemify/aim.rkt
@@ -3,7 +3,7 @@
 
 ;; macro statically ensures that the second argument is a valid target
 (define-syntax aim?
-  (syntax-rules (cify interp)
+  (syntax-rules (cify interp system)
     [(_ e 'cify) (eq? e 'cify)]
     [(_ e 'interp) (eq? e 'interp)]
     [(_ e 'system) (eq? e 'system)]))


### PR DESCRIPTION
Leaving `system` out of the keyword list happens to work, since `system` is handled in the last clause. My guess is that `system` wasn't left out on purpose though.

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change
<!-- Please provide a description of the change here. -->
