### PR TITLE
schemify: change `aim?` macro

### DIFF
--- a/racket/src/schemify/aim.rkt
+++ b/racket/src/schemify/aim.rkt
@@ -1,10 +1,11 @@
 #lang racket/base
+(require (for-syntax racket/base))
 (provide aim?)
 
 ;; macro statically ensures that the second argument is a valid target
-(define-syntax aim?
-  (syntax-rules (cify interp system)
-    [(_ e 'cify) (eq? e 'cify)]
-    [(_ e 'interp) (eq? e 'interp)]
-    [(_ e 'compile) (eq? e 'compile)]
-    [(_ e 'system) (eq? e 'system)]))
+(define-syntax (aim? stx)
+  (syntax-case stx (quote)
+    [(_ e 'target)
+     (and (identifier? #'target)
+          (memq (syntax->datum #'target) '(cify interp system)))
+     #'(eq? e 'target)]))


### PR DESCRIPTION
The `aim?` macro, intended to be used as e.g. `(aim? aim 'cify)`, checks statically that the argument is a valid aim. However, in the previous implementation,

    (syntax-rules stx (valid-aim-1 ...)
      [(_ e 'valid-aim-1) (eq? e 'valid-aim-1)] ...)

the valid aims listed in the case clause have gotten out of sync with those listed in syntax-rules's literals list multiple times, e.g.

fc04bbf154226cec11893ae4f07f16fda4e37bcd (introduced one omission, yet unfixed) 25a4d551f0b114e98570b8872eebb84ffdcc0542 (fixed a different omission)

Rewrite the macro so the valid aims are listed only once, and also remove the `compile` aim which appears to have never been introduced (accidentally?) by the first commit above but never used.

Testing: no changes for `make derived`, and

    > (define some-aim 'cify)
    > (aim? some-aim 'cify)
    #t
    > (aim? some-aim 'interp)
    #f
    > (aim? some-aim 'system)
    #f
    > (aim? some-aim 'boop)
    aim?: bad syntax in: (aim? some-aim (quote boop))
    > (aim? some-aim not-quoted)
    aim?: bad syntax in: (aim? some-aim not-quoted)
    >
