### PR TITLE
WIP: Add `keyword-prefixed-field`

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/struct.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/struct.scrbl
@@ -772,7 +772,7 @@ struct instance from being considered quotable. For example:
 (print (list (point2 1 2) (point2 3 4)))
 ]
 
-Keyword arguments can be simulated with @racket[unquoted-printing-string]:
+Keyword arguments can be printed with @racket[keyword-prefixed-field]:
 
 @examples[#:eval struct-eval #:label #f
 (code:comment "Private implementation")
@@ -782,10 +782,8 @@ Keyword arguments can be simulated with @racket[unquoted-printing-string]:
      (make-constructor-style-printer
       (lambda (obj) 'kwpoint)
       (lambda (obj)
-        (list (unquoted-printing-string "#:x")
-              (kwpoint-impl-x obj)
-              (unquoted-printing-string "#:y")
-              (kwpoint-impl-y obj)))))])
+        (list (keyword-prefixed-field '#:x (kwpoint-impl-x obj))
+              (keyword-prefixed-field '#:y (kwpoint-impl-y obj))))))])
 (code:comment "Public ``constructor''")
 (define (kwpoint #:x x #:y y)
   (kwpoint-impl x y))
@@ -795,6 +793,21 @@ Keyword arguments can be simulated with @racket[unquoted-printing-string]:
 ]
 
 @history[#:added "6.3"]{}
+}
+
+@defstruct*[keyword-prefixed-field ([keyword keyword?] [value any/c])]{
+ A @deftech{keyword prefixed field} wraps @racket[value] and @racket[print]s, @racket[write]s, and
+ @racket[display]s the same way that @racket[value] does, except that @racket[keyword] is printed
+ before it as a prefix. This printing cooperates with the pretty printer --- if the keyword and
+ @racket[value] are too large to fit on a single line (including the single space separating them)
+ then @racket[value] will be printed on the following line, indented by two spaces. This behavior is
+ useful in combination with @racket[make-constructor-style-printer] for printing "named fields" that
+ are meant to correspond to keyword arguments of a smart constructor.
+
+ This is intended to replace the previously recommended solution to this problem, which was to use
+ @racket[unquoted-printing-string]. Unlike @racket[unquoted-printing-string],
+ using @racket[keyword-prefixed-field] keeps the keyword and corresponding value on the same line in
+ most cases.
 }
 
 @defproc[(struct->list [v any/c]

--- a/racket/collects/racket/private/custom-write.rkt
+++ b/racket/collects/racket/private/custom-write.rkt
@@ -1,6 +1,13 @@
 #lang racket/base
-(require racket/pretty)
-(provide make-constructor-style-printer)
+
+
+(provide make-constructor-style-printer
+         (struct-out keyword-prefixed-field))
+
+
+(require racket/contract
+         racket/pretty)
+
 
 ;; make-constructor-style-printer : (Any -> (U String Symbol))
 ;;                                  (Any -> (Sequenceof Any))
@@ -73,3 +80,56 @@
           [else
            (print/one-line port)])
     (void)))
+
+
+(struct keyword-prefixed-field (keyword value)
+
+  #:transparent
+
+  #:guard (struct-guard/c keyword? any/c)
+
+  #:methods gen:custom-write
+  [(define (write-proc this port mode)
+     (define keyword (keyword-prefixed-field-keyword this))
+     (define field-value (keyword-prefixed-field-value this))
+
+     (define (recur x p)
+       (case mode
+         ((#t) (write x p))
+         ((#f) (display x p))
+         ((0 1) (print x p mode))))
+
+     (define (print-field p leading-space)
+       (write-string "#:" p)
+       (write-string (keyword->string keyword) p)
+       (define lead (make-string (+ (or leading-space 0) 2) #\space))
+       (when leading-space
+         (pretty-print-newline p (pretty-print-columns)))
+       (write-string lead p)
+       (recur field-value p))
+
+     (define (print/one-line p)
+       (print-field p #f))
+
+     (define (print/multi-line p)
+       (define-values (unused-line col unused-pos) (port-next-location p))
+       (print-field p col))
+
+     (cond
+       [(and (pretty-printing)
+             (integer? (pretty-print-columns)))
+        ((let/ec esc
+           (define tport
+             (make-tentative-pretty-print-output-port
+              port
+              (- (pretty-print-columns) 1)
+              (λ () 
+                (esc
+                 (λ ()
+                   (tentative-pretty-print-port-cancel tport)
+                   (print/multi-line port))))))
+           (print/one-line tport)
+           (tentative-pretty-print-port-transfer tport port)
+           void))]
+       [else (print/one-line port)])
+     (void))])

--- a/racket/collects/racket/private/custom-write.rkt
+++ b/racket/collects/racket/private/custom-write.rkt
@@ -5,7 +5,7 @@
          (struct-out keyword-prefixed-field))
 
 
-(require racket/contract
+(require racket/contract/base
          racket/pretty)
 
 
@@ -102,7 +102,11 @@
      (define (print-field p leading-space)
        (write-string "#:" p)
        (write-string (keyword->string keyword) p)
-       (define lead (make-string (+ (or leading-space 0) 2) #\space))
+       (define lead-space-count
+         (if leading-space
+             (+ leading-space 2)
+             1))
+       (define lead (make-string lead-space-count #\space))
        (when leading-space
          (pretty-print-newline p (pretty-print-columns)))
        (write-string lead p)

--- a/racket/collects/racket/struct.rkt
+++ b/racket/collects/racket/struct.rkt
@@ -1,12 +1,18 @@
 #lang racket/base
+
+
 (require "private/custom-write.rkt"
          racket/contract/base)
+
+
 (provide (contract-out
           [make-constructor-style-printer
            (-> (-> any/c (or/c symbol? string?))
                (-> any/c sequence?)
                (-> any/c output-port? (or/c #t #f 0 1) void?))])
-         struct->list)
+         struct->list
+         (struct-out keyword-prefixed-field))
+
 
 (define dummy-value (box 'dummy))
 


### PR DESCRIPTION
## Checklist

- [x] Feature
- [ ] tests included
- [x] documentation

## Description of change

When using `make-constructor-style-printer`, the current guidance for handling fields that are passed to the struct's constructor by name instead of by position is to use `unquoted-printing-string` to insert quoteless keywords into the printed representation. This has downsides when the struct is too long to print on a single line with the pretty printer. For example, printing `(foo #:a 1 #:b 2)` over multiple lines would print out thusly:

```scheme
(foo
 #:a
 1
 #:b
 2)
```

This is unreadable. Far better is to keep each keyword and argument on the same line unless *that specific field* is the one that's long enough to force the line break. And in that instance, it would be better to indent the field value slightly to better communicate via indentation that it's associated with the keyword on the line above it. Supposing that the `#:a` field in the example above was the one that was excessively long, the above would be more readable like this:

```scheme
(foo
 #:a
   1
 #:b 2)
```

This commit adds a `keyword-prefixed-field` struct wrapping a keyword and an arbitrary value which, when printed, implements the above behavior for a single keyword field. By combining this with `make-constructor-style-printer`, we can achieve the desired pretty printing behavior.