### PR TITLE
Enable Racket to build and run on Haiku OS x86_64.

### DIFF
--- a/racket/src/cs/c/configure
+++ b/racket/src/cs/c/configure
@@ -4801,6 +4801,14 @@ case "$host_os" in
     MACH_OS=qnx
     use_flag_pthread=no
     ;;
+  haiku*)
+    MACH_OS=hk
+    CFLAGS="${CFLAGS} -I/boot/system/develop/headers -I/boot/system/develop/headers/posix"
+    LDFLAGS="${LDFLAGS} -L/boot/system/develop/lib"
+    LIBS="${LIBS} -lm -lpthread -lroot -lnetwork -lposix_error_mapper"
+    LINK_DYNAMIC="-rdynamic"
+    add_iconv_lib="-liconv"
+    ;;
   *)
     ;;
 esac

--- a/racket/src/cs/c/configure.ac
+++ b/racket/src/cs/c/configure.ac
@@ -376,6 +376,14 @@ case "$host_os" in
     MACH_OS=qnx
     use_flag_pthread=no
     ;;
+  haiku*)
+    MACH_OS=hk
+    CFLAGS="${CFLAGS} -I/boot/system/develop/headers -I/boot/system/develop/headers/posix"
+    LDFLAGS="${LDFLAGS} -L/boot/system/develop/lib"
+    LIBS="${LIBS} -lm -lpthread -lroot -lnetwork -lposix_error_mapper"
+    LINK_DYNAMIC="-rdynamic"
+    add_iconv_lib="-liconv"
+    ;;
   *)
     ;;
 esac


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ ] Bugfix
- [x] Feature
- [ ] tests included
- [ ] documentation

## Description of change

As my changes to Chez, to support Haiku OS on x86_64, have now been merged into the Racket codebase, I was able to make these very simple changes to support building Racket on that platform too.  I've been running this successfully since the 26th of July and I'm able to work happily in DrRacket on the platform, use raco, etc. etc.   

Building on Haiku should be as simple as `make in-place`, so long as you have installed the correct dependencies (I'll go about making a proper package for Haiku when and if support is "official").  

However, I'd appreciate some pointers on how to run exhaustive tests for Haiku.  I've poked around a bit but didn't find my way in.  