### PR TITLE
Fix CI failure

### DIFF
--- a/pkgs/racket-test/tests/db/sqlite3.rkt
+++ b/pkgs/racket-test/tests/db/sqlite3.rkt
@@ -1,11 +1,13 @@
 #lang racket/base
 
 (require db/private/pre
-         db/unsafe/sqlite3
+         (only-in db/private/sqlite3/connection
+                  unsafe-create-function)
+         racket/class
          rackunit)
 
 (test-case
  "sqlite3-create-function supports NULL values"
  (define db (sqlite3-connect #:database 'memory))
- (sqlite3-create-function db "identity" 1 values)
+ (send db unsafe-create-function 'sqlite3-create-function "identity" 1 values)
  (check-equal? (query-value db "SELECT identity(NULL)") sql-null))


### PR DESCRIPTION
Co-authored by GPT-5.6 Sol

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [x] Bugfix
- [ ] Feature
- [ ] tests included
- [ ] documentation

## Description of change

https://github.com/racket/racket/pull/5581 added a test file that [fails the CI](https://github.com/racket/racket/actions/runs/34072960453/job/101593607736). The reason is that it imports `db/unsafe/sqlite3` for `sqlite3-create-function`, but `db/unsafe/sqlite3` is defined in a [different package](https://github.com/racket/db/blob/master/db-lib/db/unsafe/sqlite3.rkt), which is not installed during the test running.

This PR instead directly uses the `unsafe-create-function` method, which is what `sqlite3-create-function` calls under the hood, and can readily be used. This fixes the issue.