### PR TITLE
doc: fix inconsistent parameter names in `stream*` docs

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/sequences.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/sequences.scrbl
@@ -1319,9 +1319,11 @@ stream, but plain lists can be used as streams, and functions such as
   but the @racket[tail-expr] pattern matches the ``rest'' of the stream after the last @racket[elem-expr].
 
 @history[#:added "6.3"
-         #:changed "8.0.0.12" @elem{Changed to delay @racket[rest-expr] even
-                                    if zero @racket[expr]s are provided.}
-         #:changed "8.8.0.7" @elem{Changed to allow multiple values.}]
+         #:changed "8.0.0.12"
+         @elem{Changed to delay @racket[tail-expr] even if zero
+               @racket[elem-expr]s are provided.}
+         #:changed "8.8.0.7"
+         @elem{Changed to allow multiple values.}]
 }
 
 @defproc[(in-stream [s stream?]) sequence?]{


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [ ] Feature
- [ ] tests included
- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->

Rename `expr` to `elem-expr` and `rest-expr` to `tail-expr` to match the names used in the `stream*` syntax definition.
