### PR TITLE
CS: fill in missing `error-message->adjusted-string` in primitives

### DIFF
--- a/racket/src/cs/rumble/foreign.ss
+++ b/racket/src/cs/rumble/foreign.ss
@@ -921,7 +921,10 @@
     (raise
      (|#%app|
       exn:fail:filesystem
-      (format "~a: not yet ready\n  name: ~a" who name)
+      (error-message->adjusted-string
+       who primitive-realm
+       (format "not yet ready\n  name: ~a" name)
+       primitive-realm)
       (current-continuation-marks)))))
 
 (define ffi-ptr->address

--- a/racket/src/cs/rumble/impersonator.ss
+++ b/racket/src/cs/rumble/impersonator.ss
@@ -254,12 +254,15 @@
   (raise
    (|#%app|
     exn:fail:contract:arity
-    (string-append
-     (symbol->string who) ": arity mismatch;\n"
-     " received wrong number of values from a chaperone's replacement procedure\n"
-     "  expected: " (number->string n) "\n"
-     "  received: " (number->string (length args)) "\n"
-     "  chaperone: " (error-value->string orig)))))
+    (error-message->adjusted-string
+     who primitive-realm
+     (string-append
+      "arity mismatch;\n"
+      " received wrong number of values from a chaperone's replacement procedure\n"
+      "  expected: " (number->string n) "\n"
+      "  received: " (number->string (length args)) "\n"
+      "  chaperone: " (error-value->string orig))
+     primitive-realm))))
 
 ;; ----------------------------------------
 
@@ -711,16 +714,22 @@
       (raise
        (|#%app|
         exn:fail:contract:variable
-        (format "~a: ~a;\n cannot ~a field before initialization"
-                n short-msg what)
+        (error-message->adjusted-string
+         n primitive-realm
+         (format "~a;\n cannot ~a field before initialization"
+                 short-msg what)
+         primitive-realm)
         (current-continuation-marks)
         n)))]
    [else
     (raise
      (|#%app|
       exn:fail:contract
-      (format "~a: ~a;\n cannot ~as field before initialization"
-              (object-name orig-proc) short-msg what)
+      (error-message->adjusted-string
+       (object-name orig-proc) primitive-realm
+       (format "~a;\n cannot ~a field before initialization"
+               short-msg what)
+       primitive-realm)
       (current-continuation-marks)))])))
 
 ;; ----------------------------------------

--- a/racket/src/cs/rumble/memory.ss
+++ b/racket/src/cs/rumble/memory.ss
@@ -226,8 +226,11 @@
       (unless (fixnum? n)
         (raise (|#%app|
                 exn:fail:out-of-memory
-                (#%format "out of memory making ~a\n  length: ~a"
-                          what len)
+                (error-message->adjusted-string
+                 #f primitive-realm
+                 (#%format "out of memory making ~a\n  length: ~a"
+                           what len)
+                 primitive-realm)
                 (current-continuation-marks))))
       (immediate-allocation-check n)
       ;; Watch out for radiply growing memory use that isn't captured

--- a/racket/src/cs/rumble/number.ss
+++ b/racket/src/cs/rumble/number.ss
@@ -419,11 +419,16 @@
              radix))
     (when (and (not (eq? radix 10)) (inexact? n))
       (raise
-       (exn:fail:contract (string-append
-                           "number->string: inexact numbers can only be printed in base 10\n"
-                           "  number: " (number->string n) "\n"
-                           "  requested base: " (number->string radix))
-                          (current-continuation-marks))))
+       (|#%app|
+        exn:fail:contract
+        (error-message->adjusted-string
+         'number->string primitive-realm
+         (string-append
+          "inexact numbers can only be printed in base 10\n"
+          "  number: " (number->string n) "\n"
+          "  requested base: " (number->string radix))
+         primitive-realm)
+        (current-continuation-marks))))
     (do-number->string n radix)]
    [(n)
     (do-number->string n 10)]))

--- a/racket/src/cs/rumble/procedure.ss
+++ b/racket/src/cs/rumble/procedure.ss
@@ -917,8 +917,11 @@
   (raise
    (|#%app|
     exn:fail:contract:arity
-    (string-append "procedure-result chaperone: result arity mismatch;\n"
-                   " expected number of values not received from wrapper on the original procedure's result")
+    (error-message->adjusted-string
+     '|procedure-result chaperone| primitive-realm
+     (string-append "result arity mismatch;\n"
+                    " expected number of values not received from wrapper on the original procedure's result")
+     primitive-realm)
     (current-continuation-marks))))
 
 (define (raise-mark-missing-key-or-val-error chaperone? pos next-p wrapper)
@@ -950,19 +953,20 @@
   (raise
    (|#%app|
     exn:fail:contract:arity
-    (string-append
+    (error-message->adjusted-string
      (if chaperone?
-         "procedure chaperone"
-         "procedure impersonator")
-     ": arity mismatch;\n"
-     " expected number of results not received from wrapper on the original\n"
-     " procedure's arguments\n"
-     "  original: " (reindent/newline (error-value->string proc))
-     "\n"
-     "  wrapper: " (reindent/newline (error-value->string wrapper))
-     "\n"
-     "  expected: " (number->string expected-n) " or more\n"
-     "  received: " (number->string got-n))
+         '|procedure chaperone|
+         '|procedure impersonator|)
+     primitive-realm
+     (string-append
+      "arity mismatch;\n"
+      " expected number of results not received from wrapper on the original\n"
+      " procedure's arguments\n"
+      "  original: " (reindent/newline (error-value->string proc)) "\n"
+      "  wrapper: " (reindent/newline (error-value->string wrapper)) "\n"
+      "  expected: " (number->string expected-n) " or more\n"
+      "  received: " (number->string got-n))
+     primitive-realm)
     (current-continuation-marks))))
 
 ;; ----------------------------------------


### PR DESCRIPTION
## Checklist
- [x] Bugfix