### PR TITLE
Rename `qq-and-or.rkt` to `core-syntax.rkt`; add section headers

### DIFF
--- a/racket/collects/racket/phase+space.rkt
+++ b/racket/collects/racket/phase+space.rkt
@@ -1,5 +1,5 @@
 (module phase+space '#%kernel
-  (#%require "private/qq-and-or.rkt")
+  (#%require "private/core-syntax.rkt")
   
   (#%provide phase?
              space?

--- a/racket/collects/racket/private/case.rkt
+++ b/racket/collects/racket/private/case.rkt
@@ -3,8 +3,8 @@
 ;;       [http://scheme2006.cs.uchicago.edu/07-clinger.pdf]
 
 (module case '#%kernel
-  (#%require '#%paramz '#%unsafe "qq-and-or.rkt" "cond.rkt" "define.rkt" "fixnum.rkt"
-             (for-syntax '#%kernel "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+  (#%require '#%paramz '#%unsafe "core-syntax.rkt" "cond.rkt" "define.rkt" "fixnum.rkt"
+             (for-syntax '#%kernel "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
                          "stxcase-scheme.rkt"
                          "qqstx.rkt" "define.rkt" "sort.rkt" "fixnum.rkt"
                          "stx.rkt"))

--- a/racket/collects/racket/private/collect.rkt
+++ b/racket/collects/racket/private/collect.rkt
@@ -1,5 +1,5 @@
 (module collect '#%kernel
-  (#%require "qq-and-or.rkt"
+  (#%require "core-syntax.rkt"
              "path.rkt"
              "kw.rkt"
 	     (prefix k: '#%kernel))

--- a/racket/collects/racket/private/config.rkt
+++ b/racket/collects/racket/private/config.rkt
@@ -1,7 +1,7 @@
 (module config '#%kernel
   (#%require '#%paramz ; for cache-configuration
              "cond.rkt"
-             "qq-and-or.rkt"
+             "core-syntax.rkt"
              "executable-path.rkt")
 
   (#%provide find-main-collects

--- a/racket/collects/racket/private/core-syntax.rkt
+++ b/racket/collects/racket/private/core-syntax.rkt
@@ -1,9 +1,39 @@
+(module core-syntax '#%kernel
 
-;;----------------------------------------------------------------------
-;; quasiquote, and, or
+  ; ======================================================================
+  ; Many of the base syntactic forms of Racket-- things like `and`, `let`,
+  ; and `cond`. These are written together in a single module for startup
+  ; time reasons, and this module forms a nice base for defining the rest
+  ; of `#lang racket/base`.
+  ; ======================================================================
+  ;
 
-(module qq-and-or '#%kernel
   (#%require (for-syntax "stx.rkt" '#%kernel))
+
+  (#%provide let*-values
+             let let* letrec
+             quasiquote
+             and or)
+
+  ; --------------------------------------------------
+  ;
+  ;
+  ;   ;;;                                ;;;;
+  ;     ;               ;               ;
+  ;     ;               ;               ;
+  ;     ;       ;;;     ;               ;       ;;     ; ;;; ; ;; ;;   ;;;;
+  ;     ;      ;   ;  ;;;;;;          ;;;;;;   ;  ;    ;;  ; ;; ;; ;  ;    ;
+  ;     ;     ;    ;    ;               ;     ;    ;   ;   ; ;  ;  ;  ;
+  ;     ;     ;;;;;;    ;               ;     ;    ;   ;     ;  ;  ;   ;;
+  ;     ;     ;         ;               ;     ;    ;   ;     ;  ;  ;     ;;
+  ;     ;     ;         ;               ;     ;    ;   ;     ;  ;  ;       ;
+  ;     ;      ;        ;               ;      ;  ;    ;     ;  ;  ;  ;    ;
+  ;     ;;;     ;;;;     ;;;            ;       ;;     ;     ;  ;  ;   ;;;;
+  ;
+  ;
+  ; let, let*, letrec, let-values
+  ;
+
   
   (define-syntaxes (let*-values let let* letrec)
     (let-values ([(lambda-stx) (quote-syntax lambda-stx)]
@@ -193,6 +223,25 @@
          (lambda (stx) (go stx #t #f (quote-syntax let-values)))
          (lambda (stx) (go stx #f #t (quote-syntax let*-values)))
          (lambda (stx) (go stx #f #f (quote-syntax letrec-values)))))))
+
+  ; --------------------------------------------------
+  ;
+  ;
+  ;     ;;;;    ;;;;
+  ;    ;   ;   ;   ;
+  ;   ;    ;  ;    ;
+  ;   ;    ;  ;    ;
+  ;   ;    ;  ;    ;
+  ;   ;    ;  ;    ;
+  ;   ;   ;;  ;   ;;
+  ;    ;;; ;   ;;; ;
+  ;        ;       ;
+  ;        ;       ;
+  ;        ;       ;
+  ;
+  ;
+  ; quasiquote
+  ;
 
   (define-values (qq-append)
     (lambda (a b)
@@ -439,6 +488,25 @@
 	    form)
 	   in-form)))))
 
+  ; --------------------------------------------------
+  ;
+  ;
+  ;                        ;       ;
+  ;                        ;       ;
+  ;                        ;      ;
+  ;     ;;;;  ; ;;;     ;;;;      ;     ;;     ; ;;;
+  ;    ;   ;  ;;   ;   ;   ;     ;     ;  ;    ;;  ;
+  ;   ;    ;  ;    ;  ;    ;    ;     ;    ;   ;   ;
+  ;   ;    ;  ;    ;  ;    ;    ;     ;    ;   ;
+  ;   ;    ;  ;    ;  ;    ;   ;      ;    ;   ;
+  ;   ;    ;  ;    ;  ;    ;   ;      ;    ;   ;
+  ;   ;   ;;  ;    ;  ;   ;;  ;        ;  ;    ;
+  ;    ;;; ;  ;    ;   ;;; ;  ;         ;;     ;
+  ;
+  ;
+  ; `and` and `or`
+  ;
+
   (define-syntaxes (and)
     (let-values ([(here) (quote-syntax here)])
       (lambda (x)
@@ -501,6 +569,6 @@
 		       "bad syntax"
 		       x))))))))
 
-  (#%provide let*-values
-             let let* letrec
-             quasiquote and or))
+  ;
+  ; --------------------------------------------------
+  )

--- a/racket/collects/racket/private/define-struct.rkt
+++ b/racket/collects/racket/private/define-struct.rkt
@@ -2,11 +2,11 @@
 ;;  (planet "struct.ss" ("ryanc" "macros.plt" 1 0)))
 
 (module define-struct '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "define.rkt" "../stxparam.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "define.rkt" "../stxparam.rkt"
              "generic-methods.rkt"
              (for-syntax '#%kernel "define.rkt"
                          "procedure-alias.rkt"
-                         "stx.rkt" "stxcase-scheme.rkt" "qq-and-or.rkt" "cond.rkt"
+                         "stx.rkt" "stxcase-scheme.rkt" "core-syntax.rkt" "cond.rkt"
                          "define-et-al.rkt"
                          "stxloc.rkt" "qqstx.rkt"
                          "struct-info.rkt"

--- a/racket/collects/racket/private/executable-path.rkt
+++ b/racket/collects/racket/private/executable-path.rkt
@@ -1,5 +1,5 @@
 (module path-list '#%kernel
-  (#%require "qq-and-or.rkt"
+  (#%require "core-syntax.rkt"
              "cond.rkt"
              "define-et-al.rkt"
              "path.rkt"

--- a/racket/collects/racket/private/for.rkt
+++ b/racket/collects/racket/private/for.rkt
@@ -14,7 +14,7 @@
                          "qqstx.rkt"
                          "define.rkt"
                          "fixnum.rkt"
-                         "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+                         "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
                          "stxcase-scheme.rkt"
                          "more-scheme.rkt"))
 

--- a/racket/collects/racket/private/generic-methods.rkt
+++ b/racket/collects/racket/private/generic-methods.rkt
@@ -1,6 +1,6 @@
 (module generic-methods '#%kernel
 
-  (#%require (for-syntax '#%kernel "qq-and-or.rkt" "define-et-al.rkt" "cond.rkt" "define.rkt"
+  (#%require (for-syntax '#%kernel "core-syntax.rkt" "define-et-al.rkt" "cond.rkt" "define.rkt"
                          "stx.rkt" "stxcase-scheme.rkt")
              "define.rkt" "../stxparam.rkt")
 

--- a/racket/collects/racket/private/immediate-default.rkt
+++ b/racket/collects/racket/private/immediate-default.rkt
@@ -1,6 +1,6 @@
 (module kw '#%kernel
   (#%require "define.rkt"
-             "define-et-al.rkt" "qq-and-or.rkt"
+             "define-et-al.rkt" "core-syntax.rkt"
              "stxcase-scheme.rkt"
              (for-template '#%kernel))
 

--- a/racket/collects/racket/private/kw.rkt
+++ b/racket/collects/racket/private/kw.rkt
@@ -1,6 +1,6 @@
 (module kw '#%kernel
   (#%require "define.rkt"
-             "qq-and-or.rkt"
+             "core-syntax.rkt"
              "cond.rkt"
              "define-et-al.rkt"
              "more-scheme.rkt"
@@ -12,7 +12,7 @@
                          '#%unsafe
                          "procedure-alias.rkt"
                          "stx.rkt"
-                         "qq-and-or.rkt"
+                         "core-syntax.rkt"
                          "define-et-al.rkt"
                          "cond.rkt"
                          "stxcase-scheme.rkt"
@@ -23,7 +23,7 @@
                          "kw-prop-key.rkt"
                          "immediate-default.rkt")
              (for-meta 2 '#%kernel
-                       "qq-and-or.rkt"
+                       "core-syntax.rkt"
                        "cond.rkt"
                        "stxcase-scheme.rkt"
                        "qqstx.rkt"))

--- a/racket/collects/racket/private/letstx-scheme.rkt
+++ b/racket/collects/racket/private/letstx-scheme.rkt
@@ -3,7 +3,7 @@
 ;; #%stxcase-scheme: adds let-syntax, letrec-syntax, etc.
 
 (module letstx-scheme '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax)
              (for-syntax '#%kernel "stxcase.rkt" 
@@ -55,5 +55,5 @@
 	     (let-syntaxes ([(id) expr] ...)
 	       body1 body ...))])))
 
-  (#%provide (all-from "define-et-al.rkt") (all-from "qq-and-or.rkt") (all-from "cond.rkt")
+  (#%provide (all-from "define-et-al.rkt") (all-from "core-syntax.rkt") (all-from "cond.rkt")
              letrec-syntaxes letrec-syntax let-syntaxes let-syntax))

--- a/racket/collects/racket/private/logger.rkt
+++ b/racket/collects/racket/private/logger.rkt
@@ -1,7 +1,7 @@
 
 (module logger '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "define.rkt"
-             (for-syntax '#%kernel "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "define.rkt"
+             (for-syntax '#%kernel "stx.rkt" "define-et-al.rkt" "core-syntax.rkt"
                          "stxcase-scheme.rkt"))
 
   (#%provide log-fatal log-error log-warning log-info log-debug

--- a/racket/collects/racket/private/map.rkt
+++ b/racket/collects/racket/private/map.rkt
@@ -3,7 +3,7 @@
 ;;  but the JIT generates faster code, especially for the common cases.
 
 (module map '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "define.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "define.rkt"
              "performance-hint.rkt"
              "kw.rkt"
              '#%paramz

--- a/racket/collects/racket/private/misc.rkt
+++ b/racket/collects/racket/private/misc.rkt
@@ -3,10 +3,10 @@
 ;; #%misc : file utilities, etc. - remaining functions
 
 (module misc '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "define.rkt" "path.rkt" "old-path.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "define.rkt" "path.rkt" "old-path.rkt"
              "path-list.rkt" "executable-path.rkt"
              "reading-param.rkt" "../repl.rkt"
-             (for-syntax '#%kernel "qq-and-or.rkt" "stx.rkt" "stxcase-scheme.rkt" "stxcase.rkt"))
+             (for-syntax '#%kernel "core-syntax.rkt" "stx.rkt" "stxcase-scheme.rkt" "stxcase.rkt"))
   
   ;; -------------------------------------------------------------------------
 

--- a/racket/collects/racket/private/more-scheme.rkt
+++ b/racket/collects/racket/private/more-scheme.rkt
@@ -3,8 +3,8 @@
 ;; more-scheme : case, do, etc. - remaining syntax
 
 (module more-scheme '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "define.rkt" '#%paramz "case.rkt" "logger.rkt"
-             (for-syntax '#%kernel "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "stxcase-scheme.rkt" "qqstx.rkt"))
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "define.rkt" '#%paramz "case.rkt" "logger.rkt"
+             (for-syntax '#%kernel "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "stxcase-scheme.rkt" "qqstx.rkt"))
 
   ;; For `old-case`:
   (define-syntax case-test

--- a/racket/collects/racket/private/name.rkt
+++ b/racket/collects/racket/private/name.rkt
@@ -1,6 +1,6 @@
 
 (module name '#%kernel
-  (#%require "define.rkt" "qq-and-or.rkt" "cond.rkt")
+  (#%require "define.rkt" "core-syntax.rkt" "cond.rkt")
   (#%provide syntax-local-infer-name
              simplify-inferred-name)
 

--- a/racket/collects/racket/private/namespace.rkt
+++ b/racket/collects/racket/private/namespace.rkt
@@ -1,6 +1,6 @@
 (module namespace "pre-base.rkt"
   (require (for-syntax '#%kernel "define.rkt"
-                       "stx.rkt" "stxcase-scheme.rkt" "define-et-al.rkt" "qq-and-or.rkt"
+                       "stx.rkt" "stxcase-scheme.rkt" "define-et-al.rkt" "core-syntax.rkt"
                        "stxloc.rkt"))
 
   (provide make-base-empty-namespace

--- a/racket/collects/racket/private/norm-arity.rkt
+++ b/racket/collects/racket/private/norm-arity.rkt
@@ -1,5 +1,5 @@
 (module norm-arity '#%kernel
-  (#%require "define.rkt" "qq-and-or.rkt" "define-et-al.rkt" "sort.rkt")
+  (#%require "define.rkt" "core-syntax.rkt" "define-et-al.rkt" "sort.rkt")
   (#%provide normalize-arity)
 
   ;; normalize-arity : (or/c arity (listof arity))

--- a/racket/collects/racket/private/norm-define.rkt
+++ b/racket/collects/racket/private/norm-define.rkt
@@ -1,6 +1,6 @@
 
 (module norm-define '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "stxcase-scheme.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "stxcase-scheme.rkt"
              "stx.rkt" "qqstx.rkt")
 
   (#%provide normalize-definition normalize-definition/mk-rhs)

--- a/racket/collects/racket/private/old-path.rkt
+++ b/racket/collects/racket/private/old-path.rkt
@@ -2,7 +2,7 @@
 ;; `path-add-extension` that do the wrong thing with
 ;; file names that start "."
 (module path '#%kernel
-  (#%require "qq-and-or.rkt" "define-et-al.rkt"
+  (#%require "core-syntax.rkt" "define-et-al.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax))
 

--- a/racket/collects/racket/private/path-list.rkt
+++ b/racket/collects/racket/private/path-list.rkt
@@ -1,5 +1,5 @@
 (module path-list '#%kernel
-  (#%require "qq-and-or.rkt" "define-et-al.rkt"
+  (#%require "core-syntax.rkt" "define-et-al.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax))
 

--- a/racket/collects/racket/private/path.rkt
+++ b/racket/collects/racket/private/path.rkt
@@ -1,5 +1,5 @@
 (module path '#%kernel
-  (#%require "qq-and-or.rkt" "cond.rkt" "define-et-al.rkt"
+  (#%require "core-syntax.rkt" "cond.rkt" "define-et-al.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax))
 

--- a/racket/collects/racket/private/pre-base.rkt
+++ b/racket/collects/racket/private/pre-base.rkt
@@ -3,7 +3,7 @@
 (module pre-base '#%kernel
   (#%require (for-syntax '#%kernel
                          "stx.rkt"
-                         "qq-and-or.rkt"))
+                         "core-syntax.rkt"))
   (#%require "more-scheme.rkt"
              "misc.rkt"
              (all-except "define.rkt" define define-syntax define-for-syntax)

--- a/racket/collects/racket/private/promise.rkt
+++ b/racket/collects/racket/private/promise.rkt
@@ -12,12 +12,12 @@
 ;; definitions. See "racket/private/for-compatibility-lib.rkt" for an example.
 
 (module promise '#%kernel
-(#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+(#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
            "more-scheme.rkt"
            "define.rkt"
            (rename "define-struct.rkt" define-struct define-struct*)
            (for-syntax '#%kernel
-                       "cond.rkt" "qq-and-or.rkt"
+                       "cond.rkt" "core-syntax.rkt"
                        "define.rkt"
                        "struct.rkt"
                        "stxcase-scheme.rkt"

--- a/racket/collects/racket/private/qqstx.rkt
+++ b/racket/collects/racket/private/qqstx.rkt
@@ -5,7 +5,7 @@
   (#%require "define-et-al.rkt" "stxcase-scheme.rkt" "stx.rkt" "template.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax)
-             (for-syntax '#%kernel "qq-and-or.rkt" "cond.rkt" "stxcase-scheme.rkt" "stx.rkt"))
+             (for-syntax '#%kernel "core-syntax.rkt" "cond.rkt" "stxcase-scheme.rkt" "stx.rkt"))
 
   (#%provide quasisyntax
              quasisyntax/loc

--- a/racket/collects/racket/private/reqprov.rkt
+++ b/racket/collects/racket/private/reqprov.rkt
@@ -2,7 +2,7 @@
   (#%require "define.rkt"
              (for-syntax '#%kernel
                          "stx.rkt" "stxcase-scheme.rkt" "define-et-al.rkt"
-                         "qq-and-or.rkt" "cond.rkt"
+                         "core-syntax.rkt" "cond.rkt"
                          "stxloc.rkt" "qqstx.rkt" "more-scheme.rkt"
                          "../require-transform.rkt" "require-lift.rkt"
                          "../provide-transform.rkt"

--- a/racket/collects/racket/private/sc.rkt
+++ b/racket/collects/racket/private/sc.rkt
@@ -3,7 +3,7 @@
 ;; based on Shriram's pattern matcher for Zodiac
 
 (module sc '#%kernel
-  (#%require "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+  (#%require "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax)
              (for-template (only '#%kernel set!)

--- a/racket/collects/racket/private/small-scheme.rkt
+++ b/racket/collects/racket/private/small-scheme.rkt
@@ -5,9 +5,9 @@
 ;; Not used in racket/base but kept for backwards-compatibility
 
 (module small-scheme '#%kernel
-  (#%require "qq-and-or.rkt" "cond.rkt" "define-et-al.rkt")
+  (#%require "core-syntax.rkt" "cond.rkt" "define-et-al.rkt")
   
-  (#%provide (all-from "qq-and-or.rkt")
+  (#%provide (all-from "core-syntax.rkt")
              (all-from "cond.rkt")
              (all-from "define-et-al.rkt")))
 

--- a/racket/collects/racket/private/sort.rkt
+++ b/racket/collects/racket/private/sort.rkt
@@ -1,6 +1,6 @@
 (module sort '#%kernel
 
-(#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "define.rkt" (for-syntax "stxcase-scheme.rkt"))
+(#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "define.rkt" (for-syntax "stxcase-scheme.rkt"))
 
 ;; note, these are the raw interfaces --- user-facing definitions
 ;; are exported from private/list.rkt and vector.rkt

--- a/racket/collects/racket/private/struct-info.rkt
+++ b/racket/collects/racket/private/struct-info.rkt
@@ -3,7 +3,7 @@
 ;; record for static info produced by `define-struct'
 
 (module struct-info '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt")
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt")
 
   (#%provide make-struct-info
              struct-info?

--- a/racket/collects/racket/private/struct.rkt
+++ b/racket/collects/racket/private/struct.rkt
@@ -3,7 +3,7 @@
   (#%require "define.rkt"
              "define-struct.rkt"
              (for-syntax '#%kernel "define.rkt"
-                         "stx.rkt" "stxcase-scheme.rkt" "qq-and-or.rkt" "cond.rkt"
+                         "stx.rkt" "stxcase-scheme.rkt" "core-syntax.rkt" "cond.rkt"
                          "stxloc.rkt"))
 
   (#%provide struct)

--- a/racket/collects/racket/private/stxcase-scheme.rkt
+++ b/racket/collects/racket/private/stxcase-scheme.rkt
@@ -4,7 +4,7 @@
 ;;  check-duplicate-identifier, and assembles everything we have so far
 
 (module stxcase-scheme '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "stx.rkt" "stxcase.rkt" "with-stx.rkt" "stxloc.rkt"
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "stx.rkt" "stxcase.rkt" "with-stx.rkt" "stxloc.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax)
              (for-syntax '#%kernel "define-et-al.rkt" "stx.rkt" "stxcase.rkt"

--- a/racket/collects/racket/private/stxcase.rkt
+++ b/racket/collects/racket/private/stxcase.rkt
@@ -2,11 +2,11 @@
 ;; syntax-case and syntax
 
 (module stxcase '#%kernel
-  (#%require "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" '#%paramz '#%unsafe
+  (#%require "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" '#%paramz '#%unsafe
              "ellipses.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax)
-             (for-syntax "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+             (for-syntax "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
                           "stx.rkt" "sc.rkt" '#%kernel
                           (rename "define-et-al.rkt" -define define)
                           (rename "define-et-al.rkt" -define-syntax define-syntax)))

--- a/racket/collects/racket/private/stxparam.rkt
+++ b/racket/collects/racket/private/stxparam.rkt
@@ -3,7 +3,7 @@
   (#%require "define.rkt"
              (for-syntax '#%kernel 
                          "stx.rkt" "stxcase-scheme.rkt" 
-                         "define-et-al.rkt" "qq-and-or.rkt"
+                         "define-et-al.rkt" "core-syntax.rkt"
                          "stxloc.rkt" "stxparamkey.rkt"))
 
   (#%provide (for-syntax do-syntax-parameterize)

--- a/racket/collects/racket/private/stxparamkey.rkt
+++ b/racket/collects/racket/private/stxparamkey.rkt
@@ -1,6 +1,6 @@
 
 (module stxparamkey '#%kernel
-  (#%require "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "define.rkt" 
+  (#%require "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "define.rkt"
              "stxcase.rkt" "stxloc.rkt" "with-stx.rkt"
              (only '#%unsafe unsafe-root-continuation-prompt-tag)
              (for-template '#%kernel))

--- a/racket/collects/racket/private/template.rkt
+++ b/racket/collects/racket/private/template.rkt
@@ -1,7 +1,7 @@
 (module template '#%kernel
-(#%require "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "performance-hint.rkt"
+(#%require "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "performance-hint.rkt"
            "ellipses.rkt"
-           (for-syntax "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt"
+           (for-syntax "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt"
                        "sc.rkt" '#%kernel))
 (#%provide syntax
            syntax/loc

--- a/racket/collects/racket/private/with-stx.rkt
+++ b/racket/collects/racket/private/with-stx.rkt
@@ -2,11 +2,11 @@
 ;; with-syntax, generate-temporaries
 
 (module with-stx '#%kernel
-  (#%require "stx.rkt" "define-et-al.rkt" "qq-and-or.rkt" "cond.rkt" "stxcase.rkt"
+  (#%require "stx.rkt" "define-et-al.rkt" "core-syntax.rkt" "cond.rkt" "stxcase.rkt"
              (rename "define-et-al.rkt" -define define)
              (rename "define-et-al.rkt" -define-syntax define-syntax)
              (for-syntax '#%kernel "stxcase.rkt" "stxloc.rkt" 
-                         "stx.rkt" "sc.rkt" "qq-and-or.rkt" "cond.rkt"))
+                         "stx.rkt" "sc.rkt" "core-syntax.rkt" "cond.rkt"))
 
   (-define (with-syntax-fail stx)
     (raise-syntax-error

--- a/racket/collects/racket/provide-transform.rkt
+++ b/racket/collects/racket/provide-transform.rkt
@@ -3,7 +3,7 @@
              "private/stx.rkt"
              "private/define-struct.rkt"
              "private/define-et-al.rkt"
-             "private/qq-and-or.rkt"
+             "private/core-syntax.rkt"
              "private/cond.rkt"
              "private/define.rkt"
              "phase+space.rkt")

--- a/racket/collects/racket/require-transform.rkt
+++ b/racket/collects/racket/require-transform.rkt
@@ -3,7 +3,7 @@
              "private/stx.rkt"
              "private/define-struct.rkt"
              "private/define-et-al.rkt"
-             "private/qq-and-or.rkt"
+             "private/core-syntax.rkt"
              "private/cond.rkt"
              "private/define.rkt"
              "private/require-lift.rkt"

--- a/racket/collects/racket/stxparam-exptime.rkt
+++ b/racket/collects/racket/stxparam-exptime.rkt
@@ -2,7 +2,7 @@
 (module stxparam-exptime '#%kernel
   (#%require "private/stxcase-scheme.rkt"
              "private/define-et-al.rkt"
-             "private/qq-and-or.rkt"
+             "private/core-syntax.rkt"
              "private/stxparamkey.rkt")
 
   (#%provide syntax-parameter-value

--- a/racket/collects/racket/stxparam.rkt
+++ b/racket/collects/racket/stxparam.rkt
@@ -6,7 +6,7 @@
              (for-syntax '#%kernel 
                          "stxparam-exptime.rkt"
                          "private/stxcase-scheme.rkt" 
-                         "private/qq-and-or.rkt" 
+                         "private/core-syntax.rkt"
                          "private/stxloc.rkt"
                          "private/stxparamkey.rkt"))
 


### PR DESCRIPTION
This rename makes twofold sense. First, `qq-and-or.rkt` is already more than just what it says on the tin-- it also defines `let`, `let*`, and `letrec`. Second, as part of the effort to reduce startup time, we plan on merging more core macros into the same file; for more info about the overall effort, see https://github.com/racket/racket/pull/5406

Testing: manually reviewed `git grep qq-and-or` in this repo; the only hits are #%requires which this commit adjusts. Searched all `*.rkt` and `*.ss` files in my copy of the package archive; the hits are `stxparse-info` which appears to include a copy of a decent chunk of racket/base's implementation and is broken anyway, and one hit in TR which will need a coordinated change.

# NOTE coordinated change in TR

This requires a backwards-compatible change to Typed Racket before this can be committed, so TR is aware of the rename. The changes do not need to be simultaneous. The PR on the Typed Racket side is https://github.com/racket/typed-racket/pull/1499 . The proper order for things is probably (1) get approval for both PRs, (2) merge the PR to Typed Racket and wait a couple hours for the package server to update, (3) merge this.