### PR TITLE
track literals as `'disappeared-use` in `syntax-case` and alike

### DIFF
--- a/pkgs/racket-test-core/tests/racket/expobs-regression.rktd
+++ b/pkgs/racket-test-core/tests/racket/expobs-regression.rktd
@@ -557,6 +557,7 @@
              #f
              ((s4 s5) (s6 (s7 s2 s5)))
              (s4 (s8 s2 (s9 (s5)))))))
+        (track-syntax s0 #s(stx-boundary s1) . #s(stx-boundary s1))
         (macro-post-x
          #s(stx-boundary
             (s0

--- a/racket/collects/racket/private/stxcase.rkt
+++ b/racket/collects/racket/private/stxcase.rkt
@@ -207,8 +207,13 @@
 		 [lit-comp-is-mod? (and (identifier? lit-comp)
 					(free-identifier=? 
 					 lit-comp
-					 (quote-syntax free-identifier=?)))])
-            (syntax-arm
+					 (quote-syntax free-identifier=?)))]
+                 [track-use (lambda (stx)
+                              (if s-exp?
+                                  stx
+                                  (let ([kws (map syntax-local-introduce (stx->list kws))])
+                                    (syntax-property stx 'disappeared-use kws))))])
+            (track-use
              (datum->syntax
               (quote-syntax here)
               (list (quote-syntax let) (list (list arg (if (or s-exp? (syntax-e arg-is-stx?))

--- a/racket/collects/racket/private/stxcase.rkt
+++ b/racket/collects/racket/private/stxcase.rkt
@@ -307,10 +307,15 @@
                                            (list rslt
                                                  (if cant-fail?
                                                      arg
-                                                     (list* (datum->syntax
-                                                             (quote-syntax here)
-                                                             mtch
-                                                             pattern)
+                                                     (list* (let ([mtch (datum->syntax
+                                                                         (quote-syntax here)
+                                                                         mtch
+                                                                         pattern)])
+                                                              (if (and (not interp?) lit-comp-is-mod?)
+                                                                  (syntax-property mtch
+                                                                                   'disappeared-use
+                                                                                   (syntax-local-introduce lit-comp))
+                                                                  mtch))
                                                             arg
                                                             (if (or interp? lit-comp-is-mod?)
                                                                 null


### PR DESCRIPTION
## Checklist
- [x] Bugfix

## Description of change
This change makes it so that binding arrows are drawn for literals provided in `syntax-case`.

An additional, related change in this PR makes it so that the binding arrow for `free-identifier=?` is always drawn in `syntax-case*` (previously, the original `free-identifier=?` sometimes won’t appear in the expansion).