### PR TITLE
Expose contract-random-generate's source of randomness

### DIFF
--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -4201,12 +4201,3 @@ ended up returning @racket[contract-random-generate-fail].
 
  @history[#:added "9.3.0.2"]
 }
-
-@defproc[(contract-random-generate-seed [k (integer-in 0 (sub1 (expt 2 31)))])
-         void?]{
-
- Like @racket[random-seed], except that it seeds
- @racket[(current-contract-pseudo-random-generator)]
- rather than the current pseudo-random number generator.
-
- @history[#:added "9.3.0.2"]}

--- a/pkgs/racket-doc/scribblings/reference/contracts.scrbl
+++ b/pkgs/racket-doc/scribblings/reference/contracts.scrbl
@@ -4192,3 +4192,21 @@ ended up returning @racket[contract-random-generate-fail].
 
 @history[#:added "6.1.1.5"]
 }
+
+@defparam[current-contract-pseudo-random-generator
+          rand-gen
+          pseudo-random-generator?]{
+ A @tech{parameter} that determines the the pseudo-random number generator
+ used by @racket[contract-random-generate] and @racket[contract-exercise].
+
+ @history[#:added "9.3.0.2"]
+}
+
+@defproc[(contract-random-generate-seed [k (integer-in 0 (sub1 (expt 2 31)))])
+         void?]{
+
+ Like @racket[random-seed], except that it seeds
+ @racket[(current-contract-pseudo-random-generator)]
+ rather than the current pseudo-random number generator.
+
+ @history[#:added "9.3.0.2"]}

--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -641,10 +641,11 @@
   (check-not-exn (λ () (test-contract-generation (make-gen-choose/c)))))
 
 
-;; test contract-random-generate-seed
+;; test simple seeding for current-contract-pseudo-random-generator
 (define (test-seeding ctc seed)
   (define (seed-and-generate)
-    (contract-random-generate-seed seed)
+    (parameterize ([current-pseudo-random-generator (current-contract-pseudo-random-generator)])
+      (random-seed seed))
     (contract-random-generate ctc))
 
   (define generated1 (seed-and-generate))
@@ -661,7 +662,7 @@
 (check-not-exn (λ () (test-seeding number? 43)))
 (check-not-exn (λ () (test-seeding string? 125290)))
 
-;; test current-contract-pseudo-random-generator
+;; test seeding current-contract-pseudo-random-generator directly with vector
 (define (test-seed-by-vector ctc vec)
   (define (vector-set-and-generate)
     (vector->pseudo-random-generator!

--- a/pkgs/racket-test/tests/racket/contract/random-generate.rkt
+++ b/pkgs/racket-test/tests/racket/contract/random-generate.rkt
@@ -639,3 +639,48 @@
      #:generate
      (λ (ctc) (λ (fuel) (contract-random-generate/choose number? 10)))))
   (check-not-exn (λ () (test-contract-generation (make-gen-choose/c)))))
+
+
+;; test contract-random-generate-seed
+(define (test-seeding ctc seed)
+  (define (seed-and-generate)
+    (contract-random-generate-seed seed)
+    (contract-random-generate ctc))
+
+  (define generated1 (seed-and-generate))
+  (define generated2 (seed-and-generate))
+  
+  (unless (equal? generated1 generated2)
+    (error 'test-seeding
+           "contract-random-generate produced different values (~e and ~e) from the same seed (~e) on contract ~e"
+           generated1
+           generated2
+           seed
+           ctc)))
+
+(check-not-exn (λ () (test-seeding number? 43)))
+(check-not-exn (λ () (test-seeding string? 125290)))
+
+;; test current-contract-pseudo-random-generator
+(define (test-seed-by-vector ctc vec)
+  (define (vector-set-and-generate)
+    (vector->pseudo-random-generator!
+     (current-contract-pseudo-random-generator)
+     vec)
+    (contract-random-generate ctc))
+
+  (define generated1 (vector-set-and-generate))
+  (define generated2 (vector-set-and-generate))
+  
+  (unless (equal? generated1 generated2)
+    (error 'test-seed-by-vector
+           "contract-random-generate produced different values (~e and ~e) from the same vector state (~e) on contract ~e"
+           generated1
+           generated2
+           vec
+           ctc)))
+
+(check-not-exn (λ () (test-seed-by-vector number? '#(725075057 2853679635 3454706443 2613380953
+                                                               675109520 2167642600))))
+(check-not-exn (λ () (test-seed-by-vector string? '#(1406683016 984745282 2427635517 3466950283
+                                                                3024258523 1696545797))))

--- a/racket/collects/racket/contract.rkt
+++ b/racket/collects/racket/contract.rkt
@@ -20,6 +20,8 @@
          contract-random-generate-fail
          contract-random-generate-fail?
          contract-random-generate-env?
+         current-contract-pseudo-random-generator
+         contract-random-generate-seed
          contract-exercise
          get/build-val-first-projection
          contract-custom-write-property-proc)

--- a/racket/collects/racket/contract.rkt
+++ b/racket/collects/racket/contract.rkt
@@ -21,7 +21,6 @@
          contract-random-generate-fail?
          contract-random-generate-env?
          current-contract-pseudo-random-generator
-         contract-random-generate-seed
          contract-exercise
          get/build-val-first-projection
          contract-custom-write-property-proc)

--- a/racket/collects/racket/contract/private/generate.rkt
+++ b/racket/collects/racket/contract/private/generate.rkt
@@ -15,6 +15,8 @@
          contract-exercise
          contract-random-generate-fail
          contract-random-generate-fail?
+         current-contract-pseudo-random-generator
+         (rename-out [rand-seed contract-random-generate-seed])
          with-definitely-available-contracts
          can-generate/env?
          try/env

--- a/racket/collects/racket/contract/private/generate.rkt
+++ b/racket/collects/racket/contract/private/generate.rkt
@@ -16,7 +16,6 @@
          contract-random-generate-fail
          contract-random-generate-fail?
          current-contract-pseudo-random-generator
-         (rename-out [rand-seed contract-random-generate-seed])
          with-definitely-available-contracts
          can-generate/env?
          try/env

--- a/racket/collects/racket/contract/private/rand.rkt
+++ b/racket/collects/racket/contract/private/rand.rkt
@@ -7,18 +7,21 @@
          rand-choice
          rand-range
          rand-nat
+         current-contract-pseudo-random-generator
          permute
          oneof)
 
-(define my-generator (make-pseudo-random-generator))
+(define current-contract-pseudo-random-generator
+  (make-parameter (make-pseudo-random-generator)))
+
 (define (rand [x #f]) 
   (if x
-      (random x my-generator)
-      (random my-generator)))
+      (random x (current-contract-pseudo-random-generator))
+      (random (current-contract-pseudo-random-generator))))
 
 
 (define (rand-seed x)
-  (parameterize ([current-pseudo-random-generator my-generator])
+  (parameterize ([current-pseudo-random-generator (current-contract-pseudo-random-generator)])
     (random-seed x)))
 
 (define-syntax (rand-choice stx)


### PR DESCRIPTION
<!--
Thank you for contributing. Please provide a description to help reviewers. 

For more information about how to contribute please see
* https://github.com/racket/racket/blob/master/.github/CONTRIBUTING.md
* https://docs.racket-lang.org/racket-build-guide/contribute.html

Bug fixes and new features should include tests.
-->

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Feature
- [x] Tests included
- [x] Documentation

## Description of change
<!-- Please provide a description of the change here. -->
Creates a parameter `contract-random-generate-pseudo-random-generator`, which contract-based generation often uses as a source of randomness in addition to `current-pseudo-random-generator`.