### PR TITLE
CS & BC: fix inconsistencies in divide-by-zero error messages

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/numbers.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/numbers.scrbl
@@ -318,6 +318,9 @@ If @racket[z] is exact @racket[0] and no @racket[w] is exact
 
 Returns @racket[(truncate (/ n m))].
 
+If @racket[m] is exact @racket[0], @racket[0.0], or @racket[-0.0], the
+ @exnraise[exn:fail:contract:divide-by-zero].
+
 @mz-examples[(quotient 10 3) (quotient -10.0 3) (eval:error (quotient +inf.0 3))]}
 
 
@@ -333,7 +336,7 @@ Returns @racket[_q] with the same sign as @racket[n] such that
 
 ]
 
-If @racket[m] is exact @racket[0], the
+If @racket[m] is exact @racket[0], @racket[0.0], or @racket[-0.0], the
  @exnraise[exn:fail:contract:divide-by-zero].
 
 @mz-examples[(remainder 10 3) (remainder -10.0 3) (remainder 10.0 -3) (remainder -10 -3) (eval:error (remainder +inf.0 3))]}
@@ -344,6 +347,9 @@ If @racket[m] is exact @racket[0], the
 Returns @racket[(values (quotient n m) (remainder n m))], but the
  combination may be computed more efficiently than separate calls to
  @racket[quotient] and @racket[remainder].
+
+If @racket[m] is exact @racket[0], @racket[0.0], or @racket[-0.0], the
+ @exnraise[exn:fail:contract:divide-by-zero].
 
 @mz-examples[
 (quotient/remainder 10 3)
@@ -362,7 +368,7 @@ Returns @racket[_q] with the same sign as @racket[m] where
 
 ]
 
-If @racket[m] is exact @racket[0], the
+If @racket[m] is exact @racket[0], @racket[0.0], or @racket[-0.0], the
  @exnraise[exn:fail:contract:divide-by-zero].
 
 @mz-examples[(modulo 10 3) (modulo -10.0 3)  (modulo 10.0 -3) (modulo -10 -3) (eval:error (modulo +inf.0 3))]}
@@ -814,6 +820,9 @@ Returns the imaginary part of the complex number @racket[z] in
  The result is guaranteed to be between @racket[(- pi)] and
  @racket[pi], possibly equal to @racket[pi] (but never equal
  to @racket[(- pi)]).
+
+ If @racket[z] is exact @racket[0], the
+ @exnraise[exn:fail:contract:divide-by-zero].
 
 @mz-examples[(angle -3) (angle 3.0) (angle 3+4i) (angle +inf.0+inf.0i) (angle -1)]}
 

