### PR TITLE
syntax/parse: track `'disappeared-use` in syntax-class definitions

### DIFF
--- a/racket/collects/syntax/parse/private/parse.rkt
+++ b/racket/collects/syntax/parse/private/parse.rkt
@@ -61,30 +61,31 @@
  (define (tx:define-*-syntax-class stx splicing?)
    (syntax-case stx ()
      [(_ header . rhss)
-      (parameterize ((current-syntax-context stx))
-        (let-values ([(name formals arity)
-                      (let ([p (check-stxclass-header #'header stx)])
-                        (values (car p) (cadr p) (caddr p)))])
-          (let ([the-rhs (parse-rhs #'rhss splicing? #:context stx
-                                    #:default-description (symbol->string (syntax-e name)))])
-            (with-syntax ([name name]
-                          [formals formals]
-                          [splicing? splicing?]
-                          [desc (cond [(rhs-description the-rhs) => string-expr-value] [else #f])]
-                          [parser (generate-temporary (format-symbol "parse-~a" name))]
-                          [arity arity]
-                          [attrs (rhs-attrs the-rhs)]
-                          [commit? (rhs-commit? the-rhs)]
-                          [delimit-cut? (rhs-delimit-cut? the-rhs)]
-                          [the-rhs-expr (datum->expression the-rhs)])
-              #`(begin (define-syntax name
-                         (stxclass (quote name) (quote arity) (quote attrs)
-                                   (quote-syntax parser)
-                                   (quote splicing?)
-                                   (scopts (length 'attrs) 'commit? 'delimit-cut? desc)
-                                   #f))
-                       (define-values (parser)
-                         (parser/rhs name formals attrs the-rhs-expr splicing? #,stx)))))))])))
+      (with-disappeared-uses
+        (parameterize ((current-syntax-context stx))
+          (let-values ([(name formals arity)
+                        (let ([p (check-stxclass-header #'header stx)])
+                          (values (car p) (cadr p) (caddr p)))])
+            (let ([the-rhs (parse-rhs #'rhss splicing? #:context stx
+                                      #:default-description (symbol->string (syntax-e name)))])
+              (with-syntax ([name name]
+                            [formals formals]
+                            [splicing? splicing?]
+                            [desc (cond [(rhs-description the-rhs) => string-expr-value] [else #f])]
+                            [parser (generate-temporary (format-symbol "parse-~a" name))]
+                            [arity arity]
+                            [attrs (rhs-attrs the-rhs)]
+                            [commit? (rhs-commit? the-rhs)]
+                            [delimit-cut? (rhs-delimit-cut? the-rhs)]
+                            [the-rhs-expr (datum->expression the-rhs)])
+                #`(begin (define-syntax name
+                           (stxclass (quote name) (quote arity) (quote attrs)
+                                     (quote-syntax parser)
+                                     (quote splicing?)
+                                     (scopts (length 'attrs) 'commit? 'delimit-cut? desc)
+                                     #f))
+                         (define-values (parser)
+                           (parser/rhs name formals attrs the-rhs-expr splicing? #,stx))))))))])))
 
 (define-syntax (parser/rhs stx)
   (syntax-case stx ()
@@ -270,52 +271,56 @@
   (define (parse-alt x)
     (syntax-case x (pattern)
       [(pattern alt)
-       #'alt]
-      [else
+       (begin
+         (record-disappeared-uses (list (stx-car x)))
+         #'alt)]
+      [_
        (wrong-syntax x "expected eh-alternative-set alternative")]))
   (parameterize ((current-syntax-context stx))
     (syntax-case stx ()
       [(_ name a ...)
-       (unless (identifier? #'name)
-         (wrong-syntax #'name "expected identifier"))
-       (let* ([alts (map parse-alt (syntax->list #'(a ...)))]
-              [decls (new-declenv null #:conventions null)]
-              [ehpat+hstx-list
-               (apply append
-                      (for/list ([alt (in-list alts)])
-                        (parse-EH-variant alt decls #t #:context stx)))]
-              [eh-alt+defs-list
-               (for/list ([ehpat+hstx (in-list ehpat+hstx-list)])
-                 (let ([ehpat (car ehpat+hstx)]
-                       [hstx (cadr ehpat+hstx)])
-                   (cond [(syntax? hstx)
-                          (define the-pattern (ehpat-head ehpat))
-                          (define attrs (iattrs->sattrs (pattern-attrs the-pattern)))
-                          (define the-variant (variant hstx attrs the-pattern null))
-                          (define the-rhs (rhs attrs #t #f (list the-variant) null #f #f))
-                          (with-syntax ([(parser) (generate-temporaries '(eh-alt-parser))]
-                                        [the-rhs-expr (datum->expression the-rhs)])
-                            (list (eh-alternative (ehpat-repc ehpat) attrs #'parser)
-                                  (list #`(define parser
-                                            (parser/rhs parser () #,attrs
-                                                        the-rhs-expr #t #,stx)))))]
-                         [(eh-alternative? hstx)
-                          (list hstx null)]
-                         [else
-                          (error 'define-eh-alternative-set "internal error: unexpected ~e"
-                                 hstx)])))]
-              [eh-alts (map car eh-alt+defs-list)]
-              [defs (apply append (map cadr eh-alt+defs-list))])
-         (with-syntax ([(def ...) defs]
-                       [(alt-expr ...)
-                        (for/list ([alt (in-list eh-alts)])
-                          (with-syntax ([repc-expr
-                                         (datum->expression (eh-alternative-repc alt))]
-                                        [attrs-expr
-                                         #`(quote #,(eh-alternative-attrs alt))]
-                                        [parser-expr
-                                         #`(quote-syntax #,(eh-alternative-parser alt))])
-                            #'(eh-alternative repc-expr attrs-expr parser-expr)))])
-           #'(begin def ...
-                    (define-syntax name
-                      (eh-alternative-set (list alt-expr ...))))))])))
+       (begin
+         (unless (identifier? #'name)
+           (wrong-syntax #'name "expected identifier"))
+         (with-disappeared-uses
+           (let* ([alts (map parse-alt (syntax->list #'(a ...)))]
+                  [decls (new-declenv null #:conventions null)]
+                  [ehpat+hstx-list
+                   (apply append
+                          (for/list ([alt (in-list alts)])
+                            (parse-EH-variant alt decls #t #:context stx)))]
+                  [eh-alt+defs-list
+                   (for/list ([ehpat+hstx (in-list ehpat+hstx-list)])
+                     (let ([ehpat (car ehpat+hstx)]
+                           [hstx (cadr ehpat+hstx)])
+                       (cond [(syntax? hstx)
+                              (define the-pattern (ehpat-head ehpat))
+                              (define attrs (iattrs->sattrs (pattern-attrs the-pattern)))
+                              (define the-variant (variant hstx attrs the-pattern null))
+                              (define the-rhs (rhs attrs #t #f (list the-variant) null #f #f))
+                              (with-syntax ([(parser) (generate-temporaries '(eh-alt-parser))]
+                                            [the-rhs-expr (datum->expression the-rhs)])
+                                (list (eh-alternative (ehpat-repc ehpat) attrs #'parser)
+                                      (list #`(define parser
+                                                (parser/rhs parser () #,attrs
+                                                            the-rhs-expr #t #,stx)))))]
+                             [(eh-alternative? hstx)
+                              (list hstx null)]
+                             [else
+                              (error 'define-eh-alternative-set "internal error: unexpected ~e"
+                                     hstx)])))]
+                  [eh-alts (map car eh-alt+defs-list)]
+                  [defs (apply append (map cadr eh-alt+defs-list))])
+             (with-syntax ([(def ...) defs]
+                           [(alt-expr ...)
+                            (for/list ([alt (in-list eh-alts)])
+                              (with-syntax ([repc-expr
+                                             (datum->expression (eh-alternative-repc alt))]
+                                            [attrs-expr
+                                             #`(quote #,(eh-alternative-attrs alt))]
+                                            [parser-expr
+                                             #`(quote-syntax #,(eh-alternative-parser alt))])
+                                #'(eh-alternative repc-expr attrs-expr parser-expr)))])
+               #'(begin def ...
+                        (define-syntax name
+                          (eh-alternative-set (list alt-expr ...))))))))])))

--- a/racket/collects/syntax/parse/private/rep-data.rkt
+++ b/racket/collects/syntax/parse/private/rep-data.rkt
@@ -246,7 +246,5 @@ expressions are duplicated, and may be evaluated in different scopes.
 (provide get-eh-alternative-set)
 
 (define (get-eh-alternative-set id)
-  (let ([v (syntax-local-value id (lambda () #f))])
-    (unless (eh-alternative-set? v)
-      (wrong-syntax id "not defined as an eh-alternative-set"))
-    v))
+  (or (syntax-local-value/record id eh-alternative-set?)
+      (wrong-syntax id "not defined as an eh-alternative-set")))

--- a/racket/collects/syntax/parse/private/rep.rkt
+++ b/racket/collects/syntax/parse/private/rep.rkt
@@ -479,8 +479,8 @@
      (begin (disappeared! stx)
             (pat:any))]
     [~!
-     (disappeared! stx)
      (begin
+       (disappeared! stx)
        (unless (cut-allowed?)
          (wrong-syntax stx
                        "cut (~~!) not allowed within ~~not pattern"))
@@ -497,89 +497,112 @@
      (atomic-datum-stx? #'datum)
      (pat:datum (syntax->datum #'datum))]
     [(~var . rest)
-     (disappeared! stx)
-     (parse-pat:var stx decls allow-head?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:var stx decls allow-head?))]
     [(~datum . rest)
-     (disappeared! stx)
-     (syntax-case stx (~datum)
-       [(~datum d)
-        (pat:datum (syntax->datum #'d))]
-       [_ (wrong-syntax stx "bad ~~datum form")])]
+     (begin
+       (disappeared! stx)
+       (syntax-case stx (~datum)
+         [(~datum d)
+          (pat:datum (syntax->datum #'d))]
+         [_ (wrong-syntax stx "bad ~~datum form")]))]
     [(~literal . rest)
-     (disappeared! stx)
-     (parse-pat:literal stx decls)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:literal stx decls))]
     [(~and . rest)
-     (disappeared! stx)
-     (parse-pat:and stx decls allow-head? allow-action?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:and stx decls allow-head? allow-action?))]
     [(~or . rest)
-     (disappeared! stx)
-     (parse-pat:or stx decls allow-head?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:or stx decls allow-head?))]
     [(~or* . rest)
-     (disappeared! stx)
-     (parse-pat:or stx decls allow-head?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:or stx decls allow-head?))]
     [(~alt . rest)
      (wrong-syntax stx "ellipsis-head pattern allowed only before ellipsis")]
     [(~not . rest)
-     (disappeared! stx)
-     (parse-pat:not stx decls)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:not stx decls))]
     [(~rest . rest)
-     (disappeared! stx)
-     (parse-pat:rest stx decls)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:rest stx decls))]
     [(~describe . rest)
-     (disappeared! stx)
-     (parse-pat:describe stx decls allow-head?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:describe stx decls allow-head?))]
     [(~delimit-cut . rest)
-     (disappeared! stx)
-     (parse-pat:delimit stx decls allow-head?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:delimit stx decls allow-head?))]
     [(~commit . rest)
-     (disappeared! stx)
-     (parse-pat:commit stx decls allow-head?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:commit stx decls allow-head?))]
     [(~reflect . rest)
-     (disappeared! stx)
-     (parse-pat:reflect stx decls #f)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:reflect stx decls #f))]
     [(~seq . rest)
-     (disappeared! stx)
-     (check-head!
-      (parse-hpat:seq stx #'rest decls))]
+     (begin
+       (disappeared! stx)
+       (check-head!
+        (parse-hpat:seq stx #'rest decls)))]
     [(~optional . rest)
-     (disappeared! stx)
-     (check-head!
-      (parse-hpat:optional stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-head!
+        (parse-hpat:optional stx decls)))]
     [(~splicing-reflect . rest)
-     (disappeared! stx)
-     (check-head!
-      (parse-pat:reflect stx decls #t))]
+     (begin
+       (disappeared! stx)
+       (check-head!
+        (parse-pat:reflect stx decls #t)))]
     [(~bind . rest)
-     (disappeared! stx)
-     (check-action!
-      (parse-pat:bind stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-action!
+        (parse-pat:bind stx decls)))]
     [(~fail . rest)
-     (disappeared! stx)
-     (check-action!
-      (parse-pat:fail stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-action!
+        (parse-pat:fail stx decls)))]
     [(~post . rest)
-     (disappeared! stx)
-     (parse-pat:post stx decls allow-head? allow-action?)]
+     (begin
+       (disappeared! stx)
+       (parse-pat:post stx decls allow-head? allow-action?))]
     [(~peek . rest)
-     (disappeared! stx)
-     (check-head!
-      (parse-pat:peek stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-head!
+        (parse-pat:peek stx decls)))]
     [(~peek-not . rest)
-     (disappeared! stx)
-     (check-head!
-      (parse-pat:peek-not stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-head!
+        (parse-pat:peek-not stx decls)))]
     [(~parse . rest)
-     (disappeared! stx)
-     (check-action!
-      (parse-pat:parse stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-action!
+        (parse-pat:parse stx decls)))]
     [(~do . rest)
-     (disappeared! stx)
-     (check-action!
-      (parse-pat:do stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-action!
+        (parse-pat:do stx decls)))]
     [(~undo . rest)
-     (disappeared! stx)
-     (check-action!
-      (parse-pat:undo stx decls))]
+     (begin
+       (disappeared! stx)
+       (check-action!
+        (parse-pat:undo stx decls)))]
     [(head dots . tail)
      (and (dots? #'dots) (not-shadowed? #'dots))
      (begin (disappeared! #'dots)
@@ -644,8 +667,8 @@
      (begin (disappeared! #'id)
             (recur (expand-pattern (syntax-local-value #'id) #'id stx)))]
     [(~eh-var name eh-alt-set-id)
-     (disappeared! stx)
      (let ()
+       (disappeared! stx)
        (define prefix (name->prefix #'name "."))
        (define eh-alt-set (get-eh-alternative-set #'eh-alt-set-id))
        (for/list ([alt (in-list (eh-alternative-set-alts eh-alt-set))])
@@ -659,20 +682,25 @@
                  (replace-eh-alternative-attrs
                   alt (iattrs->sattrs iattrs))))))]
     [(~or . _)
-     (disappeared! stx)
-     (recur-cdr-list stx)]
+     (begin
+       (disappeared! stx)
+       (recur-cdr-list stx))]
     [(~alt . _)
-     (disappeared! stx)
-     (recur-cdr-list stx)]
+     (begin
+       (disappeared! stx)
+       (recur-cdr-list stx))]
     [(~optional . _)
-     (disappeared! stx)
-     (list (parse*-ehpat/optional stx decls))]
+     (begin
+       (disappeared! stx)
+       (list (parse*-ehpat/optional stx decls)))]
     [(~once . _)
-     (disappeared! stx)
-     (list (parse*-ehpat/once stx decls))]
+     (begin
+       (disappeared! stx)
+       (list (parse*-ehpat/once stx decls)))]
     [(~between . _)
-     (disappeared! stx)
-     (list (parse*-ehpat/bounds stx decls))]
+     (begin
+       (disappeared! stx)
+       (list (parse*-ehpat/bounds stx decls)))]
     [_
      (let ([head (parse-head-pattern stx decls)])
        (list (list (create-ehpat head #f stx) stx)))]))
@@ -752,9 +780,10 @@
   (define name0
     (syntax-case stx ()
       [(_ name . _)
-       (unless (identifier? #'name)
-         (wrong-syntax #'name "expected identifier"))
-       #'name]
+       (begin
+         (unless (identifier? #'name)
+           (wrong-syntax #'name "expected identifier"))
+         #'name)]
       [_
        (wrong-syntax stx "bad ~~var form")]))
   (define-values (scname sc+args-stx argu pfx role)
@@ -870,14 +899,15 @@
 (define (parse-pat:literal stx decls)
   (syntax-case stx ()
     [(_ lit . more)
-     (unless (identifier? #'lit)
-       (wrong-syntax #'lit "expected identifier"))
-     (let* ([chunks (parse-keyword-options/eol #'more phase-directive-table
-                                               #:no-duplicates? #t
-                                               #:context stx)]
-            [phase (options-select-value chunks '#:phase #:default #f)]
-            [phase (if phase (txlift phase) slpl-expr)])
-       (pat:literal #'lit phase phase))]
+     (begin
+       (unless (identifier? #'lit)
+         (wrong-syntax #'lit "expected identifier"))
+       (let* ([chunks (parse-keyword-options/eol #'more phase-directive-table
+                                                 #:no-duplicates? #t
+                                                 #:context stx)]
+              [phase (options-select-value chunks '#:phase #:default #f)]
+              [phase (if phase (txlift phase) slpl-expr)])
+         (pat:literal #'lit phase phase)))]
     [_
      (wrong-syntax stx "bad ~~literal pattern")]))
 


### PR DESCRIPTION
## Checklist
- [x] Bugfix

## Description of change
Currently, `define-syntax-class`, `define-splicing-syntax-class`, and `define-eh-alternative-set` are missing a `with-disappeared-uses`. Add this, so that the recorded keywords (including `pattern` and syntax-pattern keywords) are attached as `'disappeared-use` to the expansion.

Related to the `define-eh-alternative-set` change, record `pattern` in each eh-alt, and record the referenced eh-alt-set id in `~eh-var`.

An additional commit in this PR also cleans up some `syntax-case` fenders in `"rep.rkt"` that I noticed along the way.