### PR TITLE
Fix unintentional provide of old-cond from racket/base

### DIFF
--- a/racket/collects/racket/private/core-syntax.rkt
+++ b/racket/collects/racket/private/core-syntax.rkt
@@ -14,11 +14,14 @@
              define-values-for-syntax
              when unless
              call/ec let/ec
-             cond old-cond else =>
+             cond else =>
              let*-values
              let let* letrec
              quasiquote
              and or)
+
+  (module* old-cond #f
+    (#%provide old-cond))
 
   ; --------------------------------------------------
   ;

--- a/racket/collects/racket/private/for-compatibility-lib.rkt
+++ b/racket/collects/racket/private/for-compatibility-lib.rkt
@@ -10,6 +10,7 @@
 (module for-compatibility-lib '#%kernel
   (#%require "more-scheme.rkt"
              "core-syntax.rkt"
+             (submod "core-syntax.rkt" old-cond)
              "stx.rkt")
   (#%provide define define-syntax define-for-syntax
              old-cond old-case

--- a/racket/collects/racket/private/pre-base.rkt
+++ b/racket/collects/racket/private/pre-base.rkt
@@ -207,8 +207,7 @@
              (all-from-except "misc.rkt" collection-path collection-file-path)
              (all-from "core-syntax.rkt")
              (all-from-except "letstx-scheme.rkt"
-                              define define-syntax define-for-syntax
-                              old-cond)
+                              define define-syntax define-for-syntax)
              (rename new-lambda lambda)
              (rename new-λ λ)
              (rename new-define define)


### PR DESCRIPTION
The recent merge of files into `core-syntax.rkt` (PR #5499) inadvertently started providing `old-cond` from `racket/base`. Specifically, f00c7f2c74c76df3626bfd86834b5ed17b15dcca changed pre-base.rkt from

    (#%require (all-except "define.rkt" define define-syntax define-for-syntax))
    (#%provide (all-from "define.rkt"))

to "core-syntax.rkt" without taking into consideration that core-syntax provided old-cond.

Fix by having core-syntax simply not provide old-cond (and provide `old-cond` to its one user through a submodule instead.)
