### PR TITLE
Add structured template strings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,7 @@ EXTRA_REPOS_BASE =
 # to include in a distribution; if "{}" appears at the start,
 # then the content of "build/PKGS" can override when that file
 # exists:
-PKGS = {} main-distribution main-distribution-test
+PKGS = {} main-distribution main-distribution-test racket-tstring tstring
 
 # Needed for any distribution (not meant to be configured):
 REQUIRED_PKGS = racket-lib

--- a/pkgs/racket-tstring/info.rkt
+++ b/pkgs/racket-tstring/info.rkt
@@ -1,0 +1,23 @@
+#lang info
+
+(define collection "racket-tstring")
+
+(define deps
+  '("base")
+) ; end define deps
+
+(define build-deps
+  '("rackunit-lib")
+) ; end define build-deps
+
+(define pkg-desc "Structured template strings for Racket")
+
+(define pkg-authors
+  '(cutiedeng)
+) ; end define pkg-authors
+
+(define version "0.1")
+
+(define license
+  '(Apache-2.0 OR MIT)
+) ; end define license

--- a/pkgs/racket-tstring/lang/reader.rkt
+++ b/pkgs/racket-tstring/lang/reader.rkt
@@ -1,0 +1,57 @@
+#lang racket/base
+
+(require
+ racket/port
+ racket/runtime-path
+ syntax/readerr
+ "../private/source-transform.rkt"
+) ; end require
+
+(provide
+ read
+ read-syntax
+ get-info
+) ; end provide
+
+(define-runtime-path main-rkt "../main.rkt")
+
+(define base-read-syntax
+  (dynamic-require 'racket/base 'read-syntax)
+) ; end define base-read-syntax
+
+(define (read in)
+  (syntax->datum (read-syntax #f in))
+) ; end define read
+
+(define (read-syntax path in)
+  (define source (port->string in))
+  (define transformed-body
+    (with-handlers ((exn:fail?
+                     (lambda (exn)
+                       (raise-read-error (exn-message exn)
+                                         path
+                                         #f
+                                         #f
+                                         #f
+                                         #f
+                       ) ; end raise-read-error
+                     ) ; end lambda
+                    ) ; end exn:fail?
+                   ) ; end handlers
+      (transform-template-prefixes source)
+    ) ; end with-handlers
+  ) ; end define transformed-body
+  (define transformed-source
+    (string-append "#lang racket/base\n"
+                   (format "(require (file ~s))\n" (path->string main-rkt))
+                   transformed-body
+    ) ; end string-append
+  ) ; end define transformed-source
+  (define transformed-in (open-input-string transformed-source))
+  (port-count-lines! transformed-in)
+  (base-read-syntax path transformed-in)
+) ; end define read-syntax
+
+(define (get-info key default default-filter)
+  (default-filter key default)
+) ; end define get-info

--- a/pkgs/racket-tstring/main.rkt
+++ b/pkgs/racket-tstring/main.rkt
@@ -1,0 +1,28 @@
+#lang racket/base
+
+(require
+ "private/template.rkt"
+ "private/render.rkt"
+ "private/parse.rkt"
+ "private/expand.rkt"
+) ; end require
+
+(provide
+ template
+ template?
+ template-strings
+ template-interpolations
+ interpolation
+ interpolation?
+ interpolation-value
+ interpolation-syntax
+ interpolation-kind
+ interpolation-source
+ render-template
+ render-fstring
+ template->sql
+ html-render
+ parse-template-string
+ tpl
+ fpl
+) ; end provide

--- a/pkgs/racket-tstring/main.rkt
+++ b/pkgs/racket-tstring/main.rkt
@@ -10,14 +10,15 @@
 (provide
  template
  template?
+ template-parts
  template-strings
  template-interpolations
  interpolation
  interpolation?
  interpolation-value
  interpolation-syntax
- interpolation-kind
- interpolation-source
+ interpolation-format-spec
+ interpolation-conversion
  render-template
  render-fstring
  template->sql

--- a/pkgs/racket-tstring/private/expand.rkt
+++ b/pkgs/racket-tstring/private/expand.rkt
@@ -6,6 +6,8 @@
  "render.rkt"
  (for-syntax
   racket/base
+  racket/port
+  racket/string
   "parse.rkt"
   "source-transform.rkt"
  ) ; end for-syntax
@@ -41,18 +43,19 @@
 ) ; end define-syntax fpl
 
 (define-for-syntax (expand-template who context-stx input-stx)
-  (define-values (strings expression-stxs)
+  (define-values (strings expression-infos)
     (parse-template-parts who context-stx input-stx)
   ) ; end define-values
   #`(template (list #,@(map datum->syntax-literal strings))
-              (list #,@(map interpolation-syntax expression-stxs))
+              (list #,@(map interpolation-syntax expression-infos))
     ) ; end template
 ) ; end define-for-syntax expand-template
 
 (define-for-syntax (expand-fstring who context-stx input-stx)
-  (define-values (strings expression-stxs)
+  (define-values (strings expression-infos)
     (parse-template-parts who context-stx input-stx)
   ) ; end define-values
+  (define expression-stxs (map car expression-infos))
   (cond
     ((null? expression-stxs)
      (datum->syntax-literal (car strings))
@@ -79,13 +82,62 @@
     ) ; end define-values
     (values strings
             (map (lambda (source)
-                   (source-string->syntax who context-stx source)
+                   (source-string->expression-info who context-stx source)
                  ) ; end lambda
                  expression-sources
             ) ; end map
     ) ; end values
   ) ; end with-handlers
 ) ; end define-for-syntax parse-template-parts
+
+(define-for-syntax (source-string->expression-info who context-stx source)
+  (define transformed-source (transform-template-prefixes source))
+  (define port (open-input-string transformed-source))
+  (define expression-stx (read-syntax 'template-interpolation port))
+  (when (eof-object? expression-stx)
+    (raise-syntax-error who "empty interpolation is not allowed" context-stx)
+  ) ; end when eof
+  (define-values (conversion format-spec)
+    (parse-interpolation-suffix (port->string port))
+  ) ; end define-values
+  (list (datum->syntax context-stx
+                       (syntax->datum expression-stx)
+                       context-stx
+                       context-stx
+        ) ; end datum->syntax
+        format-spec
+        conversion
+  ) ; end list
+) ; end define-for-syntax source-string->expression-info
+
+(define-for-syntax (parse-interpolation-suffix suffix)
+  (define text (string-trim suffix))
+  (cond
+    ((equal? text "")
+     (values "" #f)
+    ) ; end empty suffix
+    (else
+     (define parts (regexp-split #px"\\s+" text))
+     (define first-part (car parts))
+     (cond
+       ((conversion-token? first-part)
+        (values first-part
+                (let ((rest (string-trim (substring text (string-length first-part)))))
+                  (if (equal? rest "") #f rest)
+                ) ; end let
+        ) ; end values
+       ) ; end conversion and maybe format spec
+       (else
+        (values "" text)
+       ) ; end format spec only
+     ) ; end cond
+    ) ; end non-empty suffix
+  ) ; end cond
+) ; end define-for-syntax parse-interpolation-suffix
+
+(define-for-syntax (conversion-token? text)
+  (regexp-match? #px"^[A-Za-z]+$" text)
+) ; end define-for-syntax conversion-token?
 
 (define-for-syntax (datum->syntax-literal value)
   #`'#,value
@@ -130,16 +182,128 @@
   ) ; end let loop
 ) ; end define-for-syntax fstring-append-parts
 
-(define-for-syntax (interpolation-syntax expression-stx)
-  (define kind
-    (if (identifier? expression-stx)
-        'identifier
-        'expression
-    ) ; end if
-  ) ; end define kind
+(define-for-syntax (interpolation-syntax expression-info)
+  (define expression-stx (list-ref expression-info 0))
+  (define format-spec (list-ref expression-info 1))
+  (define conversion (list-ref expression-info 2))
   #`(interpolation #,expression-stx
                    (quote-syntax #,expression-stx)
-                   '#,kind
-                   (quote-syntax #,expression-stx)
+                   '#,format-spec
+                   '#,conversion
     ) ; end interpolation
 ) ; end define-for-syntax interpolation-syntax
+
+(define-for-syntax (nested-template-var-usages source)
+  (define length (string-length source))
+  (let loop ((index 0)
+             (vars '())
+        ) ; end loop bindings
+    (cond
+      ((= index length)
+       vars
+      ) ; end end of source
+      ((char=? (string-ref source index) #\")
+       (loop (find-racket-string-end source index)
+             vars
+       ) ; end loop
+      ) ; end ordinary string
+      ((template-prefix-at? source index)
+       (define end-index (find-template-source-end source (add1 index)))
+       (define content (substring source (+ index 2) (sub1 end-index)))
+       (define-values (_strings expression-sources)
+         (parse-template-string content)
+       ) ; end define-values
+       (define nested-vars
+         (foldl (lambda (expression-source acc)
+                  (append-unique acc (source-string-var-usages expression-source))
+                ) ; end lambda
+                '()
+                expression-sources
+         ) ; end foldl
+       ) ; end define nested-vars
+       (loop end-index
+             (append-unique vars nested-vars)
+       ) ; end loop
+      ) ; end nested template
+      (else
+       (loop (add1 index)
+             vars
+       ) ; end loop
+      ) ; end source character
+    ) ; end cond
+  ) ; end let loop
+) ; end define-for-syntax nested-template-var-usages
+
+(define-for-syntax (source-string-var-usages source)
+  (define expression-stx (source-string->syntax 'tpl #'here source))
+  (append-unique (syntax-var-usages expression-stx)
+                 (nested-template-var-usages source)
+  ) ; end append-unique
+) ; end define-for-syntax source-string-var-usages
+
+(define-for-syntax (append-unique left right)
+  (let loop ((items right)
+             (result left)
+        ) ; end loop bindings
+    (cond
+      ((null? items)
+       result
+      ) ; end no more items
+      ((memq (car items) result)
+       (loop (cdr items)
+             result
+       ) ; end loop
+      ) ; end already present
+      (else
+       (loop (cdr items)
+             (append result (list (car items)))
+       ) ; end loop
+      ) ; end new item
+    ) ; end cond
+  ) ; end let loop
+) ; end define-for-syntax append-unique
+
+(define-for-syntax (syntax-var-usages stx)
+  (define seen '())
+  (define ordered '())
+  (define (add! sym)
+    (unless (memq sym seen)
+      (set! seen (cons sym seen))
+      (set! ordered (cons sym ordered))
+    ) ; end unless seen
+  ) ; end define add!
+  (define (walk datum quoted?)
+    (cond
+      ((symbol? datum)
+       (unless quoted?
+         (unless (memq datum '(tpl fpl))
+           (add! datum)
+         ) ; end unless tstring macro
+       ) ; end unless quoted
+      ) ; end symbol
+      ((pair? datum)
+       (define head (car datum))
+       (define next-quoted?
+         (or quoted?
+             (and (symbol? head)
+                  (memq head '(quote quote-syntax))
+             ) ; end and
+         ) ; end or
+       ) ; end define next-quoted?
+       (for ((item (in-list datum)))
+         (walk item next-quoted?)
+       ) ; end for
+      ) ; end pair
+      ((vector? datum)
+       (for ((item (in-vector datum)))
+         (walk item quoted?)
+       ) ; end for
+      ) ; end vector
+      (else
+       (void)
+      ) ; end other datum
+    ) ; end cond
+  ) ; end define walk
+  (walk (syntax->datum stx) #f)
+  (reverse ordered)
+) ; end define-for-syntax syntax-var-usages

--- a/pkgs/racket-tstring/private/expand.rkt
+++ b/pkgs/racket-tstring/private/expand.rkt
@@ -55,13 +55,12 @@
   (define-values (strings expression-infos)
     (parse-template-parts who context-stx input-stx)
   ) ; end define-values
-  (define expression-stxs (map car expression-infos))
   (cond
-    ((null? expression-stxs)
+    ((null? expression-infos)
      (datum->syntax-literal (car strings))
     ) ; end static f-string
     (else
-     #`(string-append #,@(fstring-append-parts strings expression-stxs))
+     #`(string-append #,@(fstring-append-parts strings expression-infos))
     ) ; end dynamic f-string
   ) ; end cond
 ) ; end define-for-syntax expand-fstring
@@ -161,19 +160,19 @@
   ) ; end datum->syntax
 ) ; end define-for-syntax source-string->syntax
 
-(define-for-syntax (fstring-append-parts strings expression-stxs)
+(define-for-syntax (fstring-append-parts strings expression-infos)
   (let loop ((strings strings)
-             (expression-stxs expression-stxs)
+             (expression-infos expression-infos)
         ) ; end loop bindings
     (cond
-      ((null? expression-stxs)
+      ((null? expression-infos)
        (list (datum->syntax-literal (car strings)))
       ) ; end last static string
       (else
        (cons (datum->syntax-literal (car strings))
-             (cons #`(~a #,(car expression-stxs))
+             (cons (fstring-interpolation-syntax (car expression-infos))
                    (loop (cdr strings)
-                         (cdr expression-stxs)
+                         (cdr expression-infos)
                    ) ; end loop
              ) ; end cons expression
        ) ; end cons string
@@ -181,6 +180,16 @@
     ) ; end cond
   ) ; end let loop
 ) ; end define-for-syntax fstring-append-parts
+
+(define-for-syntax (fstring-interpolation-syntax expression-info)
+  (define expression-stx (list-ref expression-info 0))
+  (define format-spec (list-ref expression-info 1))
+  (define conversion (list-ref expression-info 2))
+  #`(format-fstring-value #,expression-stx
+                          '#,format-spec
+                          '#,conversion
+    ) ; end format-fstring-value
+) ; end define-for-syntax fstring-interpolation-syntax
 
 (define-for-syntax (interpolation-syntax expression-info)
   (define expression-stx (list-ref expression-info 0))

--- a/pkgs/racket-tstring/private/expand.rkt
+++ b/pkgs/racket-tstring/private/expand.rkt
@@ -1,0 +1,145 @@
+#lang racket/base
+
+(require
+ racket/format
+ "template.rkt"
+ "render.rkt"
+ (for-syntax
+  racket/base
+  "parse.rkt"
+  "source-transform.rkt"
+ ) ; end for-syntax
+) ; end require
+
+(provide
+ tpl
+ fpl
+) ; end provide
+
+(define-syntax (tpl stx)
+  (syntax-case stx ()
+    ((_ input)
+     (string? (syntax-e #'input))
+     (expand-template 'tpl stx #'input)
+    ) ; end literal string case
+    (_
+     (raise-syntax-error 'tpl "expected a string literal" stx)
+    ) ; end invalid syntax
+  ) ; end syntax-case
+) ; end define-syntax tpl
+
+(define-syntax (fpl stx)
+  (syntax-case stx ()
+    ((_ input)
+     (string? (syntax-e #'input))
+     (expand-fstring 'fpl stx #'input)
+    ) ; end literal string case
+    (_
+     (raise-syntax-error 'fpl "expected a string literal" stx)
+    ) ; end invalid syntax
+  ) ; end syntax-case
+) ; end define-syntax fpl
+
+(define-for-syntax (expand-template who context-stx input-stx)
+  (define-values (strings expression-stxs)
+    (parse-template-parts who context-stx input-stx)
+  ) ; end define-values
+  #`(template (list #,@(map datum->syntax-literal strings))
+              (list #,@(map interpolation-syntax expression-stxs))
+    ) ; end template
+) ; end define-for-syntax expand-template
+
+(define-for-syntax (expand-fstring who context-stx input-stx)
+  (define-values (strings expression-stxs)
+    (parse-template-parts who context-stx input-stx)
+  ) ; end define-values
+  (cond
+    ((null? expression-stxs)
+     (datum->syntax-literal (car strings))
+    ) ; end static f-string
+    (else
+     #`(string-append #,@(fstring-append-parts strings expression-stxs))
+    ) ; end dynamic f-string
+  ) ; end cond
+) ; end define-for-syntax expand-fstring
+
+(define-for-syntax (parse-template-parts who context-stx input-stx)
+  (with-handlers ((exn:fail?
+                   (lambda (exn)
+                     (raise-syntax-error who
+                                         (exn-message exn)
+                                         context-stx
+                                         input-stx
+                     ) ; end raise-syntax-error
+                   ) ; end lambda
+                  ) ; end exn:fail?
+                 ) ; end handlers
+    (define-values (strings expression-sources)
+      (parse-template-string (syntax-e input-stx))
+    ) ; end define-values
+    (values strings
+            (map (lambda (source)
+                   (source-string->syntax who context-stx source)
+                 ) ; end lambda
+                 expression-sources
+            ) ; end map
+    ) ; end values
+  ) ; end with-handlers
+) ; end define-for-syntax parse-template-parts
+
+(define-for-syntax (datum->syntax-literal value)
+  #`'#,value
+) ; end define-for-syntax datum->syntax-literal
+
+(define-for-syntax (source-string->syntax who context-stx source)
+  (define transformed-source (transform-template-prefixes source))
+  (define port (open-input-string transformed-source))
+  (define read-stx (read-syntax 'template-interpolation port))
+  (when (eof-object? read-stx)
+    (raise-syntax-error who "empty interpolation is not allowed" context-stx)
+  ) ; end when eof
+  (define extra-stx (read-syntax 'template-interpolation port))
+  (unless (eof-object? extra-stx)
+    (raise-syntax-error who "interpolation must contain exactly one expression" context-stx)
+  ) ; end unless eof
+  (datum->syntax context-stx
+                 (syntax->datum read-stx)
+                 context-stx
+                 context-stx
+  ) ; end datum->syntax
+) ; end define-for-syntax source-string->syntax
+
+(define-for-syntax (fstring-append-parts strings expression-stxs)
+  (let loop ((strings strings)
+             (expression-stxs expression-stxs)
+        ) ; end loop bindings
+    (cond
+      ((null? expression-stxs)
+       (list (datum->syntax-literal (car strings)))
+      ) ; end last static string
+      (else
+       (cons (datum->syntax-literal (car strings))
+             (cons #`(~a #,(car expression-stxs))
+                   (loop (cdr strings)
+                         (cdr expression-stxs)
+                   ) ; end loop
+             ) ; end cons expression
+       ) ; end cons string
+      ) ; end more expressions
+    ) ; end cond
+  ) ; end let loop
+) ; end define-for-syntax fstring-append-parts
+
+(define-for-syntax (interpolation-syntax expression-stx)
+  (define kind
+    (if (identifier? expression-stx)
+        'identifier
+        'expression
+    ) ; end if
+  ) ; end define kind
+  #`(interpolation #,expression-stx
+                   (quote-syntax #,expression-stx)
+                   '#,kind
+                   (quote-syntax #,expression-stx)
+    ) ; end interpolation
+) ; end define-for-syntax interpolation-syntax

--- a/pkgs/racket-tstring/private/parse.rkt
+++ b/pkgs/racket-tstring/private/parse.rkt
@@ -1,0 +1,176 @@
+#lang racket/base
+
+(require
+ "source-transform.rkt"
+) ; end require
+
+(provide
+ parse-template-string
+) ; end provide
+
+(define (parse-template-string input)
+  (unless (string? input)
+    (raise-argument-error 'parse-template-string "string?" input)
+  ) ; end unless string?
+  (define length (string-length input))
+  (let loop ((index 0)
+             (strings '())
+             (expressions '())
+             (static-out (open-output-string))
+        ) ; end loop bindings
+    (cond
+      ((= index length)
+       (values (reverse (cons (get-output-string static-out) strings))
+               (reverse expressions)
+       ) ; end values
+      ) ; end end of input
+      (else
+       (define ch (string-ref input index))
+       (cond
+         ((char=? ch #\{)
+          (cond
+            ((and (< (add1 index) length)
+                  (char=? (string-ref input (add1 index)) #\{)
+             ) ; end and
+             (write-char #\{ static-out)
+             (loop (+ index 2)
+                   strings
+                   expressions
+                   static-out
+             ) ; end loop
+            ) ; end escaped left brace
+            (else
+             (define-values (expression next-index)
+               (read-interpolation input (add1 index))
+             ) ; end define-values
+             (define static-part (get-output-string static-out))
+             (loop next-index
+                   (cons static-part strings)
+                   (cons expression expressions)
+                   (open-output-string)
+             ) ; end loop
+            ) ; end interpolation
+          ) ; end cond left brace
+         ) ; end left brace case
+         ((char=? ch #\})
+          (cond
+            ((and (< (add1 index) length)
+                  (char=? (string-ref input (add1 index)) #\})
+             ) ; end and
+             (write-char #\} static-out)
+             (loop (+ index 2)
+                   strings
+                   expressions
+                   static-out
+             ) ; end loop
+            ) ; end escaped right brace
+            (else
+             (raise-arguments-error 'parse-template-string
+                                    "unmatched } in template string; use }} for a literal }"
+                                    "input"
+                                    input
+                                    "index"
+                                    index
+             ) ; end raise-arguments-error
+            ) ; end unmatched right brace
+          ) ; end cond right brace
+         ) ; end right brace case
+         (else
+          (write-char ch static-out)
+          (loop (add1 index)
+                strings
+                expressions
+                static-out
+          ) ; end loop
+         ) ; end ordinary character
+       ) ; end cond char dispatch
+      ) ; end more input
+    ) ; end cond
+  ) ; end let loop
+) ; end define parse-template-string
+
+(define (read-interpolation input start-index)
+  (define length (string-length input))
+  (define expression-out (open-output-string))
+  (let loop ((index start-index)
+             (brace-depth 0)
+        ) ; end loop bindings
+    (cond
+      ((= index length)
+       (raise-arguments-error 'parse-template-string
+                              "unclosed interpolation in template string"
+                              "input"
+                              input
+                              "index"
+                              start-index
+       ) ; end raise-arguments-error
+      ) ; end end of input
+      (else
+       (define ch (string-ref input index))
+       (cond
+         ((char=? ch #\")
+          (define next-index (find-racket-string-end input index))
+          (write-string (substring input index next-index) expression-out)
+          (loop next-index
+                brace-depth
+          ) ; end loop
+         ) ; end racket string
+         ((template-prefix-at? input index)
+          (define next-index (find-template-source-end input (add1 index)))
+          (write-string (substring input index next-index) expression-out)
+          (loop next-index
+                brace-depth
+          ) ; end loop
+         ) ; end nested template
+         ((char=? ch #\{)
+          (write-char ch expression-out)
+          (loop (add1 index)
+                (add1 brace-depth)
+          ) ; end loop
+         ) ; end nested brace
+         ((char=? ch #\})
+          (cond
+            ((zero? brace-depth)
+             (define expression (get-output-string expression-out))
+             (when (string-blank? expression)
+               (raise-arguments-error 'parse-template-string
+                                      "empty interpolation is not allowed"
+                                      "input"
+                                      input
+                                      "index"
+                                      start-index
+               ) ; end raise-arguments-error
+             ) ; end when empty expression
+             (values expression (add1 index))
+            ) ; end interpolation close
+            (else
+             (write-char ch expression-out)
+             (loop (add1 index)
+                   (sub1 brace-depth)
+             ) ; end loop
+            ) ; end nested brace close
+          ) ; end cond right brace
+         ) ; end right brace
+         (else
+          (write-char ch expression-out)
+          (loop (add1 index)
+                brace-depth
+          ) ; end loop
+         ) ; end expression character
+        ) ; end cond char dispatch
+      ) ; end more input
+    ) ; end cond
+  ) ; end let loop
+) ; end define read-interpolation
+
+(define (string-blank? text)
+  (let loop ((index 0))
+    (cond
+      ((= index (string-length text)) #t)
+      ((char-whitespace? (string-ref text index))
+       (loop (add1 index))
+      ) ; end whitespace character
+      (else #f)
+    ) ; end cond
+  ) ; end let loop
+) ; end define string-blank?

--- a/pkgs/racket-tstring/private/render.rkt
+++ b/pkgs/racket-tstring/private/render.rkt
@@ -42,7 +42,10 @@
   (values strings interpolations)
 ) ; end define checked-template-parts
 
-(define (render-template tpl #:value->string (value->string ~a))
+(define (render-template tpl
+                         #:interpolation->string (interpolation->string interpolation-value)
+                         #:value->string (value->string ~a)
+        ) ; end define formals
   (define-values (strings interpolations)
     (checked-template-parts 'render-template tpl)
   ) ; end define-values
@@ -56,11 +59,11 @@
        (void)
       ) ; end no more interpolations
       (else
-       (write-string (value->string (interpolation-value (car interpolations))) out)
+       (write-string (value->string (interpolation->string (car interpolations))) out)
        (loop (cdr strings)
              (cdr interpolations)
        ) ; end loop
-      ) ; end interpolation case
+      ) ; end interpolation part
     ) ; end cond
   ) ; end let loop
   (get-output-string out)
@@ -85,21 +88,21 @@
          '()
         ) ; end no more interpolations
         (else
-         (define slot (car interpolations))
-         (unless (eq? (interpolation-kind slot) 'identifier)
+         (define part (car interpolations))
+         (unless (identifier? (interpolation-syntax part))
            (raise-arguments-error 'template->sql
                                   "SQL template only accepts identifier slots"
                                   "interpolation"
-                                  slot
+                                  part
            ) ; end raise-arguments-error
          ) ; end unless identifier
          (write-string "?" out)
-         (cons (interpolation-value slot)
+         (cons (interpolation-value part)
                (loop (cdr strings)
                      (cdr interpolations)
                ) ; end loop
          ) ; end cons
-        ) ; end interpolation case
+        ) ; end interpolation part
       ) ; end cond
     ) ; end let loop
   ) ; end define params
@@ -108,8 +111,11 @@
   ) ; end values
 ) ; end define template->sql
 
-(define (html-render tpl)
-  (render-template tpl #:value->string html-escape)
+(define (html-render tpl #:interpolation->string (interpolation->string interpolation-value))
+  (render-template tpl
+                   #:interpolation->string interpolation->string
+                   #:value->string html-escape
+  ) ; end render-template
 ) ; end define html-render
 
 (define (html-escape value)

--- a/pkgs/racket-tstring/private/render.rkt
+++ b/pkgs/racket-tstring/private/render.rkt
@@ -1,0 +1,130 @@
+#lang racket/base
+
+(require
+ racket/format
+ "template.rkt"
+) ; end require
+
+(provide
+ render-template
+ render-fstring
+ template->sql
+ html-render
+) ; end provide
+
+(define (checked-template-parts who tpl)
+  (unless (template? tpl)
+    (raise-argument-error who "template?" tpl)
+  ) ; end unless template?
+  (define strings (template-strings tpl))
+  (define interpolations (template-interpolations tpl))
+  (unless (and (list? strings)
+               (andmap string? strings)
+          ) ; end and
+    (raise-argument-error who "(listof string?)" strings)
+  ) ; end unless strings
+  (unless (and (list? interpolations)
+               (andmap interpolation? interpolations)
+          ) ; end and
+    (raise-argument-error who "(listof interpolation?)" interpolations)
+  ) ; end unless interpolations
+  (unless (= (length strings)
+             (add1 (length interpolations))
+          ) ; end =
+    (raise-arguments-error who
+                           "template strings and interpolations have incompatible lengths"
+                           "strings"
+                           strings
+                           "interpolations"
+                           interpolations
+    ) ; end raise-arguments-error
+  ) ; end unless length invariant
+  (values strings interpolations)
+) ; end define checked-template-parts
+
+(define (render-template tpl #:value->string (value->string ~a))
+  (define-values (strings interpolations)
+    (checked-template-parts 'render-template tpl)
+  ) ; end define-values
+  (define out (open-output-string))
+  (let loop ((strings strings)
+             (interpolations interpolations)
+        ) ; end loop bindings
+    (write-string (car strings) out)
+    (cond
+      ((null? interpolations)
+       (void)
+      ) ; end no more interpolations
+      (else
+       (write-string (value->string (interpolation-value (car interpolations))) out)
+       (loop (cdr strings)
+             (cdr interpolations)
+       ) ; end loop
+      ) ; end interpolation case
+    ) ; end cond
+  ) ; end let loop
+  (get-output-string out)
+) ; end define render-template
+
+(define (render-fstring tpl)
+  (render-template tpl)
+) ; end define render-fstring
+
+(define (template->sql tpl)
+  (define-values (strings interpolations)
+    (checked-template-parts 'template->sql tpl)
+  ) ; end define-values
+  (define out (open-output-string))
+  (define params
+    (let loop ((strings strings)
+               (interpolations interpolations)
+          ) ; end loop bindings
+      (write-string (car strings) out)
+      (cond
+        ((null? interpolations)
+         '()
+        ) ; end no more interpolations
+        (else
+         (define slot (car interpolations))
+         (unless (eq? (interpolation-kind slot) 'identifier)
+           (raise-arguments-error 'template->sql
+                                  "SQL template only accepts identifier slots"
+                                  "interpolation"
+                                  slot
+           ) ; end raise-arguments-error
+         ) ; end unless identifier
+         (write-string "?" out)
+         (cons (interpolation-value slot)
+               (loop (cdr strings)
+                     (cdr interpolations)
+               ) ; end loop
+         ) ; end cons
+        ) ; end interpolation case
+      ) ; end cond
+    ) ; end let loop
+  ) ; end define params
+  (values (get-output-string out)
+          params
+  ) ; end values
+) ; end define template->sql
+
+(define (html-render tpl)
+  (render-template tpl #:value->string html-escape)
+) ; end define html-render
+
+(define (html-escape value)
+  (define out (open-output-string))
+  (for ((ch (in-string (~a value))))
+    (write-string
+     (case ch
+       ((#\<) "&lt;")
+       ((#\>) "&gt;")
+       ((#\&) "&amp;")
+       ((#\") "&quot;")
+       (else (string ch))
+     ) ; end case
+     out
+    ) ; end write-string
+  ) ; end for
+  (get-output-string out)
+) ; end define html-escape

--- a/pkgs/racket-tstring/private/render.rkt
+++ b/pkgs/racket-tstring/private/render.rkt
@@ -2,12 +2,14 @@
 
 (require
  racket/format
+ racket/list
  "template.rkt"
 ) ; end require
 
 (provide
  render-template
  render-fstring
+ format-fstring-value
  template->sql
  html-render
 ) ; end provide
@@ -72,6 +74,345 @@
 (define (render-fstring tpl)
   (render-template tpl)
 ) ; end define render-fstring
+
+(define (format-fstring-value value format-spec conversion)
+  (define converted-value (apply-conversion value conversion))
+  (cond
+    ((not format-spec)
+     (~a converted-value)
+    ) ; end no format spec
+    ((converted-by-string-conversion? conversion)
+     (format-string-value converted-value format-spec)
+    ) ; end string conversion
+    (else
+     (format-value converted-value format-spec)
+    ) ; end ordinary value
+  ) ; end cond
+) ; end define format-fstring-value
+
+(define (apply-conversion value conversion)
+  (cond
+    ((equal? conversion "") value)
+    ((equal? conversion "s") (~a value))
+    ((equal? conversion "r") (~v value))
+    ((equal? conversion "a") (~v value))
+    (else
+     (raise-arguments-error 'format-fstring-value
+                            "unsupported conversion"
+                            "conversion"
+                            conversion
+     ) ; end raise-arguments-error
+    ) ; end unsupported conversion
+  ) ; end cond
+) ; end define apply-conversion
+
+(define (converted-by-string-conversion? conversion)
+  (not (equal? conversion ""))
+) ; end define converted-by-string-conversion?
+
+(struct format-options (fill align sign zero? width precision type) #:transparent)
+
+(define (format-value value spec)
+  (define options (parse-format-spec spec))
+  (define type (format-options-type options))
+  (cond
+    ((memv type '(#f #\s))
+     (format-string-value (~a value) spec)
+    ) ; end string-like format
+    ((memv type '(#\d #\b #\o #\x #\X))
+     (format-integer-value value options)
+    ) ; end integer format
+    ((memv type '(#\f #\F #\e #\E #\g #\G #\%))
+     (format-real-value value options)
+    ) ; end real format
+    (else
+     (raise-arguments-error 'format-fstring-value
+                            "unsupported format type"
+                            "format-spec"
+                            spec
+     ) ; end raise-arguments-error
+    ) ; end unsupported type
+  ) ; end cond
+) ; end define format-value
+
+(define (format-string-value value spec)
+  (define options (parse-format-spec spec))
+  (define type (format-options-type options))
+  (unless (or (not type) (char=? type #\s))
+    (raise-arguments-error 'format-fstring-value
+                           "numeric format type cannot be used after string conversion"
+                           "format-spec"
+                           spec
+    ) ; end raise-arguments-error
+  ) ; end unless string type
+  (define text (if (format-options-precision options)
+                   (substring value
+                              0
+                              (min (string-length value)
+                                   (format-options-precision options)
+                              ) ; end min
+                   ) ; end substring
+                   value
+               ) ; end if
+  ) ; end define text
+  (apply-alignment text options #f)
+) ; end define format-string-value
+
+(define (format-integer-value value options)
+  (unless (integer? value)
+    (raise-argument-error 'format-fstring-value "integer?" value)
+  ) ; end unless integer
+  (define type (format-options-type options))
+  (define base
+    (case type
+      ((#\b) 2)
+      ((#\o) 8)
+      ((#\x #\X) 16)
+      (else 10)
+    ) ; end case
+  ) ; end define base
+  (define is-negative? (negative? value))
+  (define digits (number->string (abs value) base))
+  (define cased-digits
+    (if (eqv? type #\X)
+        (string-upcase digits)
+        digits
+    ) ; end if
+  ) ; end define cased-digits
+  (apply-alignment (string-append (sign-prefix is-negative? (format-options-sign options))
+                                  cased-digits
+                   ) ; end string-append
+                   options
+                   #t
+  ) ; end apply-alignment
+) ; end define format-integer-value
+
+(define (format-real-value value options)
+  (unless (real? value)
+    (raise-argument-error 'format-fstring-value "real?" value)
+  ) ; end unless real
+  (define type (format-options-type options))
+  (define percent? (eqv? type #\%))
+  (define base-value (if percent? (* value 100) value))
+  (define precision
+    (or (format-options-precision options)
+        (if (memv type '(#\f #\F #\e #\E #\%)) 6 #f)
+    ) ; end or
+  ) ; end define precision
+  (define notation
+    (if (memv type '(#\e #\E))
+        'exponential
+        'positional
+    ) ; end if
+  ) ; end define notation
+  (define raw
+    (if precision
+        (~r base-value #:notation notation #:precision (list '= precision))
+        (~r base-value #:notation notation)
+    ) ; end if
+  ) ; end define raw
+  (define exponent-cased
+    (if (memv type '(#\E #\G))
+        (string-upcase raw)
+        raw
+    ) ; end if
+  ) ; end define exponent-cased
+  (define with-percent
+    (if percent?
+        (string-append exponent-cased "%")
+        exponent-cased
+    ) ; end if
+  ) ; end define with-percent
+  (define is-negative? (and (real? base-value) (negative? base-value)))
+  (define unsigned-text
+    (if is-negative?
+        (substring with-percent 1)
+        with-percent
+    ) ; end if
+  ) ; end define unsigned-text
+  (apply-alignment (string-append (sign-prefix is-negative? (format-options-sign options))
+                                  unsigned-text
+                   ) ; end string-append
+                   options
+                   #t
+  ) ; end apply-alignment
+) ; end define format-real-value
+
+(define (sign-prefix negative? sign)
+  (cond
+    (negative? "-")
+    ((eqv? sign #\+) "+")
+    ((eqv? sign #\space) " ")
+    (else "")
+  ) ; end cond
+) ; end define sign-prefix
+
+(define (parse-format-spec spec)
+  (unless (string? spec)
+    (raise-argument-error 'format-fstring-value "string?" spec)
+  ) ; end unless string
+  (define length (string-length spec))
+  (define index 0)
+  (define fill #\space)
+  (define align #f)
+  (when (and (< 1 length)
+             (alignment-char? (string-ref spec 1))
+        ) ; end and
+    (set! fill (string-ref spec 0))
+    (set! align (string-ref spec 1))
+    (set! index 2)
+  ) ; end when fill align
+  (when (and (not align)
+             (< index length)
+             (alignment-char? (string-ref spec index))
+        ) ; end and
+    (set! align (string-ref spec index))
+    (set! index (add1 index))
+  ) ; end when align
+  (define sign #f)
+  (when (and (< index length)
+             (sign-char? (string-ref spec index))
+        ) ; end and
+    (set! sign (string-ref spec index))
+    (set! index (add1 index))
+  ) ; end when sign
+  (define zero? #f)
+  (when (and (< index length)
+             (char=? (string-ref spec index) #\0)
+        ) ; end and
+    (set! zero? #t)
+    (set! index (add1 index))
+  ) ; end when zero
+  (define-values (width next-index) (read-digits spec index))
+  (set! index next-index)
+  (define precision #f)
+  (when (and (< index length)
+             (char=? (string-ref spec index) #\.)
+        ) ; end and
+    (define-values (parsed-precision after-precision)
+      (read-digits spec (add1 index))
+    ) ; end define-values
+    (unless parsed-precision
+      (raise-arguments-error 'format-fstring-value
+                             "expected precision after ."
+                             "format-spec"
+                             spec
+      ) ; end raise-arguments-error
+    ) ; end unless precision
+    (set! precision parsed-precision)
+    (set! index after-precision)
+  ) ; end when precision
+  (define type #f)
+  (when (< index length)
+    (set! type (string-ref spec index))
+    (set! index (add1 index))
+  ) ; end when type
+  (unless (= index length)
+    (raise-arguments-error 'format-fstring-value
+                           "could not parse format spec"
+                           "format-spec"
+                           spec
+    ) ; end raise-arguments-error
+  ) ; end unless fully parsed
+  (format-options fill align sign zero? width precision type)
+) ; end define parse-format-spec
+
+(define (read-digits spec index)
+  (define length (string-length spec))
+  (let loop ((index index)
+             (digits '())
+        ) ; end loop bindings
+    (cond
+      ((and (< index length)
+            (char-numeric? (string-ref spec index))
+       ) ; end and
+       (loop (add1 index)
+             (cons (string-ref spec index) digits)
+       ) ; end loop
+      ) ; end digit
+      ((null? digits)
+       (values #f index)
+      ) ; end no digits
+      (else
+       (values (string->number (list->string (reverse digits)))
+               index
+       ) ; end values
+      ) ; end done
+    ) ; end cond
+  ) ; end let loop
+) ; end define read-digits
+
+(define (alignment-char? ch)
+  (memv ch '(#\< #\> #\^ #\=))
+) ; end define alignment-char?
+
+(define (sign-char? ch)
+  (memv ch '(#\+ #\- #\space))
+) ; end define sign-char?
+
+(define (apply-alignment text options numeric?)
+  (define width (format-options-width options))
+  (cond
+    ((or (not width) (<= width (string-length text))) text)
+    (else
+     (define fill-string
+       (string (if (and numeric?
+                        (format-options-zero? options)
+                        (not (format-options-align options))
+                   ) ; end and
+                   #\0
+                   (format-options-fill options)
+               ) ; end if
+       ) ; end string
+     ) ; end define fill-string
+     (define align
+       (or (format-options-align options)
+           (if numeric? #\> #\<)
+       ) ; end or
+     ) ; end define align
+     (define pad-count (- width (string-length text)))
+     (cond
+       ((and numeric?
+             (or (eqv? align #\=)
+                 (and (format-options-zero? options)
+                      (not (format-options-align options))
+                 ) ; end and
+             ) ; end or
+             (has-sign-prefix? text)
+        ) ; end and
+        (string-append (substring text 0 1)
+                       (make-padding fill-string pad-count)
+                       (substring text 1)
+        ) ; end string-append
+       ) ; end sign-aware padding
+       ((eqv? align #\<)
+        (string-append text (make-padding fill-string pad-count))
+       ) ; end left align
+       ((eqv? align #\^)
+        (define left-count (quotient pad-count 2))
+        (define right-count (- pad-count left-count))
+        (string-append (make-padding fill-string left-count)
+                       text
+                       (make-padding fill-string right-count)
+        ) ; end string-append
+       ) ; end center align
+       (else
+        (string-append (make-padding fill-string pad-count) text)
+       ) ; end right align
+     ) ; end cond
+    ) ; end needs padding
+  ) ; end cond
+) ; end define apply-alignment
+
+(define (has-sign-prefix? text)
+  (and (positive? (string-length text))
+       (memv (string-ref text 0) '(#\+ #\- #\space))
+  ) ; end and
+) ; end define has-sign-prefix?
+
+(define (make-padding fill-string count)
+  (apply string-append (make-list count fill-string))
+) ; end define make-padding
 
 (define (template->sql tpl)
   (define-values (strings interpolations)

--- a/pkgs/racket-tstring/private/source-transform.rkt
+++ b/pkgs/racket-tstring/private/source-transform.rkt
@@ -1,0 +1,325 @@
+#lang racket/base
+
+(provide
+ transform-template-prefixes
+ find-racket-string-end
+ find-template-source-end
+ template-prefix-at?
+) ; end provide
+
+(define (transform-template-prefixes source)
+  (define length (string-length source))
+  (define out (open-output-string))
+  (let loop ((index 0))
+    (cond
+      ((= index length)
+       (get-output-string out)
+      ) ; end end of source
+      (else
+       (define ch (string-ref source index))
+       (cond
+         ((char=? ch #\")
+          (define next-index (copy-racket-string source index out))
+          (loop next-index)
+         ) ; end ordinary string
+         ((char=? ch #\;)
+          (define next-index (copy-line-comment source index out))
+          (loop next-index)
+         ) ; end line comment
+         ((and (char=? ch #\#)
+               (< (add1 index) length)
+               (char=? (string-ref source (add1 index)) #\|)
+          ) ; end and
+          (define next-index (copy-block-comment source index out))
+          (loop next-index)
+         ) ; end block comment
+         ((template-prefix-at? source index)
+          (define next-index (copy-template-form source index out))
+          (loop next-index)
+         ) ; end template prefix
+         (else
+          (write-char ch out)
+          (loop (add1 index))
+         ) ; end ordinary character
+       ) ; end cond char dispatch
+      ) ; end more source
+    ) ; end cond
+  ) ; end let loop
+) ; end define transform-template-prefixes
+
+(define (template-prefix-at? source index)
+  (define length (string-length source))
+  (and (< (add1 index) length)
+       (or (char=? (string-ref source index) #\f)
+           (char=? (string-ref source index) #\t)
+       ) ; end or
+       (template-prefix-start? source index)
+       (char=? (string-ref source (add1 index)) #\")
+  ) ; end and
+) ; end define template-prefix-at?
+
+(define (template-prefix-start? source index)
+  (or (= index 0)
+      (delimiter? (string-ref source (sub1 index)))
+  ) ; end or
+) ; end define template-prefix-start?
+
+(define (delimiter? ch)
+  (or (char-whitespace? ch)
+      (memv ch '(#\( #\) #\[ #\] #\{ #\} #\' #\` #\,))
+  ) ; end or
+) ; end define delimiter?
+
+(define (copy-template-form source index out)
+  (define prefix (string-ref source index))
+  (define literal-start (add1 index))
+  (define literal-end (find-template-source-end source literal-start))
+  (write-string
+   (if (char=? prefix #\f)
+       "(fpl "
+       "(tpl "
+   ) ; end if
+   out
+  ) ; end write-string
+  (write-string (template-content->string-literal-source
+                 (substring source (add1 literal-start) (sub1 literal-end))
+                ) ; end template-content->string-literal-source
+                out
+  ) ; end write-string
+  (write-string ")" out)
+  literal-end
+) ; end define copy-template-form
+
+(define (template-content->string-literal-source content)
+  (define out (open-output-string))
+  (write-char #\" out)
+  (let loop ((index 0))
+    (cond
+      ((= index (string-length content))
+       (write-char #\" out)
+       (get-output-string out)
+      ) ; end end of content
+      (else
+       (define ch (string-ref content index))
+       (cond
+         ((char=? ch #\\)
+          (write-char ch out)
+          (when (< (add1 index) (string-length content))
+            (write-char (string-ref content (add1 index)) out)
+          ) ; end when next character
+          (loop (if (< (add1 index) (string-length content))
+                    (+ index 2)
+                    (add1 index)
+                ) ; end if
+          ) ; end loop
+         ) ; end escape
+         ((char=? ch #\")
+          (write-string "\\\"" out)
+          (loop (add1 index))
+         ) ; end quote
+         (else
+          (write-char ch out)
+          (loop (add1 index))
+         ) ; end ordinary character
+       ) ; end cond char dispatch
+      ) ; end more content
+    ) ; end cond
+  ) ; end let loop
+) ; end define template-content->string-literal-source
+
+(define (copy-racket-string source index out)
+  (define next-index (find-racket-string-end source index))
+  (write-string (substring source index next-index) out)
+  next-index
+) ; end define copy-racket-string
+
+(define (find-racket-string-end source start-index)
+  (define length (string-length source))
+  (let loop ((index (add1 start-index)))
+    (cond
+      ((= index length)
+       (raise-arguments-error 'racket-tstring-reader
+                              "unclosed string literal"
+                              "index"
+                              start-index
+       ) ; end raise-arguments-error
+      ) ; end end of source
+      (else
+       (define ch (string-ref source index))
+       (cond
+         ((char=? ch #\\)
+          (loop (if (< (add1 index) length)
+                    (+ index 2)
+                    (add1 index)
+                ) ; end if
+          ) ; end loop
+         ) ; end escape
+         ((char=? ch #\")
+          (add1 index)
+         ) ; end close quote
+         (else
+          (loop (add1 index))
+         ) ; end ordinary string character
+       ) ; end cond char dispatch
+      ) ; end more source
+    ) ; end cond
+  ) ; end let loop
+) ; end define find-racket-string-end
+
+(define (find-template-source-end source quote-index)
+  (define length (string-length source))
+  (let loop ((index (add1 quote-index)))
+    (cond
+      ((= index length)
+       (raise-arguments-error 'racket-tstring-reader
+                              "unclosed template string literal"
+                              "index"
+                              quote-index
+       ) ; end raise-arguments-error
+      ) ; end end of source
+      (else
+       (define ch (string-ref source index))
+       (cond
+         ((char=? ch #\\)
+          (loop (if (< (add1 index) length)
+                    (+ index 2)
+                    (add1 index)
+                ) ; end if
+          ) ; end loop
+         ) ; end escape
+         ((char=? ch #\")
+          (add1 index)
+         ) ; end close template quote
+         ((and (char=? ch #\{)
+               (< (add1 index) length)
+               (char=? (string-ref source (add1 index)) #\{)
+          ) ; end and
+          (loop (+ index 2))
+         ) ; end literal left brace
+         ((and (char=? ch #\})
+               (< (add1 index) length)
+               (char=? (string-ref source (add1 index)) #\})
+          ) ; end and
+          (loop (+ index 2))
+         ) ; end literal right brace
+         ((char=? ch #\{)
+          (loop (find-interpolation-source-end source (add1 index)))
+         ) ; end interpolation
+         (else
+          (loop (add1 index))
+         ) ; end text character
+       ) ; end cond char dispatch
+      ) ; end more source
+    ) ; end cond
+  ) ; end let loop
+) ; end define find-template-source-end
+
+(define (find-interpolation-source-end source start-index)
+  (define length (string-length source))
+  (let loop ((index start-index)
+             (brace-depth 0)
+        ) ; end loop bindings
+    (cond
+      ((= index length)
+       (raise-arguments-error 'racket-tstring-reader
+                              "unclosed interpolation in template string"
+                              "index"
+                              start-index
+       ) ; end raise-arguments-error
+      ) ; end end of source
+      (else
+       (define ch (string-ref source index))
+       (cond
+         ((char=? ch #\")
+          (loop (find-racket-string-end source index)
+                brace-depth
+          ) ; end loop
+         ) ; end racket string
+         ((template-prefix-at? source index)
+          (loop (find-template-source-end source (add1 index))
+                brace-depth
+          ) ; end loop
+         ) ; end nested template
+         ((char=? ch #\{)
+          (loop (add1 index)
+                (add1 brace-depth)
+          ) ; end loop
+         ) ; end nested brace
+         ((char=? ch #\})
+          (if (zero? brace-depth)
+              (add1 index)
+              (loop (add1 index)
+                    (sub1 brace-depth)
+              ) ; end loop
+          ) ; end if
+         ) ; end right brace
+         (else
+          (loop (add1 index)
+                brace-depth
+          ) ; end loop
+         ) ; end expression character
+       ) ; end cond char dispatch
+      ) ; end more source
+    ) ; end cond
+  ) ; end let loop
+) ; end define find-interpolation-source-end
+
+(define (copy-line-comment source index out)
+  (define length (string-length source))
+  (let loop ((index index))
+    (cond
+      ((= index length)
+       index
+      ) ; end end of source
+      (else
+       (define ch (string-ref source index))
+       (write-char ch out)
+       (if (char=? ch #\newline)
+           (add1 index)
+           (loop (add1 index))
+       ) ; end if
+      ) ; end more source
+    ) ; end cond
+  ) ; end let loop
+) ; end define copy-line-comment
+
+(define (copy-block-comment source index out)
+  (define length (string-length source))
+  (let loop ((index index)
+             (depth 0)
+        ) ; end loop bindings
+    (cond
+      ((= index length)
+       index
+      ) ; end end of source
+      ((and (< (add1 index) length)
+            (char=? (string-ref source index) #\#)
+            (char=? (string-ref source (add1 index)) #\|)
+       ) ; end and
+       (write-string "#|" out)
+       (loop (+ index 2)
+             (add1 depth)
+       ) ; end loop
+      ) ; end nested open comment
+      ((and (< (add1 index) length)
+            (char=? (string-ref source index) #\|)
+            (char=? (string-ref source (add1 index)) #\#)
+       ) ; end and
+       (write-string "|#" out)
+       (define next-depth (sub1 depth))
+       (if (zero? next-depth)
+           (+ index 2)
+           (loop (+ index 2)
+                 next-depth
+           ) ; end loop
+       ) ; end if
+      ) ; end close comment
+      (else
+       (write-char (string-ref source index) out)
+       (loop (add1 index)
+             depth
+       ) ; end loop
+      ) ; end ordinary comment character
+    ) ; end cond
+  ) ; end let loop
+) ; end define copy-block-comment

--- a/pkgs/racket-tstring/private/template.rkt
+++ b/pkgs/racket-tstring/private/template.rkt
@@ -1,0 +1,17 @@
+#lang racket/base
+
+(provide
+ template
+ template?
+ template-strings
+ template-interpolations
+ interpolation
+ interpolation?
+ interpolation-value
+ interpolation-syntax
+ interpolation-kind
+ interpolation-source
+) ; end provide
+
+(struct template (strings interpolations) #:transparent)
+(struct interpolation (value syntax kind source) #:transparent)

--- a/pkgs/racket-tstring/private/template.rkt
+++ b/pkgs/racket-tstring/private/template.rkt
@@ -3,15 +3,45 @@
 (provide
  template
  template?
+ template-parts
  template-strings
  template-interpolations
  interpolation
  interpolation?
  interpolation-value
  interpolation-syntax
- interpolation-kind
- interpolation-source
+ interpolation-format-spec
+ interpolation-conversion
 ) ; end provide
 
-(struct template (strings interpolations) #:transparent)
-(struct interpolation (value syntax kind source) #:transparent)
+(struct template-data (strings interpolations) #:transparent #:reflection-name 'template)
+(struct interpolation (value syntax format-spec conversion) #:transparent)
+
+(define (template strings interpolations)
+  (template-data strings interpolations)
+) ; end define template
+
+(define template? template-data?)
+(define template-strings template-data-strings)
+(define template-interpolations template-data-interpolations)
+
+(define (template-parts tpl)
+  (let loop ((strings (template-strings tpl))
+             (interpolations (template-interpolations tpl))
+        ) ; end loop bindings
+    (cond
+      ((null? interpolations)
+       strings
+      ) ; end no more interpolations
+      (else
+       (cons (car strings)
+             (cons (car interpolations)
+                   (loop (cdr strings)
+                         (cdr interpolations)
+                   ) ; end loop
+             ) ; end cons interpolation
+       ) ; end cons string
+      ) ; end more interpolations
+    ) ; end cond
+  ) ; end let loop
+) ; end define template-parts

--- a/pkgs/racket-tstring/tests/expand-test.rkt
+++ b/pkgs/racket-tstring/tests/expand-test.rkt
@@ -13,16 +13,41 @@
 ) ; end define simple-template
 
 (check-true (template? simple-template))
+(check-equal? (length (template-parts simple-template)) 3)
 (check-equal? (template-strings simple-template) (list "hello " ""))
+(check-equal? (syntax-e (interpolation-syntax (car (template-interpolations simple-template)))) 'name)
 (check-equal? (map interpolation-value (template-interpolations simple-template))
               (list "Alice")
 ) ; end check-equal?
-(check-equal? (map interpolation-kind (template-interpolations simple-template))
-              (list 'identifier)
-) ; end check-equal?
+(check-equal? (map interpolation-format-spec (template-interpolations simple-template)) (list #f))
+(check-equal? (map interpolation-conversion (template-interpolations simple-template)) (list ""))
 (check-equal? (render-template simple-template) "hello Alice")
 (check-equal? (fpl "hello {name}") "hello Alice")
 (check-equal? (fpl "static") "static")
+(check-exn
+ exn:fail?
+ (lambda ()
+   (eval '(let ()
+            (require "../main.rkt")
+            (tpl "{missing-name}")
+          ) ; end let
+   ) ; end eval
+ ) ; end lambda
+) ; end check-exn unbound t-string interpolation
+(define t "T")
+(check-true (template? (tpl "{t}")))
+(check-equal? (interpolation-value (car (template-interpolations (tpl "{t}")))) "T")
+(check-equal? (interpolation-format-spec (car (template-interpolations (tpl "{t}")))) #f)
+(check-equal? (interpolation-conversion (car (template-interpolations (tpl "{t}")))) "")
+
+(define formatted-template
+  (tpl "{1 r .2f}")
+) ; end define formatted-template
+
+(check-equal? (interpolation-value (car (template-interpolations formatted-template))) 1)
+(check-equal? (syntax-e (interpolation-syntax (car (template-interpolations formatted-template)))) 1)
+(check-equal? (interpolation-conversion (car (template-interpolations formatted-template))) "r")
+(check-equal? (interpolation-format-spec (car (template-interpolations formatted-template))) ".2f")
 
 (check-equal? (fpl "{(string-upcase name)}") "ALICE")
 
@@ -42,8 +67,8 @@
 ) ; end define multi-template
 
 (check-equal? (render-template multi-template) "1 + 2 = 3")
-(check-equal? (map interpolation-kind (template-interpolations multi-template))
-              (list 'identifier 'identifier 'expression)
+(check-equal? (map interpolation-value (template-interpolations multi-template))
+              (list 1 2 3)
 ) ; end check-equal?
 
 (check-exn
@@ -61,9 +86,6 @@
 ) ; end define nested-template
 
 (check-true (template? (interpolation-value (car (template-interpolations nested-template)))))
-(check-equal? (render-template (interpolation-value (car (template-interpolations nested-template))))
-              "inner Alice"
-) ; end check-equal?
 
 (check-exn
  exn:fail:syntax?

--- a/pkgs/racket-tstring/tests/expand-test.rkt
+++ b/pkgs/racket-tstring/tests/expand-test.rkt
@@ -50,6 +50,19 @@
 (check-equal? (interpolation-format-spec (car (template-interpolations formatted-template))) ".2f")
 
 (check-equal? (fpl "{(string-upcase name)}") "ALICE")
+(check-equal? (fpl "{2 03d}") "002")
+(check-equal? (fpl "{10 >2d}") "10")
+(check-equal? (fpl "{7 >3d}") "  7")
+(check-equal? (fpl "{7 <3d}") "7  ")
+(check-equal? (fpl "{1.234 .2f}") "1.23")
+(check-equal? (fpl "{2 .2f}") "2.00")
+(check-equal? (fpl "{\"hi\" r}") "\"hi\"")
+(check-exn
+ exn:fail?
+ (lambda ()
+   (fpl "{\"hi\" r .2f}")
+ ) ; end lambda
+) ; end check-exn string conversion numeric format
 
 (define evaluation-order '())
 

--- a/pkgs/racket-tstring/tests/expand-test.rkt
+++ b/pkgs/racket-tstring/tests/expand-test.rkt
@@ -1,0 +1,121 @@
+#lang racket/base
+
+(require
+ rackunit
+ racket/string
+ "../main.rkt"
+) ; end require
+
+(define name "Alice")
+
+(define simple-template
+  (tpl "hello {name}")
+) ; end define simple-template
+
+(check-true (template? simple-template))
+(check-equal? (template-strings simple-template) (list "hello " ""))
+(check-equal? (map interpolation-value (template-interpolations simple-template))
+              (list "Alice")
+) ; end check-equal?
+(check-equal? (map interpolation-kind (template-interpolations simple-template))
+              (list 'identifier)
+) ; end check-equal?
+(check-equal? (render-template simple-template) "hello Alice")
+(check-equal? (fpl "hello {name}") "hello Alice")
+(check-equal? (fpl "static") "static")
+
+(check-equal? (fpl "{(string-upcase name)}") "ALICE")
+
+(define evaluation-order '())
+
+(check-equal?
+ (fpl "{(begin (set! evaluation-order (append evaluation-order '(a))) \"A\")}{(begin (set! evaluation-order (append evaluation-order '(b))) \"B\")}")
+ "AB"
+) ; end check-equal?
+(check-equal? evaluation-order '(a b))
+
+(define a 1)
+(define b 2)
+
+(define multi-template
+  (tpl "{a} + {b} = {(+ a b)}")
+) ; end define multi-template
+
+(check-equal? (render-template multi-template) "1 + 2 = 3")
+(check-equal? (map interpolation-kind (template-interpolations multi-template))
+              (list 'identifier 'identifier 'expression)
+) ; end check-equal?
+
+(check-exn
+ exn:fail?
+ (lambda ()
+   (template->sql (tpl "WHERE id = {(+ 1 2)}"))
+ ) ; end lambda
+) ; end check-exn
+
+(check-equal? (fpl "{{name}}") "{name}")
+(check-equal? (fpl "outer {f\"inner {name}\"}") "outer inner Alice")
+
+(define nested-template
+  (tpl "outer {t\"inner {name}\"}")
+) ; end define nested-template
+
+(check-true (template? (interpolation-value (car (template-interpolations nested-template)))))
+(check-equal? (render-template (interpolation-value (car (template-interpolations nested-template))))
+              "inner Alice"
+) ; end check-equal?
+
+(check-exn
+ exn:fail:syntax?
+ (lambda ()
+   (eval '(let ()
+            (require "../main.rkt")
+            (tpl 1)
+          ) ; end let
+   ) ; end eval
+ ) ; end lambda
+) ; end check-exn
+
+(check-exn
+ exn:fail:syntax?
+ (lambda ()
+   (eval '(let ()
+            (require "../main.rkt")
+            (tpl "hello {}")
+          ) ; end let
+   ) ; end eval
+ ) ; end lambda
+) ; end check-exn empty template interpolation
+
+(check-exn
+ exn:fail:syntax?
+ (lambda ()
+   (eval '(let ()
+            (require "../main.rkt")
+            (tpl "hello {")
+          ) ; end let
+   ) ; end eval
+ ) ; end lambda
+) ; end check-exn unclosed template interpolation
+
+(check-exn
+ exn:fail:syntax?
+ (lambda ()
+   (eval '(let ()
+            (require "../main.rkt")
+            (tpl "hello }")
+          ) ; end let
+   ) ; end eval
+ ) ; end lambda
+) ; end check-exn unmatched right brace
+
+(check-exn
+ exn:fail:syntax?
+ (lambda ()
+   (eval '(let ()
+            (require "../main.rkt")
+            (tpl "hello {(+ 1 2}")
+          ) ; end let
+   ) ; end eval
+ ) ; end lambda
+) ; end check-exn malformed expression

--- a/pkgs/racket-tstring/tests/parse-test.rkt
+++ b/pkgs/racket-tstring/tests/parse-test.rkt
@@ -1,0 +1,69 @@
+#lang racket/base
+
+(require
+ rackunit
+ "../main.rkt"
+) ; end require
+
+(define-syntax-rule (check-parse input expected-strings expected-expressions)
+  (let-values (((strings expressions) (parse-template-string input)))
+    (check-equal? strings expected-strings)
+    (check-equal? expressions expected-expressions)
+  ) ; end let-values
+) ; end define-syntax-rule check-parse
+
+(check-parse "hello" (list "hello") '())
+(check-parse "hello {name}" (list "hello " "") (list "name"))
+(check-parse "{name}" (list "" "") (list "name"))
+(check-parse "{a} + {b}" (list "" " + " "") (list "a" "b"))
+(check-parse "sum = {(+ a b)}" (list "sum = " "") (list "(+ a b)"))
+(check-parse "brace = {(string-append \"}\" \"x\")}"
+             (list "brace = " "")
+             (list "(string-append \"}\" \"x\")")
+) ; end check-parse
+(check-parse "outer {f\"inner {x}\"}"
+             (list "outer " "")
+             (list "f\"inner {x}\"")
+) ; end check-parse
+(check-parse "{{" (list "{") '())
+(check-parse "}}" (list "}") '())
+(check-parse "{{name}}" (list "{name}") '())
+(check-parse "before {{ {name} }} after"
+             (list "before { " " } after")
+             (list "name")
+) ; end check-parse
+
+(check-exn
+ exn:fail?
+ (lambda ()
+   (parse-template-string "hello {}")
+ ) ; end lambda
+) ; end check-exn empty interpolation
+
+(check-exn
+ exn:fail?
+ (lambda ()
+   (parse-template-string "hello {   }")
+ ) ; end lambda
+) ; end check-exn blank interpolation
+
+(check-exn
+ exn:fail?
+ (lambda ()
+   (parse-template-string "hello {")
+ ) ; end lambda
+) ; end check-exn unclosed interpolation
+
+(check-exn
+ exn:fail?
+ (lambda ()
+   (parse-template-string "hello }")
+ ) ; end lambda
+) ; end check-exn unmatched right brace
+
+(check-exn
+ exn:fail:contract?
+ (lambda ()
+   (parse-template-string 42)
+ ) ; end lambda
+) ; end check-exn non-string

--- a/pkgs/racket-tstring/tests/reader-basic.rkt
+++ b/pkgs/racket-tstring/tests/reader-basic.rkt
@@ -1,0 +1,12 @@
+#lang reader "../lang/reader.rkt"
+
+(provide
+ rendered
+ template-value
+ ordinary-string
+) ; end provide
+
+(define name "Alice")
+(define rendered f"hello {name}")
+(define template-value t"hello {name}")
+(define ordinary-string "f\"not a template\"")

--- a/pkgs/racket-tstring/tests/reader-error-test.rkt
+++ b/pkgs/racket-tstring/tests/reader-error-test.rkt
@@ -1,0 +1,24 @@
+#lang racket/base
+
+(require
+ rackunit
+ "../lang/reader.rkt"
+) ; end require
+
+(define (read-tstring-source source)
+  (read-syntax 'reader-error-test (open-input-string source))
+) ; end define read-tstring-source
+
+(check-exn
+ exn:fail:read?
+ (lambda ()
+   (read-tstring-source "f\"hello")
+ ) ; end lambda
+) ; end check-exn unclosed template string
+
+(check-exn
+ exn:fail:read?
+ (lambda ()
+   (read-tstring-source "f\"hello {name")
+ ) ; end lambda
+) ; end check-exn unclosed reader interpolation

--- a/pkgs/racket-tstring/tests/reader-nesting.rkt
+++ b/pkgs/racket-tstring/tests/reader-nesting.rkt
@@ -1,0 +1,14 @@
+#lang reader "../lang/reader.rkt"
+
+(provide
+ nested-rendered
+ nested-template
+ expression-nested-rendered
+ string-brace-rendered
+) ; end provide
+
+(define x 1)
+(define nested-rendered f"outer {f"inner {x}"}")
+(define nested-template t"outer {t"inner {x}"}")
+(define expression-nested-rendered f"{(string-append f"a{x}" "b")}")
+(define string-brace-rendered f"{(string-append "}" "x")}")

--- a/pkgs/racket-tstring/tests/reader-test.rkt
+++ b/pkgs/racket-tstring/tests/reader-test.rkt
@@ -1,0 +1,18 @@
+#lang racket/base
+
+(require
+ rackunit
+ "../main.rkt"
+ "reader-basic.rkt"
+ "reader-nesting.rkt"
+) ; end require
+
+(check-equal? rendered "hello Alice")
+(check-true (template? template-value))
+(check-equal? (render-template template-value) "hello Alice")
+(check-equal? ordinary-string "f\"not a template\"")
+(check-equal? nested-rendered "outer inner 1")
+(check-true (template? nested-template))
+(check-true (template? (interpolation-value (car (template-interpolations nested-template)))))
+(check-equal? expression-nested-rendered "a1b")
+(check-equal? string-brace-rendered "}x")

--- a/pkgs/racket-tstring/tests/reader-test.rkt
+++ b/pkgs/racket-tstring/tests/reader-test.rkt
@@ -9,7 +9,9 @@
 
 (check-equal? rendered "hello Alice")
 (check-true (template? template-value))
-(check-equal? (render-template template-value) "hello Alice")
+(check-equal? (interpolation-value (car (template-interpolations template-value))) "Alice")
+(check-equal? (interpolation-format-spec (car (template-interpolations template-value))) #f)
+(check-equal? (interpolation-conversion (car (template-interpolations template-value))) "")
 (check-equal? ordinary-string "f\"not a template\"")
 (check-equal? nested-rendered "outer inner 1")
 (check-true (template? nested-template))

--- a/pkgs/racket-tstring/tests/render-test.rkt
+++ b/pkgs/racket-tstring/tests/render-test.rkt
@@ -1,0 +1,77 @@
+#lang racket/base
+
+(require
+ rackunit
+ "../main.rkt"
+) ; end require
+
+(define name "Alice")
+
+(define hello-template
+  (template (list "hello " "")
+            (list (interpolation name #'name 'identifier #'name))
+  ) ; end template
+) ; end define hello-template
+
+(check-true (template? hello-template))
+(check-equal? (template-strings hello-template) (list "hello " ""))
+(check-equal? (map interpolation-value (template-interpolations hello-template))
+              (list "Alice")
+) ; end check-equal?
+(check-equal? (render-template hello-template) "hello Alice")
+(check-equal? (render-fstring hello-template) "hello Alice")
+
+(define sum-template
+  (template (list "sum = " "")
+            (list (interpolation 3 #'(+ 1 2) 'expression #'(+ 1 2)))
+  ) ; end template
+) ; end define sum-template
+
+(check-equal? (render-template sum-template) "sum = 3")
+(check-equal? (render-template sum-template #:value->string number->string) "sum = 3")
+
+(define id 42)
+(define status "active")
+
+(define sql-template
+  (template (list "WHERE id = " " AND status = " "")
+            (list (interpolation id #'id 'identifier #'id)
+                  (interpolation status #'status 'identifier #'status)
+            ) ; end list
+  ) ; end template
+) ; end define sql-template
+
+(define-values (sql params)
+  (template->sql sql-template)
+) ; end define-values
+
+(check-equal? sql "WHERE id = ? AND status = ?")
+(check-equal? params (list 42 "active"))
+
+(check-exn
+ exn:fail?
+ (lambda ()
+   (template->sql sum-template)
+ ) ; end lambda
+) ; end check-exn
+
+(define html-template
+  (template (list "<p>" "</p>")
+            (list (interpolation "<script>&\"" #'user-input 'identifier #'user-input))
+  ) ; end template
+) ; end define html-template
+
+(check-equal? (html-render html-template)
+              "<p>&lt;script&gt;&amp;&quot;</p>"
+) ; end check-equal?
+
+(check-exn
+ exn:fail:contract?
+ (lambda ()
+   (render-template
+    (template (list "too " "many " "strings")
+              (list (interpolation 1 #'x 'identifier #'x))
+    ) ; end template
+   ) ; end render-template
+ ) ; end lambda
+) ; end check-exn

--- a/pkgs/racket-tstring/tests/render-test.rkt
+++ b/pkgs/racket-tstring/tests/render-test.rkt
@@ -7,36 +7,43 @@
 
 (define name "Alice")
 
+(define hello-interpolation
+  (interpolation name #'name #f "")
+) ; end define hello-interpolation
+
 (define hello-template
   (template (list "hello " "")
-            (list (interpolation name #'name 'identifier #'name))
+            (list hello-interpolation)
   ) ; end template
 ) ; end define hello-template
 
 (check-true (template? hello-template))
+(check-equal? (template-parts hello-template) (list "hello " hello-interpolation ""))
 (check-equal? (template-strings hello-template) (list "hello " ""))
-(check-equal? (map interpolation-value (template-interpolations hello-template))
-              (list "Alice")
-) ; end check-equal?
+(check-equal? (map interpolation-value (template-interpolations hello-template)) (list "Alice"))
 (check-equal? (render-template hello-template) "hello Alice")
 (check-equal? (render-fstring hello-template) "hello Alice")
 
 (define sum-template
   (template (list "sum = " "")
-            (list (interpolation 3 #'(+ 1 2) 'expression #'(+ 1 2)))
+            (list (interpolation 3 #'(+ 1 2) #f ""))
   ) ; end template
 ) ; end define sum-template
 
 (check-equal? (render-template sum-template) "sum = 3")
-(check-equal? (render-template sum-template #:value->string number->string) "sum = 3")
+(check-equal? (render-template sum-template
+                               #:value->string number->string
+              ) ; end render-template
+              "sum = 3"
+) ; end check-equal?
 
 (define id 42)
 (define status "active")
 
 (define sql-template
   (template (list "WHERE id = " " AND status = " "")
-            (list (interpolation id #'id 'identifier #'id)
-                  (interpolation status #'status 'identifier #'status)
+            (list (interpolation id #'id #f "")
+                  (interpolation status #'status #f "")
             ) ; end list
   ) ; end template
 ) ; end define sql-template
@@ -57,7 +64,7 @@
 
 (define html-template
   (template (list "<p>" "</p>")
-            (list (interpolation "<script>&\"" #'user-input 'identifier #'user-input))
+            (list (interpolation "<script>&\"" #'user-input #f ""))
   ) ; end template
 ) ; end define html-template
 
@@ -67,11 +74,11 @@
 
 (check-exn
  exn:fail:contract?
- (lambda ()
-   (render-template
-    (template (list "too " "many " "strings")
-              (list (interpolation 1 #'x 'identifier #'x))
-    ) ; end template
-   ) ; end render-template
- ) ; end lambda
+  (lambda ()
+    (render-template
+     (template (list "too " "many " "strings")
+               '()
+     ) ; end template
+    ) ; end render-template
+  ) ; end lambda
 ) ; end check-exn

--- a/pkgs/tstring/info.rkt
+++ b/pkgs/tstring/info.rkt
@@ -1,0 +1,24 @@
+#lang info
+
+(define collection "tstring")
+
+(define deps
+  '("base"
+    "racket-tstring")
+) ; end define deps
+
+(define build-deps
+  '("rackunit-lib")
+) ; end define build-deps
+
+(define pkg-desc "Short alias for structured template strings")
+
+(define pkg-authors
+  '(cutiedeng)
+) ; end define pkg-authors
+
+(define version "0.1")
+
+(define license
+  '(Apache-2.0 OR MIT)
+) ; end define license

--- a/pkgs/tstring/lang/reader.rkt
+++ b/pkgs/tstring/lang/reader.rkt
@@ -1,0 +1,98 @@
+#lang racket/base
+
+(require
+ racket/port
+ racket/runtime-path
+ syntax/module-reader
+ syntax/readerr
+ (file "../../racket-tstring/private/source-transform.rkt")
+) ; end require
+
+(provide
+ (rename-out (tstring-read read)
+             (tstring-read-syntax read-syntax)
+             (tstring-get-info get-info)
+ ) ; end rename-out
+) ; end provide
+
+(define-runtime-path main-rkt "../main.rkt")
+
+(define (wrap-reader proc)
+  (lambda args
+    (define-values (prefix port suffix)
+      (split-reader-args args)
+    ) ; end define-values
+    (define transformed-port
+      (open-input-string
+       (string-append (format "(require (file ~s))\n" (path->string main-rkt))
+                      (transform-with-read-errors port)
+       ) ; end string-append
+      ) ; end open-input-string
+    ) ; end define transformed-port
+    (port-count-lines! transformed-port)
+    (apply proc
+           (append prefix
+                   (list transformed-port)
+                   suffix
+           ) ; end append
+    ) ; end apply
+  ) ; end lambda
+) ; end define wrap-reader
+
+(define (split-reader-args args)
+  (let loop ((prefix '())
+             (rest args)
+        ) ; end loop bindings
+    (cond
+      ((null? rest)
+       (error 'tstring-reader "reader arguments do not include an input port")
+      ) ; end no port
+      ((input-port? (car rest))
+       (values (reverse prefix)
+               (car rest)
+               (cdr rest)
+       ) ; end values
+      ) ; end found port
+      (else
+       (loop (cons (car rest) prefix)
+             (cdr rest)
+       ) ; end loop
+      ) ; end keep searching
+    ) ; end cond
+  ) ; end let loop
+) ; end define split-reader-args
+
+(define (transform-with-read-errors port)
+  (define source (port->string port))
+  (with-handlers ((exn:fail?
+                   (lambda (exn)
+                     (raise-read-error (exn-message exn)
+                                       (object-name port)
+                                       #f
+                                       #f
+                                       #f
+                                       #f
+                     ) ; end raise-read-error
+                   ) ; end lambda
+                  ) ; end exn:fail?
+                 ) ; end handlers
+    (transform-template-prefixes source)
+  ) ; end with-handlers
+) ; end define transform-with-read-errors
+
+(define-values (tstring-read tstring-read-syntax tstring-get-info)
+  (make-meta-reader 'tstring
+                    "language path"
+                    lang-reader-module-paths
+                    wrap-reader
+                    wrap-reader
+                    (lambda (proc)
+                      (lambda (key default)
+                        (if proc
+                            (proc key default)
+                            default
+                        ) ; end if
+                      ) ; end lambda
+                    ) ; end get-info wrapper
+  ) ; end make-meta-reader
+) ; end define-values

--- a/pkgs/tstring/main.rkt
+++ b/pkgs/tstring/main.rkt
@@ -1,0 +1,9 @@
+#lang racket/base
+
+(require
+ (file "../racket-tstring/main.rkt")
+) ; end require
+
+(provide
+ (all-from-out (file "../racket-tstring/main.rkt"))
+) ; end provide

--- a/pkgs/tstring/tests/require-test.rkt
+++ b/pkgs/tstring/tests/require-test.rkt
@@ -1,0 +1,16 @@
+#lang racket/base
+
+(require
+ rackunit
+ "../main.rkt"
+) ; end require
+
+(define tpl-value
+  (template (list "hello " "")
+            (list (interpolation "Alice" #'name 'identifier #'name))
+  ) ; end template
+) ; end define tpl-value
+
+(check-true (template? tpl-value))
+(check-equal? (render-template tpl-value) "hello Alice")
+(check-equal? (fpl "{(+ 1 2)}") "3")

--- a/pkgs/tstring/tests/require-test.rkt
+++ b/pkgs/tstring/tests/require-test.rkt
@@ -7,7 +7,7 @@
 
 (define tpl-value
   (template (list "hello " "")
-            (list (interpolation "Alice" #'name 'identifier #'name))
+            (list (interpolation "Alice" #'name #f ""))
   ) ; end template
 ) ; end define tpl-value
 

--- a/pkgs/tstring/tests/wrapper-racket-base.rkt
+++ b/pkgs/tstring/tests/wrapper-racket-base.rkt
@@ -1,0 +1,12 @@
+#lang reader "../lang/reader.rkt" racket/base
+
+(provide
+ rendered
+ template-value
+ nested-rendered
+) ; end provide
+
+(define name "Alice")
+(define rendered f"hello {name}")
+(define template-value t"hello {name}")
+(define nested-rendered f"outer {f"inner {name}"}")

--- a/pkgs/tstring/tests/wrapper-test.rkt
+++ b/pkgs/tstring/tests/wrapper-test.rkt
@@ -8,5 +8,7 @@
 
 (check-equal? rendered "hello Alice")
 (check-true (template? template-value))
-(check-equal? (render-template template-value) "hello Alice")
+(check-equal? (interpolation-value (car (template-interpolations template-value))) "Alice")
+(check-equal? (interpolation-format-spec (car (template-interpolations template-value))) #f)
+(check-equal? (interpolation-conversion (car (template-interpolations template-value))) "")
 (check-equal? nested-rendered "outer inner Alice")

--- a/pkgs/tstring/tests/wrapper-test.rkt
+++ b/pkgs/tstring/tests/wrapper-test.rkt
@@ -1,0 +1,12 @@
+#lang racket/base
+
+(require
+ rackunit
+ "../main.rkt"
+ "wrapper-racket-base.rkt"
+) ; end require
+
+(check-equal? rendered "hello Alice")
+(check-true (template? template-value))
+(check-equal? (render-template template-value) "hello Alice")
+(check-equal? nested-rendered "outer inner Alice")

--- a/racket/collects/racket/interactive/tstring.rkt
+++ b/racket/collects/racket/interactive/tstring.rkt
@@ -1,0 +1,81 @@
+#lang racket/base
+
+(require
+ racket/port
+ racket/string
+ syntax/readerr
+) ; end require
+
+(namespace-require '(lib "tstring/main.rkt"))
+
+(define (tstring-read-interaction source-name in)
+  (let loop ((lines '()))
+    (define line (read-line in 'any))
+    (cond
+      ((eof-object? line)
+       (if (null? lines)
+           eof
+           (read-transformed-interaction source-name (string-join (reverse lines) "\n"))
+       ) ; end if
+      ) ; end eof
+      (else
+       (define source (string-join (reverse (cons line lines)) "\n"))
+       (with-handlers ((exn:fail:read:eof?
+                        (lambda (exn)
+                          (loop (cons line lines))
+                        ) ; end lambda
+                       ) ; end exn:fail:read:eof?
+                      ) ; end handlers
+         (read-transformed-interaction source-name source)
+       ) ; end with-handlers
+      ) ; end line
+    ) ; end cond
+  ) ; end let loop
+) ; end define tstring-read-interaction
+
+(define (read-transformed-interaction source-name source)
+  (define transformed-source ((get-transform-template-prefixes) source))
+  (define in (open-input-string transformed-source))
+  (port-count-lines! in)
+  (define stx (read-syntax source-name in))
+  (define extra-stx (read-syntax source-name in))
+  (unless (eof-object? extra-stx)
+    (raise-read-error "expected a single interaction"
+                      source-name
+                      #f
+                      #f
+                      #f
+                      #f
+    ) ; end raise-read-error
+  ) ; end unless eof
+  stx
+) ; end define read-transformed-interaction
+
+(define transform-template-prefixes-proc #f)
+
+(define (get-transform-template-prefixes)
+  (unless transform-template-prefixes-proc
+    (set! transform-template-prefixes-proc
+          (dynamic-require '(lib "racket-tstring/private/source-transform.rkt")
+                           'transform-template-prefixes
+          ) ; end dynamic-require
+    ) ; end set!
+  ) ; end unless cached
+  transform-template-prefixes-proc
+) ; end define get-transform-template-prefixes
+
+(when (collection-file-path "main.rkt" "xrepl"
+                            #:fail (lambda _ #f)
+      ) ; end collection-file-path
+  (dynamic-require 'xrepl #f)
+  (define toplevel-prefix (dynamic-require 'xrepl/xrepl 'toplevel-prefix))
+  (toplevel-prefix "")
+) ; end when xrepl
+
+(let ((init-file (cleanse-path (find-system-path 'init-file))))
+  (when (file-exists? init-file)
+    (load init-file)
+  ) ; end when init file
+) ; end let init-file
+
+(current-read-interaction tstring-read-interaction)

--- a/racket/src/pkgs-config.rkt
+++ b/racket/src/pkgs-config.rkt
@@ -99,10 +99,10 @@
                          #t
                          'build-stamp
                          (auto-stamp)
-                         'interactive-file
-                         'racket/interactive
-                         'gui-interactive-file
-                         'racket/gui/interactive))]))
+                          'interactive-file
+                          'racket/interactive/tstring
+                          'gui-interactive-file
+                          'racket/gui/interactive))]))
 
 (define (maybe-update-stamp)
   (when (file-exists? config-file-path)


### PR DESCRIPTION
## Summary

- Add a new `racket-tstring` package that implements structured template strings, including parsing, expansion, rendering, and reader support.
- Add the `tstring` package as the public wrapper/alias and register both packages in the build configuration.
- Add `racket/interactive/tstring` support for REPL use.

## Tests

- `raco make pkgs/racket-tstring/tests/*.rkt pkgs/tstring/tests/*.rkt`
- `raco test pkgs/racket-tstring/tests pkgs/tstring/tests` (95 tests passed)