### PR TITLE
openssl secure tests: raise bad-host connect timeout to 10s

### DIFF
--- a/pkgs/racket-test/tests/openssl/test-secure.rkt
+++ b/pkgs/racket-test/tests/openssl/test-secure.rkt
@@ -18,7 +18,8 @@
 
 (define-logger test)
 
-(define TIMEOUT-SEC 3)
+;; badssl.com can introduce delays because it's all served from the same host.
+(define TIMEOUT-SEC 10)
 
 ;; Racket sites
 (define racket-hosts


### PR DESCRIPTION
Avoid errors seen on DrDr