### PR TITLE
Correct barcode module filename in Guide example

### DIFF
--- a/pkgs/racket-doc/scribblings/guide/module-basics.scrbl
+++ b/pkgs/racket-doc/scribblings/guide/module-basics.scrbl
@@ -100,7 +100,7 @@ its own source to access the @filepath{db/barcodes.rkt} and
 @racketmod[
 #:file "db/lookup.rkt"
 racket
-(require "barcode.rkt" "makers.rkt")
+(require "barcodes.rkt" "makers.rkt")
 ....]
 
 Ditto for @filepath{machine/control.rkt}:


### PR DESCRIPTION
## Checklist

- [x] documentation

## Description of change

The [Organizing Modules example](https://docs.racket-lang.org/guide/module-basics.html#%28part._module-org%29) names the helper module `db/barcodes.rkt` in its prose and diagram, but the adjacent `db/lookup.rkt` example requires `barcode.rkt`.

Change the example to require `barcodes.rkt` so the references agree.