### PR TITLE
doc: fix ffi2-lib-ref description

### DIFF
--- a/pkgs/ffi2/ffi2/scribblings/lib.scrbl
+++ b/pkgs/ffi2/ffi2/scribblings/lib.scrbl
@@ -29,8 +29,8 @@ is called to produce a result.
 
 }
 
-@defproc[(ffi2-lib-ref [name (or/c string? bytes? symbol?)]
-                       [lib (or/c ffi2-lib? #f)]
+@defproc[(ffi2-lib-ref [lib (or/c ffi2-lib? #f)]
+                       [name (or/c string? bytes? symbol?)]
                        [#:fail fail (or/c (->/c any) #f) #f])
          any]{
 


### PR DESCRIPTION
## Checklist

- [x] documentation

## Description of Change

Proper order as seen in <https://docs.racket-lang.org/ffi2/tutorial1.html?lang=ar&#(part._.Finding_.C_.Functions)>
