### PR TITLE
CS: fix `struct-constructor-procedure?` on builtin struct types

### DIFF
--- a/pkgs/racket-test-core/tests/racket/struct.rktl
+++ b/pkgs/racket-test-core/tests/racket/struct.rktl
@@ -38,6 +38,8 @@
     (arity-test makex 0 0)
     (arity-test sel 2 2)
     (arity-test set 3 3)
+    (test #t struct-constructor-procedure? make)
+    (test #t struct-predicate-procedure? pred)
     (test #t struct-mutator-procedure? set)
     (test #t struct-accessor-procedure? sel)
     (test #f struct-mutator-procedure? sel)
@@ -704,6 +706,10 @@
 (test #t struct-accessor-procedure? exn-message)
 (test #t struct-accessor-procedure? srcloc-line)
 (test #t struct-accessor-procedure? date-month)
+
+(test #t struct-constructor-procedure? exn)
+(test #t struct-constructor-procedure? date)
+(test #t struct-constructor-procedure? srcloc)
 
 ;; ------------------------------------------------------------
 ;; Property accessor errors

--- a/racket/src/cs/rumble/struct.ss
+++ b/racket/src/cs/rumble/struct.ss
@@ -1478,7 +1478,9 @@
              #'(begin
                  (define struct:name (make-record-type-descriptor 'name struct:parent 'uid #f #f '(field-count . 0)))
                  (define unsafe-make-name (record-constructor (make-record-constructor-descriptor struct:name #f #f)))
-                 (define name ctr-expr)
+                 (define name
+                   (let ([ctr ctr-expr])
+                     (|#%struct-constructor| ctr (procedure-arity-mask ctr))))
                  (define authentic-name? (record-predicate struct:name))
                  (define name? (|#%struct-predicate|
                                 (|#%name|


### PR DESCRIPTION
Somebody familiar with this code should review this PR; the fix *seems* straightforward given surrounding code and other uses of `|#%struct-constructor|`, but I am unfamiliar with this layer of the implementation and don't know if there are might be unintended side effects.

# Commit message

Struct types declared in Rumble using the Rumble `struct` macro were constructing the constructors without passing them through `|#%struct-constructor|`, so `struct-constructor-procedure?` couldn't recognize them. Fix it.

Testing:

    Welcome to Racket v9.2.0.1-2026-04-08-cbc702d25f* [cs].
    > (struct-constructor-procedure? exn)
    #t
    >
