### PR TITLE
Fix flaky test with promises and concurrency

### DIFF
--- a/pkgs/racket-test-core/tests/racket/syntax.rktl
+++ b/pkgs/racket-test-core/tests/racket/syntax.rktl
@@ -1002,9 +1002,13 @@
   (test (void) sync/timeout 0 pr))
 
 (let* ([p (delay/sync (sync never-evt))]
-       [th (thread (lambda () (force p)))])
+       [sem (make-semaphore)]
+       [th (thread (lambda ()
+                     (semaphore-wait sem)
+                     (force p)))])
   (test #f promise-forced? p)
   (test #f promise-running? p)
+  (semaphore-post sem)
   (sync (system-idle-evt))
   (test #f promise-forced? p)
   (test #t promise-running? p)


### PR DESCRIPTION
For the code

    (let* ([p (delay/sync (sync never-evt))]
           [th (thread (lambda () (force p)))])
      (test #f promise-forced? p)
      (test #f promise-running? p)
      (sync (system-idle-evt))
      ...)

it's unlikely with cooperative threads that `th` starts to force the promise before `promise-running?` has a chance to look at it, but not outright impossible. Add a bit of synchronization to make sure things happen in the order we want them to.