### PR TITLE
Chez Scheme: fuse call-with-values through non-atomic values args

### DIFF
--- a/racket/src/ChezScheme/mats/cp0.ms
+++ b/racket/src/ChezScheme/mats/cp0.ms
@@ -382,6 +382,31 @@
           (lambda () (div-and-mod 7 3))
           (lambda (x y) (#2%cons (* x 10) (/ y 10)))))
      '(#2%cons 20 1/10))
+  ; verify call-with-values still fuses producer and consumer when a
+  ; non-atomic `values` argument forces cp0 to bind it to a temp before
+  ; constructing the tuple, instead of leaving a residual call-with-values
+  ; (github issue #4634)
+   (equivalent-expansion?
+     (expand/optimize
+       '(lambda (x)
+          (call-with-values
+            (lambda () (values (add1 x) (sub1 x)))
+            (lambda (a b) (+ a b)))))
+     '(lambda (x) (#3%+ (#2%add1 x) (#2%sub1 x))))
+   (equivalent-expansion?
+     (expand/optimize
+       '(lambda (x)
+          (call-with-values
+            (lambda () (values (add1 x) x))
+            (lambda (a b) (+ a b)))))
+     '(lambda (x) (#2%+ (#2%add1 x) x)))
+   (equivalent-expansion?
+     (expand/optimize
+       '(lambda (x)
+          (call-with-values
+            (lambda () (values (add1 x) (sub1 x) (* x 2)))
+            (lambda (a b c) (+ a b c)))))
+     '(lambda (x) (#3%+ (#2%add1 x) (#2%sub1 x) (#2%* 2 x))))
 
   (equivalent-expansion?
    (expand/optimize '(lambda (t) (#3%$value (if t 1 (values 3 3 3))) #t))

--- a/racket/src/ChezScheme/s/cp0.ss
+++ b/racket/src/ChezScheme/s/cp0.ss
@@ -961,6 +961,37 @@
           [(seq ,e1 ,e2) `(seq ,e1 ,body)]
           [else body])))
 
+    ; Like `result-exp`, but also looks through the wrappers cp0 introduces
+    ; to sequence evaluation of non-atomic subexpressions before combining
+    ; them, e.g. the `(add1 x)` in `(values (add1 x) (sub1 x))` gets bound
+    ; to a temp first. cp0 represents that binding not as `letrec`, but as
+    ; an immediate call to a single-clause `case-lambda` (i.e., `let`'s
+    ; actual internal Lsrc shape). Used to recognize a producer that
+    ; tail-calls `values` even after that sequencing.
+    (define (find-values-in-tail e)
+      (nanopass-case (Lsrc Expr) e
+        [(seq ,e1 ,e2) (find-values-in-tail e2)]
+        [(letrec ([,x* ,e*] ...) ,body) (find-values-in-tail body)]
+        [(letrec* ([,x* ,e*] ...) ,body) (find-values-in-tail body)]
+        [(call ,preinfo (case-lambda ,preinfo2 (clause (,x* ...) ,interface ,body)) ,e* ...)
+         (find-values-in-tail body)]
+        [(call ,preinfo ,pr ,e* ...)
+         (guard (eq? (primref-name pr) 'values))
+         e*]
+        [else #f]))
+
+    ; The `non-result-exp` counterpart to `find-values-in-tail`: rebuilds
+    ; the same chain of wrappers found by `find-values-in-tail`, with
+    ; `new-body` spliced in as the new tail.
+    (define (rewrap-tail e new-body)
+      (nanopass-case (Lsrc Expr) e
+        [(seq ,e1 ,e2) `(seq ,e1 ,(rewrap-tail e2 new-body))]
+        [(letrec ([,x* ,e*] ...) ,body) `(letrec ([,x* ,e*] ...) ,(rewrap-tail body new-body))]
+        [(letrec* ([,x* ,e*] ...) ,body) `(letrec* ([,x* ,e*] ...) ,(rewrap-tail body new-body))]
+        [(call ,preinfo (case-lambda ,preinfo2 (clause (,x* ...) ,interface ,body)) ,e* ...)
+         `(call ,preinfo (case-lambda ,preinfo2 (clause (,x* ...) ,interface ,(rewrap-tail body new-body))) ,e* ...)]
+        [else new-body]))
+
     (define (arity-okay? arity n)
       (or (not arity) ; presumably system routine w/no recorded arity
           (ormap
@@ -2558,15 +2589,20 @@
                (let ((*p-val (cp0 (build-ref p-temp) ctxt1 env sc wd #f moi)))
                  (cond
                    [(and (app-used ctxt1)
-                         (let ([e (result-exp *p-val)])
-                           (nanopass-case (Lsrc Expr) e
-                             [(call ,preinfo ,pr ,e* ...)
-                              (guard (eq? (primref-name pr) 'values))
-                              e*]
-                             [else (and (single-valued/inspect-ok? e)
-                                        (list e))]))) =>
+                         (find-values-in-tail *p-val)) =>
                     (lambda (args)
                       ; (with-values (values arg ...) c-temp) => (c-temp arg ...)
+                      (letify (make-preinfo-lambda) ids ctxt
+                        (rewrap-tail *p-val
+                          (cp0-call (app-preinfo ctxt) (build-ref c-temp)
+                            (map build-cooked-opnd args)
+                            (app-ctxt ctxt) env sc wd (app-name ctxt) moi))))]
+                   [(and (app-used ctxt1)
+                         (let ([e (result-exp *p-val)])
+                           (and (single-valued/inspect-ok? e)
+                                (list e)))) =>
+                    (lambda (args)
+                      ; (with-values (single-valued-e) c-temp) => (c-temp (single-valued-e))
                       (letify (make-preinfo-lambda) ids ctxt
                         (non-result-exp *p-val
                           (cp0-call (app-preinfo ctxt) (build-ref c-temp)


### PR DESCRIPTION
## Checklist

- [x] Bugfix
- [ ] Feature
- [x] tests included
- [ ] documentation

## Description of change

Fixes #4634.

cp0's `call-with-values` inlining only recognized a producer whose body,
after stripping a `seq` wrapper, was directly a `(values e ...)` call. When
a `values` argument is non-atomic (e.g. `(add1 x)`), cp0 must bind it to a
temp first to fix evaluation order before constructing the tuple. That
binding is represented not as `letrec`, but as an immediate application of
a single-clause `case-lambda` (`let`'s actual Lsrc shape), which the
existing `result-exp`-based check didn't see through, so the fusion
silently fell back to a residual `call-with-values` call:

```racket
(define (test x)
  (define-values (a b) (values (add1 x) (sub1 x)))
  (+ a b))
```

## Fix

Added `find-values-in-tail`/`rewrap-tail` to `s/cp0.ss`, generalizing
`result-exp`/`non-result-exp` to also look through `seq`,
`letrec`/`letrec*`, and that case-lambda-application shape, recursively
(so multiple non-atomic args, needing nested bindings, are handled too).
These are new, narrowly-scoped helpers rather than a change to the
existing global `result-exp`/`non-result-exp`, which are used in 30+
other places in this file — this keeps the change confined to the one
optimization being extended.

The fix never strips or reorders the sequencing bindings, only relocates
what they feed into (from the `values` call to the fused consumer call),
so the evaluation-order guarantee they exist for is preserved.

## Testing

- Added 3 regression tests to `mats/cp0.ms`'s `call-with-values` section:
  the issue's reported 2-value case, its already-working sibling case
  (confirming no regression), and a 3-value case with two non-atomic args
  requiring nested bindings.
- Ran the full `mats/cp0.ms` suite plus `6.ms`, `5_3.ms`, and `cptypes.ms`
  via a standalone `pb` Chez Scheme build: zero Bugs/Errors.
- Verified via `PLT_LINKLET_SHOW_CP0` on compiled modules that
  `call-with-values` is fully eliminated and runtime results are correct
  for the 2-value, already-working, and 3-value cases.