### PR TITLE
Fix documentation of `unsafe-flbit-field`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/unsafe.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/unsafe.scrbl
@@ -177,12 +177,12 @@ For @tech{flonums}: Unchecked (potentially) version of
 
 @history[#:added "7.8.0.7"]}
 
-@defproc[(flbit-field [a flonum?] [start (integer-in 0 64)] [end (integer-in 0 64)])
+@defproc[(unsafe-flbit-field [a flonum?] [start (integer-in 0 64)] [end (integer-in 0 64)])
          exact-nonnegative-integer?]{
 
 For @tech{flonums}: Unchecked version of @racket[flbit-field].
 
-@history[#:added "7.8.0.7"]}
+@history[#:added "8.15.03"]}
 
 
 @deftogether[(


### PR DESCRIPTION
This PR fixes the documentation of `unsafe-flbit-field`, which was added in 8.15.0.3 and seems to have been documented in a bit of a hurry.