### PR TITLE
parallel-do: handle EOF when worker process dies unexpectedly

### DIFF
--- a/racket/collects/setup/parallel-do.rkt
+++ b/racket/collects/setup/parallel-do.rkt
@@ -301,7 +301,11 @@
                               (loop (cons wrkr idle) (remove node-worker inflight) (add1 count) error-count)
                               (loop idle inflight count error-count))
                           (begin
-                            (queue/work-done work-queue node wrkr (string-append msg (wrkr/read-all wrkr)))
+                            (queue/work-done work-queue node wrkr
+                                             (string-append (if (eof-object? msg)
+                                                                "worker process died unexpectedly"
+                                                                msg)
+                                                            (wrkr/read-all wrkr)))
                             (kill/remove-dead-worker node-worker wrkr))))))]
                [_
                 (log-error (format "parallel-do-event-loop match node-worker failed trying to match: ~e" 


### PR DESCRIPTION
When a worker subprocess dies (e.g., killed by the OOM killer), `(read out)` returns eof. The existing dispatch checks `(pair? msg)`, which is false for eof, falling through to an else branch that calls `(string-append msg ...)` — but eof is not a string, causing a contract violation. Handle eof by substituting an informative error string.

Based on a report on Discord by "&t". 
