### PR TITLE
remove unused "break-parameterization" struct (easy)

### DIFF
--- a/racket/collects/racket/private/more-scheme.rkt
+++ b/racket/collects/racket/private/more-scheme.rkt
@@ -139,8 +139,6 @@
   
   (define-values (struct:break-paramz make-break-paramz break-paramz? break-paramz-ref break-paramz-set!)
     (make-struct-type 'break-parameterization #f 1 0 #f))
-
-  (-define-struct break-parameterization (cell))
   
   (define (current-break-parameterization)
     (make-break-paramz (continuation-mark-set-first #f break-enabled-key)))


### PR DESCRIPTION
Previously, the module defined two structs:

1. Struct `struct:break-paramz` (defined with `make-struct-type` and, confusingly, with reflexive name `break-parameterization`) used for the break parameterization

2. Struct `break-parameterization` (defined with the only remaining use of `-define-struct`) which is unused locally and not `provide`d anywhere. This goes at least as far back as v3.99.0.2, git 39cedb62edf, svn r7706.

Remove the unused one, which will enable removing `-define-struct` once https://github.com/racket/compatibility/pull/15 is also merged