### PR TITLE
add `ffi/unsafe/runtime-lib`

### DIFF
--- a/pkgs/racket-doc/scribblings/foreign/derived.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/derived.scrbl
@@ -26,4 +26,4 @@
 @include-section["file.scrbl"]
 @include-section["winapi.scrbl"]
 @include-section["vm.scrbl"]
-
+@include-section["runtime-lib.scrbl"]

--- a/pkgs/racket-doc/scribblings/foreign/runtime-lib.scrbl
+++ b/pkgs/racket-doc/scribblings/foreign/runtime-lib.scrbl
@@ -1,0 +1,78 @@
+#lang scribble/doc
+@(require "utils.rkt"
+          (for-label ffi/unsafe/runtime-lib))
+
+@title[#:tag "runtime-lib"]{Declaring Foreign Libraries Needed at Run Time}
+
+@defmodule[ffi/unsafe/runtime-lib]{The
+@racketmodname[ffi/unsafe/runtime-lib] library is similar to
+@racketmodname[racket/runtime-path] (and builds on it), but provides more
+support for platform-specific choices of libraries.}
+
+@history[#:added "9.2.0.6"]
+
+@defform[#:literals(else so or and)
+         (define-runtime-lib id
+            maybe-ffi-lib-args
+            [platform-spec lib-spec ...]
+            ...
+            [else else-body ...+])
+         #:grammar ([platform-spec os-id
+                                   os*-id
+                                   arch-id
+                                   platform-string
+                                   32
+                                   64
+                                   (or platform-spec ...)
+                                   (and platform-spec ...)]
+                    [lib-spec (so lib-string)
+                              (so lib-string (vers ...))]
+                    [vers string
+                          #f]
+                    [maybe-ffi-lib-args code:blank
+                                        (code:line #:ffi-lib-args (arg ...))])]{
+
+ Similar to @racket[define-runtime-path], but binds @racket[id] to a
+ result from @racket[ffi-lib] for a platform that matches one of the
+ @racket[platform-spec]s (which are tried in order), or to the result
+ of the @racket[else-body] sequence otherwise.
+
+ A @racket[platform-spec] implies a set of libraries that are loaded
+ in order as enumerated by the accompanying @racket[lib-spec]s, where
+ the @racket[lib-string] within a @racket[lib-spec] becomes the first
+ argument to @racket[ffi-lib], and the @racket[vers] sequence (if
+ present) is quoted as the second argument. The defined @racket[id] is
+ bound to a @racket[ffi-lib] result for the last @racket[lib-spec], or
+ to @racket[#f] if no @racket[lib-spec]s are present in the matching
+ clause. Besides loading the library for each @racket[lib-spec] at run
+ time, the libraries are declared at compile time for use by tools
+ such as @exec{raco exe} and @exec{raco dist}. Cross compilation is
+ handled automatically, so that the target platforms libraries are
+ listed at compile time, while run time loads libraries suitable to
+ the host platform.
+
+ If no @racket[platform-spec] matches, then @racket[id] is bound to
+ the result of the @racket[else-body] sequence---which does not have
+ to be a result from @racket[ffi-lib], but typically it is. The
+ @racket[else-body] sequence is evaluated only at run-time, and no
+ libraries are declared at compile time.
+
+ Each @racket[platform-spec] is is compared to the result of
+ @racket[(system-type 'os)], @racket[(system-type 'os*)],
+ @racket[(system-type 'arch)], @racket[(system-type 'platform)],
+ and/or @racket[(system-type 'word)]. In an @racket[and] form, all
+ @racket[platform-spec]s much match, while only one matching
+ @racket[platform-spec] is needed ro an @racket[or] form.
+
+ Extra keyword arguments can be supplied the run-time @racket[ffi-lib]
+ call for a @racket[platform-spec] match through an optional
+ @racket[#:ffi-lib-args] declaration. There's a single
+ @racket[#:ffi-lib-args] declaration, because it needs to be
+ independent of the @racket[platform-spec] that turns out to match.
+ The run-time call receives either an absolute path based on resolved
+ @racket[lib-spec], or it receives just the initial
+ @racket[lib-string] within a @racket[lib-spec] (due to limitations of
+ @racket[define-runtime-path]), so @racket[#:fail] is the most likely
+ useful extra argument to @racket[ffi-lib].
+
+}

--- a/pkgs/racket-test/tests/ffi/runtime-lib.rkt
+++ b/pkgs/racket-test/tests/ffi/runtime-lib.rkt
@@ -1,0 +1,96 @@
+#lang racket/base
+(require racket/path
+         ffi/unsafe/runtime-lib
+         ffi/unsafe
+         rackunit)
+
+;; This test will have to be updated if libraries
+;; change as used by the `openssl` package
+
+(define-runtime-lib ssl
+  [windows (so "libeay32")
+           (so "ssleay32")]
+  [(and macosx (or i386 ppc)) (so "libcrypto" ("1.1" #f))
+                              (so "libssl" ("1.1" #f))]
+  [macosx (so "libcrypto" ("3" #f))
+          (so "libssl" ("3" #f))]
+  [else 'none])
+
+(define-runtime-lib crypto
+  [windows (so "libeay32")]
+  [(and macosx (or i386 ppc)) (so "libcrypto" ("1.1" #f))]
+  [macosx (so "libcrypto" ("3" #f))]
+  [else 'other])
+
+(define-runtime-lib none
+  [else 'other])
+
+(define-runtime-lib also-none
+  ["no-such-patform"]
+  [else 'other])
+
+(check-equal? none 'other)
+(check-equal? also-none 'other)
+
+(case (system-type)
+  [(windows macosx)
+   (check-true (ffi-lib? crypto))
+   (check-true (ffi-lib? ssl))]
+  [else
+   (check-equal? crypto 'other)
+   (check-equal? ssl 'none)])
+
+(case (system-type)
+  [(windows)
+   (check-equal? (normal-case-path (file-name-from-path (ffi-lib-name ssl)))
+                 (string->path "ssleay32.dll"))]
+  [(macosx)
+   (check-equal? (normal-case-path (file-name-from-path (ffi-lib-name ssl)))
+                 (case (system-type 'arch)
+                   [(i386 pcc) (string->path "libssl.1.dylib")]
+                   [else (string->path "libssl.3.dylib")]))]
+  [else (void)])
+
+(case (system-type)
+  [(windows)
+   (check-equal? (normal-case-path (file-name-from-path (ffi-lib-name crypto)))
+                 (string->path "libeay32.dll"))]
+  [(macosx)
+   (check-equal? (normal-case-path (file-name-from-path (ffi-lib-name crypto)))
+                 (case (system-type 'arch)
+                   [(i386 pcc) (string->path "libcrypto.1.dylib")]
+                   [else (string->path "libcrypto.3.dylib")]))]
+  [else (void)])
+
+(define runtime-lib-ns (make-base-namespace))
+(parameterize ([current-namespace runtime-lib-ns])
+  (eval '(require ffi/unsafe/runtime-lib
+                  ffi/unsafe)))
+
+(define-syntax-rule (check-syntax e rx:msg)
+  (check-exn (lambda (exn)
+               (and (exn:fail:syntax? exn)
+                    (regexp-match? rx:msg (exn-message exn))))
+             (lambda ()
+               (parameterize ([current-namespace runtime-lib-ns]
+                              [error-print-source-location #f])
+                 (eval 'e)))))
+
+(check-syntax (define-runtime-lib x)
+              #rx"missing an `else` case")
+(check-syntax (define-runtime-lib x
+                [()]
+                [else #f])
+              #rx"expected.*identifier.*string")
+(check-syntax (define-runtime-lib x
+                #:ffi-lib-args (#f #f)
+                [else #f])
+              #rx"expected.*keyword")
+(check-syntax (define-runtime-lib x
+                [nonesuch "oops"]
+                [else #f])
+              #rx"expected.*`so`")
+(check-syntax (define-runtime-lib x
+                [nonesuch (so "oops" #f)]
+                [else #f])
+              #rx"expected library specification")

--- a/racket/collects/ffi/unsafe/runtime-lib.rkt
+++ b/racket/collects/ffi/unsafe/runtime-lib.rkt
@@ -1,0 +1,89 @@
+#lang racket/base
+(require ffi/unsafe
+         racket/runtime-path
+         setup/cross-system
+         (for-syntax racket/base
+                     syntax/parse/pre
+                     setup/cross-system))
+
+(provide define-runtime-lib)
+
+(begin-for-syntax
+  (define-syntax-class :system-spec
+    #:description "platform specification"
+    #:attributes (predicate)
+    #:datum-literals (windows macosx unix)
+    #:literals (and or)
+    (pattern (and system::system-spec ...)
+             #:attr predicate #'(lambda (os os* arch platform word)
+                                  (and (system.predicate os os* arch platform word)
+                                       ...)))
+    (pattern (or system::system-spec ...)
+             #:attr predicate #'(lambda (os os* arch platform word)
+                                  (or (system.predicate os os* arch platform word)
+                                      ...)))
+    (pattern (~and (~or windows macosx unix) sys) ; ad hoc optimization
+             #:attr predicate #'(lambda (os os* arch platform word) (eq? os 'sys)))
+    (pattern name:id
+             #:when (not (free-identifier=? #'name #'else))
+             #:attr predicate #'(lambda (os os* arch platform word)
+                                  (or (eq? 'name os)
+                                      (eq? 'name os*)
+                                      (eq? 'name arch))))
+    (pattern platform-str:string
+             #:attr predicate #'(lambda (os os* arch platform word)
+                                  (equal? platform 'platform-str)))
+    (pattern (~and (~or 32 64) size)
+             #:attr predicate #'(lambda (os os* arch platform word) (eqv? word 'size))))
+
+  (define-syntax-class :lib-spec
+    #:description "library specification using `so`"
+    #:attributes (quoted)
+    #:datum-literals (so)
+    (pattern (so lib-str:string)
+             #:attr quoted #'(so lib-str))
+    (pattern (so lib-str:string vers:string)
+             #:attr quoted #'(so lib-str vers))
+    (pattern (so lib-str:string (~and vers ((~or _:string #f) ...)))
+             #:attr quoted #'(so lib-str vers))))
+
+(define-syntax (define-runtime-lib stx)
+  (syntax-parse stx
+    #:literals (else)
+    #:datum-literals (unix)
+    [(_ lib-id:id
+        (~optional (~seq #:ffi-lib-args (~and ((~seq _:keyword _:expr) ...)
+                                              (ffi-lib-arg ...)))
+                   #:defaults ([(ffi-lib-arg 1) '()]))
+        [system::system-spec
+         ~!
+         system-lib::lib-spec
+         ...]
+        ...
+        (~optional
+         [else
+          else-lib-expr
+          ...+]))
+     (unless (attribute else-lib-expr)
+       (raise-syntax-error #f "missing an `else` case" stx))
+     #'(begin
+         (define-runtime-path-list libs
+           #:runtime?-id runtime?
+           (let* ([os (if runtime? (system-type) (cross-system-type))]
+                  [os* (if runtime? (system-type 'os*) (cross-system-type 'os*))]
+                  [arch (if runtime? (system-type 'arch) (cross-system-type 'arch))]
+                  [word (if runtime? (system-type 'word) (cross-system-type 'word))]
+                  [platform (if runtime? (system-type 'platform) (cross-system-type 'platform))])
+             (cond
+               [(system.predicate os os* arch platform word)
+                '(system-lib.quoted ...)]
+               ...
+               [else null])))
+         (define lib-id
+           (if (null? libs)
+               (let ()
+                 (begin
+                   else-lib-expr
+                   ...))
+               (for/fold ([v #f]) ([lib (in-list libs)])
+                 (ffi-lib lib ffi-lib-arg ...)))))]))


### PR DESCRIPTION
Like `define-runtime-path` (which it builds on), `define-runtime-lib` both binds a name to a foreign library and declares relevant libraries at compile time to be picked up by `raco exe` and `raco dist`.

The `define-runtime-lib` form is based on the same-named form that has long been exported by `racket/draw/private/utils/libs`, but modernized, generalized, and made public. The intent is that `racket/draw/private/utils/libs` will change to use this implementation (while also supporting its legacy syntax).
