### PR TITLE
net/http-client: propagate decoding errors to http-conn-receive!ing thread

### DIFF
--- a/pkgs/net-test/tests/net/http-client.rkt
+++ b/pkgs/net-test/tests/net/http-client.rkt
@@ -508,6 +508,32 @@
       (with-check-info (['response-raw raw])
         (test-colon-field-lws raw))))
 
+  ;; Ensure decoding errors are raised in the http-conn-recv!ing thread.
+  ;; xref: https://github.com/Bogdanp/racket-http-easy/issues/35
+  (let ()
+    (for ([coding (in-list '(deflate gzip))]
+          [exn-re (in-list '(#rx"inflate: error in compressed data"
+                             #rx"gnu-unzip: bad header"))])
+      (local-require (prefix-in gs: "http-proxy/generic-server.rkt"))
+      (define-values (gs:port _gs:thread gs:kill)
+        (gs:serve
+         (lambda (in out)
+           (void (read-request in))
+           (fprintf out "HTTP/1.1 200 OK\r\n")
+           (fprintf out "Content-Encoding: ~a\r\n" coding)
+           (fprintf out "\r\n")
+           (fprintf out "abc123")
+           (flush-output out))))
+      (define c (hc:http-conn-open "localhost" #:port gs:port))
+      (check-exn
+       exn-re
+       (lambda ()
+         (define-values (status _headers in)
+           (hc:http-conn-sendrecv! c ""))
+         (check-equal? status #"HTTP/1.1 200 OK")
+         (read-line in)))
+      (gs:kill)))
+
   ;; Test that a RST from a client during body transfer doesn't deadlock.
   (when (memq (system-type 'os) '(unix macosx))
     (for ([chunked? (in-list '(#f #t))])

--- a/racket/collects/net/http-client.rkt
+++ b/racket/collects/net/http-client.rkt
@@ -485,13 +485,15 @@
   (define decoded-response-port
     (let ([decode-response
            (λ (raw-response-port decode-function)
-             (define-values (in out) (make-pipe PIPE-SIZE))
+             (define-values (in out set-err!)
+               (make-pipe/err PIPE-SIZE))
              (define decode-t
                (thread
-                (λ ()
-                  (decode-function raw-response-port out))))
+                (lambda ()
+                  (with-handlers ([exn:fail? set-err!])
+                    (decode-function raw-response-port out)))))
              (thread
-              (λ ()
+              (lambda ()
                 (thread-wait decode-t)
                 (when wait-for-close?
                   ;; Wait for an EOF from the raw port before we send an


### PR DESCRIPTION
In #5296, I added make-pipe/err to handle RSTs received by the pumping thread, but missed that decoding also happens through a background thread. This change makes the decoding threads also use make-pipe/err.

Related to Bogdanp/racket-http-easy#35.