### PR TITLE
docs: fix another description of `body` metavariable

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/notation.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/notation.scrbl
@@ -89,10 +89,8 @@ names have implicit grammar productions:
 
  @item{A metavariable that ends with @racket[_body] stands for any
        @tech{form}; the form will be parsed as either a local definition or
-       an expression. A @racket[_body] can parse as a definition only
-       if it is not preceded by any expression, and the last
-       @racket[_body] must be an expression; see also
-       @secref["intdef-body"].}
+       an expression. The last @racket[_body] must be an expression;
+       see also @secref["intdef-body"].}
 
  @item{A metavariable that ends with @racket[_datum] stands for any
        @tech{form}, and the form is normally uninterpreted (e.g.,


### PR DESCRIPTION
Mixing expressions amid definitions has long been allowed.

Related to: 6e6166ef95cb52e921153d3d93d2ee0a05aee1e4
Related to: https://github.com/racket/racket/pull/3123
Related to: https://github.com/racket/racket/issues/2264