### PR TITLE
BC: Make interned-char? equivalent to char?

### DIFF
--- a/pkgs/racket-test-core/tests/racket/basic.rktl
+++ b/pkgs/racket-test-core/tests/racket/basic.rktl
@@ -670,7 +670,7 @@
   (test #t k:interned-char? #\()
   (test #t k:interned-char? #\ )
   (test #t k:interned-char? '#\newline)
-  (test (eq? 'chez-scheme (system-type 'vm)) k:interned-char? #\u100)
+  (test #t k:interned-char? #\u100)
   (test #f k:interned-char? 7)
   (test #f k:interned-char? #t)
   (test #f k:interned-char? #t)

--- a/pkgs/racket-test-core/tests/racket/optimize.rktl
+++ b/pkgs/racket-test-core/tests/racket/optimize.rktl
@@ -2732,7 +2732,7 @@
   (test-implies 'k:list-pair? 'pair?)
   (test-implies 'k:list-pair? 'list?)
   (test-implies 'list? 'pair? '?)
-  (test-implies 'k:interned-char? 'char? (if (eq? 'chez-scheme (system-type 'vm)) '= '=>))
+  (test-implies 'k:interned-char? 'char? '=)
   (test-implies 'not 'boolean?)
   (test-implies 'k:true-object? 'boolean?)
 )

--- a/racket/src/bc/src/char.c
+++ b/racket/src/bc/src/char.c
@@ -111,7 +111,7 @@ void scheme_init_char (Scheme_Startup_Env *env)
   scheme_addto_prim_instance("char?", p, env);
 
   REGISTER_SO(scheme_interned_char_p_proc);
-  p = scheme_make_folding_prim(interned_char_p, "interned-char?", 1, 1, 1);
+  p = scheme_make_folding_prim(char_p, "interned-char?", 1, 1, 1);
   SCHEME_PRIM_PROC_FLAGS(p) |= scheme_intern_prim_opt_flags(SCHEME_PRIM_IS_UNARY_INLINED
                                                             | SCHEME_PRIM_IS_OMITABLE
                                                             | SCHEME_PRIM_PRODUCES_BOOL);
@@ -275,12 +275,6 @@ static Scheme_Object *
 char_p (int argc, Scheme_Object *argv[])
 {
   return (SCHEME_CHARP(argv[0]) ? scheme_true : scheme_false);
-}
-
-static Scheme_Object *
-interned_char_p (int argc, Scheme_Object *argv[])
-{
-  return (SCHEME_CHARP(argv[0]) && SCHEME_CHAR_VAL(argv[0]) < 256) ? scheme_true : scheme_false;
 }
 
 #define charSTD_FOLDCASE(nl) nl;

--- a/racket/src/bc/src/optimize.c
+++ b/racket/src/bc/src/optimize.c
@@ -3714,11 +3714,8 @@ static Scheme_Object *do_expr_implies_predicate(Scheme_Object *expr, Optimize_In
       return scheme_keyword_p_proc;
     if (SCHEME_SYMBOLP(expr))
       return scheme_symbol_p_proc;
-    if (SCHEME_CHARP(expr)) {
-      if (SCHEME_CHAR_VAL(expr) < 256)
-        return scheme_interned_char_p_proc;
+    if (SCHEME_CHARP(expr))
       return scheme_char_p_proc;
-    }
     if (SAME_OBJ(expr, scheme_true))
       return scheme_true_object_p_proc;
     if (SCHEME_FALSEP(expr))
@@ -5891,9 +5888,12 @@ static int predicate_implies(Scheme_Object *pred1, Scheme_Object *pred2)
       && SAME_OBJ(pred1, scheme_list_pair_p_proc))
     return 1;
 
-  /* interned-char? => char? */
+  /* interned-char? <=> char? */
   if (SAME_OBJ(pred2, scheme_char_p_proc)
       && SAME_OBJ(pred1, scheme_interned_char_p_proc))
+    return 1;
+  if (SAME_OBJ(pred2, scheme_interned_char_p_proc)
+      && SAME_OBJ(pred1, scheme_char_p_proc))
     return 1;
 
   /* not, true-object? => boolean? */


### PR DESCRIPTION
After making chars play nice with be `eq?`, it's better to sync the implementation of `kernel:interned-char?` to return `#t` for all chars, so it's the same than `char?` like in CS.

This is an internal undocumented function that is used only in `optimize.c` because the types need a pointer to a function. It's not strictly necessary to fix this, the difference only cause a few minor missed optimizations.

I'm not sure about backward comparability in the `#%kernel` module, because another possibility is to just remove this function completely. 