### PR TITLE
specialize dynamic-send to get better performance

### DIFF
--- a/pkgs/racket-test-core/tests/racket/object.rktl
+++ b/pkgs/racket-test-core/tests/racket/object.rktl
@@ -913,6 +913,8 @@
 		      (f . w)))
 		  (define (h x #:y [y 12])
 		    (list x y))
+                  (define/public (many-args a b c d e f g h i j k l m n o p)
+                    (+ a b c d e f g h i j k l m n o p))
 		  (super-make-object)))
 (define dotted (make-object dotted%))
 (test '(3 2 1) 'dotted (send dotted f 1 2 3))
@@ -934,6 +936,8 @@
 (test '(e 12) apply dynamic-send dotted 'h '(e))
 (test '(f 13) 'dotted (apply dynamic-send dotted 'h '(f) #:y 13))
 (test '(g 14) keyword-apply dynamic-send '(#:y) '(14) dotted 'h '(g))
+(test 136 (dynamic-send dotted 'many-args 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16))
+(test 'dynamic-send object-name dynamic-send)
 
 (syntax-test #'(send/apply dotted f 2 . l))
 


### PR DESCRIPTION
I'm seeing some speed up from this change but it isn't clear that the `case-lambda` (instead of just a "lambda args") gives any speed up. Should I remove it? Is there another way to write the functions that'd help in some situation?

Here's the timings I get on my machine:

```
before this commit:
dynamic-send slowdown with various signatures
one argument: 4x
ten arguments: 5.31x
kwd argument: 2.84x
apply kwd argument: 4x

with this commit:
dynamic-send slowdown with various signatures
one argument: 2.11x
ten arguments: 2.86x
kwd argument: 2.89x
apply kwd argument: 4.08x

with a version of this commit that replaces the case-lambda with a lambda args:
dynamic-send slowdown with various signatures
one argument: 2.49x
ten arguments: 2.87x
kwd argument: 2.82x
apply kwd argument: 4.09x
```

Here's the code I was using to do the timings

```
#lang racket

(define c%
  (class object%
    (define/public (m1 x) x)
    (define/public (m2 a b c d e f g h i j) a)
    (define/public (m3 #:x x) x)
    (super-new)))

(define-syntax-rule
  (cpu-time e)
  (let-values ([(_ real cpu gc) (time-apply (λ () e) '())])
    cpu))
  
(define N 1000000)
(define o (new c%))
(define (compare what n1 n2)
  (when (or (< n1 500) (< n2 500))
    (error 'compare "the times need to be at least 500 msec\n  n1: ~s\n  n2: ~s\n  what: ~s" n1 n2 what))
  (printf "~a: ~ax\n" what (~r #:precision 2 (/ n2 n1)))
  (collect-garbage))

(printf "dynamic-send slowdown with various signatures\n")
(collect-garbage)
(compare
 "one argument"
 (cpu-time
  (for ([i (in-range 1000000)])
    (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1)
    (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1)
    (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1)
    (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1) (send o m1 1)))
 (cpu-time
  (for ([i (in-range 1000000)])
    (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1)
    (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1)
    (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1)
    (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1) (dynamic-send o 'm1 1))))
(compare
 "ten arguments"
 (cpu-time
  (for ([i (in-range 3000000)])
    (send o m2 0 1 2 3 4 5 6 7 8 9) (send o m2 0 1 2 3 4 5 6 7 8 9) (send o m2 0 1 2 3 4 5 6 7 8 9)
    (send o m2 0 1 2 3 4 5 6 7 8 9) (send o m2 0 1 2 3 4 5 6 7 8 9) (send o m2 0 1 2 3 4 5 6 7 8 9)
    (send o m2 0 1 2 3 4 5 6 7 8 9) (send o m2 0 1 2 3 4 5 6 7 8 9) (send o m2 0 1 2 3 4 5 6 7 8 9)))
 (cpu-time
  (for ([i (in-range 3000000)])
    (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9) (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9) (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9)
    (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9) (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9) (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9)
    (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9) (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9) (dynamic-send o 'm2 0 1 2 3 4 5 6 7 8 9))))

(compare
 "kwd argument"
 (cpu-time
  (for ([i (in-range 1000000)])
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)))
 (cpu-time
  (for ([i (in-range 1000000)])
    (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1)
    (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1)
    (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1)
    (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1) (dynamic-send o 'm3 #:x 1))))

(compare
 "apply kwd argument"
 (cpu-time
  (for ([i (in-range 2000000)])
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)
    (send o m3 #:x 1) (send o m3 #:x 1) (send o m3 #:x 1)))
 (cpu-time
  (for ([i (in-range 2000000)])
    (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '())
    (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '())
    (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '())
    (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '()) (keyword-apply dynamic-send '(#:x) '(1) o 'm3 '())
    )))
```