### PR TITLE
net/url, net/http-client: add proxy authentication support

### DIFF
--- a/pkgs/net-doc/net/scribblings/http-client.scrbl
+++ b/pkgs/net-doc/net/scribblings/http-client.scrbl
@@ -191,11 +191,17 @@ response, which is why there is no @racket[#:closed?] argument like
                                    [proxy-port (between/c 1 65535)]
                                    [target-host (or/c bytes? string?)]
                                    [target-port (between/c 1 65535)]
-                                   [#:ssl? ssl? base-ssl?/c #f])
+                                   [#:ssl? ssl? base-ssl?/c #f]
+                                   [#:proxy-auth proxy-auth (or/c #f string?) #f])
          (values base-ssl?/c input-port? output-port? (-> port? void?))]{
  Creates an HTTP connection to @racket[proxy-host] (on port
  @racket[proxy-port]) and invokes the HTTP ``CONNECT'' method to provide
  a tunnel to @racket[target-host] (on port @racket[target-port]).
+
+ If @racket[proxy-auth] is not @racket[#f], it should be a string of the
+ form @racket["username:password"]. The credentials will be Base64-encoded
+ and sent as a @litchar{Proxy-Authorization} header for HTTP Basic
+ authentication with the proxy server.
 
  The SSL context or symbol, if any, provided in @racket[ssl?] is
  applied to the gateway ports using @racket[ports->ssl-ports] (or
@@ -223,6 +229,7 @@ response, which is why there is no @racket[#:closed?] argument like
      @racket[tcp-abandon-port].}
  ]
 
+@history[#:changed "9.1.0.2" @elem{Added the @racket[#:proxy-auth] argument.}]
 }
 
 @defthing[data-procedure/c chaperone-contract?]{

--- a/pkgs/net-doc/net/scribblings/url.scrbl
+++ b/pkgs/net-doc/net/scribblings/url.scrbl
@@ -486,21 +486,25 @@ the connection process is interrupted by an asynchronous break
 exception.}
 
 @deftogether[(
-@defparam[current-proxy-servers mapping (listof (list/c string? string? (integer-in 0 65535)))]
+@defparam[current-proxy-servers mapping (listof (or/c (list/c string? string? (integer-in 0 65535))
+                                                      (list/c string? string? (integer-in 0 65535) (or/c #f string?))))]
 @defthing[proxiable-url-schemes (listof string?) #:value '("http" "https" "git")]
  )]{
 
 The @racket[current-proxy-servers] parameter determines a mapping of proxy servers used for
-connections. Each mapping is a list of three elements:
+connections. Each mapping is a list of three or four elements:
 
 @itemize[
 
  @item{the URL scheme, such as @racket["http"], where @racket[proxiable-url-schemes] lists the URL schemes
   that can be proxied}
 
- @item{the proxy server address; and}
+ @item{the proxy server address;}
 
- @item{the proxy server port number.}
+ @item{the proxy server port number; and}
+
+ @item{optionally, authentication credentials as a string of the form
+  @racket["username:password"], or @racket[#f] for no authentication.}
 
 ]
 
@@ -533,11 +537,17 @@ connections are proxied using an HTTP ``CONNECT'' tunnel}
 ]
 
 Each environment variable contains a single URL of the form
-@litchar{http://}@nonterm{hostname}@litchar{:}@nonterm{portno}.
+@litchar{http://}@nonterm{hostname}@litchar{:}@nonterm{portno} or
+@litchar{http://}@nonterm{user}@litchar{:}@nonterm{password}@litchar["@"]@nonterm{hostname}@litchar{:}@nonterm{portno}.
+If authentication credentials are included in the URL, they will be used
+for HTTP Basic authentication with the proxy server when making CONNECT
+tunnel connections for HTTPS or Git URLs.
 If any other components of the URL are provided, a warning will be logged to a @racket[net/url]
 logger.
 
-The default mapping is the empty list (i.e., no proxies).}
+The default mapping is the empty list (i.e., no proxies).
+
+@history[#:changed "9.1.0.2" @elem{Added support for proxy authentication credentials.}]}
 
 @defparam[current-no-proxy-servers dest-hosts-list (listof (or/c string? regexp?))]{
 

--- a/pkgs/net-test/tests/net/url.rkt
+++ b/pkgs/net-test/tests/net/url.rkt
@@ -60,7 +60,7 @@
    ;; Test the current-proxy-servers parameter can be set
    (parameterize ([current-proxy-servers '(("http" "proxy.com" 3128))])
      (current-proxy-servers))
-   => '(("http" "proxy.com" 3128))
+   => '(("http" "proxy.com" 3128 #f))
 
    ;; we have at least http, https, git
    (member "http" proxiable-url-schemes)
@@ -81,66 +81,66 @@
 
    ;; ------------------------------------------------------------------
    ;; HTTP: Test Proxy Servers (loading from environment and proxy-server-for)
-   
+
    ;; proxy servers set in current-proxy-servers are not overridden by environment
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:plt-http-proxy "http://proxy.net:1234"
                           #:http-proxy "http://proxy.net:1234"
                           "http" "test.racket-lang.org")
-   => '("http" "proxy.com" 3128)
+   => '("http" "proxy.com" 3128 #f)
 
    ;; plt_http_proxy is is prioritised over http_proxy
    (test-proxy-server-for #:plt-http-proxy "http://proxy.net:3128"
                           #:http-proxy "http://proxy.net:3228"
                           "http" "test.racket-lang.org")
-   => '("http" "proxy.net" 3128)
+   => '("http" "proxy.net" 3128 #f)
 
    ;; otherwise fall back to http_proxy
    (test-proxy-server-for #:http-proxy "http://proxy.net:3228"
                           "http" "test.racket-lang.org")
-   => '("http" "proxy.net" 3228)
+   => '("http" "proxy.net" 3228 #f)
 
    ;; ------------------------------------------------------------------
    ;; HTTPS: Test Proxy Servers (loading from environment and proxy-server-for)
-   
+
    ;; proxy servers set in current-proxy-servers are not overridden by environment
    (test-proxy-server-for #:current-proxy-servers '(("https" "proxy.com" 3128))
                           #:plt-https-proxy "http://proxy.net:1234"
                           #:https-proxy "http://proxy.net:1234"
                           "https" "test.racket-lang.org")
-   => '("https" "proxy.com" 3128)
+   => '("https" "proxy.com" 3128 #f)
 
    ;; plt_https_proxy is is prioritised over https_proxy
    (test-proxy-server-for #:plt-https-proxy "http://proxy.net:3128"
                           #:https-proxy "http://proxy.net:3228"
                           "https" "test.racket-lang.org")
-   => '("https" "proxy.net" 3128)
+   => '("https" "proxy.net" 3128 #f)
 
    ;; otherwise fall back to https_proxy
    (test-proxy-server-for #:https-proxy "http://proxy.net:3228"
                           "https" "test.racket-lang.org")
-   => '("https" "proxy.net" 3228)
+   => '("https" "proxy.net" 3228 #f)
 
    ;; ------------------------------------------------------------------
    ;; GIT: Test Proxy Servers (loading from environment and proxy-server-for)
-   
+
    ;; proxy servers set in current-proxy-servers are not overridden by environment
    (test-proxy-server-for #:current-proxy-servers '(("git" "proxy.com" 3128))
                           #:plt-git-proxy "http://proxy.net:1234"
                           #:git-proxy "http://proxy.net:1234"
                           "git" "test.racket-lang.org")
-   => '("git" "proxy.com" 3128)
+   => '("git" "proxy.com" 3128 #f)
 
    ;; plt_git_proxy is is prioritised over git_proxy
    (test-proxy-server-for #:plt-git-proxy "http://proxy.net:3128"
                           #:git-proxy "http://proxy.net:3228"
                           "git" "test.racket-lang.org")
-   => '("git" "proxy.net" 3128)
+   => '("git" "proxy.net" 3128 #f)
 
    ;; otherwise fall back to git_proxy
    (test-proxy-server-for #:git-proxy "http://proxy.net:3228"
                           "git" "test.racket-lang.org")
-   => '("git" "proxy.net" 3228)
+   => '("git" "proxy.net" 3228 #f)
 
    ;; ---------------------------------------------------------------------
    ;; Test NO Proxy Servers (loading from environment and proxy-server-for)
@@ -150,18 +150,18 @@
    ;; prove that we need a proxy if not otherwise told...
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           "http" "test.racket-lang.org")
-   => '("http" "proxy.com" 3128)
-   
+   => '("http" "proxy.com" 3128 #f)
+
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:current-no-proxy-servers '("test.racket-lang.org")
                           "http" "test.racket-lang.org")
    => #f
-   
+
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:plt-no-proxy "test.racket-lang.org"
                           "http" "test.racket-lang.org")
    => #f
-   
+
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:no-proxy "test.racket-lang.org"
                           "http" "test.racket-lang.org")
@@ -173,12 +173,12 @@
                           #:current-no-proxy-servers '(#rx".racket-lang.org")
                           "http" "test.racket-lang.org")
    => #f
-   
+
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:plt-no-proxy ".racket-lang.org"
                           "http" "test.racket-lang.org")
    => #f
-   
+
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:no-proxy ".racket-lang.org"
                           "http" "test.racket-lang.org")
@@ -188,12 +188,12 @@
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:plt-no-proxy ".racket-lang.org"
                           "http" "test.bracket-lang.org")
-   => '("http" "proxy.com" 3128)
-   
+   => '("http" "proxy.com" 3128 #f)
+
    (test-proxy-server-for #:current-proxy-servers '(("http" "proxy.com" 3128))
                           #:no-proxy ".racket-lang.org"
                           "http" "test.bracket-lang.org")
-   => '("http" "proxy.com" 3128)
+   => '("http" "proxy.com" 3128 #f)
 
    ;; Look at this... the no-proxes has a regexp which starts with a '.', a regexp
    ;; any char... that will match the 'b' in bracket
@@ -201,6 +201,28 @@
                              #:current-no-proxy-servers '(#rx".racket-lang.org")
                              "http" "test.bracket-lang.org")
    => #f
+
+   ;; ------------------------------------------------------------------
+   ;; Test proxy authentication credentials
+
+   ;; current-proxy-servers accepts 4-element lists with credentials
+   (parameterize ([current-proxy-servers '(("https" "proxy.com" 3128 "user:pass"))])
+     (current-proxy-servers))
+   => '(("https" "proxy.com" 3128 "user:pass"))
+
+   ;; credentials from environment variable URLs are extracted
+   (test-proxy-server-for #:https-proxy "http://user:pass@proxy.net:3128"
+                          "https")
+   => '("https" "proxy.net" 3128 "user:pass")
+
+   ;; credentials work for other schemes too
+   (test-proxy-server-for #:http-proxy "http://httpuser:httppass@proxy.net:8080"
+                          "http")
+   => '("http" "proxy.net" 8080 "httpuser:httppass")
+
+   (test-proxy-server-for #:git-proxy "http://gituser:gitpass@proxy.net:9418"
+                          "git")
+   => '("git" "proxy.net" 9418 "gituser:gitpass")
   )
 
   (define-values (ss:port ss:server-thread ss:shutdown-server)
@@ -209,7 +231,7 @@
   (define-values (ps:port ps:server-thread ps:shutdown-server)
     (ps:server))
 
-  (test (parameterize ([current-proxy-servers `(("https" "localhost" ,ps:port))])
+  (test (parameterize ([current-proxy-servers `(("https" "localhost" ,ps:port #f))])
           (port->string
            (get-pure-port
             (string->url


### PR DESCRIPTION
Support HTTP Basic authentication for proxy servers when using CONNECT tunnels for HTTPS or Git URLs. Credentials can be specified in proxy environment variables using the standard URL format: http://user:password@proxy-host:port

Note: this changes the contents of `current-proxy-servers` to be a list of 4-element lists instead of 3-element lists. The parameter guard will coerce 3-element lists to have the needed 4th element.

This is backwards-incompatible with code that does something like:

```
(match (current-proxy-servers)
  [(list (list a b c) ...) <use a b c here>])
```

This is hard to avoid given the design choices already here, but I'm happy to hear other approaches (such as something involving hidden state etc).

The fancy test was written by Claude.