### PR TITLE
Reject non-linear `match` patterns with mismatched ellipsis depth

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/match.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/match.scrbl
@@ -126,6 +126,12 @@ In more detail, patterns match as follows:
        @racketidfont{not} sub-patterns are independent. The binding for @racket[_id] is
        not available in other parts of the same pattern.
 
+       If @racket[_id] is used multiple times at different ellipsis
+       depths---that is, some uses are under @racketidfont{...} and
+       others are not, or they are under different @racketidfont{...}
+       patterns---a syntax error is raised.
+       See @secref["match-nonlinear-ellipsis"] for details and examples.
+
        @examples[
        #:eval match-eval
        (match '(1 2 3)
@@ -942,6 +948,56 @@ sub-expression to be used as the source for all syntax errors within the form.
 For example, @racket[match-lambda] expands to @racket[match/derived] so that
 errors in the body of the form are reported in terms of @racket[match-lambda]
 instead of @racket[match].}
+
+@; ----------------------------------------------------------------------
+
+@section[#:tag "match-nonlinear-ellipsis"]{Non-linear Patterns and Ellipses}
+
+When the same identifier is used multiple times within a pattern (a
+@deftech{non-linear pattern}), each occurrence must be within the same
+@racketidfont{...}, otherwise a syntax error is raised.  In order for
+the entire pattern to match, each occurrence must match the same value
+according to @racket[(match-equality-test)],
+
+When both occurrences of an identifier are under the same
+@racketidfont{...}, each repetition of the pattern checks equality
+between the occurrences within that repetition, but the identifier can
+match different values in different repetitions. The identifier
+is bound to a list of the matched values.
+
+For example, @racket[(list (list a a) ...)] matches
+@racket['((1 1) (2 2) (3 3))] successfully because within each
+repetition both @racket[a]s are equal, even though @racket[a] is
+@racket[1] in the first repetition, @racket[2] in the second, and
+@racket[3] in the third. In this case, @racket[a] is bound to @racket['(1 2 3)] on the right-hand side.
+
+@examples[
+#:eval match-eval
+(code:comment "each pair must have equal elements")
+(match '((1 1) (2 2) (3 3))
+  [(list (list a a) ...) a]
+  [_ 'no])
+(code:comment "second pair doesn't match: 2 != 3")
+(match '((1 1) (2 3) (3 3))
+  [(list (list a a) ...) a]
+  [_ 'no])
+]
+
+If an identifier is used at different ellipsis depths---for example,
+once outside @racketidfont{...} and once inside, or under different
+@racketidfont{...} patterns---a syntax error is raised.
+
+@examples[
+#:eval match-eval
+(eval:error (match '(1 1 1 1) [(cons t (list t ...)) t]))
+(eval:error (match '(1 2 3 4) [(list a ... a) a]))
+(eval:error (match '((1 2) 3) [(list (list a ...) a) a]))
+]
+
+@history[#:changed "9.1.0.9" @elem{Added equality checking for
+non-linear patterns under @racketidfont{...}, and changed
+non-linear patterns with differing ellipsis depth to raise a syntax
+error.}]
 
 @; ----------------------------------------------------------------------
 

--- a/pkgs/racket-test/tests/match/main.rkt
+++ b/pkgs/racket-test/tests/match/main.rkt
@@ -254,7 +254,191 @@
                     [_ #f]))
      (check-equal? (match '((1 1 2 3) (2 1 2 3) (3 1 2 3))
                      [(list (cons a (list pre ... a post ...)) ...) (list a pre post)])
-                   '((1 2 3) (() (1) (1 2)) ((2 3) (3) ()))))))
+                   '((1 2 3) (() (1) (1 2)) ((2 3) (3) ()))))
+
+   (test-case "Non-linear under ... still works"
+     ;; Both occurrences of a are under the same ...
+     (check-equal? (match '((1 1) (2 2) (3 3))
+                     [(list (list a a) ...) a]
+                     [_ 'no])
+                   '(1 2 3))
+     (check-equal? (match '((1 2) (2 2) (3 3))
+                     [(list (list a a) ...) a]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear under ... with three occurrences"
+     (check-equal? (match '((1 1 1) (2 2 2))
+                     [(list (list a a a) ...) a]
+                     [_ 'no])
+                   '(1 2))
+     (check-equal? (match '((1 1 2) (2 2 2))
+                     [(list (list a a a) ...) a]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear under ... with cons"
+     ;; Both uses of a inside the same ... via cons
+     (check-equal? (match '((1 . 1) (2 . 2) (3 . 3))
+                     [(list (cons a a) ...) a]
+                     [_ 'no])
+                   '(1 2 3))
+     (check-equal? (match '((1 . 1) (2 . 9) (3 . 3))
+                     [(list (cons a a) ...) a]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear under ... with nested list"
+     ;; a appears twice in nested structure, both under same ...
+     (check-equal? (match '((1 (1)) (2 (2)))
+                     [(list (list a (list a)) ...) a]
+                     [_ 'no])
+                   '(1 2))
+     (check-equal? (match '((1 (1)) (2 (3)))
+                     [(list (list a (list a)) ...) a]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear under ... empty list"
+     ;; Vacuously true: zero repetitions
+     (check-equal? (match '()
+                     [(list (list a a) ...) a]
+                     [_ 'no])
+                   '()))
+
+   (test-case "Non-linear under ... with other bindings"
+     ;; a is non-linear under ..., b is a separate binding
+     (check-equal? (match '((1 2 1) (3 4 3))
+                     [(list (list a b a) ...) (list a b)]
+                     [_ 'no])
+                   '((1 3) (2 4)))
+     (check-equal? (match '((1 2 1) (3 4 5))
+                     [(list (list a b a) ...) (list a b)]
+                     [_ 'no])
+                   'no))
+
+   (test-case "Non-linear under ... with match-equality-test"
+     ;; Custom equality for non-linear under ...
+     (check-equal? (parameterize ([match-equality-test
+                                   (lambda (a b) (= (modulo a 3) (modulo b 3)))])
+                     (match '((1 4) (2 5))
+                       [(list (list a a) ...) a]
+                       [_ 'no]))
+                   '(1 2)))
+
+   (test-case "Non-linear under nested ..."
+     ;; Both uses of a under the same nested ...
+     (check-equal? (match '(((1 1) (2 2)) ((3 3)))
+                     [(list (list (list a a) ...) ...) a]
+                     [_ 'no])
+                   '((1 2) (3)))
+     (check-equal? (match '(((1 1) (2 9)) ((3 3)))
+                     [(list (list (list a a) ...) ...) a]
+                     [_ 'no])
+                   'no))
+
+   ;; Patterns where an identifier appears at different ellipsis depths
+   ;; should be syntax errors, regardless of direction.
+
+   (test-case "Syntax error: cons x (list (cons x _) ...)"
+     ;; Regression for issue #5442
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 . 2) (1 . 3)) [(cons (cons x _) (list (cons x _) ___)) x])))))
+
+   (test-case "Syntax error: quasiquote ,t ,t ..."
+     ;; Regression for issue #2152
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 1 1) [`(,t ,t ___) t])))))
+
+   (test-case "Syntax error: cons t (list t ...)"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 1 1) [(cons t (list t ___)) t])))))
+
+   (test-case "Syntax error: list-no-order across ..."
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(2 1 2 3) [(cons a (list-no-order a rst ___)) (list a rst)])))))
+
+   (test-case "Syntax error: list x x ..."
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 1 1) [(list x x ___) x])))))
+
+   ;; Patterns where the first use of an identifier is under ...
+   ;; and a later use is not under the same ... should be syntax errors.
+   ;; We use ___ (alias for ...) to avoid template ellipsis issues in #'(...).
+   (test-case "Syntax error: list a ... a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 2 3 4) [(list a ___ a) a])))))
+
+   (test-case "Syntax error: list (list a ...) a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2) 3) [(list (list a ___) a) a])))))
+
+   (test-case "Syntax error: list (list a ... _) a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2 3) 4) [(list (list a ___ _) a) a])))))
+
+   (test-case "Syntax error: list (list x ...) (list x ...)"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2) (1 2)) [(list (list x ___) (list x ___)) x])))))
+
+   (test-case "Syntax error: list (list x _) ... x"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 a) (1 b) 99) [(list (list x _) ___ x) x])))))
+
+   ;; ..k variants
+   (test-case "Syntax error: list a ..2 a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 2 3) [(list a ..2 a) a])))))
+
+   (test-case "Syntax error: list (list a ..3) a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2 3) 4) [(list (list a ..3) a) a])))))
+
+   ;; list-rest
+   (test-case "Syntax error: list-rest with mismatched depth"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '((1 2) 3) [(list-rest (list a ___) a) a])))))
+
+   ;; quasipatterns
+   (test-case "Syntax error: quasipattern ,a ... ,a"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 2 3 4) [`(,a ___ ,a) a])))))
+
+   (test-case "Syntax error: list-rest with mismatched depth (other direction)"
+     (check-exn exn:fail:syntax?
+                (lambda ()
+                  (expand #'(match '(1 1 1) [(list-rest a (list a ___)) a])))))
+
+   ;; Check that errors reference both occurrences of the identifier
+   (test-case "Syntax error exprs include both occurrences (first outside, then under ...)"
+     (check-equal?
+      (with-handlers ([exn:fail:syntax?
+                       (lambda (e)
+                         (length (exn:fail:syntax-exprs e)))])
+        (expand #'(match '(1 1 1) [(cons t (list t ___)) t])))
+      2))
+
+   (test-case "Syntax error exprs include both occurrences (first under ..., then outside)"
+     (check-equal?
+      (with-handlers ([exn:fail:syntax?
+                       (lambda (e)
+                         (length (exn:fail:syntax-exprs e)))])
+        (expand #'(match '(1 2 3 4) [(list a ___ a) a])))
+      2))))
 
 
 (define doc-tests

--- a/racket/collects/racket/match/compiler.rkt
+++ b/racket/collects/racket/match/compiler.rkt
@@ -217,21 +217,23 @@
                  =>
                  (lambda (id)
                    (if (identifier? id)
-                       (make-Row ps
-                                 #`(if ((match-equality-test) #,x #,id)
-                                       #,(Row-rhs row)
-                                       (fail))
-                                 (Row-unmatch row)
-                                 seen)
-                       (begin
-                         (log-error "non-linear pattern used in `match` with ... at ~a and ~a"
-                                    (car id) (cadr id)) 
-                         (let ([v* (free-identifier-mapping-get
-                                    (current-renaming) v (lambda () v))])
-                           (make-Row ps
-                                     #`(let ([#,v* #,x]) #,(Row-rhs row))
-                                     (Row-unmatch row)
-                                     (cons (cons v x) (Row-vars-seen row)))))))]
+                       (let ([v* (free-identifier-mapping-get
+                                  (current-renaming) v (lambda () v))])
+                         (make-Row ps
+                                   #`(if ((match-equality-test) #,x #,id)
+                                         (let ([#,v* #,x]) #,(Row-rhs row))
+                                         (fail))
+                                   (Row-unmatch row)
+                                   seen))
+                       ;; id is (list v v*): variable was first bound under
+                      ;; ... and is now used outside it. This is a non-linear
+                      ;; pattern with mismatched ellipsis depths.
+                      ;; Include both occurrences in extra-sources so the
+                      ;; error can point to both locations.
+                      (raise-syntax-error
+                       'match
+                       "non-linear pattern used in `match` with ..."
+                       (car id) #f (list (cadr id)))))]
                 ;; otherwise, bind the matched variable to x, and add it to the
                 ;; list of vars we've seen
                 [else (let ([v* (free-identifier-mapping-get
@@ -378,6 +380,47 @@
     [(GSeq? first)
      (unless (null? (cdr block))
        (error 'compile-one "GSeq block with multiple rows: ~a" block))
+     ;; Optimization: (list x ...) where x is a fresh variable can be
+     ;; compiled as (and (? list?) x) instead of a full GSeq loop,
+     ;; since binding x to the whole list is equivalent to collecting
+     ;; each element. But this is only valid when x is NOT a repeated
+     ;; (non-linear) variable, because non-linear matching needs to
+     ;; compare each element individually.
+     (define (simple-var-gseq?)
+       (and (= (length (GSeq-headss first)) 1)
+            (= (length (car (GSeq-headss first))) 1)
+            (Var? (caar (GSeq-headss first)))
+            (not (Dummy? (caar (GSeq-headss first))))
+            (Null? (GSeq-tail first))
+            (not (car (GSeq-mins first)))
+            (not (car (GSeq-maxs first)))
+            (not (car (GSeq-onces? first)))
+            (not (GSeq-mutable? first))
+            (let ([v (Var-v (caar (GSeq-headss first)))])
+              (not (for/or ([e (in-list (Row-vars-seen (car block)))])
+                     (bound-identifier=? v (car e)))))))
+     (cond
+      [(simple-var-gseq?)
+       ;; Compile as (and (? list?) x) — just check list? and bind
+       (define-values (_p rest-pats) (Row-split-pats (car block)))
+       (define row (car block))
+       (define v (Var-v (caar (GSeq-headss first))))
+       (define v* (free-identifier-mapping-get
+                   (current-renaming) v (lambda () v)))
+       ;; Mark v with #f in vars-seen (like heads-seen does in the
+       ;; full GSeq path) so that if v appears again in rest-pats,
+       ;; it triggers a syntax error for mismatched ellipsis depth.
+       (with-syntax ([body (compile**
+                            xs
+                            (list (make-Row rest-pats
+                                            (Row-rhs row)
+                                            (Row-unmatch row)
+                                            (cons (cons v #f) (Row-vars-seen row))))
+                            esc)])
+         #`(if (list? #,x)
+               (let ([#,v* #,x]) body)
+               (#,esc)))]
+      [else
      (let* ([headss (GSeq-headss first)]
             [mins (GSeq-mins first)]
             [maxs (GSeq-maxs first)]
@@ -403,6 +446,16 @@
             [heads-seen
              (map (lambda (x) (cons x #f))
                   (apply append (map bound-vars heads)))]
+            [_ (for* ([hids (in-list head-idss)]
+                      [hv (in-list hids)])
+                 (define prev
+                   (for/or ([e (in-list (Row-vars-seen (car block)))])
+                     (and (bound-identifier=? hv (car e)) (car e))))
+                 (when prev
+                   (raise-syntax-error
+                    'match
+                    "non-linear pattern used in `match` with ..."
+                    hv #f (list prev))))]
             [tail-seen
              (map (lambda (x) (cons x x))
                   (bound-vars tail))]
@@ -486,7 +539,7 @@
                                       heads-seen
                                       (Row-vars-seen
                                        (car block))))))
-                    #'failkv))))))]
+                    #'failkv))))))])]
     [else (error 'compile "unsupported pattern: ~a\n" first)]))
 
 (define (generate-block esc rhs unmatch)

--- a/racket/collects/racket/match/parse-helper.rkt
+++ b/racket/collects/racket/match/parse-helper.rkt
@@ -58,7 +58,7 @@
   (cond [(and (not (in-splicing?)) ;; when we're inside splicing, rest-pat isn't the rest
               (not min) ;; if we have a count, better generate general code
               (Null? rest-pat)
-              (or (Var? pat) (Dummy? pat)))
+              (Dummy? pat))
          (make-OrderedAnd (list (make-Pred pred?)
                                 (if to-list
                                     (make-App to-list (list pat))


### PR DESCRIPTION
Non-linear pattern variables (same variable used multiple times) in match are now required to be at the same ellipsis depth. Patterns like `(cons x (list x ...))` or `(list a ... a)` where a variable appears both inside and outside of ... are syntax errors.

This requires re-implementing an optimization for patterns like `(list x ...)`, since it still have to track that `x` was used non-linearly.

This also repairs crashes/incorrect behavior for non-linear patterns across ... boundaries (fixes #5442, #2152, #1386).

Backwards compatibility: this may be incompatible in two ways:

1. It creates syntax errors for previously working programs. These programs have had a warning when compiled for the past decade.

2. It adds a check that the non-linear patterns actually match the same value. This may cause some matches to fail where previously they (incorrectly) succeeded.

I have run a full pkg-build which confirms that problem (1) does not seem to appear. I hope for testing between now and the next release to confirm whether problem (2) is significant.
