### PR TITLE
possible latent bug in cify's function.rkt's extract-functions's with-continuation-mark case?

### DIFF
--- a/racket/src/cify/function.rkt
+++ b/racket/src/cify/function.rkt
@@ -63,9 +63,9 @@
     [`(if ,tst ,thn ,els)
      (not-just-functions
       (extract-expr-functions knowns `(begin ,tst ,thn ,els) #f lambdas))]
-    [`(with-continuation-marks ,tst ,thn ,els)
+    [`(with-continuation-mark ,key ,val ,body)
      (not-just-functions
-      (extract-expr-functions knowns `(with-continuation-marks ,tst ,thn ,els) #f lambdas))]
+      (extract-expr-functions knowns `(begin ,key ,val ,body) #f lambdas))]
     [`(set! ,id ,rhs)
      (not-just-functions
       (extract-expr-functions knowns rhs #f lambdas))]


### PR DESCRIPTION
I accidentally searched the repo for `with-continuation-marks` instead of `with-continuation-mark`, and got a result in cify. Based on context, I think it's a latent bug and the code should read as in this PR instead. If somebody with knowledge of this code can confirm, then the PR should be merge-ready; the commit message is written as:

> fix latent bug with with-continuation-mark in cify
> 
> In the implementation of cify's function.rkt's extract-functions, the case for `with-continuation-mark` was buggy. Fix it. The bug appears to be be latent, in that running `make derived` generates no changes to startup.inc.

If this is not a latent bug or the fix is incorrect, feel free to close.