### PR TITLE
Add comments to private modules used by main-distribution packages, part 2 (easy)

### DIFF
--- a/racket/collects/racket/private/class-c.rkt
+++ b/racket/collects/racket/private/class-c.rkt
@@ -1,4 +1,18 @@
 #lang racket/base
+
+;; Note that this module is only semi-private in the sense that other packages
+;; which are in the main distribution but in separate repositories require
+;; it. This means any backwards-incompatible API changes need coordination.
+;; The following packages are known to use this module:
+;;
+;; - compatability-lib
+;;
+;; Please try not to add more packages which require this file. Instead,
+;; consider whether a public API is appropriate, or if a currently-private
+;; API should be made public. If not, then make a new file
+;; "racket/private/for-yourpackage.rkt" which exports the necessary
+;; definitions. See "racket/private/for-compatability-lib.rkt" for an example.
+
 (require (for-syntax racket/base
                      racket/stxparam
                      syntax/parse/pre)


### PR DESCRIPTION
In a previous commit 3014b7dc0a1df2d1228c8e2da1add7b668140d0a, we had:

> Add comments to (most) `private` modules used by main-distribution packages
>
>
> This patch is part of an effort to clarify what in `racket/private`
> is intended to be used (or is used) by other first-party packages.
> The overall plan is:
>
> (1) Change first-party packages to use public APIs when possible.
>
> (2) For any packages which have racket/private dependencies which are
> part of racket/base's implementation, make a new
> `racket/private/for-thatpackage` module which provides only the appropriate
> chunks.
>
> (3) For packages which have dependencies on racket/private which are not
> part of racket/base's implementation, add a comment to the appropriate
> file noting that it's used by the other package.

Step (3) was incomplete due to a concurrently active long-lived branch modifying one file, which is now called `class-c.rkt`. Add the comment to that file, too.
