### PR TITLE
Stabilize ephemeral listener startup in url-port test

### DIFF
--- a/pkgs/net-test/tests/net/url-port.rkt
+++ b/pkgs/net-test/tests/net/url-port.rkt
@@ -4,6 +4,18 @@
          openssl
          tests/eli-tester)
 
+(define (listen-on-ephemeral-port max-allow-wait hostname)
+  (let loop ([tries 8] [pause 0.01])
+    (with-handlers ([exn:fail:network?
+                     (λ (e)
+                       (cond
+                         [(zero? tries)
+                          (raise e)]
+                         [else
+                          (sleep pause)
+                          (loop (sub1 tries) (* 2 pause))]))])
+      (tcp-listen 0 max-allow-wait #f hostname))))
+
 (define (run-tests scheme wrap-ports skip-actual-redirect?)
   (define ((make-tester url->port) response . responses)
     (define server-cust
@@ -36,7 +48,10 @@
                          void
                          (λ (_port-no [max-allow-wait 4] [reuse? #f] [hostname #f])
                            (define listener
-                             (tcp-listen 0 max-allow-wait reuse? hostname))
+                             ;; `run-server` always requests reuse, but for an
+                             ;; ephemeral listener we do not need it. Retry a
+                             ;; few times to smooth over transient bind races.
+                             (listen-on-ephemeral-port max-allow-wait hostname))
                            (define-values (_local-addr port-no _remote-addr _remote-port)
                              (tcp-addresses listener #t))
                            (channel-put startup-ch (cons i port-no))


### PR DESCRIPTION
Written by Codex.

**Summary**

This updates `tests/net/url-port` to make ephemeral listener startup more robust.

The current test already uses `tcp-listen 0` and reports startup failures instead of hanging indefinitely, but we still saw intermittent `Address already in use` failures during listener creation on macOS CI.

**Change**

- Keep the existing startup-hang fix structure.
- Continue to avoid socket reuse for ephemeral listeners.
- Add a small retry loop around the `tcp-listen 0` call used by the test’s custom listener startup path.

The retry only applies to transient `exn:fail:network` failures during listener creation, using a short backoff before retrying.

**Why**

Even when asking the OS to choose an ephemeral port, listener setup could still fail intermittently on macOS runners. A few retries make the test startup path more stable without changing the `net/url` behavior being tested.

**Validation**

- Local run:
  - `raco test pkgs/net-test/tests/net/url-port.rkt`
- GitHub Actions passed on:
  - `soegaard/racket`
  - branch `codex/fix-url-port-ephemeral-reuse`