### PR TITLE
Update URL for pregexp documentation

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/guide.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/guide.scrbl
@@ -101,7 +101,7 @@ precise details to @|Racket| and other reference manuals.
  (bib-entry #:key "Sitaram05"
             #:author "Dorai Sitaram"
             #:title "pregexp: Portable Regular Expressions for Scheme and Common Lisp"
-            #:url "http://www.ccs.neu.edu/home/dorai/pregexp/"
+            #:url "https://ds26gte.github.io/pregexp/"
             #:date "2002")
 
 )


### PR DESCRIPTION
The pregexp bibliography entry points to an obsolete Northeastern
University URL. Replace it with Dorai Sitaram's current
author-maintained page:

https://ds26gte.github.io/pregexp/

<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] documentation

## Description of change
<!-- Please provide a description of the change here. -->
update the url of pregexp to valid url