--- a/pkgs/racket-test-core/tests/racket/number.rktl
+++ b/pkgs/racket-test-core/tests/racket/number.rktl
@@ -1035,11 +1035,11 @@
 (test #t zero? (exact->inexact (* 5 (expt 10 -325))))
 (test #t positive? (exact->inexact (* 45 (expt 10 -325))))
 
-(err/rt-test (/ 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (/ 1 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (/ 1/2 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (/ 1+2i 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (/ 1.0 0) exn:fail:contract:divide-by-zero?)
+(err/rt-test (/ 0) exn:fail:contract:divide-by-zero? #rx"/: division by zero")
+(err/rt-test (/ 1 0) exn:fail:contract:divide-by-zero? #rx"/: division by zero")
+(err/rt-test (/ 1/2 0) exn:fail:contract:divide-by-zero? #rx"/: division by zero")
+(err/rt-test (/ 1+2i 0) exn:fail:contract:divide-by-zero? #rx"/: division by zero")
+(err/rt-test (/ 1.0 0) exn:fail:contract:divide-by-zero? #rx"/: division by zero")
 
 (test -1 - 3 4)
 (test -3 - 3)
@@ -1163,15 +1163,19 @@
 
 (test 13.0 quotient 1324.0 100)
 
-(err/rt-test (quotient 6 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (modulo 6 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (remainder 6 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (quotient 6 0.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (modulo 6 0.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (remainder 6 0.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (quotient 6 -0.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (modulo 6 -0.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (remainder 6 -0.0) exn:fail:contract:divide-by-zero?)
+(err/rt-test (quotient 6 0) exn:fail:contract:divide-by-zero? #rx"quotient: undefined for 0")
+(err/rt-test (modulo 6 0) exn:fail:contract:divide-by-zero? #rx"modulo: undefined for 0")
+(err/rt-test (remainder 6 0) exn:fail:contract:divide-by-zero? #rx"remainder: undefined for 0")
+(err/rt-test (quotient 6 0.0) exn:fail:contract:divide-by-zero? #rx"quotient: undefined for 0.0")
+(err/rt-test (modulo 6 0.0) exn:fail:contract:divide-by-zero? #rx"modulo: undefined for 0.0")
+(err/rt-test (remainder 6 0.0) exn:fail:contract:divide-by-zero? #rx"remainder: undefined for 0.0")
+(err/rt-test (quotient 6 -0.0) exn:fail:contract:divide-by-zero? #rx"quotient: undefined for -0.0")
+(err/rt-test (modulo 6 -0.0) exn:fail:contract:divide-by-zero? #rx"modulo: undefined for -0.0")
+(err/rt-test (remainder 6 -0.0) exn:fail:contract:divide-by-zero? #rx"remainder: undefined for -0.0")
+
+(err/rt-test (quotient/remainder 6 0) exn:fail:contract:divide-by-zero? #rx"quotient/remainder: undefined for 0")
+(err/rt-test (quotient/remainder 6 0.0) exn:fail:contract:divide-by-zero? #rx"quotient/remainder: undefined for 0.0")
+(err/rt-test (quotient/remainder 6 -0.0) exn:fail:contract:divide-by-zero? #rx"quotient/remainder: undefined for -0.0")
 
 (let ()
   (define (check-rem-mod a b rem mod)
@@ -1860,7 +1864,7 @@
   (test pi angle -3+0.0i))
 
 (err/rt-test (angle 'a))
-(err/rt-test (angle 0) exn:fail:contract:divide-by-zero?)
+(err/rt-test (angle 0) exn:fail:contract:divide-by-zero? #rx"angle: undefined for 0")
 (err/rt-test (magnitude 'a))
 (arity-test angle 1 1)
 (arity-test magnitude 1 1)
@@ -2111,16 +2115,18 @@
 
 (test 1.0-9.9998886718268e-321i expt 1+1.0e-320i -1)
 
-(err/rt-test (expt 0 -1) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 -1.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 -inf.0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 -1+2i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 -1.0+2i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 0+2i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 0.0+2i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 -0.0+2i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 0+0.0i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (expt 0 +nan.0+1.0i) exn:fail:contract:divide-by-zero?)
+(err/rt-test (expt 0 -1) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and -1")
+(err/rt-test (expt 0 -1.0) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and -1.0")
+(err/rt-test (expt 0 -inf.0) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and -inf.0")
+(err/rt-test (expt 0 -1+2i) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and -1[+]2i")
+(err/rt-test (expt 0 -1.0+2i) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and -1.0[+]2.0i")
+(err/rt-test (expt 0 0+2i) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and 0[+]2i")
+(err/rt-test (expt 0 0.0+2i) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and 0.0[+]2.0i")
+(err/rt-test (expt 0 -0.0+2i) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and -0.0[+]2.0i")
+(err/rt-test (expt 0 0+0.0i) exn:fail:contract:divide-by-zero? (if has-exact-zero-inexact-complex?
+                                                                   #rx"expt: undefined for 0 and 0[+]0.0i"
+                                                                   #rx"expt: undefined for 0 and 0.0[+]0.0i"))
+(err/rt-test (expt 0 +nan.0+1.0i) exn:fail:contract:divide-by-zero? #rx"expt: undefined for 0 and [+]nan.0[+]1.0i")
 
 (err/rt-test (expt 'a 0))
 (err/rt-test (expt 'a 1))
@@ -2296,9 +2302,9 @@
 (test 0 atan 0 5/2)
 (test 0 atan 0 1.0)
 (test 314.0 round (* 100 (atan 0 -1)))
-(err/rt-test (atan 0 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (atan 0+i) exn:fail:contract:divide-by-zero?)
-(err/rt-test (atan 0-i) exn:fail:contract:divide-by-zero?)
+(err/rt-test (atan 0 0) exn:fail:contract:divide-by-zero? #rx"atan: undefined for 0 and 0")
+(err/rt-test (atan 0+i) exn:fail:contract:divide-by-zero? #rx"atan: undefined for 0[+]1i")
+(err/rt-test (atan 0-i) exn:fail:contract:divide-by-zero? #rx"atan: undefined for 0-1i")
 
 (when has-exact-zero-inexact-complex?
   (test -inf.0 atan 0+1.0i)
@@ -2402,8 +2408,8 @@
 (test 2.0 log 100 10)
 (test 3.0 log 8 2)
 (test 1.0 log 5 5)
-(err/rt-test (log 0) exn:fail:contract:divide-by-zero?)
-(err/rt-test (log 5 1) exn:fail:contract:divide-by-zero?)
+(err/rt-test (log 0) exn:fail:contract:divide-by-zero? #rx"log: undefined for 0")
+(err/rt-test (log 5 1) exn:fail:contract:divide-by-zero? #rx"log: undefined for base 1")
 
 (test 1 cos 0)
 (test 1.0 cos 0.0)

--- a/racket/src/bc/src/numarith.c
+++ b/racket/src/bc/src/numarith.c
@@ -898,9 +898,14 @@ do_bin_quotient(const char *name, const Scheme_Object *n1, const Scheme_Object *
 #ifdef MZ_USE_SINGLE_FLOATS
       (SCHEME_FLTP(n2) && (SCHEME_FLT_VAL(n2) == 0.0f)) ||
 #endif
-      (SCHEME_DBLP(n2) && (SCHEME_DBL_VAL(n2) == 0.0)))
+      (SCHEME_DBLP(n2) && (SCHEME_DBL_VAL(n2) == 0.0))) {
+    int neg;
+    neg = scheme_minus_zero_p(SCHEME_FLOAT_VAL(n2));
     scheme_raise_exn(MZEXN_FAIL_CONTRACT_DIVIDE_BY_ZERO,
-		     "%s: undefined for 0.0", name);
+		     "%s: undefined for %s0.0",
+		     name,
+		     neg ? "-" : "");
+  }
 
   if (SCHEME_INTP(n1) && SCHEME_INTP(n2)) {
     /* Beware that most negative fixnum divided by -1

--- a/racket/src/cs/rumble/error-rewrite.ss
+++ b/racket/src/cs/rumble/error-rewrite.ss
@@ -11,12 +11,12 @@
     exn:fail:contract:arity]
    [(and (format-condition? v)
          (who-condition? v)
-         (#%memq (condition-who v) '(/ modulo remainder quotient atan angle log))
+         (#%memq (condition-who v) '(/ modulo remainder quotient atan angle log $quotient-remainder))
          (string=? "undefined for ~s" (condition-message v)))
     exn:fail:contract:divide-by-zero]
    [(and (format-condition? v)
          (who-condition? v)
-         (#%memq (condition-who v) '(expt atan2))
+         (#%memq (condition-who v) '(expt atan2 log))
          (string=? "undefined for values ~s and ~s" (condition-message v)))
     exn:fail:contract:divide-by-zero]
    [(and (format-condition? v)
@@ -70,7 +70,9 @@
                 exact inexact->exact
                 real->flonum ->fl
                 time-utc->date seconds->date
-                make-record-type-descriptor* make-struct-type)
+                make-record-type-descriptor* make-struct-type
+                atan2 atan
+                $quotient-remainder quotient/remainder)
         (set! rewrites-added? #t)))
     (getprop n 'error-rename n)))
 
@@ -86,9 +88,17 @@
              "~a: undefined;\n cannot reference an identifier before its definition"
              "\n  alert: compiler pass failed to add more specific guard!")
             irritants)]
-   [(and (equal? str "undefined for ~s")
+   [(and (eq? who '/)
+         (equal? str "undefined for ~s")
          (equal? irritants '(0)))
     (values "division by zero" null)]
+   [(equal? str "undefined for values ~s and ~s")
+    (cond
+     [(and (eq? who 'log)
+           (eqv? (cadr irritants) 1))
+      (values "undefined for base ~s" '(1))]
+     [else
+      (values "undefined for ~s and ~s" irritants)])]
    [(and (string-prefix? result-arity-msg-head str)
          (string-suffix? result-arity-msg-tail str))
     (values (string-append "result arity mismatch;\n"

--- a/racket/src/cs/rumble/number.ss
+++ b/racket/src/cs/rumble/number.ss
@@ -476,10 +476,24 @@
 (define/who (quotient/remainder n m)
   (check who integer? n)
   (check who integer? m)
-  (if (and (exact? n) (exact? m))
+  (let ([raise-undefined (lambda (what)
+                           (raise (|#%app|
+                                   exn:fail:contract:divide-by-zero
+                                   (error-message->adjusted-string
+                                    'quotient/remainder primitive-realm
+                                    (format "undefined for ~s" what)
+                                    primitive-realm)
+                                   (current-continuation-marks))))])
+    (cond
+     [(and (exact? n) (exact? m))
       (let ([q+r (#%$quotient-remainder n m)])
-        (values (car q+r) (cdr q+r)))
-      (values (quotient n m) (remainder n m))))
+        (values (car q+r) (cdr q+r)))]
+     [(eqv? m 0.0)
+      (raise-undefined 0.0)]
+     [(eqv? m -0.0)
+      (raise-undefined -0.0)]
+     [else
+      (values (quotient n m) (remainder n m))])))
 
 (define/who gcd
   (case-lambda


### PR DESCRIPTION
## Checklist
- [x] Bugfix
- [x] tests included
- [x] documentation

## Description of change
For `/`, say “division by zero”; for `log`, say either “undefined for 0” or “undefined for base 1”; for other functions, say “undefined for *x* (and *y*)”.  Also, correct function names for `atan` and `quotient/remainder` on CS, and correct printing of `-0.0` in `quotient{,/remainder}` on BC.

Update tests to include the error message strings, and add missing specs for raising of `exn:fail:contract:divide-by-zero` in docs.

The base-one error message in `log` on CS requires cisco/ChezScheme#1048.

Fix #5527.