### PR TITLE
xml,reader: slightly improve read-xml performance 

### DIFF
--- a/racket/collects/xml/private/reader.rkt
+++ b/racket/collects/xml/private/reader.rkt
@@ -336,6 +336,7 @@
 ;; lex-pcdata : Input-port (-> Location) -> Pcdata
 ;; deviation - disallow ]]> "for compatibility" with SGML, sec 2.4 XML spec
 (define (lex-pcdata in pos)
+  (define collapse? (collapse-whitespace))
   (define start (pos))
   (define data
     (let loop ([chars null])
@@ -346,7 +347,7 @@
                (eq? next #\&)
                (eq? next #\<))
            (apply string (reverse chars))]
-          [(and (char-whitespace? next) (collapse-whitespace))
+          [(and collapse? (char-whitespace? next))
            (skip-space in)
            (loop (cons #\space chars))]
           [else


### PR DESCRIPTION
I noticed the repeated lookups on `collapse-whitespace` were taking a long time while profiling `read-xml` on a 14MB file, so this seemed like an easy win. With this change in place, reading that file takes about 339ms, versus about 382ms before.

The change to use `for/and` instead of `andmap` doesn't make a difference in this case, but it can't hurt, either. Happy to drop it, though.