### PR TITLE
Fix spelling of "compatible" and "compatibility"

### DIFF
--- a/racket/collects/racket/private/class-internal.rkt
+++ b/racket/collects/racket/private/class-internal.rkt
@@ -5,13 +5,13 @@
 ;; it. This means any backwards-incompatible API changes need coordination.
 ;; The following packages are known to use this module:
 ;;
-;; - compatability-lib
+;; - compatibility-lib
 ;;
 ;; Please try not to add more packages which require this file. Instead,
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (require (for-syntax racket/base)
          (only-in racket/list remove-duplicates)

--- a/racket/collects/racket/private/for-compatibility-lib.rkt
+++ b/racket/collects/racket/private/for-compatibility-lib.rkt
@@ -1,13 +1,13 @@
 ;;----------------------------------------------------------------------
-;; Internals needed by the `compatability-lib` package; primarily used
+;; Internals needed by the `compatibility-lib` package; primarily used
 ;; to implement `mzscheme`
 ;;
-;; Note that this module only semi-private, in the sense that `compatability-lib`
-;; lives in another repository. This means any backwards-compatable API
+;; Note that this module only semi-private, in the sense that `compatibility-lib`
+;; lives in another repository. This means any backwards-compatible API
 ;; changes need coordination. Try to avoid adding new exports to this file;
 ;; instead, consider whether a public API is appropriate.
 
-(module for-compatability-lib '#%kernel
+(module for-compatibility-lib '#%kernel
   (#%require "more-scheme.rkt"
              "cond.rkt"
              "define.rkt"

--- a/racket/collects/racket/private/generic.rkt
+++ b/racket/collects/racket/private/generic.rkt
@@ -11,7 +11,7 @@
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (require (for-syntax racket/base
                      racket/local

--- a/racket/collects/racket/private/increader.rkt
+++ b/racket/collects/racket/private/increader.rkt
@@ -3,13 +3,13 @@
 ;; it. This means any backwards-incompatible API changes need coordination.
 ;; The following packages are known to use this module:
 ;;
-;; - compatability-lib
+;; - compatibility-lib
 ;;
 ;; Please try not to add more packages which require this file. Instead,
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (module increader racket/base
   (define-struct reader (val))

--- a/racket/collects/racket/private/promise.rkt
+++ b/racket/collects/racket/private/promise.rkt
@@ -9,7 +9,7 @@
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (module promise '#%kernel
 (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"

--- a/racket/collects/racket/private/serialize.rkt
+++ b/racket/collects/racket/private/serialize.rkt
@@ -3,13 +3,13 @@
 ;; it. This means any backwards-incompatible API changes need coordination.
 ;; The following packages are known to use this module:
 ;;
-;; - compatability-lib
+;; - compatibility-lib
 ;;
 ;; Please try not to add more packages which require this file. Instead,
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (module serialize racket/base
   (require syntax/modcollapse

--- a/racket/collects/racket/private/shared-body.rkt
+++ b/racket/collects/racket/private/shared-body.rkt
@@ -11,7 +11,7 @@
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (require (for-syntax racket/base
                      syntax/kerncase

--- a/racket/collects/racket/private/stream-cons.rkt
+++ b/racket/collects/racket/private/stream-cons.rkt
@@ -31,7 +31,7 @@
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (require (prefix-in for: racket/private/for))
 

--- a/racket/collects/racket/private/this-expression-source-directory.rkt
+++ b/racket/collects/racket/private/this-expression-source-directory.rkt
@@ -5,14 +5,14 @@
 ;; it. This means any backwards-incompatible API changes need coordination.
 ;; The following packages are known to use this module:
 ;;
-;; - compatability-lib
+;; - compatibility-lib
 ;; - planet-lib
 ;;
 ;; Please try not to add more packages which require this file. Instead,
 ;; consider whether a public API is appropriate, or if a currently-private
 ;; API should be made public. If not, then make a new file
 ;; "racket/private/for-yourpackage.rkt" which exports the necessary
-;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (require (for-syntax racket/base 
                      setup/collects

--- a/racket/collects/racket/private/unit-compiletime.rkt
+++ b/racket/collects/racket/private/unit-compiletime.rkt
@@ -1,11 +1,11 @@
 #lang racket/base
 
 ;;----------------------------------------------------------------------
-;; Internals needed by the `compatability` package; used to implement
+;; Internals needed by the `compatibility` package; used to implement
 ;; `mzlib/a-signature`
 ;;
-;; Note that this module only semi-private, in the sense that `compatability-lib`
-;; lives in another repository. This means any backwards-compatable API
+;; Note that this module only semi-private, in the sense that `compatibility-lib`
+;; lives in another repository. This means any backwards-compatible API
 ;; changes need coordination. Try to avoid adding new exports to this file;
 ;; instead, consider whether a public API is appropriate.
 

--- a/racket/collects/racket/private/unit-syntax.rkt
+++ b/racket/collects/racket/private/unit-syntax.rkt
@@ -1,11 +1,11 @@
 #lang racket/base
 
 ;;----------------------------------------------------------------------
-;; Internals needed by the `compatability` package; used to implement
+;; Internals needed by the `compatibility` package; used to implement
 ;; `mzlib/a-signature`
 ;;
-;; Note that this module only semi-private, in the sense that `compatability-lib`
-;; lives in another repository. This means any backwards-compatable API
+;; Note that this module only semi-private, in the sense that `compatibility-lib`
+;; lives in another repository. This means any backwards-compatible API
 ;; changes need coordination. Try to avoid adding new exports to this file;
 ;; instead, consider whether a public API is appropriate.
 


### PR DESCRIPTION
In https://github.com/racket/racket/pull/5425
commits 8086563f63cd4321cd70f7bcd805b16fef250dcc
and 3014b7dc0a1df2d1228c8e2da1add7b668140d0a,
I spelled "compatible" and "compatibility" consistently as "compatable" and "compatability".

`git grep compatab` and `find . | grep compatab`

Fixing the filename requires a cross-repo change, so it'll be the second cross-repo breaking change in ~3 hours, but it seems better to do it now than wait until later or leave the misspelling there forever.
