### PR TITLE
racket/private: new raise-syntax-error-{if,unless} helpers

### DIFF
--- a/racket/collects/racket/private/stx.rkt
+++ b/racket/collects/racket/private/stx.rkt
@@ -206,6 +206,39 @@
           (set! counter (add1 counter))
           (string->uninterned-symbol (format "~a~a" prefix counter))))))
 
+  ; (raise-syntax-error-if condition msg expr [sub-expr] [extra-sources])
+  ;   condition     : any/c                     (used for true/false)
+  ;   message       : string?                   (suitable for 2nd argument of `raise-syntax-error`)
+  ;   expr          : syntax?                   (suitable for 3rd argument of `raise-syntax-error`)
+  ;   sub-expr      : syntax? = #f              (suitable for 4th argument of `raise-syntax-error`)
+  ;   extra-sources : (listof syntax?) = null   (suitable for 5th argument of `raise-syntax-error`)
+  ;  -> (if/c condition none/c void?)
+  (define-values (raise-syntax-error-if)
+    (case-lambda
+      [(condition message expr sub-expr extra-sources)
+       (if condition (raise-syntax-error #f message expr sub-expr extra-sources) (void))]
+      [(condition message expr sub-expr)
+       (if condition (raise-syntax-error #f message expr sub-expr) (void))]
+      [(condition message expr)
+       (if condition (raise-syntax-error #f message expr) (void))]))
+
+  ; (raise-syntax-error-unless condition msg expr [sub-expr] [extra-sources])
+  ;   condition     : any/c                     (used for true/false)
+  ;   message       : string?                   (suitable for 2nd argument of `raise-syntax-error`)
+  ;   expr          : syntax?                   (suitable for 3rd argument of `raise-syntax-error`)
+  ;   sub-expr      : syntax? = #f              (suitable for 4th argument of `raise-syntax-error`)
+  ;   extra-sources : (listof syntax?) = null   (suitable for 5th argument of `raise-syntax-error`)
+  ;  -> (if/c condition none/c void?)
+  (define-values (raise-syntax-error-unless)
+    (case-lambda
+      [(condition message expr sub-expr extra-sources)
+       (if condition (void) (raise-syntax-error #f message expr sub-expr extra-sources))]
+      [(condition message expr sub-expr)
+       (if condition (void) (raise-syntax-error #f message expr sub-expr))]
+      [(condition message expr)
+       (if condition (void) (raise-syntax-error #f message expr))]))
+
+
   (#%provide identifier? stx-null? stx-null/#f stx-pair? stx-list?
              stx-car stx-cdr stx->list
              stx-vector? stx-vector-ref
@@ -214,4 +247,6 @@
              stx-check/esc cons/#f append/#f
              stx-rotate stx-rotate*
              split-stx-list
-             make-stx-id-counter))
+             make-stx-id-counter
+             raise-syntax-error-if
+             raise-syntax-error-unless))


### PR DESCRIPTION
This is just the first commit of https://github.com/racket/racket/pull/5453, extracted as its own PR. It exclusively adds two functions to a private module, and (in contrast to that PR) has no changes to existing functions or macros. I'm splitting this out in the hope that it could be merged sooner, since this commit is also a prereq of other PRs I'd like to create in parallel with #5453. (Creating those other PRs before the commit in this PR is merged would create spurious merge-order dependencies among the other PRs because of github's poor support for stacked PRs.)

Commit log:

## racket/private: new raise-syntax-error-{if,unless} helpers

There is a very common pattern in the implementation of low-level macros:

    (if something
        (void)
        (raise-syntax-error #f constant-string local-variable))

Introduce the appropriate abstraction to handle them.

This does not introduce uses; rather, uses will be added as more of the core syntax is centralized and some of the implementations are slightly modernized. See https://github.com/racket/racket/pull/5406 for more on that effort.
